### PR TITLE
zh-CN: Restores lost translations

### DIFF
--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -1,4 +1,3 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
@@ -12,33 +11,27 @@ msgstr ""
 "Language: zh-Hans\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/SUMMARY.md:4
-#: src/index.md:1
+#: src/SUMMARY.md:4 src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "欢迎来到 Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:5
-#: src/running-the-course.md:1
+#: src/SUMMARY.md:5 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "授课"
 
-#: src/SUMMARY.md:6
-#: src/running-the-course/course-structure.md:1
+#: src/SUMMARY.md:6 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "课程结构"
 
-#: src/SUMMARY.md:7
-#: src/running-the-course/keyboard-shortcuts.md:1
+#: src/SUMMARY.md:7 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "键盘快捷键"
 
-#: src/SUMMARY.md:8
-#: src/running-the-course/translations.md:1
+#: src/SUMMARY.md:8 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "翻译"
 
-#: src/SUMMARY.md:9
-#: src/cargo.md:1
+#: src/SUMMARY.md:9 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "使用 Cargo"
 
@@ -58,84 +51,65 @@ msgstr "在本地运行 Cargo"
 msgid "Day 1: Morning"
 msgstr "第一天：早上"
 
-#: src/SUMMARY.md:19
-#: src/SUMMARY.md:80
-#: src/SUMMARY.md:135
-#: src/SUMMARY.md:193
-#: src/SUMMARY.md:219
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md:19 src/SUMMARY.md:80 src/SUMMARY.md:135 src/SUMMARY.md:193
+#: src/SUMMARY.md:219 src/SUMMARY.md:269
 msgid "Welcome"
 msgstr "欢迎"
 
-#: src/SUMMARY.md:20
-#: src/welcome-day-1/what-is-rust.md:1
+#: src/SUMMARY.md:20 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "什么是 Rust？"
 
-#: src/SUMMARY.md:21
-#: src/hello-world.md:1
+#: src/SUMMARY.md:21 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Hello World!"
 
-#: src/SUMMARY.md:22
-#: src/hello-world/small-example.md:1
+#: src/SUMMARY.md:22 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "简短示例"
 
-#: src/SUMMARY.md:23
-#: src/why-rust.md:1
+#: src/SUMMARY.md:23 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "为什么选择 Rust？"
 
-#: src/SUMMARY.md:24
-#: src/why-rust/an-example-in-c.md:1
-#: src/credits.md:32
+#: src/SUMMARY.md:24 src/why-rust/an-example-in-c.md:1 src/credits.md:32
 #, fuzzy
 msgid "An Example in C"
 msgstr "C++ 示例"
 
-#: src/SUMMARY.md:25
-#: src/why-rust/compile-time.md:1
+#: src/SUMMARY.md:25 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "编译期保障"
 
-#: src/SUMMARY.md:26
-#: src/why-rust/runtime.md:1
+#: src/SUMMARY.md:26 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "运行时保障"
 
-#: src/SUMMARY.md:27
-#: src/why-rust/modern.md:1
+#: src/SUMMARY.md:27 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "现代特性"
 
-#: src/SUMMARY.md:28
-#: src/basic-syntax.md:1
+#: src/SUMMARY.md:28 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "基本语法"
 
-#: src/SUMMARY.md:29
-#: src/basic-syntax/scalar-types.md:1
+#: src/SUMMARY.md:29 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "标量类型"
 
-#: src/SUMMARY.md:30
-#: src/basic-syntax/compound-types.md:1
+#: src/SUMMARY.md:30 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "复合类型"
 
-#: src/SUMMARY.md:31
-#: src/basic-syntax/references.md:1
+#: src/SUMMARY.md:31 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "引用"
 
-#: src/SUMMARY.md:32
-#: src/basic-syntax/references-dangling.md:1
+#: src/SUMMARY.md:32 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "悬垂引用"
 
-#: src/SUMMARY.md:33
-#: src/basic-syntax/slices.md:1
+#: src/SUMMARY.md:33 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "切片"
 
@@ -143,19 +117,15 @@ msgstr "切片"
 msgid "String vs str"
 msgstr "String 和 str"
 
-#: src/SUMMARY.md:35
-#: src/basic-syntax/functions.md:1
+#: src/SUMMARY.md:35 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "函数"
 
-#: src/SUMMARY.md:36
-#: src/basic-syntax/rustdoc.md:1
+#: src/SUMMARY.md:36 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr "Rustdoc"
 
-#: src/SUMMARY.md:37
-#: src/SUMMARY.md:103
-#: src/basic-syntax/methods.md:1
+#: src/SUMMARY.md:37 src/SUMMARY.md:103 src/basic-syntax/methods.md:1
 #: src/methods.md:1
 msgid "Methods"
 msgstr "方法"
@@ -164,27 +134,17 @@ msgstr "方法"
 msgid "Overloading"
 msgstr "重载"
 
-#: src/SUMMARY.md:39
-#: src/SUMMARY.md:72
-#: src/SUMMARY.md:106
-#: src/SUMMARY.md:126
-#: src/SUMMARY.md:155
-#: src/SUMMARY.md:185
-#: src/SUMMARY.md:212
-#: src/SUMMARY.md:233
-#: src/SUMMARY.md:261
-#: src/SUMMARY.md:283
-#: src/SUMMARY.md:304
-#: src/exercises/android/morning.md:1
-#: src/exercises/bare-metal/morning.md:1
+#: src/SUMMARY.md:39 src/SUMMARY.md:72 src/SUMMARY.md:106 src/SUMMARY.md:126
+#: src/SUMMARY.md:155 src/SUMMARY.md:185 src/SUMMARY.md:212 src/SUMMARY.md:233
+#: src/SUMMARY.md:261 src/SUMMARY.md:283 src/SUMMARY.md:304
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
 #: src/exercises/bare-metal/afternoon.md:1
 #: src/exercises/concurrency/morning.md:1
 #: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "习题"
 
-#: src/SUMMARY.md:40
-#: src/exercises/day-1/implicit-conversions.md:1
+#: src/SUMMARY.md:40 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "隐式类型转换"
 
@@ -196,14 +156,11 @@ msgstr "数组与 for 循环"
 msgid "Day 1: Afternoon"
 msgstr "第 1 天：下午"
 
-#: src/SUMMARY.md:45
-#: src/SUMMARY.md:296
-#: src/control-flow.md:1
+#: src/SUMMARY.md:45 src/SUMMARY.md:296 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "控制流"
 
-#: src/SUMMARY.md:46
-#: src/control-flow/blocks.md:1
+#: src/SUMMARY.md:46 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "块"
 
@@ -227,13 +184,11 @@ msgstr "break & continue"
 msgid "loop expressions"
 msgstr "loop 表达式"
 
-#: src/SUMMARY.md:53
-#: src/basic-syntax/variables.md:1
+#: src/SUMMARY.md:53 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "变量"
 
-#: src/SUMMARY.md:54
-#: src/basic-syntax/type-inference.md:1
+#: src/SUMMARY.md:54 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "类型推导"
 
@@ -241,28 +196,23 @@ msgstr "类型推导"
 msgid "static & const"
 msgstr "静态与常量"
 
-#: src/SUMMARY.md:56
-#: src/basic-syntax/scopes-shadowing.md:1
+#: src/SUMMARY.md:56 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "作用域和隐藏 (Shadowing)"
 
-#: src/SUMMARY.md:57
-#: src/enums.md:1
+#: src/SUMMARY.md:57 src/enums.md:1
 msgid "Enums"
 msgstr "枚举"
 
-#: src/SUMMARY.md:58
-#: src/enums/variant-payloads.md:1
+#: src/SUMMARY.md:58 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "变体载荷"
 
-#: src/SUMMARY.md:59
-#: src/enums/sizes.md:1
+#: src/SUMMARY.md:59 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "枚举大小"
 
-#: src/SUMMARY.md:61
-#: src/control-flow/novel.md:1
+#: src/SUMMARY.md:61 src/control-flow/novel.md:1
 #, fuzzy
 msgid "Novel Control Flow"
 msgstr "控制流"
@@ -279,34 +229,27 @@ msgstr "while let 表达式"
 msgid "match expressions"
 msgstr "match 表达式"
 
-#: src/SUMMARY.md:66
-#: src/SUMMARY.md:74
-#: src/pattern-matching.md:1
+#: src/SUMMARY.md:66 src/SUMMARY.md:74 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "模式匹配"
 
-#: src/SUMMARY.md:67
-#: src/pattern-matching/destructuring-enums.md:1
+#: src/SUMMARY.md:67 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "解构枚举"
 
-#: src/SUMMARY.md:68
-#: src/pattern-matching/destructuring-structs.md:1
+#: src/SUMMARY.md:68 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "解构结构体"
 
-#: src/SUMMARY.md:69
-#: src/pattern-matching/destructuring-arrays.md:1
+#: src/SUMMARY.md:69 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "解构数组"
 
-#: src/SUMMARY.md:70
-#: src/pattern-matching/match-guards.md:1
+#: src/SUMMARY.md:70 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "匹配守卫"
 
-#: src/SUMMARY.md:73
-#: src/exercises/day-1/luhn.md:1
+#: src/SUMMARY.md:73 src/exercises/day-1/luhn.md:1
 #: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Luhn 算法"
@@ -315,8 +258,7 @@ msgstr "Luhn 算法"
 msgid "Day 2: Morning"
 msgstr "第二天：上午"
 
-#: src/SUMMARY.md:82
-#: src/memory-management.md:1
+#: src/SUMMARY.md:82 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "内存管理"
 
@@ -328,13 +270,11 @@ msgstr "栈 vs 堆"
 msgid "Stack Memory"
 msgstr "栈内存"
 
-#: src/SUMMARY.md:85
-#: src/memory-management/manual.md:1
+#: src/SUMMARY.md:85 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "手动内存管理"
 
-#: src/SUMMARY.md:86
-#: src/memory-management/scope-based.md:1
+#: src/SUMMARY.md:86 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "基于作用域的内存管理"
 
@@ -346,18 +286,15 @@ msgstr "垃圾回收"
 msgid "Rust Memory Management"
 msgstr "Rust 内存管理"
 
-#: src/SUMMARY.md:89
-#: src/ownership.md:1
+#: src/SUMMARY.md:89 src/ownership.md:1
 msgid "Ownership"
 msgstr "所有权"
 
-#: src/SUMMARY.md:90
-#: src/ownership/move-semantics.md:1
+#: src/SUMMARY.md:90 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "移动语义"
 
-#: src/SUMMARY.md:91
-#: src/ownership/moved-strings-rust.md:1
+#: src/SUMMARY.md:91 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Rust 中移动的字符串"
 
@@ -365,77 +302,61 @@ msgstr "Rust 中移动的字符串"
 msgid "Double Frees in Modern C++"
 msgstr "现代 C++ 中的双重释放"
 
-#: src/SUMMARY.md:93
-#: src/ownership/moves-function-calls.md:1
+#: src/SUMMARY.md:93 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "函数调用中的移动"
 
-#: src/SUMMARY.md:94
-#: src/ownership/copy-clone.md:1
+#: src/SUMMARY.md:94 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "复制和克隆"
 
-#: src/SUMMARY.md:95
-#: src/ownership/borrowing.md:1
+#: src/SUMMARY.md:95 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "借用"
 
-#: src/SUMMARY.md:96
-#: src/ownership/shared-unique-borrows.md:1
+#: src/SUMMARY.md:96 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "共享和唯一的借用"
 
-#: src/SUMMARY.md:97
-#: src/ownership/lifetimes.md:1
+#: src/SUMMARY.md:97 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "生命周期"
 
-#: src/SUMMARY.md:98
-#: src/ownership/lifetimes-function-calls.md:1
+#: src/SUMMARY.md:98 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "函数调用中的生命周期"
 
-#: src/SUMMARY.md:99
-#: src/ownership/lifetimes-data-structures.md:1
+#: src/SUMMARY.md:99 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "数据结构中的生命周期"
 
-#: src/SUMMARY.md:100
-#: src/structs.md:1
+#: src/SUMMARY.md:100 src/structs.md:1
 msgid "Structs"
 msgstr "结构体"
 
-#: src/SUMMARY.md:101
-#: src/structs/tuple-structs.md:1
+#: src/SUMMARY.md:101 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "元组结构体"
 
-#: src/SUMMARY.md:102
-#: src/structs/field-shorthand.md:1
+#: src/SUMMARY.md:102 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "字段简写语法"
 
-#: src/SUMMARY.md:104
-#: src/methods/receiver.md:1
+#: src/SUMMARY.md:104 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "方法接收者"
 
-#: src/SUMMARY.md:105
-#: src/SUMMARY.md:167
-#: src/SUMMARY.md:282
-#: src/methods/example.md:1
-#: src/concurrency/shared_state/example.md:1
+#: src/SUMMARY.md:105 src/SUMMARY.md:167 src/SUMMARY.md:282
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "示例"
 
-#: src/SUMMARY.md:107
-#: src/exercises/day-2/book-library.md:1
+#: src/SUMMARY.md:107 src/exercises/day-2/book-library.md:1
 #, fuzzy
 msgid "Storing Books"
 msgstr "字符串"
 
-#: src/SUMMARY.md:108
-#: src/exercises/day-2/health-statistics.md:1
+#: src/SUMMARY.md:108 src/exercises/day-2/health-statistics.md:1
 #: src/exercises/day-2/solutions-morning.md:151
 msgid "Health Statistics"
 msgstr "健康统计"
@@ -444,8 +365,7 @@ msgstr "健康统计"
 msgid "Day 2: Afternoon"
 msgstr "第二天：下午"
 
-#: src/SUMMARY.md:112
-#: src/std.md:1
+#: src/SUMMARY.md:112 src/std.md:1
 msgid "Standard Library"
 msgstr "标准库"
 
@@ -453,8 +373,7 @@ msgstr "标准库"
 msgid "Option and Result"
 msgstr "Option 和 Result"
 
-#: src/SUMMARY.md:114
-#: src/std/string.md:1
+#: src/SUMMARY.md:114 src/std/string.md:1
 msgid "String"
 msgstr "String"
 
@@ -474,8 +393,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "递归数据类型"
 
-#: src/SUMMARY.md:119
-#: src/std/box-niche.md:1
+#: src/SUMMARY.md:119 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "小众优化"
 
@@ -487,33 +405,27 @@ msgstr "Rc"
 msgid "Cell/RefCell"
 msgstr "Cell/RefCell"
 
-#: src/SUMMARY.md:122
-#: src/modules.md:1
+#: src/SUMMARY.md:122 src/modules.md:1
 msgid "Modules"
 msgstr "模块"
 
-#: src/SUMMARY.md:123
-#: src/modules/visibility.md:1
+#: src/SUMMARY.md:123 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "可见性"
 
-#: src/SUMMARY.md:124
-#: src/modules/paths.md:1
+#: src/SUMMARY.md:124 src/modules/paths.md:1
 msgid "Paths"
 msgstr "路径"
 
-#: src/SUMMARY.md:125
-#: src/modules/filesystem.md:1
+#: src/SUMMARY.md:125 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "文件系统层级结构"
 
-#: src/SUMMARY.md:127
-#: src/exercises/day-2/iterators-and-ownership.md:1
+#: src/SUMMARY.md:127 src/exercises/day-2/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "迭代器和所有权"
 
-#: src/SUMMARY.md:128
-#: src/exercises/day-2/strings-iterators.md:1
+#: src/SUMMARY.md:128 src/exercises/day-2/strings-iterators.md:1
 #: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Strings and Iterators"
 msgstr "字符串和迭代器"
@@ -522,48 +434,39 @@ msgstr "字符串和迭代器"
 msgid "Day 3: Morning"
 msgstr "第三天：上午"
 
-#: src/SUMMARY.md:136
-#: src/generics.md:1
+#: src/SUMMARY.md:136 src/generics.md:1
 msgid "Generics"
 msgstr "泛型"
 
-#: src/SUMMARY.md:137
-#: src/generics/data-types.md:1
+#: src/SUMMARY.md:137 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "通用数据类型"
 
-#: src/SUMMARY.md:138
-#: src/generics/methods.md:1
+#: src/SUMMARY.md:138 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "泛型方法"
 
-#: src/SUMMARY.md:139
-#: src/generics/monomorphization.md:1
+#: src/SUMMARY.md:139 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "单态化"
 
-#: src/SUMMARY.md:140
-#: src/traits.md:1
+#: src/SUMMARY.md:140 src/traits.md:1
 msgid "Traits"
 msgstr "特征"
 
-#: src/SUMMARY.md:141
-#: src/traits/trait-objects.md:1
+#: src/SUMMARY.md:141 src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "特征（Trait）对象"
 
-#: src/SUMMARY.md:142
-#: src/traits/deriving-traits.md:1
+#: src/SUMMARY.md:142 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "派生特征"
 
-#: src/SUMMARY.md:143
-#: src/traits/default-methods.md:1
+#: src/SUMMARY.md:143 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "默认方法"
 
-#: src/SUMMARY.md:144
-#: src/traits/trait-bounds.md:1
+#: src/SUMMARY.md:144 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "特征边界"
 
@@ -571,8 +474,7 @@ msgstr "特征边界"
 msgid "impl Trait"
 msgstr "impl Trait"
 
-#: src/SUMMARY.md:146
-#: src/traits/important-traits.md:1
+#: src/SUMMARY.md:146 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "重要特征"
 
@@ -580,8 +482,7 @@ msgstr "重要特征"
 msgid "Iterator"
 msgstr "迭代器"
 
-#: src/SUMMARY.md:148
-#: src/traits/from-iterator.md:1
+#: src/SUMMARY.md:148 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -613,8 +514,7 @@ msgstr "闭包：Fn、FnMut、FnOnce"
 msgid "A Simple GUI Library"
 msgstr "一个简单的 GUI 库"
 
-#: src/SUMMARY.md:157
-#: src/exercises/day-3/solutions-morning.md:142
+#: src/SUMMARY.md:157 src/exercises/day-3/solutions-morning.md:142
 msgid "Points and Polygons"
 msgstr "点和多边形"
 
@@ -622,13 +522,11 @@ msgstr "点和多边形"
 msgid "Day 3: Afternoon"
 msgstr "第三天：下午"
 
-#: src/SUMMARY.md:161
-#: src/error-handling.md:1
+#: src/SUMMARY.md:161 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "错误处理"
 
-#: src/SUMMARY.md:162
-#: src/error-handling/panics.md:1
+#: src/SUMMARY.md:162 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Panics"
 
@@ -644,84 +542,68 @@ msgstr "结构化错误处理"
 msgid "Propagating Errors with ?"
 msgstr "使用 ? 传播错误"
 
-#: src/SUMMARY.md:166
-#: src/error-handling/converting-error-types.md:1
+#: src/SUMMARY.md:166 src/error-handling/converting-error-types.md:1
 #: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "转换错误类型"
 
-#: src/SUMMARY.md:168
-#: src/error-handling/deriving-error-enums.md:1
+#: src/SUMMARY.md:168 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "派生错误枚举"
 
-#: src/SUMMARY.md:169
-#: src/error-handling/dynamic-errors.md:1
+#: src/SUMMARY.md:169 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "动态错误类型"
 
-#: src/SUMMARY.md:170
-#: src/error-handling/error-contexts.md:1
+#: src/SUMMARY.md:170 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "为错误添加背景信息"
 
-#: src/SUMMARY.md:171
-#: src/testing.md:1
+#: src/SUMMARY.md:171 src/testing.md:1
 msgid "Testing"
 msgstr "测试"
 
-#: src/SUMMARY.md:172
-#: src/testing/unit-tests.md:1
+#: src/SUMMARY.md:172 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "单元测试"
 
-#: src/SUMMARY.md:173
-#: src/testing/test-modules.md:1
+#: src/SUMMARY.md:173 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "测试模块"
 
-#: src/SUMMARY.md:174
-#: src/testing/doc-tests.md:1
+#: src/SUMMARY.md:174 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "文档测试"
 
-#: src/SUMMARY.md:175
-#: src/testing/integration-tests.md:1
+#: src/SUMMARY.md:175 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "集成测试"
 
-#: src/SUMMARY.md:176
-#: src/bare-metal/useful-crates.md:1
+#: src/SUMMARY.md:176 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr "实用 crate"
 
-#: src/SUMMARY.md:177
-#: src/unsafe.md:1
+#: src/SUMMARY.md:177 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "不安全 Rust"
 
-#: src/SUMMARY.md:178
-#: src/unsafe/raw-pointers.md:1
+#: src/SUMMARY.md:178 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "解引用裸指针"
 
-#: src/SUMMARY.md:179
-#: src/unsafe/mutable-static-variables.md:1
+#: src/SUMMARY.md:179 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "可变的静态变量"
 
-#: src/SUMMARY.md:180
-#: src/unsafe/unions.md:1
+#: src/SUMMARY.md:180 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "联合体"
 
-#: src/SUMMARY.md:181
-#: src/unsafe/calling-unsafe-functions.md:1
+#: src/SUMMARY.md:181 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "调用 Unsafe 函数"
 
-#: src/SUMMARY.md:182
-#: src/unsafe/writing-unsafe-functions.md:1
+#: src/SUMMARY.md:182 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "编写 Unsafe 函数"
 
@@ -729,30 +611,24 @@ msgstr "编写 Unsafe 函数"
 msgid "Extern Functions"
 msgstr "外部函数"
 
-#: src/SUMMARY.md:184
-#: src/unsafe/unsafe-traits.md:1
+#: src/SUMMARY.md:184 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "实现 Unsafe Trait"
 
-#: src/SUMMARY.md:186
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/SUMMARY.md:186 src/exercises/day-3/safe-ffi-wrapper.md:1
 #: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "安全 FFI 封装容器"
 
-#: src/SUMMARY.md:189
-#: src/SUMMARY.md:259
-#: src/bare-metal/android.md:1
+#: src/SUMMARY.md:189 src/SUMMARY.md:259 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:194
-#: src/android/setup.md:1
+#: src/SUMMARY.md:194 src/android/setup.md:1
 msgid "Setup"
 msgstr "设置"
 
-#: src/SUMMARY.md:195
-#: src/android/build-rules.md:1
+#: src/SUMMARY.md:195 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "构建规则"
 
@@ -764,8 +640,7 @@ msgstr "可执行文件"
 msgid "Library"
 msgstr "库"
 
-#: src/SUMMARY.md:198
-#: src/android/aidl.md:1
+#: src/SUMMARY.md:198 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -781,8 +656,7 @@ msgstr "实现"
 msgid "Server"
 msgstr "服务器"
 
-#: src/SUMMARY.md:202
-#: src/android/aidl/deploy.md:1
+#: src/SUMMARY.md:202 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "部署"
 
@@ -790,20 +664,16 @@ msgstr "部署"
 msgid "Client"
 msgstr "客户端"
 
-#: src/SUMMARY.md:204
-#: src/android/aidl/changing.md:1
+#: src/SUMMARY.md:204 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "更改 API"
 
-#: src/SUMMARY.md:205
-#: src/SUMMARY.md:249
-#: src/android/logging.md:1
+#: src/SUMMARY.md:205 src/SUMMARY.md:249 src/android/logging.md:1
 #: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "日志记录"
 
-#: src/SUMMARY.md:206
-#: src/android/interoperability.md:1
+#: src/SUMMARY.md:206 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "互操作性"
 
@@ -819,8 +689,7 @@ msgstr "使用Bindgen调用C语言"
 msgid "Calling Rust from C"
 msgstr "从C语言调用Rust语言"
 
-#: src/SUMMARY.md:210
-#: src/android/interoperability/cpp.md:1
+#: src/SUMMARY.md:210 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "与 C++ 交互"
 
@@ -844,13 +713,11 @@ msgstr "最小示例"
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:223
-#: src/bare-metal/microcontrollers.md:1
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "微控制器"
 
-#: src/SUMMARY.md:224
-#: src/bare-metal/microcontrollers/mmio.md:1
+#: src/SUMMARY.md:224 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "原始 MMIO"
 
@@ -878,18 +745,15 @@ msgstr "embedded-hal"
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs、cargo-embed"
 
-#: src/SUMMARY.md:231
-#: src/bare-metal/microcontrollers/debugging.md:1
+#: src/SUMMARY.md:231 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/SUMMARY.md:232
-#: src/SUMMARY.md:252
+#: src/SUMMARY.md:232 src/SUMMARY.md:252
 msgid "Other Projects"
 msgstr "其他项目"
 
-#: src/SUMMARY.md:234
-#: src/exercises/bare-metal/compass.md:1
+#: src/SUMMARY.md:234 src/exercises/bare-metal/compass.md:1
 #: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "罗盘"
@@ -902,8 +766,7 @@ msgstr "裸机:下午"
 msgid "Application Processors"
 msgstr "应用处理器"
 
-#: src/SUMMARY.md:239
-#: src/bare-metal/aps/entry-point.md:1
+#: src/SUMMARY.md:239 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr "准备使用 Rust"
 
@@ -927,8 +790,7 @@ msgstr "更多 trait"
 msgid "A Better UART Driver"
 msgstr "一个更好的 UART 驱动程序"
 
-#: src/SUMMARY.md:245
-#: src/bare-metal/aps/better-uart/bitflags.md:1
+#: src/SUMMARY.md:245 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "Bitflags"
 
@@ -936,18 +798,15 @@ msgstr "Bitflags"
 msgid "Multiple Registers"
 msgstr "多个寄存器"
 
-#: src/SUMMARY.md:247
-#: src/bare-metal/aps/better-uart/driver.md:1
+#: src/SUMMARY.md:247 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "驱动程序"
 
-#: src/SUMMARY.md:248
-#: src/SUMMARY.md:250
+#: src/SUMMARY.md:248 src/SUMMARY.md:250
 msgid "Using It"
 msgstr "开始使用"
 
-#: src/SUMMARY.md:251
-#: src/bare-metal/aps/exceptions.md:1
+#: src/SUMMARY.md:251 src/bare-metal/aps/exceptions.md:1
 #, fuzzy
 msgid "Exceptions"
 msgstr "函数"
@@ -976,8 +835,7 @@ msgstr "tinyvec"
 msgid "spin"
 msgstr "转动"
 
-#: src/SUMMARY.md:260
-#: src/bare-metal/android/vmbase.md:1
+#: src/SUMMARY.md:260 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
@@ -989,28 +847,23 @@ msgstr "RTC驱动"
 msgid "Concurrency: Morning"
 msgstr "并发编程：入门篇"
 
-#: src/SUMMARY.md:270
-#: src/concurrency/threads.md:1
+#: src/SUMMARY.md:270 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "线程"
 
-#: src/SUMMARY.md:271
-#: src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:271 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "范围线程"
 
-#: src/SUMMARY.md:272
-#: src/concurrency/channels.md:1
+#: src/SUMMARY.md:272 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "通道"
 
-#: src/SUMMARY.md:273
-#: src/concurrency/channels/unbounded.md:1
+#: src/SUMMARY.md:273 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "无界通道"
 
-#: src/SUMMARY.md:274
-#: src/concurrency/channels/bounded.md:1
+#: src/SUMMARY.md:274 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "有界通道"
 
@@ -1026,13 +879,11 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:278
-#: src/concurrency/send-sync/examples.md:1
+#: src/SUMMARY.md:278 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "示例"
 
-#: src/SUMMARY.md:279
-#: src/concurrency/shared_state.md:1
+#: src/SUMMARY.md:279 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "共享状态"
 
@@ -1044,15 +895,13 @@ msgstr "Arc"
 msgid "Mutex"
 msgstr "Mutex"
 
-#: src/SUMMARY.md:284
-#: src/SUMMARY.md:305
+#: src/SUMMARY.md:284 src/SUMMARY.md:305
 #: src/exercises/concurrency/dining-philosophers.md:1
 #: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "哲学家就餐问题 (Dining philosophers problem)"
 
-#: src/SUMMARY.md:285
-#: src/exercises/concurrency/link-checker.md:1
+#: src/SUMMARY.md:285 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "多线程链接检查器"
 
@@ -1068,40 +917,32 @@ msgstr "异步基础"
 msgid "async/await"
 msgstr "async/await"
 
-#: src/SUMMARY.md:291
-#: src/async/futures.md:1
+#: src/SUMMARY.md:291 src/async/futures.md:1
 msgid "Futures"
 msgstr "Futures"
 
-#: src/SUMMARY.md:292
-#: src/async/runtimes.md:1
+#: src/SUMMARY.md:292 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "Runtimes"
 
-#: src/SUMMARY.md:293
-#: src/async/runtimes/tokio.md:1
+#: src/SUMMARY.md:293 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:294
-#: src/exercises/concurrency/link-checker.md:126
-#: src/async/tasks.md:1
-#: src/exercises/concurrency/chat-app.md:143
+#: src/SUMMARY.md:294 src/exercises/concurrency/link-checker.md:126
+#: src/async/tasks.md:1 src/exercises/concurrency/chat-app.md:143
 msgid "Tasks"
 msgstr "任务"
 
-#: src/SUMMARY.md:295
-#: src/async/channels.md:1
+#: src/SUMMARY.md:295 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "异步通道"
 
-#: src/SUMMARY.md:297
-#: src/async/control-flow/join.md:1
+#: src/SUMMARY.md:297 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr "加入"
 
-#: src/SUMMARY.md:298
-#: src/async/control-flow/select.md:1
+#: src/SUMMARY.md:298 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr "选择"
 
@@ -1113,24 +954,20 @@ msgstr "误区"
 msgid "Blocking the Executor"
 msgstr "屏蔽执行器"
 
-#: src/SUMMARY.md:301
-#: src/async/pitfalls/pin.md:1
+#: src/SUMMARY.md:301 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr "固定"
 
-#: src/SUMMARY.md:302
-#: src/async/pitfalls/async-traits.md:1
+#: src/SUMMARY.md:302 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "异步特质"
 
-#: src/SUMMARY.md:303
-#: src/async/pitfalls/cancellation.md:1
+#: src/SUMMARY.md:303 src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
 msgstr "安装"
 
-#: src/SUMMARY.md:306
-#: src/exercises/concurrency/chat-app.md:1
+#: src/SUMMARY.md:306 src/exercises/concurrency/chat-app.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:95
 msgid "Broadcast Chat Application"
 msgstr "广播聊天应用程序"
@@ -1139,13 +976,11 @@ msgstr "广播聊天应用程序"
 msgid "Final Words"
 msgstr "结束语"
 
-#: src/SUMMARY.md:313
-#: src/thanks.md:1
+#: src/SUMMARY.md:313 src/thanks.md:1
 msgid "Thanks!"
 msgstr "谢谢！"
 
-#: src/SUMMARY.md:314
-#: src/glossary.md:1
+#: src/SUMMARY.md:314 src/glossary.md:1
 msgid "Glossary"
 msgstr ""
 
@@ -1153,13 +988,11 @@ msgstr ""
 msgid "Other Resources"
 msgstr "其他资源"
 
-#: src/SUMMARY.md:316
-#: src/credits.md:1
+#: src/SUMMARY.md:316 src/credits.md:1
 msgid "Credits"
 msgstr "鸣谢"
 
-#: src/SUMMARY.md:319
-#: src/exercises/solutions.md:1
+#: src/SUMMARY.md:319 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "解答"
 
@@ -1191,8 +1024,7 @@ msgstr "第三天下午"
 msgid "Bare Metal Rust Morning"
 msgstr "嵌入式 Rust：入门篇"
 
-#: src/SUMMARY.md:331
-#: src/exercises/bare-metal/solutions-afternoon.md:1
+#: src/SUMMARY.md:331 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "嵌入式 Rust：进阶篇"
 
@@ -1207,32 +1039,39 @@ msgstr "并发编程：进阶篇"
 #: src/index.md:3
 #, fuzzy
 msgid ""
-"[![Build "
-"workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) "
-"[![GitHub "
-"contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors) "
-"[![GitHub "
-"stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
-"[![构建工作流](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) "
-"[![GitHub "
-"贡献者](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
+"[![构建工作流](https://img.shields.io/github/actions/workflow/status/google/"
+"comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub 贡献者](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors)"
 
 #: src/index.md:7
 msgid ""
 "This is a free Rust course developed by the Android team at Google. The "
 "course covers the full spectrum of Rust, from basic syntax to advanced "
 "topics like generics and error handling."
-msgstr "这是由 Android 团队开发的免费 Rust 课程。该课程涵盖了 Rust 的全部范围,从基本语法到高级主题如泛型和错误处理。"
+msgstr ""
+"这是由 Android 团队开发的免费 Rust 课程。该课程涵盖了 Rust 的全部范围,从基本"
+"语法到高级主题如泛型和错误处理。"
 
 #: src/index.md:11
 msgid ""
-"The latest version of the course can be found at "
-"<https://google.github.io/comprehensive-rust/>. If you are reading somewhere "
-"else, please check there for updates."
+"The latest version of the course can be found at <https://google.github.io/"
+"comprehensive-rust/>. If you are reading somewhere else, please check there "
+"for updates."
 msgstr ""
-"如需查看课程的最新版本,请访问 "
-"<https://google.github.io/comprehensive-rust/>。如果您是在其他地方阅读,请查看这个网址了解是否有更新。"
+"如需查看课程的最新版本,请访问 <https://google.github.io/comprehensive-rust/"
+">。如果您是在其他地方阅读,请查看这个网址了解是否有更新。"
 
 #: src/index.md:15
 msgid ""
@@ -1266,8 +1105,8 @@ msgid ""
 "[Android](android.md): a half-day course on using Rust for Android platform "
 "development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"[Android](android.md)：一个半天的课程，介绍如何在 Android 平台开发中使用 Rust（AOSP）。课程内容包括与 C、C++ "
-"和 Java 的互操作性。"
+"[Android](android.md)：一个半天的课程，介绍如何在 Android 平台开发中使用 Rust"
+"（AOSP）。课程内容包括与 C、C++ 和 Java 的互操作性。"
 
 #: src/index.md:28
 msgid ""
@@ -1275,7 +1114,8 @@ msgid ""
 "(embedded) development. Both microcontrollers and application processors are "
 "covered."
 msgstr ""
-"[Bare-metal](bare-metal.md):为期一天的课程,介绍如何使用 Rust 进行裸机(嵌入式)开发。课程内容涵盖微控制器和应用处理器。"
+"[Bare-metal](bare-metal.md):为期一天的课程,介绍如何使用 Rust 进行裸机(嵌入式)"
+"开发。课程内容涵盖微控制器和应用处理器。"
 
 #: src/index.md:31
 #, fuzzy
@@ -1285,8 +1125,9 @@ msgid ""
 "mutexes) and async/await concurrency (cooperative multitasking using "
 "futures)."
 msgstr ""
-"[并发](concurrency.md):一天的课程,介绍 Rust 中的并发性。我们将涵盖传统并发(使用线程和互斥锁进行抢占式调度)和 "
-"async/await 并发(使用 futures 进行协作式多任务处理)。"
+"[并发](concurrency.md):一天的课程,介绍 Rust 中的并发性。我们将涵盖传统并发(使"
+"用线程和互斥锁进行抢占式调度)和 async/await 并发(使用 futures 进行协作式多任"
+"务处理)。"
 
 #: src/index.md:37
 msgid "Non-Goals"
@@ -1296,18 +1137,19 @@ msgstr "非目标"
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
 "days. Some non-goals of this course are:"
-msgstr "Rust 是一门庞大的语言，我们无法在几天内涵盖所有内容。本课程的一些非目标包括："
+msgstr ""
+"Rust 是一门庞大的语言，我们无法在几天内涵盖所有内容。本课程的一些非目标包括："
 
 #: src/index.md:42
 #, fuzzy
 msgid ""
-"Learning how to develop macros: please see [Chapter 19.5 in the Rust "
-"Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by "
-"Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
-"了解如何开发宏,请参阅[本书中的第 19.5 "
-"章](https://doc.rust-lang.org/book/ch19-06-macros.html)和 [Rust by "
-"Examples](https://doc.rust-lang.org/rust-by-example/macros.html)。"
+"了解如何开发宏,请参阅[本书中的第 19.5 章](https://doc.rust-lang.org/book/"
+"ch19-06-macros.html)和 [Rust by Examples](https://doc.rust-lang.org/rust-by-"
+"example/macros.html)。"
 
 #: src/index.md:46
 msgid "Assumptions"
@@ -1319,14 +1161,18 @@ msgid ""
 "The course assumes that you already know how to program. Rust is a "
 "statically-typed language and we will sometimes make comparisons with C and "
 "C++ to better explain or contrast the Rust approach."
-msgstr "本课程假设你已经具备编程知识。Rust 是一种静态类型语言,我们有时会与 C 和 C++ 进行比较,以更好地解释或对比 Rust 的方法。"
+msgstr ""
+"本课程假设你已经具备编程知识。Rust 是一种静态类型语言,我们有时会与 C 和 C++ "
+"进行比较,以更好地解释或对比 Rust 的方法。"
 
 #: src/index.md:52
 #, fuzzy
 msgid ""
 "If you know how to program in a dynamically-typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
-msgstr "如果你已经了解如 Python 或 JavaScript 等动态类型语言的编程,那么你也能够很好地跟上本课程。"
+msgstr ""
+"如果你已经了解如 Python 或 JavaScript 等动态类型语言的编程,那么你也能够很好地"
+"跟上本课程。"
 
 #: src/index.md:57
 #, fuzzy
@@ -1334,10 +1180,11 @@ msgid ""
 "This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
 "should cover as well as answers to typical questions which come up in class."
-msgstr "这是演讲者备注的示例。我们将使用这些备注来为幻灯片添加额外的信息。这可能包括讲师应该涵盖的关键点,以及课堂上常见问题的答案。"
+msgstr ""
+"这是演讲者备注的示例。我们将使用这些备注来为幻灯片添加额外的信息。这可能包括"
+"讲师应该涵盖的关键点,以及课堂上常见问题的答案。"
 
-#: src/running-the-course.md:3
-#: src/running-the-course/course-structure.md:3
+#: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
 msgid "This page is for the course instructor."
 msgstr "本页面适用于课程教师。"
 
@@ -1356,9 +1203,10 @@ msgid ""
 "The downside of longer session is that people can become very tired after 6 "
 "full hours of class in the afternoon."
 msgstr ""
-"上课时间通常是从上午 10:00 到下午 4:00,中间有 1 小时的午餐休息时间。这样,上午和下午各留了 2.5 "
-"小时的上课时间。请注意,这仅是建议:您也可以上午上课 3 小时,让学员有更多的时间进行练习。上课时间较长的缺点是,学员上了整整 6 "
-"小时的课,到了下午可能会非常疲倦。"
+"上课时间通常是从上午 10:00 到下午 4:00,中间有 1 小时的午餐休息时间。这样,上午"
+"和下午各留了 2.5 小时的上课时间。请注意,这仅是建议:您也可以上午上课 3 小时,让"
+"学员有更多的时间进行练习。上课时间较长的缺点是,学员上了整整 6 小时的课,到了下"
+"午可能会非常疲倦。"
 
 #: src/running-the-course.md:16
 msgid "Before you run the course, you will want to:"
@@ -1372,7 +1220,10 @@ msgid ""
 "notes in a popup (click the link with a little arrow next to \"Speaker "
 "Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"熟悉课程资料。我们添加了演讲者备注，借此强调要点（请帮个忙，多多贡献演讲者备注！）。演示幻灯片时，你应确保在弹出式窗口中打开演讲者备注（点击对应的链接，在“演讲者备注”旁边有一个小箭头）。这样，你就可以确保屏幕整洁有序，更好地向全班学员展示课程内容。"
+"熟悉课程资料。我们添加了演讲者备注，借此强调要点（请帮个忙，多多贡献演讲者备"
+"注！）。演示幻灯片时，你应确保在弹出式窗口中打开演讲者备注（点击对应的链接，"
+"在“演讲者备注”旁边有一个小箭头）。这样，你就可以确保屏幕整洁有序，更好地向全"
+"班学员展示课程内容。"
 
 #: src/running-the-course.md:24
 msgid ""
@@ -1381,7 +1232,9 @@ msgid ""
 "have said that they find it helpful to have a gap in the course since it "
 "helps them process all the information we give them."
 msgstr ""
-"确定培训日期。由于本课程至少需要三天的时间，因此我们建议你安排两周以上的时间。课程学员曾表示，在每堂课之间留一段间隔会很有帮助，因为这有利于他们吸收我们所提供的所有信息。"
+"确定培训日期。由于本课程至少需要三天的时间，因此我们建议你安排两周以上的时"
+"间。课程学员曾表示，在每堂课之间留一段间隔会很有帮助，因为这有利于他们吸收我"
+"们所提供的所有信息。"
 
 #: src/running-the-course.md:29
 msgid ""
@@ -1393,21 +1246,24 @@ msgid ""
 "laptops. In particular, you will be doing a lot of live-coding as an "
 "instructor, so a lectern won't be very helpful for you."
 msgstr ""
-"找一间足以容纳全体线下学员的大教室。我们建议你将课程人数控制在 15-25 "
-"人之间。这样，人数足够少，不仅便于学员提问问题，配备的一位教师也有时间答疑解惑。确保教室备有供你和学生使用的“课桌”：你们都需要能够坐下来并操作各自的笔记本电脑。特别是身为教师，你现场要进行大量编码，所以讲台对你来说用处不大。"
+"找一间足以容纳全体线下学员的大教室。我们建议你将课程人数控制在 15-25 人之间。"
+"这样，人数足够少，不仅便于学员提问问题，配备的一位教师也有时间答疑解惑。确保"
+"教室备有供你和学生使用的“课桌”：你们都需要能够坐下来并操作各自的笔记本电脑。"
+"特别是身为教师，你现场要进行大量编码，所以讲台对你来说用处不大。"
 
 #: src/running-the-course.md:37
 msgid ""
 "On the day of your course, show up to the room a little early to set things "
 "up. We recommend presenting directly using `mdbook serve` running on your "
-"laptop (see the [installation "
-"instructions](https://github.com/google/comprehensive-rust#building)). This "
-"ensures optimal performance with no lag as you change pages. Using your "
-"laptop will also allow you to fix typos as you or the course participants "
-"spot them."
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
 msgstr ""
-"在开课当天，请提前一点到教室，设置好教学设备。我们建议你直接在笔记本电脑上运行 `mdbook serve` "
-"来演示课程内容（请参阅[安装说明](https://github.com/google/comprehensive-rust#building)）。这样可以确保你在切换页面时没有延迟，演示效果更好。当你或课程学员发现拼写错误时，你也可以使用笔记本电脑及时更正。"
+"在开课当天，请提前一点到教室，设置好教学设备。我们建议你直接在笔记本电脑上运"
+"行 `mdbook serve` 来演示课程内容（请参阅[安装说明](https://github.com/google/"
+"comprehensive-rust#building)）。这样可以确保你在切换页面时没有延迟，演示效果"
+"更好。当你或课程学员发现拼写错误时，你也可以使用笔记本电脑及时更正。"
 
 #: src/running-the-course.md:43
 msgid ""
@@ -1419,8 +1275,10 @@ msgid ""
 "offer a solution, e.g., by showing people where to find the relevant "
 "information in the standard library."
 msgstr ""
-"让学员采取小组形式或独立解题。通常，我们会在上午和下午各安排 30-45 "
-"分钟的练习时间（包括查看解决方案的时间）。请务必询问学员是否遇到困难，或是否需要任何帮助。如果你看到多位学员遇到同样的问题，请在班级集体进行讲解，并提供相应的解决方案，例如告诉大家在标准库的什么位置可以找到相关信息。"
+"让学员采取小组形式或独立解题。通常，我们会在上午和下午各安排 30-45 分钟的练习"
+"时间（包括查看解决方案的时间）。请务必询问学员是否遇到困难，或是否需要任何帮"
+"助。如果你看到多位学员遇到同样的问题，请在班级集体进行讲解，并提供相应的解决"
+"方案，例如告诉大家在标准库的什么位置可以找到相关信息。"
 
 #: src/running-the-course.md:51
 msgid ""
@@ -1430,17 +1288,18 @@ msgstr "今天的分享就是这些，祝你授课顺利！希望你和我们一
 
 #: src/running-the-course.md:54
 msgid ""
-"Please [provide "
-"feedback](https://github.com/google/comprehensive-rust/discussions/86) "
-"afterwards so that we can keep improving the course. We would love to hear "
-"what worked well for you and what can be made better. Your students are also "
-"very welcome to [send us "
-"feedback](https://github.com/google/comprehensive-rust/discussions/100)!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"欢迎你课后[提供反馈](https://github.com/google/comprehensive-rust/discussions/86)，帮助我们不断改进课程。我们非常期待了解哪些方面做得不错，哪些方面还需要改进。同时非常欢迎学生们[向我们发送反馈](https://github.com/google/comprehensive-rust/discussions/100)！"
+"欢迎你课后[提供反馈](https://github.com/google/comprehensive-rust/"
+"discussions/86)，帮助我们不断改进课程。我们非常期待了解哪些方面做得不错，哪些"
+"方面还需要改进。同时非常欢迎学生们[向我们发送反馈](https://github.com/google/"
+"comprehensive-rust/discussions/100)！"
 
-#: src/running-the-course/course-structure.md:5
-#: src/glossary.md:58
+#: src/running-the-course/course-structure.md:5 src/glossary.md:58
 msgid "Rust Fundamentals"
 msgstr "Rust 二进制文件"
 
@@ -1448,7 +1307,9 @@ msgstr "Rust 二进制文件"
 msgid ""
 "The first three days make up [Rust Fundaments](../welcome-day-1.md). The "
 "days are fast paced and we cover a lot of ground:"
-msgstr "我们会在头三天介绍 [Rust 基础知识](../welcome-day-1.md)。这几天的步调会稍快,因为我们要探讨许多层面:"
+msgstr ""
+"我们会在头三天介绍 [Rust 基础知识](../welcome-day-1.md)。这几天的步调会稍快,"
+"因为我们要探讨许多层面:"
 
 #: src/running-the-course/course-structure.md:10
 msgid "Day 1: Basic Rust, syntax, control flow, creating and consuming values."
@@ -1476,8 +1337,7 @@ msgid ""
 "specialized topics:"
 msgstr "除了为期 3 天的“Rust 基础知识”课程外，我们还推出了一些专题课程："
 
-#: src/running-the-course/course-structure.md:19
-#: src/glossary.md:59
+#: src/running-the-course/course-structure.md:19 src/glossary.md:59
 #, fuzzy
 msgid "Rust in Android"
 msgstr "欢迎来到Android 中的Rust"
@@ -1489,23 +1349,21 @@ msgid ""
 "Rust for Android platform development. This includes interoperability with "
 "C, C++, and Java."
 msgstr ""
-"`[深入探究 Android](../android.md)`课程为期半天,旨在介绍如何使用 Rust 进行 Android 平台开发。其中包括与 "
-"C、C++ 和 Java 的互操作性。"
+"`[深入探究 Android](../android.md)`课程为期半天,旨在介绍如何使用 Rust 进行 "
+"Android 平台开发。其中包括与 C、C++ 和 Java 的互操作性。"
 
 #: src/running-the-course/course-structure.md:25
 msgid ""
-"You will need an [AOSP "
-"checkout](https://source.android.com/docs/setup/download/downloading). Make "
-"a checkout of the [course "
-"repository](https://github.com/google/comprehensive-rust) on the same "
-"machine and move the `src/android/` directory into the root of your AOSP "
-"checkout. This will ensure that the Android build system sees the "
-"`Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"你将需要[签出 "
-"AOSP](https://source.android.com/docs/setup/download/downloading)。在同一机器上签出[课程库](https://github.com/google/comprehensive-rust)， "
-"然后将 `src/android/` 目录移至所签出的 AOSP 的根目录。这将确保 Android 构建系统能检测到 `src/android/` "
-"中的 `Android.bp` 文件。"
+"你将需要[签出 AOSP](https://source.android.com/docs/setup/download/"
+"downloading)。在同一机器上签出[课程库](https://github.com/google/"
+"comprehensive-rust)， 然后将 `src/android/` 目录移至所签出的 AOSP 的根目录。"
+"这将确保 Android 构建系统能检测到 `src/android/` 中的 `Android.bp` 文件。"
 
 #: src/running-the-course/course-structure.md:30
 msgid ""
@@ -1513,8 +1371,9 @@ msgid ""
 "all Android examples using `src/android/build_all.sh`. Read the script to "
 "see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"确保 `adb sync` 适用于你的模拟器或实际设备， 并使用 `src/android/build_all.sh` 预构建所有 Android "
-"示例。请阅读脚本， 查看它所运行的命令，并确保这些命令能在你手动运行时正确执行。"
+"确保 `adb sync` 适用于你的模拟器或实际设备， 并使用 `src/android/build_all."
+"sh` 预构建所有 Android 示例。请阅读脚本， 查看它所运行的命令，并确保这些命令"
+"能在你手动运行时正确执行。"
 
 #: src/running-the-course/course-structure.md:37
 #, fuzzy
@@ -1528,21 +1387,21 @@ msgid ""
 "using Rust for bare-metal (embedded) development. Both microcontrollers and "
 "application processors are covered."
 msgstr ""
-"`[深入探究裸机](../bare-metal.md)`课程为期一天,旨在介绍如何使用 Rust 进行裸机(嵌入式)开发。其中涵盖了微控制器和应用 "
-"处理器。"
+"`[深入探究裸机](../bare-metal.md)`课程为期一天,旨在介绍如何使用 Rust 进行裸机"
+"(嵌入式)开发。其中涵盖了微控制器和应用 处理器。"
 
 #: src/running-the-course/course-structure.md:43
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC "
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody will need to install a number of packages as described on the "
-"[welcome page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
 "对于微控制器部分，你需要提前购买 [BBC micro:bit](https://microbit.org/) 第 2 "
-"版开发板。每个人都需要安装多个软件包， 具体如[欢迎页面](../bare-metal.md)中所述。"
+"版开发板。每个人都需要安装多个软件包， 具体如[欢迎页面](../bare-metal.md)中所"
+"述。"
 
-#: src/running-the-course/course-structure.md:48
-#: src/glossary.md:24
+#: src/running-the-course/course-structure.md:48 src/glossary.md:24
 msgid "Concurrency in Rust"
 msgstr "欢迎了解 Rust 中的并发"
 
@@ -1550,7 +1409,9 @@ msgstr "欢迎了解 Rust 中的并发"
 msgid ""
 "The [Concurrency in Rust](../concurrency.md) deep dive is a full day class "
 "on classical as well as `async`/`await` concurrency."
-msgstr "`[深入探究并发](../concurrency.md)`课程为期一天,旨在介绍传统并发和 `async`/`await` 并发。"
+msgstr ""
+"`[深入探究并发](../concurrency.md)`课程为期一天,旨在介绍传统并发和 `async`/"
+"`await` 并发。"
 
 #: src/running-the-course/course-structure.md:53
 msgid ""
@@ -1558,7 +1419,8 @@ msgid ""
 "to go. You can then copy/paste the examples into `src/main.rs` to experiment "
 "with them:"
 msgstr ""
-"你需要设置一个新 crate，下载所需的依赖项， 做好课前准备。然后，你可以将示例复制/粘贴到 `src/main.rs` 中， 以便对以下代码进行实验："
+"你需要设置一个新 crate，下载所需的依赖项， 做好课前准备。然后，你可以将示例复"
+"制/粘贴到 `src/main.rs` 中， 以便对以下代码进行实验："
 
 #: src/running-the-course/course-structure.md:64
 msgid "Format"
@@ -1590,8 +1452,7 @@ msgstr "向右箭头"
 msgid ": Navigate to the next page."
 msgstr "：转到下一页。"
 
-#: src/running-the-course/keyboard-shortcuts.md:7
-#: src/cargo/code-samples.md:19
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
 msgid "Ctrl + Enter"
 msgstr "Ctrl + Enter"
 
@@ -1616,28 +1477,29 @@ msgstr "一批优秀的志愿者已将本课程翻译成其他语言："
 #: src/running-the-course/translations.md:6
 msgid ""
 "[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
-"by [@rastringer](https://github.com/rastringer), "
-"[@hugojacob](https://github.com/hugojacob), "
-"[@joaovicmendes](https://github.com/joaovicmendes), and "
+"by [@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
+"com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), and "
 "[@henrif75](https://github.com/henrif75)."
 msgstr ""
-"[巴西葡萄牙语版本](https://google.github.io/comprehensive-rust/pt-BR/)译者:[@rastringer](https://github.com/rastringer)、[@hugojacob](https://github.com/hugojacob)、[@joaovicmendes](https://github.com/joaovicmendes) "
-"和 [@henrif75](https://github.com/henrif75)。"
+"[巴西葡萄牙语版本](https://google.github.io/comprehensive-rust/pt-BR/)译者:"
+"[@rastringer](https://github.com/rastringer)、[@hugojacob](https://github."
+"com/hugojacob)、[@joaovicmendes](https://github.com/joaovicmendes) 和 "
+"[@henrif75](https://github.com/henrif75)。"
 
 #: src/running-the-course/translations.md:7
 msgid ""
-"[Korean](https://google.github.io/comprehensive-rust/ko/) by "
-"[@keispace](https://github.com/keispace), "
-"[@jiyongp](https://github.com/jiyongp), and "
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
-"[韩语版本](https://google.github.io/comprehensive-rust/ko/)译者:[@keispace](https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp) "
-"和 [@jooyunghan](https://github.com/jooyunghan)。"
+"[韩语版本](https://google.github.io/comprehensive-rust/ko/)译者:[@keispace]"
+"(https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp) 和 "
+"[@jooyunghan](https://github.com/jooyunghan)。"
 
 #: src/running-the-course/translations.md:8
 msgid ""
-"[Spanish](https://google.github.io/comprehensive-rust/es/) by "
-"[@deavid](https://github.com/deavid)."
+"[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
+"(https://github.com/deavid)."
 msgstr ""
 
 #: src/running-the-course/translations.md:10
@@ -1657,76 +1519,78 @@ msgstr "多数语言版本仍在翻译中。我们会提供最近更新的翻译
 
 #: src/running-the-course/translations.md:17
 msgid ""
-"[Bengali](https://google.github.io/comprehensive-rust/bn/) by "
-"[@raselmandol](https://github.com/raselmandol)."
+"[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
+"(https://github.com/raselmandol)."
 msgstr ""
-"[孟加拉语版本](https://google.github.io/comprehensive-rust/bn/)译者:[@raselmandol](https://github.com/raselmandol)。"
+"[孟加拉语版本](https://google.github.io/comprehensive-rust/bn/)译者:"
+"[@raselmandol](https://github.com/raselmandol)。"
 
 #: src/running-the-course/translations.md:18
 msgid ""
 "[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
-"by [@hueich](https://github.com/hueich), "
-"[@victorhsieh](https://github.com/victorhsieh), "
-"[@mingyc](https://github.com/mingyc), and "
-"[@johnathan79717](https://github.com/johnathan79717)."
+"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
+"victorhsieh), [@mingyc](https://github.com/mingyc), and [@johnathan79717]"
+"(https://github.com/johnathan79717)."
 msgstr ""
 
 #: src/running-the-course/translations.md:19
 msgid ""
 "[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
-"by [@suetfei](https://github.com/suetfei), "
-"[@wnghl](https://github.com/wnghl), [@anlunx](https://github.com/anlunx), "
-"[@kongy](https://github.com/kongy), "
-"[@noahdragon](https://github.com/noahdragon), and "
-"[@superwhd](https://github.com/superwhd)."
+"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
+"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
+"kongy), [@noahdragon](https://github.com/noahdragon), and [@superwhd]"
+"(https://github.com/superwhd)."
 msgstr ""
 
 #: src/running-the-course/translations.md:20
 msgid ""
-"[French](https://google.github.io/comprehensive-rust/fr/) by "
-"[@KookaS](https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
-"[法语版本](https://google.github.io/comprehensive-rust/fr/)译者:[@KookaS](https://github.com/KookaS) "
-"和 [@vcaen](https://github.com/vcaen)。"
+"[法语版本](https://google.github.io/comprehensive-rust/fr/)译者:[@KookaS]"
+"(https://github.com/KookaS) 和 [@vcaen](https://github.com/vcaen)。"
 
 #: src/running-the-course/translations.md:21
 msgid ""
-"[German](https://google.github.io/comprehensive-rust/de/) by "
-"[@Throvn](https://github.com/Throvn) and "
-"[@ronaldfw](https://github.com/ronaldfw)."
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
 msgstr ""
-"[德语版本](https://google.github.io/comprehensive-rust/de/)译者:[@Throvn](https://github.com/Throvn) "
-"和 [@ronaldfw](https://github.com/ronaldfw)。"
+"[德语版本](https://google.github.io/comprehensive-rust/de/)译者:[@Throvn]"
+"(https://github.com/Throvn) 和 [@ronaldfw](https://github.com/ronaldfw)。"
 
 #: src/running-the-course/translations.md:22
 msgid ""
-"[Japanese](https://google.github.io/comprehensive-rust/ja/) by "
-"[@CoinEZ-JPN](https://github.com/CoinEZ) and "
-"[@momotaro1105](https://github.com/momotaro1105)."
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
 msgstr ""
-"[日语版本](https://google.github.io/comprehensive-rust/ja/)译者:[@CoinEZ-JPN](https://github.com/CoinEZ) "
-"和 [@momotaro1105](https://github.com/momotaro1105)。"
+"[日语版本](https://google.github.io/comprehensive-rust/ja/)译者:[@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) 和 [@momotaro1105](https://github.com/"
+"momotaro1105)。"
 
 #: src/running-the-course/translations.md:24
 msgid ""
-"If you want to help with this effort, please see [our "
-"instructions](https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) "
-"for how to get going. Translations are coordinated on the [issue "
-"tracker](https://github.com/google/comprehensive-rust/issues/282)."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"如果你想帮助我们,请参阅[我们的说明](htts://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md),了解如何开始翻译。翻译工作将通过[问题跟踪器](https://github.com/google/comprehensive-rust/issues/282)."
+"如果你想帮助我们,请参阅[我们的说明](htts://github.com/google/comprehensive-"
+"rust/blob/main/TRANSLATIONS.md),了解如何开始翻译。翻译工作将通过[问题跟踪器]"
+"(https://github.com/google/comprehensive-rust/issues/282)."
 
 #: src/cargo.md:3
 msgid ""
-"When you start reading about Rust, you will soon meet "
-"[Cargo](https://doc.rust-lang.org/cargo/), the standard tool used in the "
-"Rust ecosystem to build and run Rust applications. Here we want to give a "
-"brief overview of what Cargo is and how it fits into the wider ecosystem and "
-"how it fits into this training."
+"When you start reading about Rust, you will soon meet [Cargo](https://doc."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
-"开始了解 Rust 后，你很快就会遇到 [Cargo](https://doc.rust-lang.org/cargo/)，这是 Rust 生态系统中 "
-"用于构建和运行 Rust 应用的标准工具。在这里，我们希望 简要介绍一下什么是 Cargo，它如何融入更广泛的生态系统， 以及我们如何在本培训中合理利用 "
-"Cargo。"
+"开始了解 Rust 后，你很快就会遇到 [Cargo](https://doc.rust-lang.org/cargo/)，"
+"这是 Rust 生态系统中 用于构建和运行 Rust 应用的标准工具。在这里，我们希望 简"
+"要介绍一下什么是 Cargo，它如何融入更广泛的生态系统， 以及我们如何在本培训中合"
+"理利用 Cargo。"
 
 #: src/cargo.md:8
 msgid "Installation"
@@ -1748,14 +1612,12 @@ msgstr ""
 #: src/cargo.md:14
 msgid ""
 "After installing Rust, you should configure your editor or IDE to work with "
-"Rust. Most editors do this by talking to "
-"[rust-analyzer](https://rust-analyzer.github.io/), which provides "
-"auto-completion and jump-to-definition functionality for [VS "
-"Code](https://code.visualstudio.com/), "
-"[Emacs](https://rust-analyzer.github.io/manual.html#emacs), "
-"[Vim/Neovim](https://rust-analyzer.github.io/manual.html#vimneovim), and "
-"many others. There is also a different IDE available called "
-"[RustRover](https://www.jetbrains.com/rust/)."
+"Rust. Most editors do this by talking to [rust-analyzer](https://rust-"
+"analyzer.github.io/), which provides auto-completion and jump-to-definition "
+"functionality for [VS Code](https://code.visualstudio.com/), [Emacs](https://"
+"rust-analyzer.github.io/manual.html#emacs), [Vim/Neovim](https://rust-"
+"analyzer.github.io/manual.html#vimneovim), and many others. There is also a "
+"different IDE available called [RustRover](https://www.jetbrains.com/rust/)."
 msgstr ""
 
 #: src/cargo.md:18
@@ -1765,9 +1627,9 @@ msgid ""
 "gets you an outdated rust version and may lead to unexpected behavior. The "
 "command would be:"
 msgstr ""
-"在 Debian/Ubuntu 上,你也可以通过 `apt` 安装 Cargo、Rust 源代码和 [Rust "
-"格式设置工具](https://github.com/rust-lang/rustfmt)。但是,这样会得到一个过时的 Rust "
-"版本,可能会导致意外的行为。命令如下:"
+"在 Debian/Ubuntu 上,你也可以通过 `apt` 安装 Cargo、Rust 源代码和 [Rust 格式设"
+"置工具](https://github.com/rust-lang/rustfmt)。但是,这样会得到一个过时的 "
+"Rust 版本,可能会导致意外的行为。命令如下:"
 
 #: src/cargo/rust-ecosystem.md:1
 msgid "The Rust Ecosystem"
@@ -1791,8 +1653,9 @@ msgid ""
 "pass them to `rustc` when building your project. Cargo also comes with a "
 "built-in test runner which is used to execute unit tests."
 msgstr ""
-"`cargo`:Rust 依赖项管理器和构建工具。Cargo 知道如何 下载托管在 <https://crates.io> "
-"上的依赖项,并在构建项目时将它们 传递给 `rustc`。Cargo 还附带一个内置的 测试运行程序,用于执行单元测试。"
+"`cargo`:Rust 依赖项管理器和构建工具。Cargo 知道如何 下载托管在 <https://"
+"crates.io> 上的依赖项,并在构建项目时将它们 传递给 `rustc`。Cargo 还附带一个内"
+"置的 测试运行程序,用于执行单元测试。"
 
 #: src/cargo/rust-ecosystem.md:13
 msgid ""
@@ -1802,22 +1665,19 @@ msgid ""
 "standard library. You can have multiple versions of Rust installed at once "
 "and `rustup` will let you switch between them as needed."
 msgstr ""
-"`rustup`：Rust 工具链安装程序和更新程序。发布新版本 Rust 时，此工具用于 安装并更新 `rustc` 和 `cargo`。 "
-"此外，`rustup` 还可以下载标准 库的文档。你可以同时安装多个版本的 Rust，并且 `rustup` 可让你根据需要在这些版本之间切换。"
+"`rustup`：Rust 工具链安装程序和更新程序。发布新版本 Rust 时，此工具用于 安装"
+"并更新 `rustc` 和 `cargo`。 此外，`rustup` 还可以下载标准 库的文档。你可以同"
+"时安装多个版本的 Rust，并且 `rustup` 可让你根据需要在这些版本之间切换。"
 
-#: src/cargo/rust-ecosystem.md:21
-#: src/hello-world.md:25
-#: src/hello-world/small-example.md:27
-#: src/why-rust/runtime.md:10
-#: src/why-rust/modern.md:21
-#: src/basic-syntax/compound-types.md:32
+#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
+#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
+#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:32
 #: src/basic-syntax/references.md:24
 #: src/pattern-matching/destructuring-enums.md:35
 #: src/ownership/double-free-modern-cpp.md:55
 #: src/error-handling/try-operator.md:48
 #: src/error-handling/converting-error-types-example.md:50
-#: src/concurrency/threads.md:30
-#: src/async/async-await.md:25
+#: src/concurrency/threads.md:30 src/async/async-await.md:25
 msgid "Key points:"
 msgstr "关键点："
 
@@ -1826,10 +1686,13 @@ msgid ""
 "Rust has a rapid release schedule with a new release coming out every six "
 "weeks. New releases maintain backwards compatibility with old releases --- "
 "plus they enable new functionality."
-msgstr "Rust 有一个快速发布时间表，每六周就会发布一次 新版本。新版本保持与 旧版本的向后兼容性，还添加了新功能。"
+msgstr ""
+"Rust 有一个快速发布时间表，每六周就会发布一次 新版本。新版本保持与 旧版本的向"
+"后兼容性，还添加了新功能。"
 
 #: src/cargo/rust-ecosystem.md:27
-msgid "There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
 msgstr "共有三个发布阶段：“稳定版”“Beta 版”和“夜间版”。"
 
 #: src/cargo/rust-ecosystem.md:29
@@ -1840,17 +1703,19 @@ msgstr "我们会在“夜间版”上测试新功能，每六周将“Beta 版�
 
 #: src/cargo/rust-ecosystem.md:32
 msgid ""
-"Dependencies can also be resolved from alternative "
-"[registries](https://doc.rust-lang.org/cargo/reference/registries.html), "
-"git, folders, and more."
+"Dependencies can also be resolved from alternative [registries](https://doc."
+"rust-lang.org/cargo/reference/registries.html), git, folders, and more."
 msgstr ""
-"您也可以通过备用的[注册数据库](https://doc.rust-lang.org/cargo/reference/registries.html)、git、文件夹等资源来解析依赖项。"
+"您也可以通过备用的[注册数据库](https://doc.rust-lang.org/cargo/reference/"
+"registries.html)、git、文件夹等资源来解析依赖项。"
 
 #: src/cargo/rust-ecosystem.md:34
 msgid ""
 "Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
 "current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
-msgstr "Rust 也有三个\\[版本\\]：当前版本是 Rust 2021。之前的 版本是 Rust 2015 和 Rust 2018。"
+msgstr ""
+"Rust 也有三个\\[版本\\]：当前版本是 Rust 2021。之前的 版本是 Rust 2015 和 "
+"Rust 2018。"
 
 #: src/cargo/rust-ecosystem.md:37
 msgid ""
@@ -1862,7 +1727,9 @@ msgstr "这些版本支持对语言进行向后不兼容的 更改。"
 msgid ""
 "To prevent breaking code, editions are opt-in: you select the edition for "
 "your crate via the `Cargo.toml` file."
-msgstr "为防止破坏代码，你可以自行选择版本： 通过 `Cargo.toml` 文件为 crate 选择合适的版本。"
+msgstr ""
+"为防止破坏代码，你可以自行选择版本： 通过 `Cargo.toml` 文件为 crate 选择合适"
+"的版本。"
 
 #: src/cargo/rust-ecosystem.md:43
 msgid ""
@@ -1874,14 +1741,17 @@ msgstr "为免分割生态系统，Rust 编译器可以混合使用 为不同版
 msgid ""
 "Mention that it is quite rare to ever use the compiler directly not through "
 "`cargo` (most users never do)."
-msgstr "提及不通过 `cargo` 而直接使用编译器的情况相当少见（大多数用户从不这样做）。"
+msgstr ""
+"提及不通过 `cargo` 而直接使用编译器的情况相当少见（大多数用户从不这样做）。"
 
 #: src/cargo/rust-ecosystem.md:48
 msgid ""
 "It might be worth alluding that Cargo itself is an extremely powerful and "
 "comprehensive tool.  It is capable of many advanced features including but "
 "not limited to: "
-msgstr "值得注意的是，Cargo 本身就是一个功能强大且全面的工具。它能够实现许多高级功能，包括但不限于："
+msgstr ""
+"值得注意的是，Cargo 本身就是一个功能强大且全面的工具。它能够实现许多高级功"
+"能，包括但不限于："
 
 #: src/cargo/rust-ecosystem.md:49
 msgid "Project/package structure"
@@ -1897,14 +1767,14 @@ msgstr "开发依赖项和运行时依赖项管理/缓存"
 
 #: src/cargo/rust-ecosystem.md:52
 msgid ""
-"[build "
-"scripting](https://doc.rust-lang.org/cargo/reference/build-scripts.html)"
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
 msgstr "\\[构建脚本\\]"
 
 #: src/cargo/rust-ecosystem.md:53
 msgid ""
-"[global "
-"installation](https://doc.rust-lang.org/cargo/commands/cargo-install.html)"
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
 msgstr "\\[全局安装\\] \\]"
 
 #: src/cargo/rust-ecosystem.md:54
@@ -1912,7 +1782,8 @@ msgid ""
 "It is also extensible with sub command plugins as well (such as [cargo "
 "clippy](https://github.com/rust-lang/rust-clippy))."
 msgstr ""
-"它还可以使用子命令插件（例如 [cargo clippy](https://github.com/rust-lang/rust-clippy)）进行扩展。"
+"它还可以使用子命令插件（例如 [cargo clippy](https://github.com/rust-lang/"
+"rust-clippy)）进行扩展。"
 
 #: src/cargo/rust-ecosystem.md:55
 msgid ""
@@ -1928,7 +1799,9 @@ msgid ""
 "For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
 "and ensures a consistent experience for everyone."
-msgstr "在本培训中，我们将主要通过示例 探索 Rust 语言，这些示例可通过浏览器执行。这能大大简化设置过程， 并确保所有人都能获得一致的体验。"
+msgstr ""
+"在本培训中，我们将主要通过示例 探索 Rust 语言，这些示例可通过浏览器执行。这能"
+"大大简化设置过程， 并确保所有人都能获得一致的体验。"
 
 #: src/cargo/code-samples.md:7
 msgid ""
@@ -1936,7 +1809,8 @@ msgid ""
 "the exercises. On the last day, we will do a larger exercise which shows you "
 "how to work with dependencies and for that you need Cargo."
 msgstr ""
-"我们仍然建议你安装 Cargo：它有助于你更轻松地完成 练习。在最后一天，我们要做一个更大的练习， 向你展示如何使用依赖项，因此你需要安装 Cargo。"
+"我们仍然建议你安装 Cargo：它有助于你更轻松地完成 练习。在最后一天，我们要做一"
+"个更大的练习， 向你展示如何使用依赖项，因此你需要安装 Cargo。"
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -1968,20 +1842,26 @@ msgstr "来执行代码。"
 msgid ""
 "Most code samples are editable like shown above. A few code samples are not "
 "editable for various reasons:"
-msgstr "大多数代码示例都可修改（如上图所示）。少数代码示例 可能会因各种原因而不可修改："
+msgstr ""
+"大多数代码示例都可修改（如上图所示）。少数代码示例 可能会因各种原因而不可修"
+"改："
 
 #: src/cargo/code-samples.md:27
 msgid ""
 "The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
 "open it in the real Playground to demonstrate unit tests."
-msgstr "嵌入式 Playground 无法执行单元测试。将代码复制并粘贴 到实际 Playground 中，以演示单元测试。"
+msgstr ""
+"嵌入式 Playground 无法执行单元测试。将代码复制并粘贴 到实际 Playground 中，以"
+"演示单元测试。"
 
 #: src/cargo/code-samples.md:30
 msgid ""
 "The embedded playgrounds lose their state the moment you navigate away from "
 "the page! This is the reason that the students should solve the exercises "
 "using a local Rust installation or via the Playground."
-msgstr "嵌入式 Playground 会在你离开页面后立即 丢失其状态！正因如此，学员应使用本地安装的 Rust 或通过 Playground 解题。"
+msgstr ""
+"嵌入式 Playground 会在你离开页面后立即 丢失其状态！正因如此，学员应使用本地安"
+"装的 Rust 或通过 Playground 解题。"
 
 #: src/cargo/running-locally.md:1
 msgid "Running Code Locally with Cargo"
@@ -1995,9 +1875,10 @@ msgid ""
 "should give you a working `rustc` and `cargo`. At the time of writing, the "
 "latest stable Rust release has these version numbers:"
 msgstr ""
-"如果你想在自己的系统上对代码进行实验， 则需要先安装 Rust。为此，请按照 [Rust 图书中的 "
-"说明](https://doc.rust-lang.org/book/ch01-01-installation.html)操作。这应会为你提供一个有效的 "
-"`rustc` 和 `cargo`。在撰写 本文时，最新的 Rust 稳定版具有以下版本号："
+"如果你想在自己的系统上对代码进行实验， 则需要先安装 Rust。为此，请按照 [Rust "
+"图书中的 说明](https://doc.rust-lang.org/book/ch01-01-installation.html)操"
+"作。这应会为你提供一个有效的 `rustc` 和 `cargo`。在撰写 本文时，最新的 Rust "
+"稳定版具有以下版本号："
 
 #: src/cargo/running-locally.md:15
 msgid ""
@@ -2009,7 +1890,8 @@ msgstr "您也可以使用任何更高版本,因为 Rust 保持向后兼容性�
 msgid ""
 "With this in place, follow these steps to build a Rust binary from one of "
 "the examples in this training:"
-msgstr "了解这些信息后，请按照以下步骤从本培训中的 一个示例中构建 Rust 二进制文件："
+msgstr ""
+"了解这些信息后，请按照以下步骤从本培训中的 一个示例中构建 Rust 二进制文件："
 
 #: src/cargo/running-locally.md:20
 msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
@@ -2029,7 +1911,9 @@ msgstr "导航至 `exercise/` 并使用 `cargo run` 构建并运行你的二进�
 msgid ""
 "Replace the boiler-plate code in `src/main.rs` with your own code. For "
 "example, using the example on the previous page, make `src/main.rs` look like"
-msgstr "将 `src/main.rs` 中的样板代码替换为你自己的代码。例如， 使用上一页中的示例，将 `src/main.rs` 改为："
+msgstr ""
+"将 `src/main.rs` 中的样板代码替换为你自己的代码。例如， 使用上一页中的示例，"
+"将 `src/main.rs` 改为："
 
 #: src/cargo/running-locally.md:43
 msgid ""
@@ -2052,27 +1936,31 @@ msgstr "使用 `cargo run` 构建并运行你更新后的二进制文件："
 #: src/cargo/running-locally.md:59
 msgid ""
 "Use `cargo check` to quickly check your project for errors, use `cargo "
-"build` to compile it without running it. You will find the output in "
-"`target/debug/` for a normal debug build. Use `cargo build --release` to "
-"produce an optimized release build in `target/release/`."
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
 msgstr ""
-"使用 `cargo check` 快速检查项目是否存在错误；使用 `cargo build` 只进行编译，而不运行。你可以在 "
-"`target/debug/` 中找到常规调试 build 的输出。使用 `cargo build --release` 在 "
-"`target/release/` 中生成经过优化的 发布 build。"
+"使用 `cargo check` 快速检查项目是否存在错误；使用 `cargo build` 只进行编译，"
+"而不运行。你可以在 `target/debug/` 中找到常规调试 build 的输出。使用 `cargo "
+"build --release` 在 `target/release/` 中生成经过优化的 发布 build。"
 
 #: src/cargo/running-locally.md:64
 msgid ""
 "You can add dependencies for your project by editing `Cargo.toml`. When you "
 "run `cargo` commands, it will automatically download and compile missing "
 "dependencies for you."
-msgstr "你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你 运行 `cargo` 命令时，系统会自动为你下载和编译缺失 的依赖项。"
+msgstr ""
+"你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你 运行 `cargo` 命令时，系统"
+"会自动为你下载和编译缺失 的依赖项。"
 
 #: src/cargo/running-locally.md:72
 msgid ""
 "Try to encourage the class participants to install Cargo and use a local "
 "editor. It will make their life easier since they will have a normal "
 "development environment."
-msgstr "尽量鼓励全班学员安装 Cargo 并使用 本地编辑器。这能为他们营造常规 开发环境，让工作变得更加轻松。"
+msgstr ""
+"尽量鼓励全班学员安装 Cargo 并使用 本地编辑器。这能为他们营造常规 开发环境，让"
+"工作变得更加轻松。"
 
 #: src/welcome-day-1.md:1
 msgid "Welcome to Day 1"
@@ -2089,13 +1977,16 @@ msgstr "现在是学习 Comprehensive Rust 的第一天。今天我们会涉及�
 msgid ""
 "Basic Rust syntax: variables, scalar and compound types, enums, structs, "
 "references, functions, and methods."
-msgstr "Rust 基本语法：变量，标量（scalar）和复合（compound）类型，枚举（enum），结构体（struct），引用，函数和方法。"
+msgstr ""
+"Rust 基本语法：变量，标量（scalar）和复合（compound）类型，枚举（enum），结构"
+"体（struct），引用，函数和方法。"
 
 #: src/welcome-day-1.md:9
 msgid ""
 "Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
 "`continue`."
-msgstr "控制流的构造: `if`, `if let`, `while`, `while let`, `break`, 和 `continue`。"
+msgstr ""
+"控制流的构造: `if`, `if let`, `while`, `while let`, `break`, 和 `continue`。"
 
 #: src/welcome-day-1.md:12
 msgid "Pattern matching: destructuring enums, structs, and arrays."
@@ -2106,7 +1997,8 @@ msgid "Please remind the students that:"
 msgstr "请提醒学生："
 
 #: src/welcome-day-1.md:18
-msgid "They should ask questions when they get them, don't save them to the end."
+msgid ""
+"They should ask questions when they get them, don't save them to the end."
 msgstr "他们可以随时提问，不需要留到最后。"
 
 #: src/welcome-day-1.md:19
@@ -2119,12 +2011,14 @@ msgstr "这个课程本应该是互动的，我们鼓励大家积极讨论。"
 #, fuzzy
 msgid ""
 "As an instructor, you should try to keep the discussions relevant, i.e., "
-"keep the discussions related to how Rust does things vs some other language. "
-" It can be hard to find the right balance, but err on the side of allowing  "
-"discussions since they engage people much more than one-way communication."
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
 msgstr ""
-"作为讲师，你应该尽量保证讨论话题的相关性，例如，讨论围绕Rust是如何做某些事情，而不是其他的语言如何如何。 这个平衡点不容易找到，但是尽量倾向于允许  "
-"讨论，因为讨论比起单方面的灌输更有利于让大家投入。"
+"作为讲师，你应该尽量保证讨论话题的相关性，例如，讨论围绕Rust是如何做某些事"
+"情，而不是其他的语言如何如何。 这个平衡点不容易找到，但是尽量倾向于允许  讨"
+"论，因为讨论比起单方面的灌输更有利于让大家投入。"
 
 #: src/welcome-day-1.md:24
 msgid ""
@@ -2136,7 +2030,9 @@ msgid ""
 "This is perfectly okay! Repetition is an important part of learning. "
 "Remember that the slides are just a support and you are free to skip them as "
 "you like."
-msgstr "这完全没有问题! 重复是学习的一个重要方法。请记得 这些幻灯片只是一个辅助，你可以选择性地跳过。"
+msgstr ""
+"这完全没有问题! 重复是学习的一个重要方法。请记得 这些幻灯片只是一个辅助，你可"
+"以选择性地跳过。"
 
 #: src/welcome-day-1.md:29
 msgid ""
@@ -2144,13 +2040,16 @@ msgid ""
 "speak about the famous borrow checker. The way Rust handles memory is a "
 "major feature and we should show students this right away."
 msgstr ""
-"第一天的主要目标是要谈到著名的 borrow checker，其他方面点到为止。Rust 处理内存的方式是其主要特点，这点我们应该尽早展示给学生。"
+"第一天的主要目标是要谈到著名的 borrow checker，其他方面点到为止。Rust 处理内"
+"存的方式是其主要特点，这点我们应该尽早展示给学生。"
 
 #: src/welcome-day-1.md:33
 msgid ""
 "If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
-msgstr "如果你是在教室里教授此课程，不妨在这里介绍一下时间安排。 这边建议是把每天分成两部分（跟着幻灯片来）："
+msgstr ""
+"如果你是在教室里教授此课程，不妨在这里介绍一下时间安排。 这边建议是把每天分成"
+"两部分（跟着幻灯片来）："
 
 #: src/welcome-day-1.md:36
 msgid "Morning: 9:00 to 12:00,"
@@ -2164,15 +2063,17 @@ msgstr "下午：13:00 到 16:00。"
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
 "breaks, we recommend a break every hour!"
-msgstr "当然你也可以看情况调整时间。但是请务必记得提供休息时间。我们建议每个小时休息一次！"
+msgstr ""
+"当然你也可以看情况调整时间。但是请务必记得提供休息时间。我们建议每个小时休息"
+"一次！"
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in "
-"2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
-"Rust 是一种新的编程语言，它的[1.0 版本于 2015 "
-"年发布](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html)："
+"Rust 是一种新的编程语言，它的[1.0 版本于 2015 年发布](https://blog.rust-lang."
+"org/2015/05/15/Rust-1.0.html)："
 
 #: src/welcome-day-1/what-is-rust.md:5
 msgid "Rust is a statically compiled language in a similar role as C++"
@@ -2184,11 +2085,11 @@ msgstr "`rustc` 使用 LLVM 作为它的后端。"
 
 #: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"Rust supports many [platforms and "
-"architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):"
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"Rust "
-"支持多种[平台和架构](https://doc.rust-lang.org/nightly/rustc/platform-support.html):"
+"Rust 支持多种[平台和架构](https://doc.rust-lang.org/nightly/rustc/platform-"
+"support.html):"
 
 #: src/welcome-day-1/what-is-rust.md:9
 msgid "x86, ARM, WebAssembly, ..."
@@ -2236,7 +2137,8 @@ msgstr "高度的控制能力。"
 
 #: src/welcome-day-1/what-is-rust.md:25
 #, fuzzy
-msgid "Can be scaled down to very constrained devices such as microcontrollers."
+msgid ""
+"Can be scaled down to very constrained devices such as microcontrollers."
 msgstr "能够在资源极度有限的设备（如手机）上运行。"
 
 #: src/welcome-day-1/what-is-rust.md:26
@@ -2297,14 +2199,18 @@ msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
 "see a ton of it over the next three days so we start small with something "
 "familiar."
-msgstr "这张幻灯片试图让学生们熟悉 Rust 代码。在接下来的四天里，他们会看到很多 Rust 代码, 所以我们从一些熟悉的东西开始。"
+msgstr ""
+"这张幻灯片试图让学生们熟悉 Rust 代码。在接下来的四天里，他们会看到很多 Rust "
+"代码, 所以我们从一些熟悉的东西开始。"
 
 #: src/hello-world.md:27
 #, fuzzy
 msgid ""
 "Rust is very much like other languages in the C/C++/Java tradition. It is "
 "imperative and it doesn't try to reinvent things unless absolutely necessary."
-msgstr "Rust 非常像 C/C++/Java 等其他传统语言。它是指令式语言（而非函数式），而且除非绝对必要，它不会尝试重新发明新的概念。"
+msgstr ""
+"Rust 非常像 C/C++/Java 等其他传统语言。它是指令式语言（而非函数式），而且除非"
+"绝对必要，它不会尝试重新发明新的概念。"
 
 #: src/hello-world.md:31
 msgid "Rust is modern with full support for things like Unicode."
@@ -2315,16 +2221,19 @@ msgid ""
 "Rust uses macros for situations where you want to have a variable number of "
 "arguments (no function [overloading](basic-syntax/functions-interlude.md))."
 msgstr ""
-"在需要处理可变数量的参数的情况下，Rust 使用宏（没有函数[重载](basic-syntax/functions-interlude.md)）。"
+"在需要处理可变数量的参数的情况下，Rust 使用宏（没有函数[重载](basic-syntax/"
+"functions-interlude.md)）。"
 
 #: src/hello-world.md:36
 msgid ""
 "Macros being 'hygienic' means they don't accidentally capture identifiers "
 "from the scope they are used in. Rust macros are actually only [partially "
-"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
 msgstr ""
-"宏是“卫生的”意味着它们不会意外地捕获它们所在作用域中的标识符。Rust "
-"的宏实际上只是[部分卫生](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)。"
+"宏是“卫生的”意味着它们不会意外地捕获它们所在作用域中的标识符。Rust 的宏实际上"
+"只是[部分卫生](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)。"
 
 #: src/hello-world.md:40
 msgid ""
@@ -2377,14 +2286,18 @@ msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
 "will always end, but this is not yet proved. Edit the code and play with "
 "different inputs."
-msgstr "这段代码实现了 Collatz 猜想：猜想认为该循环总是会结束，但该猜想还没有被证明。可以编辑代码来尝试不同的输入。"
+msgstr ""
+"这段代码实现了 Collatz 猜想：猜想认为该循环总是会结束，但该猜想还没有被证明。"
+"可以编辑代码来尝试不同的输入。"
 
 #: src/hello-world/small-example.md:29
 msgid ""
 "Explain that all variables are statically typed. Try removing `i32` to "
 "trigger type inference. Try with `i8` instead and trigger a runtime integer "
 "overflow."
-msgstr "说明所有变量的类型都是静态的。尝试删除 `i32` 来触发类型推断。尝试使用 `i8` 来触发运行时整数溢出。"
+msgstr ""
+"说明所有变量的类型都是静态的。尝试删除 `i32` 来触发类型推断。尝试使用 `i8` 来"
+"触发运行时整数溢出。"
 
 #: src/hello-world/small-example.md:32
 msgid "Change `let mut x` to `let x`, discuss the compiler error."
@@ -2404,11 +2317,12 @@ msgstr "展示如何使用 `{}` 作为占位符，来输出比单个变量更复
 
 #: src/hello-world/small-example.md:40
 msgid ""
-"Show the students the standard library, show them how to search for "
-"`std::fmt` which has the rules of the formatting mini-language. It's "
-"important that the students become familiar with searching in the standard "
-"library."
-msgstr "向学生展示标准库，展示如何搜索 `std::fmt`，其中包含用于格式化字符串的微型语言规则。要点是让学生熟悉在标准库中搜索的过程。"
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"向学生展示标准库，展示如何搜索 `std::fmt`，其中包含用于格式化字符串的微型语言"
+"规则。要点是让学生熟悉在标准库中搜索的过程。"
 
 #: src/hello-world/small-example.md:44
 msgid ""
@@ -2445,8 +2359,9 @@ msgid ""
 "have the memory unsafety issues. In addition, you get a modern language with "
 "constructs like pattern matching and built-in dependency management."
 msgstr ""
-"使用过 C 或 C++：Rust 利用\"借用检查\"消除了一类 _运行时错误_ 。你可以达到堪比 C 和 C++ "
-"的性能，而没有内存不安全的问题。并且你还可以得到些现代的语言构造，比如模式匹配和内置依赖管理。"
+"使用过 C 或 C++：Rust 利用\"借用检查\"消除了一类 _运行时错误_ 。你可以达到堪"
+"比 C 和 C++ 的性能，而没有内存不安全的问题。并且你还可以得到些现代的语言构"
+"造，比如模式匹配和内置依赖管理。"
 
 #: src/why-rust.md:19
 msgid ""
@@ -2455,9 +2370,9 @@ msgid ""
 "addition you get fast and predictable performance like C and C++ (no garbage "
 "collector) as well as access to low-level hardware (should you need it)"
 msgstr ""
-"使用过 Java, Go, Python, "
-"JavaScript...：你可以得到和这些语言相同的内存安全特性，并拥有类似的使用高级语言的感受。同时你可以得到类似 C 和 C++ "
-"的高速且可预测的执行性能（无垃圾回收机制），以及在需要时对底层硬件的访问。"
+"使用过 Java, Go, Python, JavaScript...：你可以得到和这些语言相同的内存安全特"
+"性，并拥有类似的使用高级语言的感受。同时你可以得到类似 C 和 C++ 的高速且可预"
+"测的执行性能（无垃圾回收机制），以及在需要时对底层硬件的访问。"
 
 #: src/why-rust/an-example-in-c.md:4
 msgid "Let's consider the following \"minimum wrong example\" program in C:"
@@ -2478,8 +2393,7 @@ msgid ""
 "\n"
 "\tswitch (argc) {\n"
 "\t\tcase 1:\n"
-"\t\t\tprintf(\"Too few arguments!\\n"
-"\");\n"
+"\t\t\tprintf(\"Too few arguments!\\n\");\n"
 "\t\t\treturn 1;\n"
 "\n"
 "\t\tcase 2:\n"
@@ -2489,8 +2403,7 @@ msgid ""
 "\t\t\t\n"
 "\t\t\tbuf = (char*)malloc(len);\n"
 "\t\t\tif (!buf)\n"
-"\t\t\t\tprintf(\"malloc failed!\\n"
-"\", len);\n"
+"\t\t\t\tprintf(\"malloc failed!\\n\", len);\n"
 "\t\t\t\treturn 1;\n"
 "\n"
 "\t\t\tfp = fopen(filename, \"rb\");\n"
@@ -2498,12 +2411,10 @@ msgid ""
 "\t\t\tif (bytes = st.st_size)\n"
 "\t\t\t\tprintf(\"%s\", buf);\n"
 "\t\t\telse\n"
-"\t\t\t\tprintf(\"fread failed!\\n"
-"\");\n"
+"\t\t\t\tprintf(\"fread failed!\\n\");\n"
 "\n"
 "\t\tcase 3:\n"
-"\t\t\tprintf(\"Too many arguments!\\n"
-"\");\n"
+"\t\t\tprintf(\"Too many arguments!\\n\");\n"
 "\t\t\treturn 1;\n"
 "\t}\n"
 "\n"
@@ -2581,20 +2492,21 @@ msgstr ""
 #: src/why-rust/an-example-in-c.md:71
 msgid ""
 "Assignment `=` instead of equality comparison `==`: [The Linux Backdoor "
-"Attempt of "
-"2003](https://freedom-to-tinker.com/2013/10/09/the-linux-backdoor-attempt-of-2003)"
+"Attempt of 2003](https://freedom-to-tinker.com/2013/10/09/the-linux-backdoor-"
+"attempt-of-2003)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:72
 msgid ""
-"Forgotten braces in multi-line `if`: [The Apple goto fail "
-"vulnerability](https://dwheeler.com/essays/apple-goto-fail.html)"
+"Forgotten braces in multi-line `if`: [The Apple goto fail vulnerability]"
+"(https://dwheeler.com/essays/apple-goto-fail.html)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:73
 msgid ""
-"Forgotten `break` in a `switch` statement: [The break that broke "
-"sudo](https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-break-that-broke-sudo)"
+"Forgotten `break` in a `switch` statement: [The break that broke sudo]"
+"(https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-"
+"break-that-broke-sudo)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:75
@@ -2689,39 +2601,37 @@ msgid "No iterator invalidation."
 msgstr "不存在迭代器失效。"
 
 #: src/why-rust/compile-time.md:16
-msgid "It is possible to produce memory leaks in (safe) Rust. Some examples are:"
+msgid ""
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr "在（安全的）Rust 中也有可能产生内存泄漏。例如："
 
 #: src/why-rust/compile-time.md:19
 #, fuzzy
 msgid ""
-"You can use "
-"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) "
-"to leak a pointer. A use of this could be to get runtime-initialized and "
-"runtime-sized static variables"
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"可以使用 "
-"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) "
-"来泄漏一个指针。该方法可以用于得到在运行时决定大小和初始化的静态变量"
+"可以使用 [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) 来泄漏一个指针。该方法可以用于得到在运行时决定大小和初始化"
+"的静态变量"
 
 #: src/why-rust/compile-time.md:21
 msgid ""
-"You can use "
-"[`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html) to "
-"make the compiler \"forget\" about a value (meaning the destructor is never "
-"run)."
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
 msgstr ""
-"可以使用 [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html) "
-"来让编译器“忘记”一个值（即其析构函数不会被执行）。"
+"可以使用 [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) 来让编译器“忘记”一个值（即其析构函数不会被执行）。"
 
 #: src/why-rust/compile-time.md:23
 msgid ""
-"You can also accidentally create a [reference "
-"cycle](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html) with "
-"`Rc` or `Arc`."
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
 msgstr ""
-"可以使用 `Rc` 或 `Arc` 意外创建一个循环引用（[reference "
-"cycle](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html)）。"
+"可以使用 `Rc` 或 `Arc` 意外创建一个循环引用（[reference cycle](https://doc."
+"rust-lang.org/book/ch15-06-reference-cycles.html)）。"
 
 #: src/why-rust/compile-time.md:25
 msgid ""
@@ -2751,16 +2661,16 @@ msgstr "整数溢出的行为有明确定义。"
 #: src/why-rust/runtime.md:12
 #, fuzzy
 msgid ""
-"Integer overflow is defined via the "
-"[`overflow-checks`](https://doc.rust-lang.org/rustc/codegen-options/index.html#overflow-checks) "
-"compile-time flag. If enabled, the program will panic (a controlled crash of "
-"the program), otherwise you get wrap-around semantics. By default, you get "
+"Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
+"lang.org/rustc/codegen-options/index.html#overflow-checks) compile-time "
+"flag. If enabled, the program will panic (a controlled crash of the "
+"program), otherwise you get wrap-around semantics. By default, you get "
 "panics in debug mode (`cargo build`) and wrap-around in release mode (`cargo "
 "build --release`)."
 msgstr ""
-"整数溢出的行为由编译时的标志指定。可以选择 "
-"panic（一种受控的程序崩溃）或使用“绕回（wrap-around）”语义。默认情况下，使用调试模式编译（`cargo build`）的行为为 "
-"panic，使用发布模式编译（`cargo build --release`）的行为为“绕回”。"
+"整数溢出的行为由编译时的标志指定。可以选择 panic（一种受控的程序崩溃）或使"
+"用“绕回（wrap-around）”语义。默认情况下，使用调试模式编译（`cargo build`）的"
+"行为为 panic，使用发布模式编译（`cargo build --release`）的行为为“绕回”。"
 
 #: src/why-rust/runtime.md:18
 msgid ""
@@ -2769,8 +2679,8 @@ msgid ""
 "call functions such as `slice::get_unchecked` which does not do bounds "
 "checking."
 msgstr ""
-"边界检查不能使用编译标志禁用，也不能直接通过 `unsafe` 关键字禁用。然而， `unsafe` 允许你调用 "
-"`slice::get_unchecked` 等不做边界检查的函数。"
+"边界检查不能使用编译标志禁用，也不能直接通过 `unsafe` 关键字禁用。然而， "
+"`unsafe` 允许你调用 `slice::get_unchecked` 等不做边界检查的函数。"
 
 #: src/why-rust/modern.md:3
 #, fuzzy
@@ -2824,8 +2734,9 @@ msgid ""
 "writing a loop using `for` should result in roughly the same low level "
 "instructions as using the `.iter().fold()` construct."
 msgstr ""
-"与 C++ 类似的零成本抽象，意味着你不需要为高级程序语言的结构“付出”更多的内存和 CPU。例如使用 `for` 循环与使用 "
-"`.iter().fold()` 结构应该会生成大致相同的底层指令。"
+"与 C++ 类似的零成本抽象，意味着你不需要为高级程序语言的结构“付出”更多的内存"
+"和 CPU。例如使用 `for` 循环与使用 `.iter().fold()` 结构应该会生成大致相同的底"
+"层指令。"
 
 #: src/why-rust/modern.md:28
 msgid ""
@@ -2833,8 +2744,8 @@ msgid ""
 "known as 'sum types', which allow the type system to express things like "
 "`Option<T>` and `Result<T, E>`."
 msgstr ""
-"值得一提的是，Rust 的枚举是“代数数据类型”（也叫“和类型”）。它使得类型系统可以表示 `Option<T>` 和 `Result<T, E>` "
-"等结构。"
+"值得一提的是，Rust 的枚举是“代数数据类型”（也叫“和类型”）。它使得类型系统可以"
+"表示 `Option<T>` 和 `Result<T, E>` 等结构。"
 
 #: src/why-rust/modern.md:32
 msgid ""
@@ -2843,15 +2754,18 @@ msgid ""
 "talkative than other compilers. It will often provide you with _actionable_ "
 "feedback, ready to copy-paste into your code."
 msgstr ""
-"提醒学生去阅读编译错误 --- 许多开发者已经习惯去忽略冗长的编译器输出。Rust 编译器会比其它编译器更健谈。它通常会提供 _可操作的_ "
-"反馈，可以直接复制粘贴到代码中。"
+"提醒学生去阅读编译错误 --- 许多开发者已经习惯去忽略冗长的编译器输出。Rust 编"
+"译器会比其它编译器更健谈。它通常会提供 _可操作的_ 反馈，可以直接复制粘贴到代"
+"码中。"
 
 #: src/why-rust/modern.md:37
 msgid ""
 "The Rust standard library is small compared to languages like Java, Python, "
 "and Go. Rust does not come with several things you might consider standard "
 "and essential:"
-msgstr "相比 Java, Python 和 Go 等语言，Rust 标准库较为精简。Rust 并没有内置一些你可能认为标准和必要的功能："
+msgstr ""
+"相比 Java, Python 和 Go 等语言，Rust 标准库较为精简。Rust 并没有内置一些你可"
+"能认为标准和必要的功能："
 
 #: src/why-rust/modern.md:41
 msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
@@ -2872,32 +2786,35 @@ msgid ""
 "Rust community is still working on finding the best solution --- and perhaps "
 "there isn't a single \"best solution\" for some of these things."
 msgstr ""
-"Rust 这么做的原因是标准库中的功能是无法去除的，因此该功能必须非常稳定。对于以上例子，Rust 社区仍在寻找最佳解决方案 --- "
-"甚至对一些情况可能没有单一的“最佳解决方案”。"
+"Rust 这么做的原因是标准库中的功能是无法去除的，因此该功能必须非常稳定。对于以"
+"上例子，Rust 社区仍在寻找最佳解决方案 --- 甚至对一些情况可能没有单一的“最佳解"
+"决方案”。"
 
 #: src/why-rust/modern.md:50
 msgid ""
 "Rust comes with a built-in package manager in the form of Cargo and this "
 "makes it trivial to download and compile third-party crates. A consequence "
 "of this is that the standard library can be smaller."
-msgstr "Rust 内置了一个包管理器 Cargo，使得下载和编译第三方 crate 变得简单。这也导致标准库可以更加精简。"
+msgstr ""
+"Rust 内置了一个包管理器 Cargo，使得下载和编译第三方 crate 变得简单。这也导致"
+"标准库可以更加精简。"
 
 #: src/why-rust/modern.md:54
 msgid ""
-"Discovering good third-party crates can be a problem. Sites like "
-"<https://lib.rs/> help with this by letting you compare health metrics for "
-"crates to find a good and trusted one."
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
 msgstr ""
-"发现高质量的第三方 crate 也许是一个问题。 <https://lib.rs/> 等网站对此问题有所帮助。它能帮你比较 crate "
-"的健康指标，以找到一个高质量并受信任的 crate。"
+"发现高质量的第三方 crate 也许是一个问题。 <https://lib.rs/> 等网站对此问题有"
+"所帮助。它能帮你比较 crate 的健康指标，以找到一个高质量并受信任的 crate。"
 
 #: src/why-rust/modern.md:58
 msgid ""
 "[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
 "implementation used in major IDEs and text editors."
 msgstr ""
-"[rust-analyzer](https://rust-analyzer.github.io/) 是一个受到广泛支持的 LSP 实现，被主流的 IDE "
-"和文本编辑器所使用。"
+"[rust-analyzer](https://rust-analyzer.github.io/) 是一个受到广泛支持的 LSP 实"
+"现，被主流的 IDE 和文本编辑器所使用。"
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
@@ -2921,14 +2838,12 @@ msgstr "`if` 和 `while` 等关键词作用与以上语言一致。"
 msgid "Variable assignment is done with `=`, comparison is done with `==`."
 msgstr "变量赋值使用 `=`，值之间比较使用 `==`。"
 
-#: src/basic-syntax/scalar-types.md:3
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
 msgid "Types"
 msgstr "类型"
 
-#: src/basic-syntax/scalar-types.md:3
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
 msgid "Literals"
 msgstr "字面量"
 
@@ -3035,14 +2950,12 @@ msgstr "上表中还有一些未提及的语法："
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"Raw strings allow you to create a `&str` value with escapes disabled: `r\"\\n"
-"\" == \"\\\\n"
-"\"`. You can embed double-quotes by using an equal amount of `#` on either "
-"side of the quotes:"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
-"原始字符串可在创建 `&str` 时禁用转义：`r\"\\n"
-"\" == \"\\\\n"
-"\"`。可以在外层引号两侧添加相同数量的 `#`，以在字符串中嵌入双引号："
+"原始字符串可在创建 `&str` 时禁用转义：`r\"\\n\" == \"\\\\n\"`。可以在外层引号"
+"两侧添加相同数量的 `#`，以在字符串中嵌入双引号："
 
 #: src/basic-syntax/scalar-types.md:35
 msgid "Byte strings allow you to create a `&[u8]` value directly:"
@@ -3099,8 +3012,9 @@ msgid ""
 "its type_, which means that `[u8; 3]` and `[u8; 4]` are considered two "
 "different types."
 msgstr ""
-"数组中的元素具有相同的类型 `T`，数组的长度为 `N`，`N` 是一个编译期常量。 需要注意的是数组的长度是它_类型的一部分\\_, 这意味着 "
-"`[u8; 3]` 和 `[u8; 4]` 在 Rust 中被认为是不同的类型。"
+"数组中的元素具有相同的类型 `T`，数组的长度为 `N`，`N` 是一个编译期常量。 需要"
+"注意的是数组的长度是它_类型的一部分\\_, 这意味着 `[u8; 3]` 和 `[u8; 4]` 在 "
+"Rust 中被认为是不同的类型。"
 
 #: src/basic-syntax/compound-types.md:40
 msgid "We can use literals to assign values to arrays."
@@ -3113,14 +3027,17 @@ msgid ""
 "the debug output. We could also have used `{a}` and `{a:?}` without "
 "specifying the value after the format string."
 msgstr ""
-"在主函数中，打印（print）语句使用 `?` 格式请求调试实现。 使用参数 `{}` 打印默认输出，`{:?}` 表示以调试格式输出。 "
-"我们也可以不在格式化字符串后面指定变量值，直接使用 `{a}` 和 `{a:?}` 进行输出。"
+"在主函数中，打印（print）语句使用 `?` 格式请求调试实现。 使用参数 `{}` 打印默"
+"认输出，`{:?}` 表示以调试格式输出。 我们也可以不在格式化字符串后面指定变量"
+"值，直接使用 `{a}` 和 `{a:?}` 进行输出。"
 
 #: src/basic-syntax/compound-types.md:47
 msgid ""
 "Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
 "easier to read."
-msgstr "添加 `#`, 比如 `{a:#?}`, 会输出“美观打印（pretty printing）” 格式, 这种格式可能会更加易读。"
+msgstr ""
+"添加 `#`, 比如 `{a:#?}`, 会输出“美观打印（pretty printing）” 格式, 这种格式可"
+"能会更加易读。"
 
 #: src/basic-syntax/compound-types.md:49
 msgid "Tuples:"
@@ -3147,8 +3064,9 @@ msgid ""
 "value are expressed as `()`. It is used to indicate, for example, that a "
 "function or expression has no return value, as we'll see in a future slide. "
 msgstr ""
-"空元组 `()` 也被称作 “单元（unit）类型”. 它既是一个类型， 也是这种类型的唯一值——也就是说它的类型和它的  值都被表示为 "
-"`()`。它通常用于表示，比如，一个  函数或表达式没有返回值，我们会在后续的幻灯片种见到这种用法。"
+"空元组 `()` 也被称作 “单元（unit）类型”. 它既是一个类型， 也是这种类型的唯一"
+"值——也就是说它的类型和它的  值都被表示为 `()`。它通常用于表示，比如，一个  函"
+"数或表达式没有返回值，我们会在后续的幻灯片种见到这种用法。"
 
 #: src/basic-syntax/compound-types.md:61
 msgid ""
@@ -3168,19 +3086,24 @@ msgstr "一些注意事项："
 msgid ""
 "We must dereference `ref_x` when assigning to it, similar to C and C++ "
 "pointers."
-msgstr "就像 C 与 C++ 中的指针一样，对引用 `ref_x` 进行赋值时，我们必须对其解引用。"
+msgstr ""
+"就像 C 与 C++ 中的指针一样，对引用 `ref_x` 进行赋值时，我们必须对其解引用。"
 
 #: src/basic-syntax/references.md:18
 msgid ""
 "Rust will auto-dereference in some cases, in particular when invoking "
 "methods (try `ref_x.count_ones()`)."
-msgstr "Rust 有时会进行自动解引用。比如调用方法 `ref_x.count_ones()` 时，ref_x 会被解引用。"
+msgstr ""
+"Rust 有时会进行自动解引用。比如调用方法 `ref_x.count_ones()` 时，ref_x 会被解"
+"引用。"
 
 #: src/basic-syntax/references.md:20
 msgid ""
 "References that are declared as `mut` can be bound to different values over "
 "their lifetime."
-msgstr "如果引用值被声明为 `mut`（可变引用），那么这个引用值可以在它的生命周期内被绑定为不同的值。"
+msgstr ""
+"如果引用值被声明为 `mut`（可变引用），那么这个引用值可以在它的生命周期内被绑"
+"定为不同的值。"
 
 #: src/basic-syntax/references.md:26
 msgid ""
@@ -3189,8 +3112,9 @@ msgid ""
 "to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"注意 `let mut ref_x: &i32` 与 `let ref_x: &mut i32` "
-"之间的区别。第一条语句声明了一个可变引用，所以我们可以修改这个引用所绑定的值；第二条语句声明了一个指向可变变量的引用。"
+"注意 `let mut ref_x: &i32` 与 `let ref_x: &mut i32` 之间的区别。第一条语句声"
+"明了一个可变引用，所以我们可以修改这个引用所绑定的值；第二条语句声明了一个指"
+"向可变变量的引用。"
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -3237,14 +3161,16 @@ msgid ""
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
 "identical."
 msgstr ""
-"如果切片的起始下标为 0， Rust 语法允许我们省略起始下标。比如说 `&a[0..a.len()]` 与 `&a[..a.len()]` 是等价的。"
+"如果切片的起始下标为 0， Rust 语法允许我们省略起始下标。比如说 `&a[0..a."
+"len()]` 与 `&a[..a.len()]` 是等价的。"
 
 #: src/basic-syntax/slices.md:26
 #, fuzzy
 msgid ""
 "The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
 "identical."
-msgstr "结尾下标也可以用相同方式省略。比如说 `&a[2..a.len()]` 和 `&a[2..]` 是等价的。"
+msgstr ""
+"结尾下标也可以用相同方式省略。比如说 `&a[2..a.len()]` 和 `&a[2..]` 是等价的。"
 
 #: src/basic-syntax/slices.md:28
 #, fuzzy
@@ -3258,7 +3184,9 @@ msgid ""
 "`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
 "computation on slices of different sizes."
-msgstr "切片会从另外一个对象中借用数据。在这个例子中， `a` 必须在其切片存活时保持存活（处于作用域中）。"
+msgstr ""
+"切片会从另外一个对象中借用数据。在这个例子中， `a` 必须在其切片存活时保持存活"
+"（处于作用域中）。"
 
 #: src/basic-syntax/slices.md:32
 #, fuzzy
@@ -3266,8 +3194,9 @@ msgid ""
 "Slices always borrow from another object. In this example, `a` has to remain "
 "'alive' (in scope) for at least as long as our slice. "
 msgstr ""
-"关于修改 `a[3]` 的问题可能会引发精彩的讨论。正确答案是：为了保证内存安全，在创建切片后，我们不能通过 `a` 来修改数据。不过我们可以通过 "
-"`a` 或者 `s` 来读取数据。我们将会在“借用”章节着重介绍这个内容。"
+"关于修改 `a[3]` 的问题可能会引发精彩的讨论。正确答案是：为了保证内存安全，在"
+"创建切片后，我们不能通过 `a` 来修改数据。不过我们可以通过 `a` 或者 `s` 来读取"
+"数据。我们将会在“借用”章节着重介绍这个内容。"
 
 #: src/basic-syntax/slices.md:34
 msgid ""
@@ -3323,14 +3252,16 @@ msgid ""
 "encoded string data  stored in a block of memory. String literals "
 "(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"`&str` 引入了一个字符串切片，它是一个指向保存在内存块中的 UTF-8 编码字符串数据的不可变引用。   "
-"字符串字面量（`”Hello”`）会保存在程序的二进制文件中。"
+"`&str` 引入了一个字符串切片，它是一个指向保存在内存块中的 UTF-8 编码字符串数"
+"据的不可变引用。   字符串字面量（`”Hello”`）会保存在程序的二进制文件中。"
 
 #: src/basic-syntax/string-slices.md:30
 msgid ""
 "Rust’s `String` type is a wrapper around a vector of bytes. As with a "
 "`Vec<T>`, it is owned."
-msgstr "Rust 的 `String` 类型是一个字节 vector 的封装。和 `Vec<T>` 一样，它是拥有所有权的。"
+msgstr ""
+"Rust 的 `String` 类型是一个字节 vector 的封装。和 `Vec<T>` 一样，它是拥有所有"
+"权的。"
 
 #: src/basic-syntax/string-slices.md:32
 msgid ""
@@ -3338,14 +3269,17 @@ msgid ""
 "literal; `String::new()`  creates a new empty string, to which string data "
 "can be added using the `push()` and `push_str()` methods."
 msgstr ""
-"和其他类型一样，`String::from()` 会从字符串字面量创建一个字符串；`String::new()` 会创建一个新的空字符串，   "
-"之后可以使用 `push()` 和 `push_str()` 方法向其中添加字符串数据。"
+"和其他类型一样，`String::from()` 会从字符串字面量创建一个字符串；`String::"
+"new()` 会创建一个新的空字符串，   之后可以使用 `push()` 和 `push_str()` 方法"
+"向其中添加字符串数据。"
 
 #: src/basic-syntax/string-slices.md:35
 msgid ""
 "The `format!()` macro is a convenient way to generate an owned string from "
 "dynamic values. It  accepts the same format specification as `println!()`."
-msgstr "`format!()` 宏可以方便地动态生成拥有所有权的字符串。它接受和 `println!()` 相同的格式规范。"
+msgstr ""
+"`format!()` 宏可以方便地动态生成拥有所有权的字符串。它接受和 `println!()` 相"
+"同的格式规范。"
 
 #: src/basic-syntax/string-slices.md:38
 msgid ""
@@ -3360,21 +3294,25 @@ msgid ""
 "equivalent of `std::string` from C++  (main difference: it can only contain "
 "UTF-8 encoded bytes and will never use a small-string optimization)."
 msgstr ""
-"对于 C++ 程序员：可以把 `&str` 当作 C++ 中的 `const char*`，但是它总是指向内存中的一个有效字符串。   Rust 的 "
-"`String` 大致相当于 C++ 中 `std::string` （主要区别：它只能包含 UTF-8 编码的字节，   "
-"并且永远不会使用小字符串优化（small-string optimization））。"
+"对于 C++ 程序员：可以把 `&str` 当作 C++ 中的 `const char*`，但是它总是指向内"
+"存中的一个有效字符串。   Rust 的 `String` 大致相当于 C++ 中 `std::string` "
+"（主要区别：它只能包含 UTF-8 编码的字节，   并且永远不会使用小字符串优化"
+"（small-string optimization））。"
 
 #: src/basic-syntax/functions.md:3
 msgid ""
-"A Rust version of the famous "
-"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
-msgstr "一个 Rust 版本的著名 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 面试题："
+"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
+"Fizz_buzz) interview question:"
+msgstr ""
+"一个 Rust 版本的著名 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 面试"
+"题："
 
 #: src/basic-syntax/functions.md:36
 msgid ""
 "We refer in `main` to a function written below. Neither forward declarations "
 "nor headers are necessary. "
-msgstr "我们在 `main` 中引用了下面编写的一个函数。不需要提前声明或添加头文件。 "
+msgstr ""
+"我们在 `main` 中引用了下面编写的一个函数。不需要提前声明或添加头文件。 "
 
 #: src/basic-syntax/functions.md:37
 msgid ""
@@ -3386,22 +3324,29 @@ msgstr "类型跟随在声明的参数后（与某些编程语言相反），然
 msgid ""
 "The last expression in a function body (or any block) becomes the return "
 "value. Simply omit the `;` at the end of the expression."
-msgstr "函数体（或任何块）中的最后一个表达式将成为返回值。只需省略表达式末尾的 `;` 即可。"
+msgstr ""
+"函数体（或任何块）中的最后一个表达式将成为返回值。只需省略表达式末尾的 `;` 即"
+"可。"
 
 #: src/basic-syntax/functions.md:39
 msgid ""
 "Some functions have no return value, and return the 'unit type', `()`. The "
 "compiler will infer this if the `-> ()` return type is omitted."
-msgstr "有些函数没有返回值，会返回“单元类型（unit type）”`()`。如果省略了`-> ()`的返回类型，编译器将会自动推断。"
+msgstr ""
+"有些函数没有返回值，会返回“单元类型（unit type）”`()`。如果省略了`-> ()`的返"
+"回类型，编译器将会自动推断。"
 
 #: src/basic-syntax/functions.md:40
 msgid ""
 "The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
 "`=n`, which causes it to include the upper bound."
-msgstr "`print_fizzbuzz_to()`函数中`for`循环的范围表达式（range expression）包含`=n`，这会导致它包括上限。"
+msgstr ""
+"`print_fizzbuzz_to()`函数中`for`循环的范围表达式（range expression）包含"
+"`=n`，这会导致它包括上限。"
 
 #: src/basic-syntax/rustdoc.md:3
-msgid "All language items in Rust can be documented using special `///` syntax."
+msgid ""
+"All language items in Rust can be documented using special `///` syntax."
 msgstr "Rust 中的所有语言元素都可以通过特殊的 `///` 语法进行文档化。"
 
 #: src/basic-syntax/rustdoc.md:5
@@ -3442,26 +3387,31 @@ msgstr ""
 #, fuzzy
 msgid ""
 "The contents are treated as Markdown. All published Rust library crates are "
-"automatically documented at [`docs.rs`](https://docs.rs) using the "
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is idiomatic to document all public items in an API using this pattern. Code "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
+"idiomatic to document all public items in an API using this pattern. Code "
 "snippets can document usage and will be used as unit tests."
 msgstr ""
-"文档的内容会被当做 Markdown 处理。所有已发布 Rust 库 crate "
-"都会自动被[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 工具在 "
-"[`docs.rs`](https://docs.rs)存档。 按照这种方式来为 API 中的所有公开项编写文档是 Rust 中惯用的做法。"
+"文档的内容会被当做 Markdown 处理。所有已发布 Rust 库 crate 都会自动被"
+"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 工具在 "
+"[`docs.rs`](https://docs.rs)存档。 按照这种方式来为 API 中的所有公开项编写文"
+"档是 Rust 中惯用的做法。"
 
 #: src/basic-syntax/rustdoc.md:30
 msgid ""
-"Show students the generated docs for the `rand` crate at "
-"[`docs.rs/rand`](https://docs.rs/rand)."
-msgstr "向学生展示在 [`docs.rs/rand`](https://docs.rs/rand) 中为 `rand` crate 生成的文档。"
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
+msgstr ""
+"向学生展示在 [`docs.rs/rand`](https://docs.rs/rand) 中为 `rand` crate 生成的"
+"文档。"
 
 #: src/basic-syntax/rustdoc.md:33
 msgid ""
 "This course does not include rustdoc on slides, just to save space, but in "
 "real code they should be present."
-msgstr "本课程的幻灯片中不包含 rustdoc，这是为了节省空间，但是在实际的代码中，应当编写相关的程序文档。"
+msgstr ""
+"本课程的幻灯片中不包含 rustdoc，这是为了节省空间，但是在实际的代码中，应当编"
+"写相关的程序文档。"
 
 #: src/basic-syntax/rustdoc.md:36
 msgid ""
@@ -3472,15 +3422,16 @@ msgstr "内部文档注释将在稍后（在讲解模块的页面）讨论，这
 #: src/basic-syntax/rustdoc.md:39
 msgid ""
 "Rustdoc comments can contain code snippets that we can run and test using "
-"`cargo test`. We will discuss these tests in the [Testing "
-"section](../testing/doc-tests.html)."
+"`cargo test`. We will discuss these tests in the [Testing section](../"
+"testing/doc-tests.html)."
 msgstr ""
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
 "method is an instance of the type it is associated with:"
-msgstr "方法是与某种类型关联的函数。方法的 `self` 参数是与其关联类型的一个实例："
+msgstr ""
+"方法是与某种类型关联的函数。方法的 `self` 参数是与其关联类型的一个实例："
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3533,7 +3484,9 @@ msgstr ""
 msgid ""
 "Add a `Rectangle::square(width: u32)` constructor to illustrate that such "
 "static methods can take arbitrary parameters."
-msgstr "新增一个 `Rectangle::new_square(width: u32)` 构造函数来说明构造函数可以接受任意参数。"
+msgstr ""
+"新增一个 `Rectangle::new_square(width: u32)` 构造函数来说明构造函数可以接受任"
+"意参数。"
 
 #: src/basic-syntax/functions-interlude.md:1
 msgid "Function Overloading"
@@ -3600,7 +3553,9 @@ msgid ""
 "When using generics, the standard library's `Into<T>` can provide a kind of "
 "limited polymorphism on argument types. We will see more details in a later "
 "section."
-msgstr "标准库中的 `Into<T>` 通过泛型参数提供了一种具有有限多态性的参数类型。详见之后的章节。"
+msgstr ""
+"标准库中的 `Into<T>` 通过泛型参数提供了一种具有有限多态性的参数类型。详见之后"
+"的章节。"
 
 #: src/exercises/day-1/morning.md:1
 msgid "Day 1: Morning Exercises"
@@ -3624,10 +3579,12 @@ msgstr "在解题时要考虑几件事："
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"Use a local Rust installation, if possible. This way you can get "
-"auto-completion in your editor. See the page about [Using "
-"Cargo](../../cargo.md) for details on installing Rust."
-msgstr "最好使用本地安装的 Rust，以实现在编辑器中自动补全。关于安装 Rust 的细节，请参见 \\[使用 Cargo\\] 页面。"
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
+msgstr ""
+"最好使用本地安装的 Rust，以实现在编辑器中自动补全。关于安装 Rust 的细节，请参"
+"见 \\[使用 Cargo\\] 页面。"
 
 #: src/exercises/day-1/morning.md:17
 msgid "Alternatively, use the Rust Playground."
@@ -3637,63 +3594,63 @@ msgstr "也可以使用 Rust Playground 作为替代。"
 msgid ""
 "The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
-msgstr "页面内嵌的代码片段是不可编辑的：因为离开页面后内嵌代码片段中的修改会丢失。"
+msgstr ""
+"页面内嵌的代码片段是不可编辑的：因为离开页面后内嵌代码片段中的修改会丢失。"
 
-#: src/exercises/day-1/morning.md:22
-#: src/exercises/day-2/morning.md:11
-#: src/exercises/day-3/morning.md:9
-#: src/exercises/bare-metal/morning.md:7
+#: src/exercises/day-1/morning.md:22 src/exercises/day-2/morning.md:11
+#: src/exercises/day-3/morning.md:9 src/exercises/bare-metal/morning.md:7
 #: src/exercises/concurrency/morning.md:12
 #, fuzzy
 msgid ""
-"After looking at the exercises, you can look at the "
-"[solutions](solutions-morning.md) provided."
+"After looking at the exercises, you can look at the [solutions](solutions-"
+"morning.md) provided."
 msgstr "读完习题后，可以阅读本书提供的 \\[题解\\]。"
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike "
-"C++](https://en.cppreference.com/w/cpp/language/implicit_conversion)). You "
-"can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
-"[与 C++ "
-"不同](https://en.cppreference.com/w/cpp/language/implicit_conversion)，Rust "
-"不会自动进行 _隐式类型转换_。例如，下面的程序中不存在隐式类型转换："
+"[与 C++ 不同](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)，Rust 不会自动进行 _隐式类型转换_。例如，下面的程序中不"
+"存在隐式类型转换："
 
 #: src/exercises/day-1/implicit-conversions.md:20
 msgid ""
-"The Rust integer types all implement the "
-"[`From<T>`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
-"[`Into<T>`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits to "
-"let us convert between them. The `From<T>` trait has a single `from()` "
-"method and similarly, the `Into<T>` trait has a single `into()` method. "
-"Implementing these traits is how a type expresses that it can be converted "
-"into another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Rust 的整数类型都实现了 "
-"[`From<T>`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
-"[`Into<T>`](https://doc.rust-lang.org/std/convert/trait.Into.html) "
-"trait，使得我们可以在它们之间进行转换。`From<T>` trait 包含 `from()` 方法，`Into<T>` trait 包含 "
-"`into()` 方法。类型通过实现这些 trait 来表达它将被如何转换为另一个类型。"
+"Rust 的整数类型都实现了 [`From<T>`](https://doc.rust-lang.org/std/convert/"
+"trait.From.html) 和 [`Into<T>`](https://doc.rust-lang.org/std/convert/trait."
+"Into.html) trait，使得我们可以在它们之间进行转换。`From<T>` trait 包含 "
+"`from()` 方法，`Into<T>` trait 包含 `into()` 方法。类型通过实现这些 trait 来"
+"表达它将被如何转换为另一个类型。"
 
 #: src/exercises/day-1/implicit-conversions.md:26
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means that we can convert a variable `x` of type `i8` to an `i16` by calling "
-" `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16` "
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
-"标准库中包含 `From<i8> for i16` 的实现，即我们可以通过调用 `i16::from(x)` 来将 `i8` 类型的变量 `x` 转换为 "
-"`i16`。或者也可以简单地使用 `x.into()`，因为 `From<i8> for i16` 的实现会自动创建 `Into<i16> for "
-"i8` 的实现。"
+"标准库中包含 `From<i8> for i16` 的实现，即我们可以通过调用 `i16::from(x)` 来"
+"将 `i8` 类型的变量 `x` 转换为 `i16`。或者也可以简单地使用 `x.into()`，因为 "
+"`From<i8> for i16` 的实现会自动创建 `Into<i16> for i8` 的实现。"
 
 #: src/exercises/day-1/implicit-conversions.md:31
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
 "it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
-msgstr "这同样也适用于自定义类型的 `From` 实现，只需实现 `From` 就可以自动得到对应的 `Into` 实现。"
+msgstr ""
+"这同样也适用于自定义类型的 `From` 实现，只需实现 `From` 就可以自动得到对应的 "
+"`Into` 实现。"
 
 #: src/exercises/day-1/implicit-conversions.md:34
 msgid "Execute the above program and look at the compiler error."
@@ -3708,14 +3665,13 @@ msgid ""
 "Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
 "`i128`) to see which types you can convert to which other types. Try "
 "converting small types to big types and the other way around. Check the "
-"[standard library "
-"documentation](https://doc.rust-lang.org/std/convert/trait.From.html) to see "
-"if `From<T>` is implemented for the pairs you check."
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
-"修改 `x` 和 `y` 的类型（例如 `f32`, `bool`, `i128` "
-"等）来了解哪些类型之间可以相互转换。尝试将较小的类型转换为较大的类型和将较大的类型转换为较小的类型。阅读 "
-"[标准库文档](https://doc.rust-lang.org/std/convert/trait.From.html) "
-"来了解对于你所尝试的两个类型 `From<T>` 是否已被实现。"
+"修改 `x` 和 `y` 的类型（例如 `f32`, `bool`, `i128` 等）来了解哪些类型之间可以"
+"相互转换。尝试将较小的类型转换为较大的类型和将较大的类型转换为较小的类型。阅"
+"读 [标准库文档](https://doc.rust-lang.org/std/convert/trait.From.html) 来了解"
+"对于你所尝试的两个类型 `From<T>` 是否已被实现。"
 
 #: src/exercises/day-1/for-loops.md:1
 #: src/exercises/day-1/solutions-morning.md:3
@@ -3728,8 +3684,8 @@ msgstr "我们可以这样声明一个数组："
 
 #: src/exercises/day-1/for-loops.md:9
 msgid ""
-"You can print such an array by asking for its debug representation with "
-"`{:?}`:"
+"You can print such an array by asking for its debug representation with `{:?}"
+"`:"
 msgstr "你可以使用 `{:?}` 来打印这种数组的调试格式："
 
 #: src/exercises/day-1/for-loops.md:19
@@ -3781,7 +3737,8 @@ msgid ""
 "and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
-"使用以上知识，写一个用易读的格式输出矩阵的 `pretty_print` 函数，以及一个对矩阵进行转置（将行和列互换）的 `transpose` 函数："
+"使用以上知识，写一个用易读的格式输出矩阵的 `pretty_print` 函数，以及一个对矩"
+"阵进行转置（将行和列互换）的 `transpose` 函数："
 
 #: src/exercises/day-1/for-loops.md:49
 msgid "Hard-code both functions to operate on 3 × 3 matrices."
@@ -3861,20 +3818,24 @@ msgid ""
 "argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"是否可以使用 `&[i32]` 切片而不是硬编码的 3 × 3 矩阵作为函数的参数和返回类型？例如使用 `&[&[i32]]` "
-"表示一个二维的切片的切片。为什么这样做是可行或不可行的？"
+"是否可以使用 `&[i32]` 切片而不是硬编码的 3 × 3 矩阵作为函数的参数和返回类型？"
+"例如使用 `&[&[i32]]` 表示一个二维的切片的切片。为什么这样做是可行或不可行的？"
 
 #: src/exercises/day-1/for-loops.md:89
 msgid ""
 "See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
-msgstr "参考 [`ndarray` crate](https://docs.rs/ndarray/) 以了解该功能满足生产环境质量的实现。"
+msgstr ""
+"参考 [`ndarray` crate](https://docs.rs/ndarray/) 以了解该功能满足生产环境质量"
+"的实现。"
 
 #: src/exercises/day-1/for-loops.md:94
 msgid ""
 "The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
-msgstr "题目解答和附加题的答案在 [题解](solutions-morning.md#arrays-and-for-loops) 章节中。"
+msgstr ""
+"题目解答和附加题的答案在 [题解](solutions-morning.md#arrays-and-for-loops) 章"
+"节中。"
 
 #: src/exercises/day-1/for-loops.md:97
 msgid ""
@@ -3889,8 +3850,8 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:101
 msgid ""
 "The loop would have been one that consumes the array.  This is a change "
-"[introduced in the 2021 "
-"Edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)."
+"[introduced in the 2021 Edition](https://doc.rust-lang.org/edition-guide/"
+"rust-2021/IntoIterator-for-arrays.html)."
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:104
@@ -3906,8 +3867,9 @@ msgid ""
 "becomes the value of the `if` expression. Other control flow expressions "
 "work similarly in Rust."
 msgstr ""
-"正如我们所知，`if` 是 Rust 中的一个表达式。它用于有条件地 评估两个块中的一个，但这些块可以有一个值， 然后成为 `if` "
-"表达式的值。其他控制流表达式在 Rust 中也有类似 的运作方式。"
+"正如我们所知，`if` 是 Rust 中的一个表达式。它用于有条件地 评估两个块中的一"
+"个，但这些块可以有一个值， 然后成为 `if` 表达式的值。其他控制流表达式在 Rust "
+"中也有类似 的运作方式。"
 
 #: src/control-flow/blocks.md:3
 #, fuzzy
@@ -3929,14 +3891,9 @@ msgid ""
 "return value:"
 msgstr "同样的规则也适用于函数：函数主体的值 是返回值："
 
-#: src/control-flow/blocks.md:45
-#: src/enums.md:34
-#: src/enums/sizes.md:28
-#: src/pattern-matching.md:25
-#: src/pattern-matching/match-guards.md:22
-#: src/structs.md:31
-#: src/methods.md:30
-#: src/methods/example.md:46
+#: src/control-flow/blocks.md:45 src/enums.md:34 src/enums/sizes.md:28
+#: src/pattern-matching.md:25 src/pattern-matching/match-guards.md:22
+#: src/structs.md:31 src/methods.md:30 src/methods/example.md:46
 msgid "Key Points:"
 msgstr "关键点："
 
@@ -3950,7 +3907,9 @@ msgstr "这张幻灯片的重点是说明在 Rust 中，块有类型和值。"
 msgid ""
 "You can show how the value of the block changes by changing the last line in "
 "the block. For instance, adding/removing a semicolon or using a `return`."
-msgstr "你可以通过更改块的最后一行，来展示块值的变化情况。例如，添加/移除分号或使用 `return`。"
+msgstr ""
+"你可以通过更改块的最后一行，来展示块值的变化情况。例如，添加/移除分号或使用 "
+"`return`。"
 
 #: src/control-flow/if-expressions.md:1
 msgid "`if` expressions"
@@ -3958,19 +3917,19 @@ msgstr "`if` 表达式"
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if` "
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions) "
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
-"[`if` "
-"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions) "
-"的用法与其他语言中的 `if` 语句完全一样。"
+"[`if` 表达式](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-expressions) 的用法与其他语言中的 `if` 语句完全一样。"
 
 #: src/control-flow/if-expressions.md:18
 msgid ""
 "In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
-msgstr "此外，你还可以将 `if` 用作一个表达式。每个块的最后一个表达式 将成为 `if` 表达式的值："
+msgstr ""
+"此外，你还可以将 `if` 用作一个表达式。每个块的最后一个表达式 将成为 `if` 表达"
+"式的值："
 
 #: src/control-flow/if-expressions.md:35
 msgid ""
@@ -3978,8 +3937,8 @@ msgid ""
 "branch blocks must have the same type. Consider showing what happens if you "
 "add `;` after `x / 2` in the second example."
 msgstr ""
-"由于 `if` 是一个表达式且必须有一个特定的类型，因此它的两个分支块必须有相同的类型。考虑在第二个示例中将 `;` 添加到 `x / 2` "
-"的后面，看看会出现什么情况。"
+"由于 `if` 是一个表达式且必须有一个特定的类型，因此它的两个分支块必须有相同的"
+"类型。考虑在第二个示例中将 `;` 添加到 `x / 2` 的后面，看看会出现什么情况。"
 
 #: src/control-flow/for-expressions.md:1
 msgid "`for` loops"
@@ -3993,7 +3952,8 @@ msgid ""
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
 "[`for` 循环](https://doc.rust-lang.org/std/keyword.for.html) 与 [`when let` "
-"循环](when-let-expression.md)密切相关。它会 自动对表达式调用 `into_iter()`，然后对其进行迭代："
+"循环](when-let-expression.md)密切相关。它会 自动对表达式调用 `into_iter()`，"
+"然后对其进行迭代："
 
 #: src/control-flow/for-expressions.md:22
 msgid "You can use `break` and `continue` here as usual."
@@ -4017,7 +3977,9 @@ msgstr "`step_by` 是返回另一个 `Iterator` 的方法，用于逐一跳过�
 msgid ""
 "Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
-msgstr "修改矢量中的元素并说明编译器错误。将矢量 `v` 改为可变，并将 for 循环改为 `for x in v.iter_mut()`。"
+msgstr ""
+"修改矢量中的元素并说明编译器错误。将矢量 `v` 改为可变，并将 for 循环改为 "
+"`for x in v.iter_mut()`。"
 
 #: src/control-flow/while-expressions.md:1
 msgid "`while` loops"
@@ -4025,13 +3987,11 @@ msgstr "`while` 循环"
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
-"The [`while` "
-"keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops) "
-"works very similar to other languages:"
+"The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
-"[`while` "
-"关键字](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops) "
-"的工作方式与其他语言非常相似："
+"[`while` 关键字](https://doc.rust-lang.org/reference/expressions/loop-expr."
+"html#predicate-loops) 的工作方式与其他语言非常相似："
 
 #: src/control-flow/break-continue.md:1
 msgid "`break` and `continue`"
@@ -4039,19 +3999,19 @@ msgstr "`break` 和 `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"If you want to exit a loop early, use "
-"[`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions),"
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
 msgstr ""
-"如果你想提前退出循环，请使用 "
-"[`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions)，"
+"如果你想提前退出循环，请使用 [`break`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#break-expressions)，"
 
 #: src/control-flow/break-continue.md:4
 msgid ""
-"If you want to immediately start the next iteration use "
-"[`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
 msgstr ""
-"如果需要立即启动 下一次迭代，请使用 "
-"[`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)。"
+"如果需要立即启动 下一次迭代，请使用 [`continue`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#continue-expressions)。"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
@@ -4070,13 +4030,11 @@ msgstr "`loop` 表达式"
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
-"Finally, there is a [`loop` "
-"keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops) "
-"which creates an endless loop."
+"Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
-"最后是用于创建无限循环的 [`loop` "
-"关键字](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops) "
-"。"
+"最后是用于创建无限循环的 [`loop` 关键字](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#infinite-loops) 。"
 
 #: src/control-flow/loop-expressions.md:6
 msgid "Here you must either `break` or `return` to stop the loop:"
@@ -4091,7 +4049,9 @@ msgid ""
 "Note that `loop` is the only looping construct which returns a non-trivial "
 "value. This is because it's guaranteed to be entered at least once (unlike "
 "`while` and `for` loops)."
-msgstr "请注意，`loop` 是唯一返回有意义的值的循环结构。 这是因为它保证至少被输入一次（与 `while` 和 `for` 循环不同）。"
+msgstr ""
+"请注意，`loop` 是唯一返回有意义的值的循环结构。 这是因为它保证至少被输入一次"
+"（与 `while` 和 `for` 循环不同）。"
 
 #: src/basic-syntax/variables.md:3
 msgid ""
@@ -4103,7 +4063,8 @@ msgstr "Rust 通过静态类型实现了类型安全。变量绑定默认是不�
 msgid ""
 "Due to type inference the `i32` is optional. We will gradually show the "
 "types less and less as the course progresses."
-msgstr "由于类型推导，`i32` 可以省略。随着课程推进，我们会越来越少地看到类型声明。"
+msgstr ""
+"由于类型推导，`i32` 可以省略。随着课程推进，我们会越来越少地看到类型声明。"
 
 #: src/basic-syntax/type-inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
@@ -4123,7 +4084,9 @@ msgid ""
 "of a type. The compiler does the job for us and helps us write more concise "
 "code."
 msgstr ""
-"需要重点强调的是这样声明的变量并非像那种动态类型语言中可以持有任何数据的“任何类型”。这种声明所生成的机器码与明确类型声明完全相同。编译器进行类型推导能够让我们编写更简略的代码。"
+"需要重点强调的是这样声明的变量并非像那种动态类型语言中可以持有任何数据的“任何"
+"类型”。这种声明所生成的机器码与明确类型声明完全相同。编译器进行类型推导能够让"
+"我们编写更简略的代码。"
 
 #: src/basic-syntax/type-inference.md:33
 #, fuzzy
@@ -4131,21 +4094,22 @@ msgid ""
 "The following code tells the compiler to copy into a certain generic "
 "container without the code ever explicitly specifying the contained type, "
 "using `_` as a placeholder:"
-msgstr "下面的代码通过使用 `_` 占位符来告诉编译器无需明确指定其类型就可以将对应数据拷贝到该容器： "
+msgstr ""
+"下面的代码通过使用 `_` 占位符来告诉编译器无需明确指定其类型就可以将对应数据拷"
+"贝到该容器： "
 
 #: src/basic-syntax/type-inference.md:48
 #, fuzzy
 msgid ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
-"relies on "
-"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html), "
-"which "
-"[`HashSet`](https://doc.rust-lang.org/std/collections/struct.HashSet.html#impl-FromIterator%3CT%3E-for-HashSet%3CT,+S%3E) "
-"implements."
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) relies on [`FromIterator`](https://doc.rust-lang.org/"
+"std/iter/trait.FromIterator.html), which [`HashSet`](https://doc.rust-lang."
+"org/std/collections/struct.HashSet.html#impl-FromIterator%3CT%3E-for-"
+"HashSet%3CT,+S%3E) implements."
 msgstr ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
-"依赖 [`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"实现的 `FromIterator`。"
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) 依赖 [`HashSet`](https://doc.rust-lang.org/std/iter/"
+"trait.FromIterator.html) 实现的 `FromIterator`。"
 
 #: src/basic-syntax/static-and-const.md:1
 msgid "Static and Constant Variables"
@@ -4153,9 +4117,9 @@ msgstr "静态 (Static) 变量和常数 (Constant) 变量"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid ""
-"Static and constant variables are two different ways to create "
-"globally-scoped values that cannot be moved or reallocated during the "
-"execution of the program. "
+"Static and constant variables are two different ways to create globally-"
+"scoped values that cannot be moved or reallocated during the execution of "
+"the program. "
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:6
@@ -4170,13 +4134,11 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:30
 msgid ""
-"According to the [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) these are "
-"inlined upon use."
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
 msgstr ""
-"根据 [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
-"这些变量在使用时是内联 (inlined) 的。"
+"根据 [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html) 这些变量在使用时是内联 (inlined) 的。"
 
 #: src/basic-syntax/static-and-const.md:32
 msgid ""
@@ -4215,26 +4177,25 @@ msgstr ""
 #: src/basic-syntax/static-and-const.md:46
 #, fuzzy
 msgid ""
-"As noted in the [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html), these are "
-"not inlined upon use and have an actual associated memory location.  This is "
-"useful for unsafe and  embedded code, and the variable lives through the "
-"entirety of the program execution. When a globally-scoped value does not "
-"have a reason to need object identity, `const` is generally preferred."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and  embedded code, "
+"and the variable lives through the entirety of the program execution. When a "
+"globally-scoped value does not have a reason to need object identity, "
+"`const` is generally preferred."
 msgstr ""
-"正如 [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
-"中所述，这些变量在使用时并不是内联的，而且还具有实际相关联的内存位置。这对于不安全的嵌入式代码是有用的，并且这些变量存在于整个程序的执行过程之中。"
+"正如 [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html) 中所述，这些变量在使用时并不是内联的，而且还具有实际相关联的内存位置。"
+"这对于不安全的嵌入式代码是有用的，并且这些变量存在于整个程序的执行过程之中。"
 
 #: src/basic-syntax/static-and-const.md:50
 msgid ""
 "Because `static` variables are accessible from any thread, they must be "
-"`Sync`. Interior mutability is possible through a "
-"[`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html), atomic or "
-"similar. It is also possible to have mutable statics, but they require "
-"manual synchronisation so any access to them requires `unsafe` code. We will "
-"look at [mutable statics](../unsafe/mutable-static-variables.md) in the "
-"chapter on Unsafe Rust."
+"`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html), atomic or similar. It is also possible "
+"to have mutable statics, but they require manual synchronisation so any "
+"access to them requires `unsafe` code. We will look at [mutable statics](../"
+"unsafe/mutable-static-variables.md) in the chapter on Unsafe Rust."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:58
@@ -4257,7 +4218,9 @@ msgstr ""
 msgid ""
 "It isn't super common that one would need a runtime evaluated constant, but "
 "it is helpful and safer than using a static."
-msgstr "虽然需要使用在运行中求值的常量的情况并不是很常见，但是它是有帮助的，而且比使用静态变量更安全。"
+msgstr ""
+"虽然需要使用在运行中求值的常量的情况并不是很常见，但是它是有帮助的，而且比使"
+"用静态变量更安全。"
 
 #: src/basic-syntax/static-and-const.md:62
 msgid "`thread_local` data can be created with the macro `std::thread_local`."
@@ -4375,8 +4338,9 @@ msgid ""
 "both variable's memory locations exist at the same time. Both are available "
 "under the same name, depending where you use it in the code. "
 msgstr ""
-"定义: 隐藏和变更 (mutation) "
-"不同，因为在隐藏之后，两个变量都会同时存在于内存的不同位置中。在同一个名字下的两个变量都是可以被使用的，但是你在代码的哪里使用会最终决定你使用哪一个变量。"
+"定义: 隐藏和变更 (mutation) 不同，因为在隐藏之后，两个变量都会同时存在于内存"
+"的不同位置中。在同一个名字下的两个变量都是可以被使用的，但是你在代码的哪里使"
+"用会最终决定你使用哪一个变量。"
 
 #: src/basic-syntax/scopes-shadowing.md:26
 msgid "A shadowing variable can have a different type. "
@@ -4393,7 +4357,9 @@ msgid ""
 "The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
-msgstr "以下代码说明了为什么在作用域内隐藏一个不可变的变量时，即使是在变量类型没有改变的情况下，编译器也不能简单地重复利用之前的内存位置。"
+msgstr ""
+"以下代码说明了为什么在作用域内隐藏一个不可变的变量时，即使是在变量类型没有改"
+"变的情况下，编译器也不能简单地重复利用之前的内存位置。"
 
 #: src/enums.md:3
 msgid ""
@@ -4439,7 +4405,9 @@ msgstr "枚举允许你从一种类型下收集一组值"
 msgid ""
 "This page offers an enum type `CoinFlip` with two variants `Heads` and "
 "`Tails`. You might note the namespace when using variants."
-msgstr "本页提供了一个枚举类型 `CoinFlip`，其中包含 `Heads` 和`Tail`两个变体。在使用变体时，你可能会注意到命名空间。"
+msgstr ""
+"本页提供了一个枚举类型 `CoinFlip`，其中包含 `Heads` 和`Tail`两个变体。在使用"
+"变体时，你可能会注意到命名空间。"
 
 #: src/enums.md:38
 msgid "This might be a good time to compare Structs and Enums:"
@@ -4449,7 +4417,9 @@ msgstr "这可能是比较结构体和枚举的好时机："
 msgid ""
 "In both, you can have a simple version without fields (unit struct) or one "
 "with different types of fields (variant payloads). "
-msgstr "在这两者中，你可以获得一个不含字段的简单版本（单位结构体），或一个包含不同类型字段的版本（变体载荷）。"
+msgstr ""
+"在这两者中，你可以获得一个不含字段的简单版本（单位结构体），或一个包含不同类"
+"型字段的版本（变体载荷）。"
 
 #: src/enums.md:40
 msgid "In both, associated functions are defined within an `impl` block."
@@ -4460,13 +4430,17 @@ msgid ""
 "You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
-msgstr "你甚至可以使用单独的结构体实现枚举的不同变体，但这样一来，如果它们都已在枚举中定义，类型与之前也不一样。"
+msgstr ""
+"你甚至可以使用单独的结构体实现枚举的不同变体，但这样一来，如果它们都已在枚举"
+"中定义，类型与之前也不一样。"
 
 #: src/enums/variant-payloads.md:3
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
 "the `match` statement to extract the data from each variant:"
-msgstr "你可以定义更丰富的枚举，其中变体会携带数据。然后，你可以使用 `match` 语句从每个变体中提取数据："
+msgstr ""
+"你可以定义更丰富的枚举，其中变体会携带数据。然后，你可以使用 `match` 语句从每"
+"个变体中提取数据："
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -4529,7 +4503,9 @@ msgid ""
 "The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
 "after the `=>`."
-msgstr "枚举变体中的值只有在被模式匹配后，才可访问。模式将引用绑定到 `=>` 之后的“match 分支”中的字段。"
+msgstr ""
+"枚举变体中的值只有在被模式匹配后，才可访问。模式将引用绑定到 `=>` 之后"
+"的“match 分支”中的字段。"
 
 #: src/enums/variant-payloads.md:36
 msgid ""
@@ -4547,13 +4523,17 @@ msgstr "匹配表达式拥有一个值。值是 match 分支中被执行的最�
 msgid ""
 "Starting from the top we look for what pattern matches the value then run "
 "the code following the arrow. Once we find a match, we stop. "
-msgstr "从顶部开始，查找与该值匹配的模式，然后沿箭头运行代码。一旦找到匹配，我们便会停止。"
+msgstr ""
+"从顶部开始，查找与该值匹配的模式，然后沿箭头运行代码。一旦找到匹配，我们便会"
+"停止。"
 
 #: src/enums/variant-payloads.md:39
 msgid ""
 "Demonstrate what happens when the search is inexhaustive. Note the advantage "
 "the Rust compiler provides by confirming when all cases are handled. "
-msgstr "展示搜索不详尽时会发生的情况。请注意 Rust 编译器的优势，即确认所有情况何时都得到了处理。"
+msgstr ""
+"展示搜索不详尽时会发生的情况。请注意 Rust 编译器的优势，即确认所有情况何时都"
+"得到了处理。"
 
 #: src/enums/variant-payloads.md:40
 msgid "`match` inspects a hidden discriminant field in the `enum`."
@@ -4561,8 +4541,8 @@ msgstr "`match` 会检查 `enum` 中的隐藏的判别字段。"
 
 #: src/enums/variant-payloads.md:41
 msgid ""
-"It is possible to retrieve the discriminant by calling "
-"`std::mem::discriminant()`"
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
 msgstr "可以通过调用 `std::mem::discriminant()` 来检索判别"
 
 #: src/enums/variant-payloads.md:42
@@ -4573,12 +4553,12 @@ msgstr "这很有用，例如如果为结构体实现 `PartialEq`，比较字段
 
 #: src/enums/variant-payloads.md:43
 msgid ""
-"`WebEvent::Click { ... }` is not exactly the same as "
-"`WebEvent::Click(Click)` with a top level `struct Click { ... }`. The "
-"inlined version cannot implement traits, for example."
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
 msgstr ""
-"`WebEvent::Click { ... }` 与含顶层 `struct Click { ... }` 的 "
-"`WebEvent::Click(Click)` 不完全相同。例如，内嵌版本无法实现 trait。"
+"`WebEvent::Click { ... }` 与含顶层 `struct Click { ... }` 的 `WebEvent::"
+"Click(Click)` 不完全相同。例如，内嵌版本无法实现 trait。"
 
 #: src/enums/sizes.md:3
 msgid ""
@@ -4630,9 +4610,10 @@ msgstr ""
 
 #: src/enums/sizes.md:24
 msgid ""
-"See the [Rust "
-"Reference](https://doc.rust-lang.org/reference/type-layout.html)."
-msgstr "请参阅 [Rust 引用](https://doc.rust-lang.org/reference/type-layout.html)。"
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"html)."
+msgstr ""
+"请参阅 [Rust 引用](https://doc.rust-lang.org/reference/type-layout.html)。"
 
 #: src/enums/sizes.md:30
 #, fuzzy
@@ -4652,7 +4633,9 @@ msgstr "你可以根据需要控制判别（例如，与 C 的兼容性）："
 msgid ""
 "Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
 "bytes."
-msgstr "如果不使用 `repr`，判别类型会占用 2 个字节，因为 10001 是一个 2 个字节的数值。"
+msgstr ""
+"如果不使用 `repr`，判别类型会占用 2 个字节，因为 10001 是一个 2 个字节的数"
+"值。"
 
 #: src/enums/sizes.md:54
 #, fuzzy
@@ -4669,19 +4652,24 @@ msgstr "`dbg_size!(bool)`：大小占用 1 个字节，对齐占用 1 个字节�
 msgid ""
 "`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
 "see below),"
-msgstr "`dbg_size!(Option<bool>)`：大小占用 1 个字节，对齐占用 1 个字节（小众优化，请参阅下文）；"
+msgstr ""
+"`dbg_size!(Option<bool>)`：大小占用 1 个字节，对齐占用 1 个字节（小众优化，请"
+"参阅下文）；"
 
 #: src/enums/sizes.md:58
 #, fuzzy
 msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
-msgstr "`dbg_size!(&i32)`：大小占用 8 个字节，对齐占用 8 个字节（在 64 位设备上）；"
+msgstr ""
+"`dbg_size!(&i32)`：大小占用 8 个字节，对齐占用 8 个字节（在 64 位设备上）；"
 
 #: src/enums/sizes.md:59
 #, fuzzy
 msgid ""
 "`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
 "optimization, see below)."
-msgstr "`dbg_size!(Option<&i32>)`：大小占用 8 个字节，对齐占用 8 个字节（Null 指针优化，请参阅下文）。"
+msgstr ""
+"`dbg_size!(Option<&i32>)`：大小占用 8 个字节，对齐占用 8 个字节（Null 指针优"
+"化，请参阅下文）。"
 
 #: src/enums/sizes.md:61
 #, fuzzy
@@ -4693,13 +4681,13 @@ msgstr "小众优化：Rust 将对枚举判别合并使用 未使用的位模式
 #: src/enums/sizes.md:64
 #, fuzzy
 msgid ""
-"Null pointer optimization: For [some "
-"types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`."
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
 msgstr ""
-"Null 指针优化：对于[某些 "
-"类型](https://doc.rust-lang.org/std/option/#representation)，Rust 保证 "
-"`size_of::<T>()` 等效于 `size_of::<Option<T>>()`。"
+"Null 指针优化：对于[某些 类型](https://doc.rust-lang.org/std/option/"
+"#representation)，Rust 保证 `size_of::<T>()` 等效于 `size_of::"
+"<Option<T>>()`。"
 
 #: src/enums/sizes.md:68
 #, fuzzy
@@ -4707,7 +4695,9 @@ msgid ""
 "Example code if you want to show how the bitwise representation _may_ look "
 "like in practice. It's important to note that the compiler provides no "
 "guarantees regarding this representation, therefore this is totally unsafe."
-msgstr "如果你想展示位表示方式在实践中“可能”会是什么样子，请参考示例代码。 请务必注意，编译器对此表示法不提供任何保证，因此这是完全不安全的。"
+msgstr ""
+"如果你想展示位表示方式在实践中“可能”会是什么样子，请参考示例代码。 请务必注"
+"意，编译器对此表示法不提供任何保证，因此这是完全不安全的。"
 
 #: src/enums/sizes.md:105
 msgid ""
@@ -4721,8 +4711,7 @@ msgid ""
 "They are used for pattern matching:"
 msgstr ""
 
-#: src/control-flow/novel.md:6
-#: src/control-flow/if-let-expressions.md:1
+#: src/control-flow/novel.md:6 src/control-flow/if-let-expressions.md:1
 msgid "`if let` expressions"
 msgstr "`if let` 表达式"
 
@@ -4731,21 +4720,18 @@ msgstr "`if let` 表达式"
 msgid "`while let` expressions"
 msgstr "while let 表达式"
 
-#: src/control-flow/novel.md:8
-#: src/control-flow/match-expressions.md:1
+#: src/control-flow/novel.md:8 src/control-flow/match-expressions.md:1
 msgid "`match` expressions"
 msgstr "`match` 表达式"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let` "
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions) "
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
-"[`if let` "
-"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions) "
-"能让你根据某个值是否与模式相匹配来执行不同的代码："
+"[`if let` 表达式](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-let-expressions) 能让你根据某个值是否与模式相匹配来执行不同的代码："
 
 #: src/control-flow/if-let-expressions.md:7
 msgid ""
@@ -4777,7 +4763,8 @@ msgstr ""
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
 "in Rust."
-msgstr "如需详细了解 Rust 中 的模式，请参阅[模式匹配](../pattern-matching.md)。"
+msgstr ""
+"如需详细了解 Rust 中 的模式，请参阅[模式匹配](../pattern-matching.md)。"
 
 #: src/control-flow/if-let-expressions.md:23
 #, fuzzy
@@ -4798,15 +4785,14 @@ msgstr "与 `match` 不同的是，`if let` 不支持模式匹配的 guard 子�
 #: src/control-flow/if-let-expressions.md:26
 #, fuzzy
 msgid ""
-"Since 1.65, a similar "
-"[let-else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) "
-"construct allows to do a destructuring assignment, or if it fails, execute a "
-"block which is required to abort normal control flow (with "
-"`panic`/`return`/`break`/`continue`):"
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"flow_control/let_else.html) construct allows to do a destructuring "
+"assignment, or if it fails, execute a block which is required to abort "
+"normal control flow (with `panic`/`return`/`break`/`continue`):"
 msgstr ""
-"自 1.65 版以来，类似的 "
-"[let-else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) "
-"结构允许执行解构赋值，或者如果不满足条件，则有一个非返回块分支 (panic/return/break/continue)："
+"自 1.65 版以来，类似的 [let-else](https://doc.rust-lang.org/rust-by-example/"
+"flow_control/let_else.html) 结构允许执行解构赋值，或者如果不满足条件，则有一"
+"个非返回块分支 (panic/return/break/continue)："
 
 #: src/control-flow/while-let-expressions.md:1
 msgid "`while let` loops"
@@ -4814,13 +4800,13 @@ msgstr "`while let` 循环"
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
-"Like with `if let`, there is a [`while "
-"let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops) "
-"variant which repeatedly tests a value against a pattern:"
+"Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
-"与 `if let` 一样，[`with "
-"let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops) "
-"变体会针对一个模式重复测试一个值："
+"与 `if let` 一样，[`with let`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#predicate-pattern-loops) 变体会针对一个模式重复测"
+"试一个值："
 
 #: src/control-flow/while-let-expressions.md:18
 #, fuzzy
@@ -4830,8 +4816,9 @@ msgid ""
 "it will return `None`. The `while let` lets us keep iterating through all "
 "items."
 msgstr ""
-"在这里，每次 调用 `next()` 时，`v.iter()` 返回的迭代器都会返回一个 `Option<i32>`。它将一直返回 "
-"`Some(x)`，直到完成。 之后它将返回 `None`。`while let`能让我们持续迭代所有项。"
+"在这里，每次 调用 `next()` 时，`v.iter()` 返回的迭代器都会返回一个 "
+"`Option<i32>`。它将一直返回 `Some(x)`，直到完成。 之后它将返回 `None`。"
+"`while let`能让我们持续迭代所有项。"
 
 #: src/control-flow/while-let-expressions.md:27
 msgid ""
@@ -4845,19 +4832,18 @@ msgid ""
 "statement that breaks when there is no value to unwrap for `iter.next()`. "
 "The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
-"你可以使用 if 语句将 `while let` 循环重写为无限循环，当 `iter.next()` 没有值可以解封时中断。`while let` "
-"为上述情况提供了语法糖。"
+"你可以使用 if 语句将 `while let` 循环重写为无限循环，当 `iter.next()` 没有值"
+"可以解封时中断。`while let` 为上述情况提供了语法糖。"
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
-"The [`match` "
-"keyword](https://doc.rust-lang.org/reference/expressions/match-expr.html) is "
-"used to match a value against one or more patterns. In that sense, it works "
-"like a series of `if let` expressions:"
+"The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
-"[`match` "
-"关键字](https://doc.rust-lang.org/reference/expressions/match-expr.html) "
-"用于将一个值与一个或多个模式进行匹配。从这个意义上讲，它的工作方式 类似于一系列的 `if let` 表达式："
+"[`match` 关键字](https://doc.rust-lang.org/reference/expressions/match-expr."
+"html) 用于将一个值与一个或多个模式进行匹配。从这个意义上讲，它的工作方式 类似"
+"于一系列的 `if let` 表达式："
 
 #: src/control-flow/match-expressions.md:7
 msgid ""
@@ -4891,7 +4877,9 @@ msgstr ""
 msgid ""
 "Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
-msgstr "与 `if let` 类似，每个匹配分支必须有相同的类型。该类型是块的最后一个 表达式（如有）。在上例中，类型是 `()`。"
+msgstr ""
+"与 `if let` 类似，每个匹配分支必须有相同的类型。该类型是块的最后一个 表达式"
+"（如有）。在上例中，类型是 `()`。"
 
 #: src/control-flow/match-expressions.md:28
 msgid "Save the match expression to a variable and print it out."
@@ -4905,15 +4893,17 @@ msgstr "移除 `.as_deref()` 并说明错误。"
 msgid ""
 "`std::env::args().next()` returns an `Option<String>`, but we cannot match "
 "against `String`."
-msgstr "`std::env::args().next()` 会返回  `Option<String>`，但无法与 `String` 进行匹配。"
+msgstr ""
+"`std::env::args().next()` 会返回  `Option<String>`，但无法与 `String` 进行匹"
+"配。"
 
 #: src/control-flow/match-expressions.md:31
 msgid ""
 "`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
 "this turns `Option<String>` into `Option<&str>`."
 msgstr ""
-"`as_deref()` 会将 `Option<T>` 转换为 `Option<&T::Target>`。在我们的示例中，这会将 "
-"`Option<String>` 转换为 `Option<&str>`。"
+"`as_deref()` 会将 `Option<T>` 转换为 `Option<&T::Target>`。在我们的示例中，这"
+"会将 `Option<String>` 转换为 `Option<&str>`。"
 
 #: src/control-flow/match-expressions.md:32
 msgid ""
@@ -4924,7 +4914,9 @@ msgstr "现在，我们可以使用模式匹配来匹配 `Option` 中的 `&str`�
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
-msgstr "使用关键词 `match` 对一个值进行模式匹配。进行匹配时，会从上至下依次进行比较，并选定第一个匹配成功的结果。"
+msgstr ""
+"使用关键词 `match` 对一个值进行模式匹配。进行匹配时，会从上至下依次进行比较，"
+"并选定第一个匹配成功的结果。"
 
 #: src/pattern-matching.md:6
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
@@ -4956,13 +4948,15 @@ msgid ""
 "You might point out how some specific characters are being used when in a "
 "pattern"
 msgstr ""
-"你可以解释一些用于表达模式的特殊字符的用法 \\*`|` 表示或 (or) \\*`..` 可以展开为任意一个或多个值 \\*`1..=5` "
-"代表了一个闭区间范围"
+"你可以解释一些用于表达模式的特殊字符的用法 \\*`|` 表示或 (or) \\*`..` 可以展"
+"开为任意一个或多个值 \\*`1..=5` 代表了一个闭区间范围"
 
 #: src/pattern-matching.md:27
 #, fuzzy
 msgid "`|` as an `or`"
-msgstr "解释模式匹配中的绑定的原理可能会很有帮助。比如可以用一个变量替代外卡，或者去除 `q` 外面的引号。"
+msgstr ""
+"解释模式匹配中的绑定的原理可能会很有帮助。比如可以用一个变量替代外卡，或者去"
+"除 `q` 外面的引号。"
 
 #: src/pattern-matching.md:28
 #, fuzzy
@@ -4972,7 +4966,9 @@ msgstr "你可以展示如何匹配一个引用。"
 #: src/pattern-matching.md:29
 #, fuzzy
 msgid "`1..=5` represents an inclusive range"
-msgstr "现在是一个讲解不可反驳 (irrefutable) 模式的好时机。因为这个术语可能会出现在错误信息中。"
+msgstr ""
+"现在是一个讲解不可反驳 (irrefutable) 模式的好时机。因为这个术语可能会出现在错"
+"误信息中。"
 
 #: src/pattern-matching.md:30
 msgid "`_` is a wild card"
@@ -5234,14 +5230,13 @@ msgstr "Luhn 算法"
 msgid "An exercise on pattern matching."
 msgstr "枚举和模式匹配。"
 
-#: src/exercises/day-1/afternoon.md:11
-#: src/exercises/day-2/afternoon.md:7
+#: src/exercises/day-1/afternoon.md:11 src/exercises/day-2/afternoon.md:7
 #: src/exercises/bare-metal/afternoon.md:7
 #: src/exercises/concurrency/afternoon.md:13
 #, fuzzy
 msgid ""
-"After looking at the exercises, you can look at the "
-"[solutions](solutions-afternoon.md) provided."
+"After looking at the exercises, you can look at the [solutions](solutions-"
+"afternoon.md) provided."
 msgstr "读完习题后，可以阅读本书提供的 \\[题解\\]。"
 
 #: src/exercises/day-1/luhn.md:3
@@ -5490,8 +5485,11 @@ msgid ""
 msgstr "内存管理：栈与堆，手动内存管理，基于作用域的内存管理，以及垃圾回收。"
 
 #: src/welcome-day-2.md:8
-msgid "Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
-msgstr "所有权：移动（move）的语义，复制（copy）和克隆（clone），借用（borrow），以及生命周期。"
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"所有权：移动（move）的语义，复制（copy）和克隆（clone），借用（borrow），以及"
+"生命周期。"
 
 #: src/welcome-day-2.md:10
 #, fuzzy
@@ -5503,8 +5501,8 @@ msgid ""
 "The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
 "`Rc` and `Arc`."
 msgstr ""
-"标准库: `字符串（String）`, `选项（Option）` 和 `结果（Result）`, `动态数组（Vec）`, "
-"`散列表（HashMap）`, `引用计数（Rc）` 和 `共享引用计数（Arc）`。"
+"标准库: `字符串（String）`, `选项（Option）` 和 `结果（Result）`, `动态数组"
+"（Vec）`, `散列表（HashMap）`, `引用计数（Rc）` 和 `共享引用计数（Arc）`。"
 
 #: src/welcome-day-2.md:15
 msgid "Modules: visibility, paths, and filesystem hierarchy."
@@ -5592,7 +5590,8 @@ msgstr "栈 vs 堆"
 msgid ""
 "Creating a `String` puts fixed-sized metadata on the stack and dynamically "
 "sized data, the actual string, on the heap:"
-msgstr "创建 `String` 时将固定大小的数据存储在栈上， 并将动态大小的数据存储在堆上："
+msgstr ""
+"创建 `String` 时将固定大小的数据存储在栈上， 并将动态大小的数据存储在堆上："
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -5612,24 +5611,27 @@ msgstr ""
 msgid ""
 "Mention that a `String` is backed by a `Vec`, so it has a capacity and "
 "length and can grow if mutable via reallocation on the heap."
-msgstr "指出 `String` 底层由 `Vec` 实现，因此它具有容量和长度，如果值可变，则可以通过在堆上重新分配存储空间进行增长。"
+msgstr ""
+"指出 `String` 底层由 `Vec` 实现，因此它具有容量和长度，如果值可变，则可以通过"
+"在堆上重新分配存储空间进行增长。"
 
 #: src/memory-management/stack.md:30
 msgid ""
 "If students ask about it, you can mention that the underlying memory is heap "
-"allocated using the [System "
-"Allocator](https://doc.rust-lang.org/std/alloc/struct.System.html) and "
-"custom allocators can be implemented using the [Allocator "
-"API](https://doc.rust-lang.org/std/alloc/index.html)"
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
-"如果学员提出相关问题，你可以提及我们不仅能使用\\[系统分配器\\]在堆上分配底层内存，还能使用 [Allocator "
-"API](https://doc.rust-lang.org/std/alloc/index.html) 实现自定义分配器"
+"如果学员提出相关问题，你可以提及我们不仅能使用\\[系统分配器\\]在堆上分配底层"
+"内存，还能使用 [Allocator API](https://doc.rust-lang.org/std/alloc/index."
+"html) 实现自定义分配器"
 
 #: src/memory-management/stack.md:32
 msgid ""
 "We can inspect the memory layout with `unsafe` code. However, you should "
 "point out that this is rightfully unsafe!"
-msgstr "我们可以使用 `unsafe` 代码检查内存布局。不过，你应该指出，这种做法不安全！"
+msgstr ""
+"我们可以使用 `unsafe` 代码检查内存布局。不过，你应该指出，这种做法不安全！"
 
 #: src/memory-management/stack.md:34
 #, fuzzy
@@ -5644,8 +5646,8 @@ msgid ""
 "to\n"
 "    // undefined behavior.\n"
 "    unsafe {\n"
-"        let (ptr, capacity, len): (usize, usize, usize) = "
-"std::mem::transmute(s1);\n"
+"        let (ptr, capacity, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
@@ -5661,8 +5663,8 @@ msgstr ""
 "to\n"
 "    // undefined behavior.\n"
 "    unsafe {\n"
-"        let (capacity, ptr, len): (usize, usize, usize) = "
-"std::mem::transmute(s1);\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
@@ -5716,10 +5718,13 @@ msgid ""
 "the pointer is lost and we cannot deallocate the memory. Worse, freeing the "
 "pointer twice, or accessing a freed pointer can lead to exploitable security "
 "vulnerabilities."
-msgstr "如果函数在 `malloc` 和 `free` 之间提前返回，则会导致内存泄漏： 指针丢失，而我们无法释放对应的内存。"
+msgstr ""
+"如果函数在 `malloc` 和 `free` 之间提前返回，则会导致内存泄漏： 指针丢失，而我"
+"们无法释放对应的内存。"
 
 #: src/memory-management/scope-based.md:3
-msgid "Constructors and destructors let you hook into the lifetime of an object."
+msgid ""
+"Constructors and destructors let you hook into the lifetime of an object."
 msgstr "构造函数和析构函数让你可以钩入对象的生命周期。"
 
 #: src/memory-management/scope-based.md:5
@@ -5727,14 +5732,17 @@ msgid ""
 "By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
 "is raised."
-msgstr "通过将指针封装在对象中，你可以在该对象 被销毁时释放内存。编译器可保证这一点的实现，即使引发了异常也不例外。"
+msgstr ""
+"通过将指针封装在对象中，你可以在该对象 被销毁时释放内存。编译器可保证这一点的"
+"实现，即使引发了异常也不例外。"
 
 #: src/memory-management/scope-based.md:9
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
 "gives you smart pointers."
 msgstr ""
-"这通常称为“资源获取即初始化 (resource acquisition is initialization, RAII)”， 并为你提供智能指针。"
+"这通常称为“资源获取即初始化 (resource acquisition is initialization, "
+"RAII)”， 并为你提供智能指针。"
 
 #: src/memory-management/scope-based.md:12
 msgid "C++ Example"
@@ -5769,7 +5777,8 @@ msgid "The destructor frees the `Person` object it points to."
 msgstr "析构函数释放它所指向的 `Person` 对象。"
 
 #: src/memory-management/scope-based.md:25
-msgid "Special move constructors are used when passing ownership to a function:"
+msgid ""
+"Special move constructors are used when passing ownership to a function:"
 msgstr "将所有权传递给函数时，使用特殊的 move 构造函数："
 
 #: src/memory-management/garbage-collection.md:1
@@ -5834,7 +5843,8 @@ msgstr "像 C++ 一样基于作用域，但编译器会强制完全遵循规则�
 msgid ""
 "A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
-msgstr "Rust 用户可以根据具体情况选择合适的抽象，有些甚至没有像 C 那样的运行时开销。"
+msgstr ""
+"Rust 用户可以根据具体情况选择合适的抽象，有些甚至没有像 C 那样的运行时开销。"
 
 #: src/memory-management/rust.md:9
 #, fuzzy
@@ -5844,28 +5854,27 @@ msgstr "它通过对“所有权”进行显式建模来实现这一点。"
 #: src/memory-management/rust.md:13
 msgid ""
 "If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as "
-"[Box](https://doc.rust-lang.org/std/boxed/struct.Box.html), "
-"[Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html), "
-"[Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or "
-"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
 "ownership and memory allocation via various means, and prevent the potential "
 "errors in C."
 msgstr ""
-"如果此时被问及如何操作，你可以提及在 Rust 中，这通常由 RAII 封装容器类型（例如 "
-"[Box](https://doc.rust-lang.org/std/boxed/struct.Box.html)、[Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html)、[Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html) "
-"或 "
-"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html)）处理。这些类型通过各种方式封装了所有权和内存分配，并防止了 "
-"C 中潜在错误的发生。"
+"如果此时被问及如何操作，你可以提及在 Rust 中，这通常由 RAII 封装容器类型（例"
+"如 [Box](https://doc.rust-lang.org/std/boxed/struct.Box.html)、[Vec](https://"
+"doc.rust-lang.org/std/vec/struct.Vec.html)、[Rc](https://doc.rust-lang.org/"
+"std/rc/struct.Rc.html) 或 [Arc](https://doc.rust-lang.org/std/sync/struct."
+"Arc.html)）处理。这些类型通过各种方式封装了所有权和内存分配，并防止了 C 中潜"
+"在错误的发生。"
 
 #: src/memory-management/rust.md:15
 msgid ""
-"You may be asked about destructors here, the "
-"[Drop](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait is the Rust "
-"equivalent."
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
 msgstr ""
-"你可能会被问及析构函数，此处 [Drop](https://doc.rust-lang.org/std/ops/trait.Drop.html) "
-"trait 是 Rust 等效项。"
+"你可能会被问及析构函数，此处 [Drop](https://doc.rust-lang.org/std/ops/trait."
+"Drop.html) trait 是 Rust 等效项。"
 
 #: src/ownership.md:3
 msgid ""
@@ -5874,7 +5883,8 @@ msgid ""
 msgstr "所有变量绑定都有一个有效的“作用域”，使用 超出其作用域的变量是错误的："
 
 #: src/ownership.md:19
-msgid "At the end of the scope, the variable is _dropped_ and the data is freed."
+msgid ""
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr "作用域结束时，变量会“被丢弃”，数据会被释放。"
 
 #: src/ownership.md:20
@@ -5931,7 +5941,9 @@ msgstr "变量绑定在任一时刻有且“只有”一个值。"
 msgid ""
 "Mention that this is the opposite of the defaults in C++, which copies by "
 "value unless you use `std::move` (and the move constructor is defined!)."
-msgstr "指出这与 C++ 中的默认值相反。除非你使用 `std::move`（并已定义 move 构造函数！），否则 C++ 中的默认值是按值复制的。"
+msgstr ""
+"指出这与 C++ 中的默认值相反。除非你使用 `std::move`（并已定义 move 构造函"
+"数！），否则 C++ 中的默认值是按值复制的。"
 
 #: src/ownership/move-semantics.md:23
 msgid ""
@@ -5941,7 +5953,8 @@ msgid ""
 msgstr ""
 
 #: src/ownership/move-semantics.md:25
-msgid "Simple values (such as integers) can be marked `Copy` (see later slides)."
+msgid ""
+"Simple values (such as integers) can be marked `Copy` (see later slides)."
 msgstr ""
 
 #: src/ownership/move-semantics.md:27
@@ -6104,7 +6117,9 @@ msgstr ""
 msgid ""
 "With the first call to `say_hello`, `main` gives up ownership of `name`. "
 "Afterwards, `name` cannot be used anymore within `main`."
-msgstr "首次调用 `say_hello` 时，`main` 便放弃了 `name` 的所有权。此后，`main` 中不能再使用 `name`。"
+msgstr ""
+"首次调用 `say_hello` 时，`main` 便放弃了 `name` 的所有权。此后，`main` 中不能"
+"再使用 `name`。"
 
 #: src/ownership/moves-function-calls.md:21
 msgid ""
@@ -6116,19 +6131,23 @@ msgstr "在 `say_hello` 函数结束时，系统会释放为 `name` 分配的堆
 msgid ""
 "`main` can retain ownership if it passes `name` as a reference (`&name`) and "
 "if `say_hello` accepts a reference as a parameter."
-msgstr "如果 `main` 将 `name` 作为引用 (`&name`) 传递过去，且 `say_hello` 接受作为参数的引用，则可保留所有权。"
+msgstr ""
+"如果 `main` 将 `name` 作为引用 (`&name`) 传递过去，且 `say_hello` 接受作为参"
+"数的引用，则可保留所有权。"
 
 #: src/ownership/moves-function-calls.md:23
 msgid ""
-"Alternatively, `main` can pass a clone of `name` in the first call "
-"(`name.clone()`)."
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
 msgstr "此外，`main` 也可以在首次调用时传递 `name` 的克隆 (`name.clone()`)。"
 
 #: src/ownership/moves-function-calls.md:24
 msgid ""
 "Rust makes it harder than C++ to inadvertently create copies by making move "
 "semantics the default, and by forcing programmers to make clones explicit."
-msgstr "相较于 C++，Rust 通过将移动语义设为默认值，并强制程序员进行显式克隆，更难以无意中创建副本。"
+msgstr ""
+"相较于 C++，Rust 通过将移动语义设为默认值，并强制程序员进行显式克隆，更难以无"
+"意中创建副本。"
 
 #: src/ownership/copy-clone.md:3
 msgid ""
@@ -6176,8 +6195,7 @@ msgstr "克隆是一种更通用的操作，也允许通过实现 `Clone` trait 
 msgid "Copying does not work on types that implement the `Drop` trait."
 msgstr "复制不适用于实现 `Drop` trait 的类型。"
 
-#: src/ownership/copy-clone.md:44
-#: src/ownership/lifetimes-function-calls.md:30
+#: src/ownership/copy-clone.md:44 src/ownership/lifetimes-function-calls.md:30
 msgid "In the above example, try the following:"
 msgstr "在上述示例中，请尝试以下操作："
 
@@ -6185,13 +6203,16 @@ msgstr "在上述示例中，请尝试以下操作："
 msgid ""
 "Add a `String` field to `struct Point`. It will not compile because `String` "
 "is not a `Copy` type."
-msgstr "在 `struct Point` 中添加 `String` 字段。由于 `String` 不属于 `Copy` 类型，因此无法编译。"
+msgstr ""
+"在 `struct Point` 中添加 `String` 字段。由于 `String` 不属于 `Copy` 类型，因"
+"此无法编译。"
 
 #: src/ownership/copy-clone.md:47
 msgid ""
 "Remove `Copy` from the `derive` attribute. The compiler error is now in the "
 "`println!` for  `p1`."
-msgstr "从 `derive` 属性中移除 `Copy`。现在，编译器错误位于 `p1`的 `println!` 中。"
+msgstr ""
+"从 `derive` 属性中移除 `Copy`。现在，编译器错误位于 `p1`的 `println!` 中。"
 
 #: src/ownership/copy-clone.md:48
 msgid "Show that it works if you clone `p1` instead."
@@ -6203,8 +6224,8 @@ msgid ""
 "to generate code in Rust at compile time. In this case the default "
 "implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
-"如果学员问起 `derive`，只需说这是一种 在编译时生成 Rust 代码的方法。在这种情况下，系统会生成 `Copy` 和 `Clone` "
-"trait 的默认实现。"
+"如果学员问起 `derive`，只需说这是一种 在编译时生成 Rust 代码的方法。在这种情"
+"况下，系统会生成 `Copy` 和 `Clone` trait 的默认实现。"
 
 #: src/ownership/borrowing.md:3
 msgid ""
@@ -6234,9 +6255,9 @@ msgid ""
 "optimization level, the addresses should change, while they stay the same "
 "when changing to the \"RELEASE\" setting:"
 msgstr ""
-"证明从 `add` 返回的开销很低，因为编译器可以消除复制操作。更改上述代码以输出栈地址，并在 "
-"[Playground](https://play.rust-lang.org/) "
-"上运行它。在“调试”优化级别中，地址应发生变化，而在改成“发布”设置时保持不变："
+"证明从 `add` 返回的开销很低，因为编译器可以消除复制操作。更改上述代码以输出栈"
+"地址，并在 [Playground](https://play.rust-lang.org/) 上运行它。在“调试”优化级"
+"别中，地址应发生变化，而在改成“发布”设置时保持不变："
 
 #: src/ownership/borrowing.md:50
 msgid "The Rust compiler can do return value optimization (RVO)."
@@ -6250,8 +6271,9 @@ msgid ""
 "RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
 "copy."
 msgstr ""
-"在 C++ 中，必须在语言规范中定义复制省略，因为构造函数可能会有附带效应。在 Rust 中，这完全不是问题。如果 RVO 未发生，Rust "
-"将始终执行简单且高效的 `memcpy` 复制。"
+"在 C++ 中，必须在语言规范中定义复制省略，因为构造函数可能会有附带效应。在 "
+"Rust 中，这完全不是问题。如果 RVO 未发生，Rust 将始终执行简单且高效的 "
+"`memcpy` 复制。"
 
 #: src/ownership/shared-unique-borrows.md:3
 msgid "Rust puts constraints on the ways you can borrow values:"
@@ -6269,13 +6291,16 @@ msgstr "你可以有且只有一个 `&mut T` 值。"
 msgid ""
 "The above code does not compile because `a` is borrowed as mutable (through "
 "`c`) and as immutable (through `b`) at the same time."
-msgstr "上述代码无法编译，因为 `a` 同时作为可变值（通过 `c`）和不可变值（通过 `b`）被借用。"
+msgstr ""
+"上述代码无法编译，因为 `a` 同时作为可变值（通过 `c`）和不可变值（通过 `b`）被"
+"借用。"
 
 #: src/ownership/shared-unique-borrows.md:27
 msgid ""
 "Move the `println!` statement for `b` before the scope that introduces `c` "
 "to make the code compile."
-msgstr "将`b` 的 `println!` 语句移到引入 `c` 的作用域之前，这段代码就可以编译。"
+msgstr ""
+"将`b` 的 `println!` 语句移到引入 `c` 的作用域之前，这段代码就可以编译。"
 
 #: src/ownership/shared-unique-borrows.md:28
 msgid ""
@@ -6283,7 +6308,8 @@ msgid ""
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"这样更改后，编译器会发现 `b` 只在通过 `c` 对 `a` 进行新可变借用之前使用过。这是借用检查器的一个功能，名为“非词法作用域生命周期”。"
+"这样更改后，编译器会发现 `b` 只在通过 `c` 对 `a` 进行新可变借用之前使用过。这"
+"是借用检查器的一个功能，名为“非词法作用域生命周期”。"
 
 #: src/ownership/lifetimes.md:3
 msgid "A borrowed value has a _lifetime_:"
@@ -6297,8 +6323,7 @@ msgstr "生命周期可以是隐式的：add(p1: &Point, p2: &Point) -> Point\\`
 msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
 msgstr "生命周期也可以是显式的：`&'a Point`、`&'document str`。"
 
-#: src/ownership/lifetimes.md:7
-#: src/ownership/lifetimes-function-calls.md:24
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:24
 msgid ""
 "Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
 "lifetime `a`\"."
@@ -6323,8 +6348,9 @@ msgid ""
 "but Rust allows lifetimes to be elided in most cases with [a few simple "
 "rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
 msgstr ""
-"必须完全指定函数参数和返回值的生命周期， 但 Rust 允许在大多数情况下通过\\[一些简单的 "
-"规则\\](https://doc.rust-lang.org/nomicon/lifetime-elision.html）来省略此操作。"
+"必须完全指定函数参数和返回值的生命周期， 但 Rust 允许在大多数情况下通过\\[一"
+"些简单的 规则\\](https://doc.rust-lang.org/nomicon/lifetime-elision.html）来"
+"省略此操作。"
 
 #: src/ownership/lifetimes-function-calls.md:3
 msgid ""
@@ -6341,7 +6367,8 @@ msgid "Lifetimes start with `'` and `'a` is a typical default name."
 msgstr "以 `'` 和 `'a` 开头的生命周期是典型的默认名称。"
 
 #: src/ownership/lifetimes-function-calls.md:26
-msgid "The _at least_ part is important when parameters are in different scopes."
+msgid ""
+"The _at least_ part is important when parameters are in different scopes."
 msgstr "当参数在不同的作用域时，“至少”部分至关重要。"
 
 #: src/ownership/lifetimes-function-calls.md:32
@@ -6360,8 +6387,9 @@ msgid ""
 "'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
 "because the relationship between the lifetimes `'a` and `'b` is unclear."
 msgstr ""
-"重置工作区，然后将函数签名更改为 `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b "
-"Point`。这不会被编译，因为 `'a` 和 `'b` 生命周期之间的关系不明确。"
+"重置工作区，然后将函数签名更改为 `fn left_most<'a, 'b>(p1: &'a Point, p2: "
+"&'a Point) -> &'b Point`。这不会被编译，因为 `'a` 和 `'b` 生命周期之间的关系"
+"不明确。"
 
 #: src/ownership/lifetimes-function-calls.md:55
 msgid "Another way to explain it:"
@@ -6383,7 +6411,9 @@ msgid ""
 "Which one is it? The compiler needs to know, so at the call site the "
 "returned reference is not used for longer than a variable from where the "
 "reference came from."
-msgstr "是哪一个呢？编译器需要知道这一点，因此在调用点，返回的引用 的使用时间不会超过引用的来源中的变量。"
+msgstr ""
+"是哪一个呢？编译器需要知道这一点，因此在调用点，返回的引用 的使用时间不会超过"
+"引用的来源中的变量。"
 
 #: src/ownership/lifetimes-data-structures.md:3
 msgid ""
@@ -6401,8 +6431,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy "
-"dog.\");\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
 "    let fox = Highlight(&text[4..19]);\n"
 "    let dog = Highlight(&text[35..43]);\n"
 "    // erase(text);\n"
@@ -6420,8 +6450,8 @@ msgstr ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy "
-"dog.\");\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
 "    let fox = Highlight(&text[4..19]);\n"
 "    let dog = Highlight(&text[35..43]);\n"
 "    // erase(text);\n"
@@ -6436,20 +6466,25 @@ msgid ""
 "underlying the contained `&str` lives at least as long as any instance of "
 "`Highlight` that uses that data."
 msgstr ""
-"在上述示例中，`Highlight` 注释会强制包含 `&str` 的底层数据的生命周期至少与使用该数据的任何 `Highlight` 实例一样长。"
+"在上述示例中，`Highlight` 注释会强制包含 `&str` 的底层数据的生命周期至少与使"
+"用该数据的任何 `Highlight` 实例一样长。"
 
 #: src/ownership/lifetimes-data-structures.md:26
 msgid ""
 "If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
 "the borrow checker throws an error."
-msgstr "如果 `text` 在 `fox`（或 `dog`）的生命周期结束前被消耗，借用检查器将抛出一个错误。"
+msgstr ""
+"如果 `text` 在 `fox`（或 `dog`）的生命周期结束前被消耗，借用检查器将抛出一个"
+"错误。"
 
 #: src/ownership/lifetimes-data-structures.md:27
 msgid ""
 "Types with borrowed data force users to hold on to the original data. This "
 "can be useful for creating lightweight views, but it generally makes them "
 "somewhat harder to use."
-msgstr "借用数据的类型会迫使用户保留原始数据。这对于创建轻量级视图很有用，但通常会使它们更难使用。"
+msgstr ""
+"借用数据的类型会迫使用户保留原始数据。这对于创建轻量级视图很有用，但通常会使"
+"它们更难使用。"
 
 #: src/ownership/lifetimes-data-structures.md:28
 msgid "When possible, make data structures own their data directly."
@@ -6462,7 +6497,9 @@ msgid ""
 "relationships between the references themselves, in addition to the lifetime "
 "of the struct itself. Those are very advanced use cases."
 msgstr ""
-"一些包含多个引用的结构可以有多个生命周期注释。除了结构体本身的生命周期之外，如果需要描述引用之间的生命周期关系，则可能需要这样做。这些都是非常高级的用例。"
+"一些包含多个引用的结构可以有多个生命周期注释。除了结构体本身的生命周期之外，"
+"如果需要描述引用之间的生命周期关系，则可能需要这样做。这些都是非常高级的用"
+"例。"
 
 #: src/structs.md:3
 msgid "Like C and C++, Rust has support for custom structs:"
@@ -6585,7 +6622,9 @@ msgstr ""
 msgid ""
 "Newtypes are a great way to encode additional information about the value in "
 "a primitive type, for example:"
-msgstr "如需对基元类型中的值的额外信息进行编码，使用 newtype 是一种非常好的方式，例如："
+msgstr ""
+"如需对基元类型中的值的额外信息进行编码，使用 newtype 是一种非常好的方式，例"
+"如："
 
 #: src/structs/tuple-structs.md:38
 msgid "The number is measured in some units: `Newtons` in the example above."
@@ -6596,13 +6635,15 @@ msgid ""
 "The value passed some validation when it was created, so you no longer have "
 "to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
 msgstr ""
-"值在创建时已通过一些验证，因此您不再需要在每次使用时都再次验证它：`PhoneNumber(String)` 或 `OddNumber(u32)`。"
+"值在创建时已通过一些验证，因此您不再需要在每次使用时都再次验证它："
+"`PhoneNumber(String)` 或 `OddNumber(u32)`。"
 
 #: src/structs/tuple-structs.md:40
 msgid ""
 "Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
 "single field in the newtype."
-msgstr "展示如何通过访问 newtype 中的单个字段，将 `f64` 值添加到 `Newtons` 类型。"
+msgstr ""
+"展示如何通过访问 newtype 中的单个字段，将 `f64` 值添加到 `Newtons` 类型。"
 
 #: src/structs/tuple-structs.md:41
 msgid ""
@@ -6616,11 +6657,12 @@ msgstr "运算符过载在第 3 天（泛型）讨论。"
 
 #: src/structs/tuple-structs.md:43
 msgid ""
-"The example is a subtle reference to the [Mars Climate "
-"Orbiter](https://en.wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
-"此示例巧妙地引用了[火星气候探测者号](https://zh.wikipedia.org/wiki/%E7%81%AB%E6%98%9F%E6%B0%A3%E5%80%99%E6%8E%A2%E6%B8%AC%E8%80%85%E8%99%9F) "
-"的失败事故。"
+"此示例巧妙地引用了[火星气候探测者号](https://zh.wikipedia.org/wiki/"
+"%E7%81%AB%E6%98%9F%E6%B0%A3%E5%80%99%E6%8E%A2%E6%B8%AC%E8%80%85%E8%99%9F) 的"
+"失败事故。"
 
 #: src/structs/field-shorthand.md:3
 msgid ""
@@ -6701,7 +6743,8 @@ msgid ""
 msgstr ""
 
 #: src/structs/field-shorthand.md:70
-msgid "Use `{:#?}` when printing structs to request the `Debug` representation."
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
 msgstr ""
 
 #: src/methods.md:3
@@ -6822,9 +6865,9 @@ msgstr ""
 
 #: src/methods/receiver.md:18
 msgid ""
-"Beyond variants on `self`, there are also [special wrapper "
-"types](https://doc.rust-lang.org/reference/special-types-and-traits.html) "
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
 
 #: src/methods/receiver.md:24
@@ -7044,7 +7087,9 @@ msgstr ""
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
 "you need to keep track of users' health statistics."
-msgstr "你正在实现一个健康监控系统。作为其中的一部分，你需要对用户的健康统计数据进行追踪。"
+msgstr ""
+"你正在实现一个健康监控系统。作为其中的一部分，你需要对用户的健康统计数据进行"
+"追踪。"
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
@@ -7052,8 +7097,8 @@ msgid ""
 "`User` struct definition. Your goal is to implement the stubbed out methods "
 "on the `User` `struct` defined in the `impl` block."
 msgstr ""
-"`User` 结构体的定义和 `impl` 块中一些函数的框架已经给出。你的目标是实现在 `impl` 块中定义的 `User` `struct` "
-"的方法。"
+"`User` 结构体的定义和 `impl` 块中一些函数的框架已经给出。你的目标是实现在 "
+"`impl` 块中定义的 `User` `struct` 的方法。"
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
@@ -7172,8 +7217,8 @@ msgid ""
 "types used by Rust library and programs. This way, two libraries can work "
 "together smoothly because they both use the same `String` type."
 msgstr ""
-"Rust 附带一个标准库，此库有助于建立一个供 Rust 库和程序 使用的常用类型集。这样一来，两个库便可顺畅地搭配运作， 因为它们使用相同的 "
-"`String` 类型。"
+"Rust 附带一个标准库，此库有助于建立一个供 Rust 库和程序 使用的常用类型集。这"
+"样一来，两个库便可顺畅地搭配运作， 因为它们使用相同的 `String` 类型。"
 
 #: src/std.md:7
 msgid "The common vocabulary types include:"
@@ -7184,8 +7229,8 @@ msgid ""
 "[`Option` and `Result`](std/option-result.md) types: used for optional "
 "values and [error handling](error-handling.md)."
 msgstr ""
-"[`Option` 和 `Result`](std/option-result.md) 类型：用于可选值和 "
-"[错误处理](error-handling.md)。"
+"[`Option` 和 `Result`](std/option-result.md) 类型：用于可选值和 [错误处理]"
+"(error-handling.md)。"
 
 #: src/std.md:12
 msgid "[`String`](std/string.md): the default string type used for owned data."
@@ -7221,7 +7266,9 @@ msgstr "Rust 实际上含有多个层级的标准库，分别是 `core`、`alloc
 msgid ""
 "`core` includes the most basic types and functions that don't depend on "
 "`libc`, allocator or even the presence of an operating system. "
-msgstr "`core` 包括最基本的类型与函数，这些类型与函数不依赖于 `libc`、分配器 或是否存在操作系统。"
+msgstr ""
+"`core` 包括最基本的类型与函数，这些类型与函数不依赖于 `libc`、分配器 或是否存"
+"在操作系统。"
 
 #: src/std.md:28
 msgid ""
@@ -7230,7 +7277,8 @@ msgid ""
 msgstr "`alloc` 包括需要全局堆分配器的类型，例如 `Vec`、`Box` 和 `Arc`。"
 
 #: src/std.md:29
-msgid "Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr "嵌入式 Rust 应用通常只使用 `core`，偶尔会使用 `alloc`。"
 
 #: src/std/option-result.md:1
@@ -7300,8 +7348,8 @@ msgid ""
 "[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
 "standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
-"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) "
-"是标准堆分配的可扩容 UTF-8 字符串缓冲区："
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) 是标准堆"
+"分配的可扩容 UTF-8 字符串缓冲区："
 
 #: src/std/string.md:5
 msgid ""
@@ -7325,13 +7373,13 @@ msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = "
-"str>`](https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str), "
-"which means that you can call all `str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` 会实现 [`Deref<Target = "
-"str>`](https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str)，这意味着您可以 "
-"对 `String` 调用所有 `str` 方法。"
+"`String` 会实现 [`Deref<Target = str>`](https://doc.rust-lang.org/std/string/"
+"struct.String.html#deref-methods-str)，这意味着您可以 对 `String` 调用所有 "
+"`str` 方法。"
 
 #: src/std/string.md:30
 msgid ""
@@ -7349,8 +7397,8 @@ msgstr ""
 msgid ""
 "`String::chars` returns an iterator over the actual characters. Note that a "
 "`char` can be different from what a human will consider a \"character\" due "
-"to [grapheme "
-"clusters](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html)."
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
 msgstr ""
 
 #: src/std/string.md:33
@@ -7407,7 +7455,8 @@ msgid ""
 "[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
 "resizable heap-allocated buffer:"
 msgstr ""
-"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 是标准的可调整大小堆分配缓冲区："
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 是标准的可调整大小"
+"堆分配缓冲区："
 
 #: src/std/vec.md:5
 msgid ""
@@ -7438,13 +7487,13 @@ msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = "
-"[T]>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-%5BT%5D), "
-"which means that you can call slice methods on a `Vec`."
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
+"methods on a `Vec`."
 msgstr ""
-"`Vec` 会实现 [`Deref<Target = "
-"[T]>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-%5BT%5D)，这意味着您可以对 "
-"`Vec` 调用 slice 方法。"
+"`Vec` 会实现 [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D)，这意味着您可以对 `Vec` 调用 slice 方"
+"法。"
 
 #: src/std/vec.md:37
 msgid ""
@@ -7479,8 +7528,7 @@ msgid ""
 "+= 50; }`"
 msgstr ""
 
-#: src/std/hashmap.md:1
-#: src/bare-metal/no_std.md:46
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
 msgid "`HashMap`"
 msgstr "`HashMap`"
 
@@ -7516,8 +7564,8 @@ msgid ""
 "    // Use the .entry() method to insert a value if nothing is found.\n"
 "    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
 "Wonderland\"] {\n"
-"        let page_count: &mut i32 = "
-"page_counts.entry(book.to_string()).or_insert(0);\n"
+"        let page_count: &mut i32 = page_counts.entry(book.to_string())."
+"or_insert(0);\n"
 "        *page_count += 1;\n"
 "    }\n"
 "\n"
@@ -7556,9 +7604,10 @@ msgstr ""
 
 #: src/std/hashmap.md:50
 msgid ""
-"Although, since Rust 1.56, HashMap implements [`From<[(K, V); "
-"N]>`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), "
-"which allows us to easily initialize a hash map from a literal array:"
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
 msgstr ""
 
 #: src/std/hashmap.md:52
@@ -7573,8 +7622,8 @@ msgstr ""
 
 #: src/std/hashmap.md:59
 msgid ""
-"Alternatively HashMap can be built from any `Iterator` which yields "
-"key-value tuples."
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
 msgstr ""
 
 #: src/std/hashmap.md:60
@@ -7592,10 +7641,10 @@ msgstr ""
 
 #: src/std/hashmap.md:64
 msgid ""
-"This type has several \"method-specific\" return types, such as "
-"`std::collections::hash_map::Keys`. These types often appear in searches of "
-"the Rust docs. Show students the docs for this type, and the helpful link "
-"back to the `keys` method."
+"This type has several \"method-specific\" return types, such as `std::"
+"collections::hash_map::Keys`. These types often appear in searches of the "
+"Rust docs. Show students the docs for this type, and the helpful link back "
+"to the `keys` method."
 msgstr ""
 
 #: src/std/box.md:1
@@ -7607,7 +7656,8 @@ msgid ""
 "[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
 "pointer to data on the heap:"
 msgstr ""
-"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 是指向堆上数据的自有指针："
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 是指向堆上数据的"
+"自有指针："
 
 #: src/std/box.md:5
 msgid ""
@@ -7622,23 +7672,26 @@ msgstr ""
 #: src/std/box.md:26
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods from `T` directly on a "
-"`Box<T>`](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion)."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
-"`Box<T>` 会实现 `Deref<Target = T>`，这意味着您可以[直接在 `Box<T>` 上通过 `T` "
-"调用相应方法](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion)。"
+"`Box<T>` 会实现 `Deref<Target = T>`，这意味着您可以[直接在 `Box<T>` 上通过 "
+"`T` 调用相应方法](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-"
+"deref-coercion)。"
 
 #: src/std/box.md:34
 msgid ""
 "`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
 "not null. "
-msgstr "在 C++ 中，`Box` 与 `std::unique_ptr` 类似，除了它一定会不为 null 以外。"
+msgstr ""
+"在 C++ 中，`Box` 与 `std::unique_ptr` 类似，除了它一定会不为 null 以外。"
 
 #: src/std/box.md:35
 msgid ""
 "In the above example, you can even leave out the `*` in the `println!` "
 "statement thanks to `Deref`. "
-msgstr "在上面的示例中，因为有 `Deref`，您甚至可以在 `println!` 语句中省略 `*`。"
+msgstr ""
+"在上面的示例中，因为有 `Deref`，您甚至可以在 `println!` 语句中省略 `*`。"
 
 #: src/std/box.md:36
 msgid "A `Box` can be useful when you:"
@@ -7655,7 +7708,9 @@ msgid ""
 "want to transfer ownership of a large amount of data. To avoid copying large "
 "amounts of data on the stack, instead store the data on the heap in a `Box` "
 "so only the pointer is moved."
-msgstr "想要转让大量数据的所有权。为避免在堆栈上复制大量数据，请改为将数据存储在 `Box` 中的堆上，以便仅移动指针。"
+msgstr ""
+"想要转让大量数据的所有权。为避免在堆栈上复制大量数据，请改为将数据存储在 "
+"`Box` 中的堆上，以便仅移动指针。"
 
 #: src/std/box-recursive.md:1
 msgid "Box with Recursive Data Structures"
@@ -7666,8 +7721,7 @@ msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr "递归数据类型或具有动态大小的数据类型需要使用 `Box`："
 
-#: src/std/box-recursive.md:5
-#: src/std/box-niche.md:3
+#: src/std/box-recursive.md:5 src/std/box-niche.md:3
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
@@ -7677,8 +7731,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, "
-"Box::new(List::Nil))));\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::"
+"new(List::Nil))));\n"
 "    println!(\"{list:?}\");\n"
 "}\n"
 "```"
@@ -7690,20 +7744,17 @@ msgid ""
 " Stack                           Heap\n"
 ".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
 "- -.\n"
-":                         :     :                                            "
-"   :\n"
-":    list                 :     :                                            "
-"   :\n"
-":   +------+----+----+    :     :    +------+----+----+    "
-"+------+----+----+   :\n"
+":                         :     :                                               :\n"
+":    "
+"list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
 ":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
 "|   :\n"
-":   +------+----+----+    :     :    +------+----+----+    "
-"+------+----+----+   :\n"
-":                         :     :                                            "
-"   :\n"
-":                         :     :                                            "
-"   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
+":                         :     :                                               :\n"
+":                         :     :                                               :\n"
 "'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
 "- -'\n"
 "```"
@@ -7716,13 +7767,16 @@ msgid ""
 "`List`, the compiler would not compute a fixed size of the struct in memory "
 "(`List` would be of infinite size)."
 msgstr ""
-"如果这里未使用 `Box`，且我们曾尝试将一个 `List` 直接嵌入 `List`， 编译器就不会计算内存中结构体的固定大小，结构体看起来会像是无限大。"
+"如果这里未使用 `Box`，且我们曾尝试将一个 `List` 直接嵌入 `List`， 编译器就不"
+"会计算内存中结构体的固定大小，结构体看起来会像是无限大。"
 
 #: src/std/box-recursive.md:36
 msgid ""
 "`Box` solves this problem as it has the same size as a regular pointer and "
 "just points at the next element of the `List` in the heap."
-msgstr "`Box` 大小与一般指针相同，并且只会指向堆中的下一个 `List` 元素， 因此可以解决这个问题。"
+msgstr ""
+"`Box` 大小与一般指针相同，并且只会指向堆中的下一个 `List` 元素， 因此可以解决"
+"这个问题。"
 
 #: src/std/box-recursive.md:39
 msgid ""
@@ -7730,14 +7784,17 @@ msgid ""
 "\"Recursive with indirection\" is a hint you might want to use a Box or "
 "reference of some kind, instead of storing a value directly."
 msgstr ""
-"将 `Box` 从 List 定义中移除后，画面上会显示编译器错误。如果您看到“Recursive with "
-"indirection”错误消息，这是在提示您使用 Box 或其他类型的引用，而不是直接储存值。"
+"将 `Box` 从 List 定义中移除后，画面上会显示编译器错误。如果您看到“Recursive "
+"with indirection”错误消息，这是在提示您使用 Box 或其他类型的引用，而不是直接"
+"储存值。"
 
 #: src/std/box-niche.md:16
 msgid ""
 "A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
-msgstr "`Box` 不得为空，因此指针始终有效且非 `null`。这样， 编译器就可以优化内存布局："
+msgstr ""
+"`Box` 不得为空，因此指针始终有效且非 `null`。这样， 编译器就可以优化内存布"
+"局："
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -7745,20 +7802,17 @@ msgid ""
 " Stack                           Heap\n"
 ".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
 "-.\n"
-":                         :     :                                            "
-" :\n"
-":    list                 :     :                                            "
-" :\n"
-":   +----+----+           :     :    +----+----+    +----+------+            "
-" :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |            "
-" :\n"
-":   +----+----+           :     :    +----+----+    +----+------+            "
-" :\n"
-":                         :     :                                            "
-" :\n"
-":                         :     :                                            "
-" :\n"
+":                         :     :                                             :\n"
+":    "
+"list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
+"|             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":                         :     :                                             :\n"
+":                         :     :                                             :\n"
 "`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
 "-'\n"
 "```"
@@ -7770,12 +7824,12 @@ msgstr "`Rc`"
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a "
-"reference-counted shared pointer. Use this when you need to refer to the "
-"same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) "
-"是引用计数的共享指针。如果您需要从多个位置 引用相同的数据，请使用此指针："
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) 是引用计数的共享指"
+"针。如果您需要从多个位置 引用相同的数据，请使用此指针："
 
 #: src/std/rc.md:6
 msgid ""
@@ -7795,20 +7849,20 @@ msgstr ""
 #: src/std/rc.md:18
 #, fuzzy
 msgid ""
-"See [`Arc`](../concurrency/shared_state/arc.md) and "
-"[`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
-"in a multi-threaded context."
+"See [`Arc`](../concurrency/shared_state/arc.md) and [`Mutex`](https://doc."
+"rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
+"context."
 msgstr ""
-"如果您在多线程情境中，请参阅 [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)。"
+"如果您在多线程情境中，请参阅 [`Arc`](https://doc.rust-lang.org/std/sync/"
+"struct.Mutex.html)。"
 
 #: src/std/rc.md:19
 msgid ""
-"You can _downgrade_ a shared pointer into a "
-"[`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) pointer to "
-"create cycles that will get dropped."
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
-"您可以将共享指针_降级_为 [`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) "
-"指针， 以便创建之后会被舍弃的循环引用。"
+"您可以将共享指针_降级_为 [`Weak`](https://doc.rust-lang.org/std/rc/struct."
+"Weak.html) 指针， 以便创建之后会被舍弃的循环引用。"
 
 #: src/std/rc.md:29
 msgid ""
@@ -7825,13 +7879,16 @@ msgid ""
 "`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
 "be ignored when looking for performance issues in code."
-msgstr "`Rc::clone` 的成本很低：这个做法会创建指向相同分配的指针，并增加引用计数，而不会产生深层的克隆，排查代码性能问题时通常可以忽略。"
+msgstr ""
+"`Rc::clone` 的成本很低：这个做法会创建指向相同分配的指针，并增加引用计数，而"
+"不会产生深层的克隆，排查代码性能问题时通常可以忽略。"
 
 #: src/std/rc.md:32
 msgid ""
 "`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
 "and returns a mutable reference."
-msgstr "`make_mut` 实际上会在必要时克隆内部值（“clone-on-write”），并返回可变的引用。"
+msgstr ""
+"`make_mut` 实际上会在必要时克隆内部值（“clone-on-write”），并返回可变的引用。"
 
 #: src/std/rc.md:33
 msgid "Use `Rc::strong_count` to check the reference count."
@@ -7843,7 +7900,9 @@ msgid ""
 "`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
 "cycles that will be dropped properly (likely in combination with `RefCell`, "
 "on the next slide)."
-msgstr "`Rc::downgrade` 会向您提供 _弱引用计数_ 对象， 以便创建之后会被适当舍弃的周期（可能会与 `RefCell` 组合）。"
+msgstr ""
+"`Rc::downgrade` 会向您提供 _弱引用计数_ 对象， 以便创建之后会被适当舍弃的周期"
+"（可能会与 `RefCell` 组合）。"
 
 #: src/std/cell.md:1
 #, fuzzy
@@ -7853,14 +7912,13 @@ msgstr "Cell/RefCell"
 #: src/std/cell.md:3
 #, fuzzy
 msgid ""
-"[`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and "
-"[`RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html) "
-"implement what Rust calls _interior mutability:_ mutation of values in an "
-"immutable context."
+"[`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and [`RefCell`]"
+"(https://doc.rust-lang.org/std/cell/struct.RefCell.html) implement what Rust "
+"calls _interior mutability:_ mutation of values in an immutable context."
 msgstr ""
 "您可以使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
-"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` "
-"来源进行抽象化处理："
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` 来源"
+"进行抽象化处理："
 
 #: src/std/cell.md:8
 msgid ""
@@ -7887,8 +7945,8 @@ msgid ""
 "    }\n"
 "\n"
 "    fn sum(&self) -> i64 {\n"
-"        self.value + self.children.iter().map(|c| "
-"c.borrow().sum()).sum::<i64>()\n"
+"        self.value + self.children.iter().map(|c| c.borrow().sum()).sum::"
+"<i64>()\n"
 "    }\n"
 "}\n"
 "\n"
@@ -7922,8 +7980,8 @@ msgstr ""
 
 #: src/std/cell.md:49
 msgid ""
-"Demonstrate that reference loops can be created by adding `root` to "
-"`subtree.children` (don't try to print it!)."
+"Demonstrate that reference loops can be created by adding `root` to `subtree."
+"children` (don't try to print it!)."
 msgstr ""
 
 #: src/std/cell.md:50
@@ -8040,8 +8098,8 @@ msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"See the [Rust "
-"Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
 #: src/modules/visibility.md:44
@@ -8099,9 +8157,9 @@ msgstr ""
 
 #: src/modules/filesystem.md:9
 msgid ""
-"This tells rust that the `garden` module content is found at "
-"`src/garden.rs`. Similarly, a `garden::vegetables` module can be found at "
-"`src/garden/vegetables.rs`."
+"This tells rust that the `garden` module content is found at `src/garden."
+"rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
+"vegetables.rs`."
 msgstr ""
 
 #: src/modules/filesystem.md:12
@@ -8150,9 +8208,8 @@ msgstr ""
 
 #: src/modules/filesystem.md:39
 msgid ""
-"The main reason to introduce `filename.rs` as alternative to "
-"`filename/mod.rs` was because many files named `mod.rs` can be hard to "
-"distinguish in IDEs."
+"The main reason to introduce `filename.rs` as alternative to `filename/mod."
+"rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
 msgstr ""
 
 #: src/modules/filesystem.md:42
@@ -8195,8 +8252,7 @@ msgid ""
 "traits."
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:8
-#: src/bare-metal/no_std.md:28
+#: src/exercises/day-2/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
 msgid "`Iterator`"
 msgstr ""
 
@@ -8286,8 +8342,8 @@ msgstr ""
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), "
-"String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "    let mut iter = v.into_iter();\n"
 "\n"
 "    let v0: Option<..> = iter.next();\n"
@@ -8311,8 +8367,8 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), "
-"String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "\n"
 "    for word in &v {\n"
 "        println!(\"word: {word}\");\n"
@@ -8332,11 +8388,10 @@ msgstr ""
 #: src/exercises/day-2/iterators-and-ownership.md:105
 msgid ""
 "Experiment with the code above and then consult the documentation for [`impl "
-"IntoIterator for "
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E) "
-"and [`impl IntoIterator for "
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT,+A%3E) "
-"to check your answers."
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E) and [`impl IntoIterator for "
+"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
+"for-Vec%3CT,+A%3E) to check your answers."
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:3
@@ -8366,15 +8421,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", "
-"\"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -8392,8 +8447,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -8441,7 +8496,8 @@ msgstr ""
 msgid ""
 "Rust support generics, which lets you abstract algorithms or data structures "
 "(such as sorting or a binary tree) over the types used or stored."
-msgstr "Rust 支持泛型，允许您根据算法（例如排序）中使用的类型对算法进行抽象化处理。"
+msgstr ""
+"Rust 支持泛型，允许您根据算法（例如排序）中使用的类型对算法进行抽象化处理。"
 
 #: src/generics/data-types.md:3
 msgid "You can use generics to abstract over the concrete field type:"
@@ -8501,7 +8557,8 @@ msgstr ""
 msgid ""
 "_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
 "redundant?"
-msgstr "\\*问：\\*为什么 `T` 在 `impl<T> Point<T> {}` 中指定了两次？这不是多余的吗？"
+msgstr ""
+"\\*问：\\*为什么 `T` 在 `impl<T> Point<T> {}` 中指定了两次？这不是多余的吗？"
 
 #: src/generics/methods.md:26
 msgid ""
@@ -8521,7 +8578,9 @@ msgstr "可以编写 `impl Point<u32> { .. }`。"
 msgid ""
 "`Point` is still generic and you can use `Point<f64>`, but methods in this "
 "block will only be available for `Point<u32>`."
-msgstr "`Point` 依然是一个泛型，并且您可以使用 `Point<f64>`，但此块中的方法将仅适用于 `Point<u32>`。"
+msgstr ""
+"`Point` 依然是一个泛型，并且您可以使用 `Point<f64>`，但此块中的方法将仅适用"
+"于 `Point<u32>`。"
 
 #: src/generics/monomorphization.md:3
 msgid "Generic code is turned into non-generic code based on the call sites:"
@@ -8535,7 +8594,9 @@ msgstr "具体行为与您所编写的一样"
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
 "had hand-coded the data structures without the abstraction."
-msgstr "这是零成本的抽象化处理：您得到的结果不会受到影响，也就是说，与在没有进行抽象化处理的情况下，对数据结构进行手动编码时的结果一样。"
+msgstr ""
+"这是零成本的抽象化处理：您得到的结果不会受到影响，也就是说，与在没有进行抽象"
+"化处理的情况下，对数据结构进行手动编码时的结果一样。"
 
 #: src/traits.md:3
 msgid ""
@@ -8553,8 +8614,8 @@ msgid ""
 "}\n"
 "\n"
 "impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self.name) "
-"}\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
+"name) }\n"
 "}\n"
 "\n"
 "impl Pet for Cat {\n"
@@ -8592,8 +8653,8 @@ msgid ""
 "}\n"
 "\n"
 "impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self.name) "
-"}\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
+"name) }\n"
 "}\n"
 "\n"
 "impl Pet for Cat {\n"
@@ -8622,58 +8683,56 @@ msgid ""
 " Stack                             Heap\n"
 ".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
 "- -.\n"
-":                           :     :                                          "
-"   :\n"
-":    pets                   :     :                     "
-"+----+----+----+----+   :\n"
+":                           :     :                                             :\n"
+":    pets                   :     :                     +----+----+----+----"
+"+   :\n"
 ":   +-----------+-------+   :     :   +-----+-----+  .->| F  | i  | d  | o  "
 "|   :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |  |  "
-"+----+----+----+----+   :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+  `---------.             "
-"   :\n"
-":   | capacity  |     2 |   :     :     | |   | |    data      |             "
-"   :\n"
-":   +-----------+-------+   :     :     | |   | |   +-------+--|-------+     "
-"   :\n"
-":                           :     :     | |   | '-->| name  |  o, 4, 4 |     "
-"   :\n"
-":                           :     :     | |   |     | age   |        5 |     "
-"   :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |     +-------+----------+     "
-"   :\n"
-"                                  :     | |   |                              "
-"   :\n"
-"                                  :     | |   |      vtable                  "
-"   :\n"
-"                                  :     | |   |     +----------------------+ "
-"   :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o |  |  +----+----+----+----"
+"+   :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-+  "
+"`---------.                :\n"
+":   | capacity  |     2 |   :     :     | |   | |    data      "
+"|                :\n"
+":   +-----------+-------+   :     :     | |   | |   +-------+--|-------"
+"+        :\n"
+":                           :     :     | |   | '-->| name  |  o, 4, 4 "
+"|        :\n"
+":                           :     :     | |   |     | age   |        5 "
+"|        :\n"
+"`- - - - - - - - - - - - - -'     :     | |   |     +-------+----------"
+"+        :\n"
+"                                  :     | |   "
+"|                                 :\n"
+"                                  :     | |   |      "
+"vtable                     :\n"
+"                                  :     | |   |     +----------------------"
+"+    :\n"
 "                                  :     | |   '---->| \"<Dog as Pet>::talk\" "
 "|    :\n"
-"                                  :     | |         +----------------------+ "
-"   :\n"
-"                                  :     | |                                  "
-"   :\n"
-"                                  :     | |    data                          "
-"   :\n"
-"                                  :     | |   +-------+-------+              "
-"   :\n"
-"                                  :     | '-->| lives |     9 |              "
-"   :\n"
-"                                  :     |     +-------+-------+              "
-"   :\n"
-"                                  :     |                                    "
-"   :\n"
-"                                  :     |      vtable                        "
-"   :\n"
-"                                  :     |     +----------------------+       "
-"   :\n"
-"                                  :     '---->| \"<Cat as Pet>::talk\" |     "
-"     :\n"
-"                                  :           +----------------------+       "
-"   :\n"
-"                                  :                                          "
-"   :\n"
+"                                  :     | |         +----------------------"
+"+    :\n"
+"                                  :     | "
+"|                                     :\n"
+"                                  :     | |    "
+"data                             :\n"
+"                                  :     | |   +-------+-------"
+"+                 :\n"
+"                                  :     | '-->| lives |     9 "
+"|                 :\n"
+"                                  :     |     +-------+-------"
+"+                 :\n"
+"                                  :     "
+"|                                       :\n"
+"                                  :     |      "
+"vtable                           :\n"
+"                                  :     |     +----------------------"
+"+          :\n"
+"                                  :     '---->| \"<Cat as Pet>::talk\" "
+"|          :\n"
+"                                  :           +----------------------"
+"+          :\n"
+"                                  :                                             :\n"
 "                                  '- - - - - - - - - - - - - - - - - - - - - "
 "- -'\n"
 "```"
@@ -8700,9 +8759,9 @@ msgstr ""
 #: src/traits/trait-objects.md:74
 msgid ""
 "A fat pointer is a double-width pointer. It has two components: a pointer to "
-"the actual object and a pointer to the [virtual method "
-"table](https://en.wikipedia.org/wiki/Virtual_method_table) (vtable) for the "
-"`Pet` implementation of that particular object."
+"the actual object and a pointer to the [virtual method table](https://en."
+"wikipedia.org/wiki/Virtual_method_table) (vtable) for the `Pet` "
+"implementation of that particular object."
 msgstr ""
 
 #: src/traits/trait-objects.md:77
@@ -8718,10 +8777,10 @@ msgstr ""
 #: src/traits/trait-objects.md:80
 msgid ""
 "```rust,ignore\n"
-"    println!(\"{} {}\", std::mem::size_of::<Dog>(), "
-"std::mem::size_of::<Cat>());\n"
-"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), "
-"std::mem::size_of::<&Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
 "    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
 "    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
 "```"
@@ -8751,9 +8810,7 @@ msgid ""
 "fn main() {\n"
 "    let p1 = Player::default();\n"
 "    let p2 = p1.clone();\n"
-"    println!(\"Is {:?}\\n"
-"equal to {:?}?\\n"
-"The answer is {}!\", &p1, &p2,\n"
+"    println!(\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2,\n"
 "             if p1 == p2 { \"yes\" } else { \"no\" });\n"
 "}\n"
 "```"
@@ -8820,7 +8877,8 @@ msgstr ""
 msgid ""
 "When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
-msgstr "使用泛型时，您通常会想要利用类型来实现某些特性， 这样才能调用此特征的方法。"
+msgstr ""
+"使用泛型时，您通常会想要利用类型来实现某些特性， 这样才能调用此特征的方法。"
 
 #: src/traits/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
@@ -8870,7 +8928,8 @@ msgstr "它具有额外功能，因此也更强大。"
 msgid ""
 "If someone asks, the extra feature is that the type on the left of \":\" can "
 "be arbitrary, like `Option<T>`."
-msgstr "如果有人提问，便阐明额外功能是指“:”左侧的类别可为任意值，例如 `Option<T>`。"
+msgstr ""
+"如果有人提问，便阐明额外功能是指“:”左侧的类别可为任意值，例如 `Option<T>`。"
 
 #: src/traits/impl-trait.md:1
 msgid "`impl Trait`"
@@ -8919,7 +8978,8 @@ msgid ""
 "implements the trait, without naming the type. This can be useful when you "
 "don't want to expose the concrete type in a public API."
 msgstr ""
-"对返回值类型来说，它则意味着返回值类型就是实现该特征的某具体类型， 无需为该类型命名。如果您不想在公共 API 中公开该具体类型，便可 使用此方法。"
+"对返回值类型来说，它则意味着返回值类型就是实现该特征的某具体类型， 无需为该类"
+"型命名。如果您不想在公共 API 中公开该具体类型，便可 使用此方法。"
 
 #: src/traits/impl-trait.md:31
 msgid ""
@@ -8927,12 +8987,13 @@ msgid ""
 "the concrete type it returns, without writing it out in the source. A "
 "function returning a generic type like `collect<B>() -> B` can return any "
 "type satisfying `B`, and the caller may need to choose one, such as with "
-"`let x: Vec<_> = foo.collect()` or with the turbofish, "
-"`foo.collect::<Vec<_>>()`."
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
 msgstr ""
-"在返回位置处进行推断有一定难度。会返回 `impl Foo` 的函数会挑选 自身返回的具体类型，而不必在来源中写出此信息。会返回 泛型类型（例如 "
-"`collect<B>() -> B`）的函数则可返回符合 `B` 的任何类型，而调用方可能需要选择一个类型，例如使用 `let x: Vec<_> = "
-"foo.collect()` 或使用以下 Turbofish：`foo.collect::<Vec<_>>()`。"
+"在返回位置处进行推断有一定难度。会返回 `impl Foo` 的函数会挑选 自身返回的具体"
+"类型，而不必在来源中写出此信息。会返回 泛型类型（例如 `collect<B>() -> B`）的"
+"函数则可返回符合 `B` 的任何类型，而调用方可能需要选择一个类型，例如使用 `let "
+"x: Vec<_> = foo.collect()` 或使用以下 Turbofish：`foo.collect::<Vec<_>>()`。"
 
 #: src/traits/impl-trait.md:37
 msgid ""
@@ -8944,10 +9005,11 @@ msgid ""
 "`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
 "need two independent generic parameters."
 msgstr ""
-"这是一个非常棒的示例，因为它使用了两次 `impl Display`。这有助于说明 此处没有任何项目会强制使用相同的 `impl Display` "
-"类型。如果我们使用单个 `T: Display`，它会强制限制输入 `T` 和返回 `T` 均为同一类型。 "
-"这并不适用于这个特定函数，因为我们预期作为输入的类型可能 不会是 `format!` 返回的值。如果我们希望通过 `: Display` "
-"语法执行相同的操作，则需要两个 独立的泛型形参。"
+"这是一个非常棒的示例，因为它使用了两次 `impl Display`。这有助于说明 此处没有"
+"任何项目会强制使用相同的 `impl Display` 类型。如果我们使用单个 `T: Display`，"
+"它会强制限制输入 `T` 和返回 `T` 均为同一类型。 这并不适用于这个特定函数，因为"
+"我们预期作为输入的类型可能 不会是 `format!` 返回的值。如果我们希望通过 `: "
+"Display` 语法执行相同的操作，则需要两个 独立的泛型形参。"
 
 #: src/traits/important-traits.md:3
 msgid ""
@@ -8967,43 +9029,45 @@ msgstr ""
 
 #: src/traits/important-traits.md:6
 msgid ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) used to "
-"convert values,"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
 msgstr ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 用于转换值，"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) 用于转换值，"
 
 #: src/traits/important-traits.md:7
 msgid ""
-"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
-"[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
 msgstr ""
-"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
-"[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 用于实现 IO。"
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) 用于实现 IO。"
 
 #: src/traits/important-traits.md:8
 msgid ""
-"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), "
-"[`Mul`](https://doc.rust-lang.org/std/ops/trait.Mul.html), ... used for "
-"operator overloading, and"
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
 msgstr ""
-"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html)、[`Mul`](https://doc.rust-lang.org/std/ops/trait.Mul.html) "
-"等用于实现运算符重载，"
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html)、[`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html) 等用于实现运算符重载，"
 
 #: src/traits/important-traits.md:9
 msgid ""
 "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
 "defining destructors."
-msgstr "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 用于定义析构函数。"
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 用于定义析构函"
+"数。"
 
 #: src/traits/important-traits.md:10
 msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
 "to construct a default instance of a type."
 msgstr ""
-"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
-"用于构建相应类型的默认实例。"
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 用于构"
+"建相应类型的默认实例。"
 
 #: src/traits/iterator.md:1
 msgid "Iterators"
@@ -9011,12 +9075,11 @@ msgstr "迭代器"
 
 #: src/traits/iterator.md:3
 msgid ""
-"You can implement the "
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) trait "
-"on your own types:"
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
-"您可以自行实现 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
-"特征："
+"您可以自行实现 [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) 特征："
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -9054,8 +9117,9 @@ msgid ""
 "functions should produce the code as efficient as equivalent imperative "
 "implementations."
 msgstr ""
-"`Iterator` 特征会对集合实现许多常见的函数程序操作， 例如 ` map`filter \\``和`reduce` "
-"等。您可以通过此特征找到有关它们的所有 文档。在 Rust 中，这些函数应生成代码，且生成的代码应与等效命令式实现一样 高效。"
+"`Iterator` 特征会对集合实现许多常见的函数程序操作， 例如 ` map`filter \\``和"
+"`reduce` 等。您可以通过此特征找到有关它们的所有 文档。在 Rust 中，这些函数应"
+"生成代码，且生成的代码应与等效命令式实现一样 高效。"
 
 #: src/traits/iterator.md:37
 msgid ""
@@ -9064,19 +9128,20 @@ msgid ""
 "and `&[T]`. Ranges also implement it. This is why you can iterate over a "
 "vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
-"`IntoIterator` 是迫使 for 循环运作的特征。此特征由集合类型 （例如 `Vec<T>`）和相关引用（例如 `&Vec<T>` 和 "
-"`&[T]`）而实现。此外，范围也会实现这项特征。因此， 您可以使用 `for i in some_vec { .. }` 来遍历某矢量，但 "
-"`some_vec.next()` 不存在。"
+"`IntoIterator` 是迫使 for 循环运作的特征。此特征由集合类型 （例如 `Vec<T>`）"
+"和相关引用（例如 `&Vec<T>` 和 `&[T]`）而实现。此外，范围也会实现这项特征。因"
+"此， 您可以使用 `for i in some_vec { .. }` 来遍历某矢量，但 `some_vec."
+"next()` 不存在。"
 
 #: src/traits/from-iterator.md:3
 msgid ""
 "[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"lets you build a collection from an "
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html)."
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
 "[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"让您可通过 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
-"构建一个集合。"
+"让您可通过 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator."
+"html) 构建一个集合。"
 
 #: src/traits/from-iterator.md:5
 #, fuzzy
@@ -9105,19 +9170,19 @@ msgstr ""
 
 #: src/traits/from-iterator.md:18
 msgid ""
-"`Iterator` implements `fn collect<B>(self) -> B where B: "
-"FromIterator<Self::Item>, Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"`Iterator` 会实现 `fn collect<B>(self) -> B where B: FromIterator<Self::Item>, "
-"Self: Sized`"
+"`Iterator` 会实现 `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 
 #: src/traits/from-iterator.md:24
 msgid ""
 "There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
-"还有一些实现，让您可执行一些很酷的操作，比如 将 `Iterator<Item = Result<V, E>>` 转换成 `Result<Vec<V>, "
-"E>`。"
+"还有一些实现，让您可执行一些很酷的操作，比如 将 `Iterator<Item = Result<V, "
+"E>>` 转换成 `Result<Vec<V>, E>`。"
 
 #: src/traits/from-into.md:1
 msgid "`From` and `Into`"
@@ -9125,13 +9190,13 @@ msgstr "`From` 和 `Into`"
 
 #: src/traits/from-into.md:3
 msgid ""
-"Types implement "
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
 "facilitate type conversions:"
 msgstr ""
-"类型会实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 以加快类型转换："
+"类型会实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) "
+"和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 以加快类型"
+"转换："
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -9149,12 +9214,11 @@ msgstr ""
 #: src/traits/from-into.md:15
 msgid ""
 "[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
-"automatically implemented when "
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) is "
-"implemented:"
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
-"实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 后，系统会自动实现 "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)："
+"实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 后，系统"
+"会自动实现 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)："
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -9182,8 +9246,9 @@ msgid ""
 "Your function will accept types that implement `From` and those that _only_ "
 "implement `Into`."
 msgstr ""
-"若要声明某个函数实参输入类型（例如“任何可转换成 `String` 的类型”），规则便会相反，此时应使用 `Into`。 您的函数会接受可实现 "
-"`From` 的类型，以及那些仅实现 `Into` 的类型。"
+"若要声明某个函数实参输入类型（例如“任何可转换成 `String` 的类型”），规则便会"
+"相反，此时应使用 `Into`。 您的函数会接受可实现 `From` 的类型，以及那些仅实现 "
+"`Into` 的类型。"
 
 #: src/traits/read-write.md:1
 msgid "`Read` and `Write`"
@@ -9196,8 +9261,8 @@ msgid ""
 "abstract over `u8` sources:"
 msgstr ""
 "您可以使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
-"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` "
-"来源进行抽象化处理："
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` 来源"
+"进行抽象化处理："
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -9210,10 +9275,7 @@ msgid ""
 "}\n"
 "\n"
 "fn main() -> Result<()> {\n"
-"    let slice: &[u8] = b\"foo\\n"
-"bar\\n"
-"baz\\n"
-"\";\n"
+"    let slice: &[u8] = b\"foo\\nbar\\nbaz\\n\";\n"
 "    println!(\"lines in slice: {}\", count_lines(slice));\n"
 "\n"
 "    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
@@ -9228,8 +9290,8 @@ msgid ""
 "Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
 "you abstract over `u8` sinks:"
 msgstr ""
-"您同样可使用 [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 对 `u8` "
-"接收器进行抽象化处理："
+"您同样可使用 [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 对 "
+"`u8` 接收器进行抽象化处理："
 
 #: src/traits/read-write.md:25
 msgid ""
@@ -9238,8 +9300,7 @@ msgid ""
 "\n"
 "fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
 "    writer.write_all(msg.as_bytes())?;\n"
-"    writer.write_all(\"\\n"
-"\".as_bytes())\n"
+"    writer.write_all(\"\\n\".as_bytes())\n"
 "}\n"
 "\n"
 "fn main() -> Result<()> {\n"
@@ -9258,12 +9319,11 @@ msgstr "`Drop` 特征"
 
 #: src/traits/drop.md:3
 msgid ""
-"Values which implement "
-"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) can specify code "
-"to run when they go out of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
-"用于实现 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) "
-"的值可以指定在超出范围时运行的代码："
+"用于实现 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 的值可以"
+"指定在超出范围时运行的代码："
 
 #: src/traits/drop.md:5
 msgid ""
@@ -9305,8 +9365,8 @@ msgstr ""
 
 #: src/traits/drop.md:36
 msgid ""
-"When a value is dropped, if it implements `std::ops::Drop` then its "
-"`Drop::drop` implementation will be called."
+"When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
+"drop` implementation will be called."
 msgstr ""
 
 #: src/traits/drop.md:38
@@ -9328,8 +9388,7 @@ msgid ""
 "closing files, etc."
 msgstr ""
 
-#: src/traits/drop.md:45
-#: src/traits/operators.md:26
+#: src/traits/drop.md:45 src/traits/operators.md:26
 msgid "Discussion points:"
 msgstr "讨论点："
 
@@ -9341,7 +9400,9 @@ msgstr "为什么 `Drop::drop` 不使用 `self`？"
 msgid ""
 "Short-answer: If it did, `std::mem::drop` would be called at the end of the "
 "block, resulting in another call to `Drop::drop`, and a stack overflow!"
-msgstr "简答：如果这样的话，系统会在代码块结尾 调用 `std::mem::drop`，进而引发再一次调用 `Drop::drop`，并引发堆栈 溢出！"
+msgstr ""
+"简答：如果这样的话，系统会在代码块结尾 调用 `std::mem::drop`，进而引发再一次"
+"调用 `Drop::drop`，并引发堆栈 溢出！"
 
 #: src/traits/drop.md:51
 msgid "Try replacing `drop(a)` with `a.drop()`."
@@ -9356,8 +9417,8 @@ msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
 "produces a default value for a type."
 msgstr ""
-"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
-"特征会为类型生成默认值。"
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 特征会"
+"为类型生成默认值。"
 
 #: src/traits/default.md:5
 msgid ""
@@ -9415,7 +9476,8 @@ msgstr "这意味着，该结构体中的所有类型也都必须实现 `Default
 msgid ""
 "Standard Rust types often implement `Default` with reasonable values (e.g. "
 "`0`, `\"\"`, etc)."
-msgstr "标准的 Rust 类型通常会以合理的值（例如 ` 0`\"\" \\`` 等）实现 `Default`。"
+msgstr ""
+"标准的 Rust 类型通常会以合理的值（例如 ` 0`\"\" \\`` 等）实现 `Default`。"
 
 #: src/traits/default.md:44
 msgid "The partial struct copy works nicely with default."
@@ -9429,8 +9491,9 @@ msgstr "Rust 标准库了解类型可能会实现 `Default`，因此提供了便
 
 #: src/traits/default.md:46
 msgid ""
-"the `..` syntax is called [struct update "
-"syntax](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax)"
+"the `..` syntax is called [struct update syntax](https://doc.rust-lang.org/"
+"book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
+"with-struct-update-syntax)"
 msgstr ""
 
 #: src/traits/operators.md:1
@@ -9439,10 +9502,11 @@ msgstr "` Add`Mul \\``…"
 
 #: src/traits/operators.md:3
 msgid ""
-"Operator overloading is implemented via traits in "
-"[`std::ops`](https://doc.rust-lang.org/std/ops/index.html):"
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
-"运算符重载是通过 [`std::ops`](https://doc.rust-lang.org/std/ops/index.html) 中的特征实现的："
+"运算符重载是通过 [`std::ops`](https://doc.rust-lang.org/std/ops/index.html) "
+"中的特征实现的："
 
 #: src/traits/operators.md:5
 msgid ""
@@ -9477,8 +9541,8 @@ msgid ""
 "the operator is not `Copy`, you should consider overloading the operator for "
 "`&T` as well. This avoids unnecessary cloning on the call site."
 msgstr ""
-"回答：`Add:add` 会耗用 `self`。如果您的运算符重载对象 （即类型 `T`）不是 `Copy`，建议您也为 `&T` "
-"重载运算符。这可避免调用点上存在不必要的 克隆任务。"
+"回答：`Add:add` 会耗用 `self`。如果您的运算符重载对象 （即类型 `T`）不是 "
+"`Copy`，建议您也为 `&T` 重载运算符。这可避免调用点上存在不必要的 克隆任务。"
 
 #: src/traits/operators.md:33
 msgid ""
@@ -9491,14 +9555,17 @@ msgid ""
 "Short answer: Function type parameters are controlled by the caller, but "
 "associated types (like `Output`) are controlled by the implementor of a "
 "trait."
-msgstr "简答：函数类型形参是由调用方控管，但 `Output` 这类关联类型则由特征实现人员 控管。"
+msgstr ""
+"简答：函数类型形参是由调用方控管，但 `Output` 这类关联类型则由特征实现人员 控"
+"管。"
 
 #: src/traits/operators.md:37
 msgid ""
 "You could implement `Add` for two different types, e.g. `impl Add<(i32, "
 "i32)> for Point` would add a tuple to a `Point`."
 msgstr ""
-"您可以针对两种不同类型实现 `Add`，例如， `impl Add<(i32, i32)> for Point` 会向 `Point` 中添加元组。"
+"您可以针对两种不同类型实现 `Add`，例如， `impl Add<(i32, i32)> for Point` 会"
+"向 `Point` 中添加元组。"
 
 #: src/traits/closures.md:1
 msgid "Closures"
@@ -9507,15 +9574,14 @@ msgstr "闭包"
 #: src/traits/closures.md:3
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they implement special "
-"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), "
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
-"闭包或 lambda 表达式具有无法命名的类型。不过，它们会 实现特殊的 "
-"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)， "
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和 "
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) 特征："
+"闭包或 lambda 表达式具有无法命名的类型。不过，它们会 实现特殊的 [`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html)， [`FnMut`](https://doc."
+"rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://doc.rust-lang."
+"org/std/ops/trait.FnOnce.html) 特征："
 
 #: src/traits/closures.md:8
 msgid ""
@@ -9549,19 +9615,25 @@ msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
 "perhaps captures nothing at all. It can be called multiple times "
 "concurrently."
-msgstr "`Fn`（例如 `add_3`）既不会耗用也不会修改捕获的值，或许 也不会捕获任何值。它可被并发调用多次。"
+msgstr ""
+"`Fn`（例如 `add_3`）既不会耗用也不会修改捕获的值，或许 也不会捕获任何值。它可"
+"被并发调用多次。"
 
 #: src/traits/closures.md:37
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
 "multiple times, but not concurrently."
-msgstr "`FnMut`（例如 `accumulate`）可能会改变捕获的值。您可以多次调用它， 但不能并发调用它。"
+msgstr ""
+"`FnMut`（例如 `accumulate`）可能会改变捕获的值。您可以多次调用它， 但不能并发"
+"调用它。"
 
 #: src/traits/closures.md:40
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
 "might consume captured values."
-msgstr "如果您使用 `FnOnce`（例如 `multiply_sum`），或许只能调用它一次。它可能会耗用 所捕获的值。"
+msgstr ""
+"如果您使用 `FnOnce`（例如 `multiply_sum`），或许只能调用它一次。它可能会耗用 "
+"所捕获的值。"
 
 #: src/traits/closures.md:43
 msgid ""
@@ -9569,20 +9641,25 @@ msgid ""
 "I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
 "use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
-"`FnMut` 是 `FnOnce` 的子类型。`Fn` 是 `FnMut` 和 `FnOnce` 的子类型。也就是说，您可以在任何 需要调用 "
-"`FnOnce` 的地方使用 `FnMut`，还可在任何需要调用 `FnMut` 或 `FnOnce` 的地方 使用 `Fn`。"
+"`FnMut` 是 `FnOnce` 的子类型。`Fn` 是 `FnMut` 和 `FnOnce` 的子类型。也就是"
+"说，您可以在任何 需要调用 `FnOnce` 的地方使用 `FnMut`，还可在任何需要调用 "
+"`FnMut` 或 `FnOnce` 的地方 使用 `Fn`。"
 
 #: src/traits/closures.md:47
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
 "`multiply_sum`), depending on what the closure captures."
-msgstr "编译器也会推断 `Copy`（例如针对 `add_3`）和 `Clone`（例如 `multiply_sum`）， 具体取决于闭包捕获的数据。"
+msgstr ""
+"编译器也会推断 `Copy`（例如针对 `add_3`）和 `Clone`（例如 `multiply_sum`）， "
+"具体取决于闭包捕获的数据。"
 
 #: src/traits/closures.md:50
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
 "keyword makes them capture by value."
-msgstr "默认情况下，闭包会依据引用来捕获数据（如果可以的话）。`move` 关键字则可让闭包依据值 来捕获数据。"
+msgstr ""
+"默认情况下，闭包会依据引用来捕获数据（如果可以的话）。`move` 关键字则可让闭包"
+"依据值 来捕获数据。"
 
 #: src/traits/closures.md:52
 msgid ""
@@ -9757,8 +9834,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
-"demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\"\n"
 "    )));\n"
@@ -9773,10 +9850,10 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:140
 msgid ""
-"If you want to draw aligned text, you can use the "
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment) "
-"formatting operators. In particular, notice how you can pad with different "
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:145
@@ -10013,7 +10090,8 @@ msgstr ""
 msgid ""
 "This can be useful in servers which should keep running even if a single "
 "request crashes."
-msgstr "如果服务器需要持续运行（即使是在请求发生崩溃的情况下）， 此方法十分有用。"
+msgstr ""
+"如果服务器需要持续运行（即使是在请求发生崩溃的情况下）， 此方法十分有用。"
 
 #: src/error-handling/panic-unwind.md:23
 msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
@@ -10027,7 +10105,9 @@ msgstr "使用 `Result` 进行结构化错误处理"
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
 "are expected as part of normal operation:"
-msgstr "在前面，我们看到了 `Result` 枚举。在遇到正常操作产生的预期错误时， 我们常会用到此方法："
+msgstr ""
+"在前面，我们看到了 `Result` 枚举。在遇到正常操作产生的预期错误时， 我们常会用"
+"到此方法："
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10058,15 +10138,18 @@ msgid ""
 "case where an error should never happen, `unwrap()` or `expect()` can be "
 "called, and this is a signal of the developer intent too."
 msgstr ""
-"与 `Option` 方法相同，成功值位于 `Result` 方法内部， 开发者必须显示提取成功值。因此，建议进行错误检查。在绝不应出现错误的情况下， "
-"可以调用 `unwrap()` 或 `expect()` 方法，这也是一种开发者意向信号。"
+"与 `Option` 方法相同，成功值位于 `Result` 方法内部， 开发者必须显示提取成功"
+"值。因此，建议进行错误检查。在绝不应出现错误的情况下， 可以调用 `unwrap()` "
+"或 `expect()` 方法，这也是一种开发者意向信号。"
 
 #: src/error-handling/result.md:30
 msgid ""
 "`Result` documentation is a recommended read. Not during the course, but it "
 "is worth mentioning.  It contains a lot of convenience methods and functions "
 "that help functional-style programming. "
-msgstr "我们建议阅读 `Result` 文档。虽然课程中不会涉及该文档，但是有必要提到它。 该文档中包含许多便捷的方法和函数，对于函数式编程很有帮助。"
+msgstr ""
+"我们建议阅读 `Result` 文档。虽然课程中不会涉及该文档，但是有必要提到它。 该文"
+"档中包含许多便捷的方法和函数，对于函数式编程很有帮助。"
 
 #: src/error-handling/try-operator.md:1
 msgid "Propagating Errors with `?`"
@@ -10125,7 +10208,9 @@ msgstr "`username` 变量可以是 `Ok(string)` 或 `Err(error)`。"
 msgid ""
 "Use the `fs::write` call to test out the different scenarios: no file, empty "
 "file, file with username."
-msgstr "可以使用 `fs::write` 调用来测试不同的场景：没有文件、空文件、包含用户名的文件。"
+msgstr ""
+"可以使用 `fs::write` 调用来测试不同的场景：没有文件、空文件、包含用户名的文"
+"件。"
 
 #: src/error-handling/try-operator.md:52
 msgid ""
@@ -10159,7 +10244,8 @@ msgstr "效果等同于"
 msgid ""
 "The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
-msgstr "此处的 `From::from` 调用表示，我们尝试将错误类型转换为 函数返回的类型："
+msgstr ""
+"此处的 `From::from` 调用表示，我们尝试将错误类型转换为 函数返回的类型："
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -10214,9 +10300,8 @@ msgstr ""
 msgid ""
 "It is good practice for all error types that don't need to be `no_std` to "
 "implement `std::error::Error`, which requires `Debug` and `Display`. The "
-"`Error` crate for `core` is only available in "
-"[nightly](https://github.com/rust-lang/rust/issues/103765), so not fully "
-"`no_std` compatible yet."
+"`Error` crate for `core` is only available in [nightly](https://github.com/"
+"rust-lang/rust/issues/103765), so not fully `no_std` compatible yet."
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:57
@@ -10226,16 +10311,18 @@ msgid ""
 "possible, to make life easier for tests and consumers of your library. In "
 "this case we can't easily do so, because `io::Error` doesn't implement them."
 msgstr ""
-"对所有错误类型实现 `std::error::Error` 是一种很好的做法，而这需要结合使用 `Debug` 和 `Display` 方法。 "
-"通常，在可能的情况下实现 `Clone` 和 `Eq` 也十分有益， 可以让库的测试和使用变得更加简单。在本例中，我们无法轻松做到这一点， 因为 "
-"`io::Error` 不能实现这些方法。"
+"对所有错误类型实现 `std::error::Error` 是一种很好的做法，而这需要结合使用 "
+"`Debug` 和 `Display` 方法。 通常，在可能的情况下实现 `Clone` 和 `Eq` 也十分有"
+"益， 可以让库的测试和使用变得更加简单。在本例中，我们无法轻松做到这一点， 因"
+"为 `io::Error` 不能实现这些方法。"
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
 "an error enum like we did on the previous page:"
 msgstr ""
-"[thiserror](https://docs.rs/thiserror/) crate 是创建错误枚举的常用方法， 就像前一页中提供的示例一样："
+"[thiserror](https://docs.rs/thiserror/) crate 是创建错误枚举的常用方法， 就像"
+"前一页中提供的示例一样："
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -10277,8 +10364,9 @@ msgid ""
 "optionally `Display` (if the `#[error(...)]` attributes are provided) and "
 "`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
-"`thiserror` 的派生宏会自动实现 `std::error::Error`，并且可以选择性地实现 `Display` （如果提供了 "
-"`#[error(...)]` 属性）和 `From`（如果添加了 `#[from]` 属性）。 此规则也适用于结构体。"
+"`thiserror` 的派生宏会自动实现 `std::error::Error`，并且可以选择性地实现 "
+"`Display` （如果提供了 `#[error(...)]` 属性）和 `From`（如果添加了 `#[from]` "
+"属性）。 此规则也适用于结构体。"
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
@@ -10290,7 +10378,8 @@ msgid ""
 "our own enum covering all the different possibilities. `std::error::Error` "
 "makes this easy."
 msgstr ""
-"有时，我们需要允许返回任意类型的错误，但又不想自己手动编写枚举来涵盖所有不同的可能性。 `std::error::Error` 可以让我们轻松做到这一点。"
+"有时，我们需要允许返回任意类型的错误，但又不想自己手动编写枚举来涵盖所有不同"
+"的可能性。 `std::error::Error` 可以让我们轻松做到这一点。"
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -10331,8 +10420,10 @@ msgid ""
 "good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
-"虽然这可以省却编写代码的麻烦，但也会导致我们无法在程序中以不同的方式正常处理不同的 错误情况。因此，在库的公共 API 中使用 `Box<dyn "
-"Error>` 通常不是一个好主意。 但是对于您只需要在某处显示错误消息的程序来说，这不失为一个 很好的选择。"
+"虽然这可以省却编写代码的麻烦，但也会导致我们无法在程序中以不同的方式正常处理"
+"不同的 错误情况。因此，在库的公共 API 中使用 `Box<dyn Error>` 通常不是一个好"
+"主意。 但是对于您只需要在某处显示错误消息的程序来说，这不失为一个 很好的选"
+"择。"
 
 #: src/error-handling/error-contexts.md:3
 msgid ""
@@ -10340,8 +10431,8 @@ msgid ""
 "contextual information to your errors and allows you to have fewer custom "
 "error types:"
 msgstr ""
-"广泛使用的 [anyhow](https://docs.rs/anyhow/) crate 可以帮助我们为错误添加 背景信息，并减少自定义错误类型的 "
-"数量。"
+"广泛使用的 [anyhow](https://docs.rs/anyhow/) crate 可以帮助我们为错误添加 背"
+"景信息，并减少自定义错误类型的 数量。"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -10398,12 +10489,13 @@ msgid ""
 "developers, as it provides similar usage patterns and ergonomics to `(T, "
 "error)` from Go."
 msgstr ""
-"”的封装容器。因此，就像前面提到的那样，在库的公共 API 中 使用它通常不是一个好主意。但是它广泛用于应用中。\n"
+"”的封装容器。因此，就像前面提到的那样，在库的公共 API 中 使用它通常不是一个好"
+"主意。但是它广泛用于应用中。\n"
 "\n"
 "如果需要，可以提取其内部的实际错误类型进行检查。\n"
 "\n"
-"Go 开发者可能会十分熟悉 `anyhow::Result<T>` 提供的功能， 因为它的使用模式和工效学设计与 Go 的 `(T, error)` "
-"方法十分相似。"
+"Go 开发者可能会十分熟悉 `anyhow::Result<T>` 提供的功能， 因为它的使用模式和工"
+"效学设计与 Go 的 `(T, error)` 方法十分相似。"
 
 #: src/testing.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
@@ -10454,9 +10546,11 @@ msgstr "使用 `cargo test` 查找并运行单元测试。"
 
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the "
-"[Playground](https://play.rust-lang.org/)):"
-msgstr "单元测试通常会放在嵌套模块中（在 [Playground](https://play.rust-lang.org/) 上运行测试）："
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
+msgstr ""
+"单元测试通常会放在嵌套模块中（在 [Playground](https://play.rust-lang.org/) 上"
+"运行测试）："
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -10519,17 +10613,17 @@ msgstr "代码会作为 `cargo test` 的一部分进行编译和执行。"
 
 #: src/testing/doc-tests.md:20
 msgid ""
-"Adding `# ` in the code will hide it from the docs, but will still "
-"compile/run it."
+"Adding `# ` in the code will hide it from the docs, but will still compile/"
+"run it."
 msgstr ""
 
 #: src/testing/doc-tests.md:21
 msgid ""
-"Test the above code on the [Rust "
-"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"在 [Rust "
-"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
+"在 [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
 "上测试上述代码。"
 
 #: src/testing/integration-tests.md:3
@@ -10561,7 +10655,8 @@ msgid ""
 "[googletest](https://docs.rs/googletest): Comprehensive test assertion "
 "library in the tradition of GoogleTest for C++."
 msgstr ""
-"[googletest](https://docs.rs/googletest)：遵从 GoogleTest for C++ 传统的综合测试断言库。"
+"[googletest](https://docs.rs/googletest)：遵从 GoogleTest for C++ 传统的综合"
+"测试断言库。"
 
 #: src/testing/useful-crates.md:8
 msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
@@ -10591,13 +10686,16 @@ msgstr "\\*\\*不安全 Rust：\\*\\*如果违反了前提条件，可能会触�
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
 "know what Unsafe Rust is."
-msgstr "本课程中出现的大多为“安全 Rust”，但是了解“不安全 Rust”的定义 非常重要。"
+msgstr ""
+"本课程中出现的大多为“安全 Rust”，但是了解“不安全 Rust”的定义 非常重要。"
 
 #: src/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
 "carefully documented. It is usually wrapped in a safe abstraction layer."
-msgstr "不安全的代码通常内容很少而且与其他代码隔离， 其正确性也应得到仔细记录。这类代码通常封装在安全的抽象层中。"
+msgstr ""
+"不安全的代码通常内容很少而且与其他代码隔离， 其正确性也应得到仔细记录。这类代"
+"码通常封装在安全的抽象层中。"
 
 #: src/unsafe.md:14
 msgid "Unsafe Rust gives you access to five new capabilities:"
@@ -10626,12 +10724,11 @@ msgstr "实现 `unsafe` trait。"
 #: src/unsafe.md:22
 msgid ""
 "We will briefly cover unsafe capabilities next. For full details, please see "
-"[Chapter 19.1 in the Rust "
-"Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) and the "
-"[Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
-"下面，我们将简要介绍这些不安全功能。如需了解完整详情，请参阅 [《Rust 手册》第 19.1 "
-"章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) 和 "
+"下面，我们将简要介绍这些不安全功能。如需了解完整详情，请参阅 [《Rust 手册》"
+"第 19.1 章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) 和 "
 "[Rustonomicon](https://doc.rust-lang.org/nomicon/)。"
 
 #: src/unsafe.md:28
@@ -10641,8 +10738,8 @@ msgid ""
 "by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
-"不安全 Rust 并不意味着代码不正确，而是这意味着开发者已停用 编译器的安全功能，必须自行编写正确的 代码。也就是说，编译器不再强制执行 Rust "
-"的内存安全规则。"
+"不安全 Rust 并不意味着代码不正确，而是这意味着开发者已停用 编译器的安全功能，"
+"必须自行编写正确的 代码。也就是说，编译器不再强制执行 Rust 的内存安全规则。"
 
 #: src/unsafe/raw-pointers.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
@@ -10678,16 +10775,16 @@ msgid ""
 "a comment for each `unsafe` block explaining how the code inside it "
 "satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
-"我们建议（而且 Android Rust 样式指南要求）为每个 `unsafe` 代码块编写一条注释， "
-"说明该代码块中的代码如何满足其所执行的不安全操作的 安全要求。"
+"我们建议（而且 Android Rust 样式指南要求）为每个 `unsafe` 代码块编写一条注"
+"释， 说明该代码块中的代码如何满足其所执行的不安全操作的 安全要求。"
 
 #: src/unsafe/raw-pointers.md:31
 msgid ""
 "In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
-"对于指针解除引用，这意味着指针必须为 "
-"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety)，即："
+"对于指针解除引用，这意味着指针必须为 [_valid_](https://doc.rust-lang.org/std/"
+"ptr/index.html#safety)，即："
 
 #: src/unsafe/raw-pointers.md:34
 msgid "The pointer must be non-null."
@@ -10711,7 +10808,9 @@ msgstr "不得并发访问相同位置。"
 msgid ""
 "If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
-msgstr "如果通过转换引用类型来获取指针，则底层对象必须处于活跃状态， 而且不得使用任何引用来访问内存。"
+msgstr ""
+"如果通过转换引用类型来获取指针，则底层对象必须处于活跃状态， 而且不得使用任何"
+"引用来访问内存。"
 
 #: src/unsafe/raw-pointers.md:41
 msgid "In most cases the pointer must also be properly aligned."
@@ -10760,7 +10859,9 @@ msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
-msgstr "通常，我们不建议使用可变的静态变量，但在某些情况下，在低层级 `no_std` 代码中可能需要这样做， 例如实现堆分配器或使用某些 C API。"
+msgstr ""
+"通常，我们不建议使用可变的静态变量，但在某些情况下，在低层级 `no_std` 代码中"
+"可能需要这样做， 例如实现堆分配器或使用某些 C API。"
 
 #: src/unsafe/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
@@ -10787,24 +10888,28 @@ msgstr ""
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
-msgstr "在 Rust 中很少需要用到联合体，因为您通常可以使用枚举。联合体只是偶尔用于 与 C 库 API 进行交互。"
+msgstr ""
+"在 Rust 中很少需要用到联合体，因为您通常可以使用枚举。联合体只是偶尔用于 与 "
+"C 库 API 进行交互。"
 
 #: src/unsafe/unions.md:24
 msgid ""
 "If you just want to reinterpret bytes as a different type, you probably want "
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
-"or a safe wrapper such as the "
-"[`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
-"如果您只是想将字节重新解释为其他类型，则可能需要使用 "
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
-"或 安全的封装容器，例如 [`zerocopy`](https://crates.io/crates/zerocopy) crate。"
+"如果您只是想将字节重新解释为其他类型，则可能需要使用 [`std::mem::transmute`]"
+"(https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) 或 安全的封装容"
+"器，例如 [`zerocopy`](https://crates.io/crates/zerocopy) crate。"
 
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
 "you must uphold to avoid undefined behaviour:"
-msgstr "如果函数或方法具有额外的前提条件，您必须遵守这些前提条件来避免未定义的行为， 则可以将该函数或方法标记为 `unsafe`："
+msgstr ""
+"如果函数或方法具有额外的前提条件，您必须遵守这些前提条件来避免未定义的行为， "
+"则可以将该函数或方法标记为 `unsafe`："
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
@@ -10821,13 +10926,13 @@ msgid ""
 "        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
 "    }\n"
 "\n"
-"    println!(\"char count: {}\", count_chars(unsafe { "
-"emojis.get_unchecked(0..7) }));\n"
+"    println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..7) }));\n"
 "\n"
 "    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe { "
-"emojis.get_unchecked(0..3) }));\n"
+"    // println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..3) }));\n"
 "}\n"
 "\n"
 "fn count_chars(s: &str) -> usize {\n"
@@ -10840,7 +10945,9 @@ msgstr ""
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
 "conditions to avoid undefined behaviour."
-msgstr "如果您自己编写的函数需要满足特定条件以避免未定义的行为， 您可以将这些函数标记为 `unsafe`。"
+msgstr ""
+"如果您自己编写的函数需要满足特定条件以避免未定义的行为， 您可以将这些函数标记"
+"为 `unsafe`。"
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -10882,8 +10989,9 @@ msgid ""
 "`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
 "Try adding it and see what happens."
 msgstr ""
-"请注意，在不安全函数中，可以在没有 `unsafe` 代码块的情况下使用不安全代码。我们可以 使用 "
-"`#[deny(unsafe_op_in_unsafe_fn)]` 来禁止此行为。请尝试添加该命令，看看会出现什么情况。"
+"请注意，在不安全函数中，可以在没有 `unsafe` 代码块的情况下使用不安全代码。我"
+"们可以 使用 `#[deny(unsafe_op_in_unsafe_fn)]` 来禁止此行为。请尝试添加该命"
+"令，看看会出现什么情况。"
 
 #: src/unsafe/extern-functions.md:1
 msgid "Calling External Code"
@@ -10893,7 +11001,8 @@ msgstr "调用外部代码"
 msgid ""
 "Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
-msgstr "基于其他语言的函数可能会违反 Rust 的保证。因此， 调用这类函数是不安全的："
+msgstr ""
+"基于其他语言的函数可能会违反 Rust 的保证。因此， 调用这类函数是不安全的："
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
@@ -10916,27 +11025,31 @@ msgid ""
 "This is usually only a problem for extern functions which do things with "
 "pointers which might violate Rust's memory model, but in general any C "
 "function might have undefined behaviour under any arbitrary circumstances."
-msgstr "这个问题通常仅存在于使用指针执行违反 Rust 内存模型的操作的外部函数中。 但一般而言，任何 C 函数都有可能在任意情况下出现未定义行为。"
+msgstr ""
+"这个问题通常仅存在于使用指针执行违反 Rust 内存模型的操作的外部函数中。 但一般"
+"而言，任何 C 函数都有可能在任意情况下出现未定义行为。"
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI; [other ABIs are available "
-"too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
 "must guarantee particular conditions to avoid undefined behaviour."
-msgstr "与函数一样，如果您在实现某个 trait 时必须保证特定条件来避免未定义的行为， 您也可以将该 trait 标记为 `unsafe`。"
+msgstr ""
+"与函数一样，如果您在实现某个 trait 时必须保证特定条件来避免未定义的行为， 您"
+"也可以将该 trait 标记为 `unsafe`。"
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
 "For example, the `zerocopy` crate has an unsafe trait that looks [something "
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
-"例如，`zerocopy` crate 包含一个不安全的 trait， "
-"[大致内容是这样的](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html)："
+"例如，`zerocopy` crate 包含一个不安全的 trait， [大致内容是这样的](https://"
+"docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html)："
 
 #: src/unsafe/unsafe-traits.md:9
 msgid ""
@@ -10965,7 +11078,9 @@ msgstr ""
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
-msgstr "在 Rustdoc 中有关 trait 的章节下，有一个标题为 `# 安全` 的部分介绍了 安全实现 trait 的要求。"
+msgstr ""
+"在 Rustdoc 中有关 trait 的章节下，有一个标题为 `# 安全` 的部分介绍了 安全实"
+"现 trait 的要求。"
 
 #: src/unsafe/unsafe-traits.md:33
 msgid ""
@@ -10999,8 +11114,8 @@ msgstr ""
 
 #: src/exercises/day-3/afternoon.md:14
 msgid ""
-"After looking at the exercise, you can look at the "
-"[solution](solutions-afternoon.md) provided."
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
@@ -11028,9 +11143,9 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the "
-"[`std::ffi`](https://doc.rust-lang.org/std/ffi/) module. There you find a "
-"number of string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
@@ -11043,8 +11158,8 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and "
-"[`String`](https://doc.rust-lang.org/std/string/struct.String.html)"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:18
@@ -11057,8 +11172,8 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:19
 msgid ""
-"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and "
-"[`CString`](https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:19
@@ -11111,9 +11226,8 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28
 msgid ""
-"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use "
-"[`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) "
-"to create it,"
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:31
@@ -11149,8 +11263,8 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, "
-"core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
 "    // Layout according to the Linux man page for readdir(3), where ino_t "
@@ -11250,7 +11364,9 @@ msgid ""
 "Rust is supported for native platform development on Android. This means "
 "that you can write new operating system services in Rust, as well as "
 "extending existing services."
-msgstr "Rust 支持Android 的原生平台开发。这意味着您可以在Rust 中编写新的操作系统服务，以及扩展现有服务。"
+msgstr ""
+"Rust 支持Android 的原生平台开发。这意味着您可以在Rust 中编写新的操作系统服"
+"务，以及扩展现有服务。"
 
 #: src/android.md:7
 msgid ""
@@ -11259,23 +11375,25 @@ msgid ""
 "to Rust. The fewer dependencies and \"exotic\" types the better. Something "
 "that parses some raw bytes would be ideal."
 msgstr ""
-"今天我们会尝试在你自己的项目中调用Rust。 所以试着在你的代码中找一小段来改成Rust。 "
-"代码中越少依赖(dependencies)，越少“独特”的类型，越好。比如 一段解析原始字符的代码就很理想。"
+"今天我们会尝试在你自己的项目中调用Rust。 所以试着在你的代码中找一小段来改成"
+"Rust。 代码中越少依赖(dependencies)，越少“独特”的类型，越好。比如 一段解析原"
+"始字符的代码就很理想。"
 
 #: src/android/setup.md:3
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
 "have access to one or create a new one with:"
 msgstr ""
-"我们将会使用Android 虚拟设备（Android Virtual Device）来测试我们的代码。 确保你有权限访问一个，或者用以下命令创建一个新的："
+"我们将会使用Android 虚拟设备（Android Virtual Device）来测试我们的代码。 确保"
+"你有权限访问一个，或者用以下命令创建一个新的："
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer "
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-"更多细节请参考 [Android Developer "
-"Codelab](https://source.android.com/docs/setup/start)."
+"更多细节请参考 [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start)."
 
 #: src/android/build-rules.md:3
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
@@ -11285,18 +11403,21 @@ msgstr "Android 构建系统（Soong）通过一系列模块来支持Rust："
 #, fuzzy
 msgid "Module Type"
 msgstr ""
-"\\| 模块类型      | 描述                                                           "
-"                             | "
-"\\|—————————|——————————————————————————————————————————————————| \\| "
-"`rust_binary`     | Rust 二进制文件。                                              "
-"                             | \\| `rust_library`    | 生成Rust 库，并且提供 `rlib` "
-"和 `dylib` 变体。                       | \\| `rust_ffi`        | 生成可由 cc 模块使用的 "
-"Rust C 库，并提供静态和共享变体。    | \\| `rust_proc_macro` | 生成 proc-macro Rust 库。 "
-"这些宏与编译器插件类似。                     | \\| `rust_test`       | 生成使用标准 Rust "
-"自动化测试框架的 Rust 测试二进制文件。                             | \\| `rust_fuzz`       | "
-"生成使用 libfuzzer 的 Rust 模糊测试二进制文件。                                         | "
-"\\| `rust_protobuf`   | 生成源代码，并生成为特定 protobuf 提供接口的 Rust 库。| \\| "
-"`rust_bindgen`    | 生成源代码，并生成包含与 C 库的 Rust 绑定的 Rust 库。｜"
+"\\| 模块类型      | 描"
+"述                                                                                        "
+"| \\|—————————|——————————————————————————————————————————————————| \\| "
+"`rust_binary`     | Rust 二进制文"
+"件。                                                                           "
+"| \\| `rust_library`    | 生成Rust 库，并且提供 `rlib` 和 `dylib` 变"
+"体。                       | \\| `rust_ffi`        | 生成可由 cc 模块使用的 "
+"Rust C 库，并提供静态和共享变体。    | \\| `rust_proc_macro` | 生成 proc-"
+"macro Rust 库。 这些宏与编译器插件类似。                     | \\| "
+"`rust_test`       | 生成使用标准 Rust 自动化测试框架的 Rust 测试二进制文"
+"件。                             | \\| `rust_fuzz`       | 生成使用 "
+"libfuzzer 的 Rust 模糊测试二进制文"
+"件。                                         | \\| `rust_protobuf`   | 生成源"
+"代码，并生成为特定 protobuf 提供接口的 Rust 库。| \\| `rust_bindgen`    | 生"
+"成源代码，并生成包含与 C 库的 Rust 绑定的 Rust 库。｜"
 
 #: src/android/build-rules.md:5
 msgid "Description"
@@ -11388,8 +11509,7 @@ msgid ""
 "create the following files:"
 msgstr "让我们从一个简单的应用程序开始。在 AOSP 签出的根目录下，创建以下文件："
 
-#: src/android/build-rules/binary.md:6
-#: src/android/build-rules/library.md:13
+#: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 msgid "_hello_rust/Android.bp_:"
 msgstr "_hello_rust/Android.bp_:"
 
@@ -11411,8 +11531,7 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/android/build-rules/binary.md:16
-#: src/android/build-rules/library.md:34
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
 msgid "_hello_rust/src/main.rs_:"
 msgstr "_hello_rust/src/main.rs_:"
 
@@ -11441,7 +11560,6 @@ msgid "You can now build, push, and run the binary:"
 msgstr "你现在可以构建、推送和运行二进制文件："
 
 #: src/android/build-rules/binary.md:29
-#, fuzzy
 msgid ""
 "```shell\n"
 "m hello_rust\n"
@@ -11468,12 +11586,13 @@ msgstr "`libgreeting`, 我们在下面进行了定义，"
 
 #: src/android/build-rules/library.md:8
 msgid ""
-"`libtextwrap`, which is a crate already vendored in "
-"[`external/rust/crates/`](https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/)."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"`libtextwrap`, 一个已经在 "
-"[`external/rust/crates/`](https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/) "
-"中提供的 crate。"
+"`libtextwrap`, 一个已经在 [`external/rust/crates/`](https://cs.android.com/"
+"android/platform/superproject/+/master:external/rust/crates/) 中提供的 "
+"crate。"
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -11570,24 +11689,22 @@ msgid "You build, push, and run the binary like before:"
 msgstr "您可以像之前一样构建、推送和运行二进制文件："
 
 #: src/android/build-rules/library.md:61
-#, fuzzy
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/hello_rust_with_dep\n"
 "```"
 msgstr ""
 
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language "
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
-"Rust 支持 [Android 接口定义语言 "
-"(AIDL)](https://developer.android.com/guide/components/aidl)："
+"Rust 支持 [Android 接口定义语言 (AIDL)](https://developer.android.com/guide/"
+"components/aidl)："
 
 #: src/android/aidl.md:6
 msgid "Rust code can call existing AIDL servers,"
@@ -11647,7 +11764,9 @@ msgstr ""
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
 "vendor partition."
-msgstr "如果供应商分区中的二进制文件使用了您的 AIDL 文件，请添加 `vendor_available: true`。"
+msgstr ""
+"如果供应商分区中的二进制文件使用了您的 AIDL 文件，请添加 `vendor_available: "
+"true`。"
 
 #: src/android/aidl/implementation.md:1
 msgid "Service Implementation"
@@ -11665,8 +11784,8 @@ msgstr "_birthday_service/src/lib.rs_:"
 msgid ""
 "```rust,ignore\n"
 "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "/// The `IBirthdayService` implementation.\n"
@@ -11675,11 +11794,11 @@ msgid ""
 "impl binder::Interface for BirthdayService {}\n"
 "\n"
 "impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
-"binder::Result<String> {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
+"Result<String> {\n"
 "        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} "
-"years!\"\n"
+"            \"Happy Birthday {name}, congratulations with the {years} years!"
+"\"\n"
 "        ))\n"
 "    }\n"
 "}\n"
@@ -11687,8 +11806,8 @@ msgid ""
 msgstr ""
 "```rust,ignore\n"
 "//! 实现了 `IBirthdayService` AIDL 接口。\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "/// `IBirthdayService` 接口的具体实现。\n"
@@ -11697,18 +11816,17 @@ msgstr ""
 "impl binder::Interface for BirthdayService {}\n"
 "\n"
 "impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
-"binder::Result<String> {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
+"Result<String> {\n"
 "        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} "
-"years!\"\n"
+"            \"Happy Birthday {name}, congratulations with the {years} years!"
+"\"\n"
 "        ))\n"
 "    }\n"
 "}\n"
 "```"
 
-#: src/android/aidl/implementation.md:26
-#: src/android/aidl/server.md:28
+#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
 msgid "_birthday_service/Android.bp_:"
 msgstr "_birthday_service/Android.bp_:"
@@ -11756,8 +11874,8 @@ msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
 "use birthdayservice::BirthdayService;\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
@@ -11769,8 +11887,8 @@ msgid ""
 "        birthday_service,\n"
 "        binder::BinderFeatures::default(),\n"
 "    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, "
-"birthday_service_binder.as_binder())\n"
+"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
+"as_binder())\n"
 "        .expect(\"Failed to register service\");\n"
 "    binder::ProcessState::join_thread_pool()\n"
 "}\n"
@@ -11779,8 +11897,8 @@ msgstr ""
 "```rust,ignore\n"
 "//! 生日服务。\n"
 "use birthdayservice::BirthdayService;\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
@@ -11792,8 +11910,8 @@ msgstr ""
 "        birthday_service,\n"
 "        binder::BinderFeatures::default(),\n"
 "    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, "
-"birthday_service_binder.as_binder())\n"
+"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
+"as_binder())\n"
 "        .expect(\"Failed to register service\");\n"
 "    binder::ProcessState::join_thread_pool()\n"
 "}\n"
@@ -11834,12 +11952,11 @@ msgid "We can now build, push, and start the service:"
 msgstr "我们现在可以构建、推送和启动服务："
 
 #: src/android/aidl/deploy.md:5
-#, fuzzy
 msgid ""
 "```shell\n"
 "m birthday_server\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/birthday_server\n"
 "```"
 msgstr ""
@@ -11868,15 +11985,15 @@ msgstr "_birthday_service/src/client.rs_:"
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
 "\n"
 "/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
-"binder::StatusCode> {\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
+"StatusCode> {\n"
 "    binder::get_interface(SERVICE_IDENTIFIER)\n"
 "}\n"
 "\n"
@@ -11901,15 +12018,15 @@ msgid ""
 msgstr ""
 "```rust,ignore\n"
 "//! 生日服务。\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
 "\n"
 "/// 连接到 BirthdayService。\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
-"binder::StatusCode> {\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
+"StatusCode> {\n"
 "    binder::get_interface(SERVICE_IDENTIFIER)\n"
 "}\n"
 "\n"
@@ -11969,12 +12086,11 @@ msgid "Build, push, and run the client on your device:"
 msgstr "在您的设备上构建、推送并运行客户端："
 
 #: src/android/aidl/client.md:56
-#, fuzzy
 msgid ""
 "```shell\n"
 "m birthday_client\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/birthday_client Charlie 60\n"
 "```"
 msgstr ""
@@ -11989,7 +12105,9 @@ msgstr "让我们扩展API以提供更多功能：我们希望允许客户端指
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
 "or `stdout` (on-host):"
-msgstr "你应该使用 `log` crate 来自动记录日志到 `logcat` （设备上）或 `stdout`（主机上）："
+msgstr ""
+"你应该使用 `log` crate 来自动记录日志到 `logcat` （设备上）或 `stdout`（主机"
+"上）："
 
 #: src/android/logging.md:6
 msgid "_hello_rust_logs/Android.bp_:"
@@ -12067,19 +12185,17 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/android/logging.md:42
-#: src/android/interoperability/with-c/bindgen.md:98
+#: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
 #: src/android/interoperability/with-c/rust.md:73
 msgid "Build, push, and run the binary on your device:"
 msgstr "在你的设备上构建，推送，并运行二进制文件 ："
 
 #: src/android/logging.md:44
-#, fuzzy
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 msgstr ""
@@ -12139,8 +12255,8 @@ msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper "
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:23
@@ -12182,14 +12298,10 @@ msgid ""
 "#include \"libbirthday.h\"\n"
 "\n"
 "void print_card(const card* card) {\n"
-"  printf(\"+--------------\\n"
-"\");\n"
-"  printf(\"| Happy Birthday %s!\\n"
-"\", card->name);\n"
-"  printf(\"| Congratulations with the %i years!\\n"
-"\", card->years);\n"
-"  printf(\"+--------------\\n"
-"\");\n"
+"  printf(\"+--------------\\n\");\n"
+"  printf(\"| Happy Birthday %s!\\n\", card->name);\n"
+"  printf(\"| Congratulations with the %i years!\\n\", card->years);\n"
+"  printf(\"+--------------\\n\");\n"
 "}\n"
 "```"
 msgstr ""
@@ -12289,12 +12401,11 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:100
-#, fuzzy
 msgid ""
 "```shell\n"
 "m print_birthday_card\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
@@ -12421,12 +12532,11 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:75
-#, fuzzy
 msgid ""
 "```shell\n"
 "m analyze_numbers\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/analyze_numbers\n"
 "```"
 msgstr ""
@@ -12456,8 +12566,8 @@ msgstr ""
 
 #: src/android/interoperability/cpp.md:14
 msgid ""
-"At this point, the instructor should switch to the [CXX "
-"tutorial](https://cxx.rs/tutorial.html)."
+"At this point, the instructor should switch to the [CXX tutorial](https://"
+"cxx.rs/tutorial.html)."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:16
@@ -12472,16 +12582,16 @@ msgstr ""
 
 #: src/android/interoperability/cpp.md:20
 msgid ""
-"Show the correspondence between [Rust and C++ "
-"types](https://cxx.rs/bindings.html):"
+"Show the correspondence between [Rust and C++ types](https://cxx.rs/bindings."
+"html):"
 msgstr ""
 
 #: src/android/interoperability/cpp.md:22
 msgid ""
 "Explain how a Rust `String` cannot map to a C++ `std::string` (the latter "
 "does not uphold the UTF-8 invariant). Show that despite being different "
-"types, `rust::String` in C++ can be easily constructed from a C++ "
-"`std::string`, making it very ergonomic to use."
+"types, `rust::String` in C++ can be easily constructed from a C++ `std::"
+"string`, making it very ergonomic to use."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:28
@@ -12496,9 +12606,9 @@ msgstr ""
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface "
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni` "
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 
 #: src/android/interoperability/java.md:7
@@ -12620,8 +12730,8 @@ msgstr ""
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
 "who are familiar with the basics of Rust (perhaps from completing the "
-"Comprehensive Rust course), and ideally also have some experience with "
-"bare-metal programming in some other language such as C."
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/bare-metal.md:7
@@ -12648,19 +12758,21 @@ msgstr ""
 
 #: src/bare-metal.md:15
 msgid ""
-"For the microcontroller part of the course we will use the [BBC "
-"micro:bit](https://microbit.org/) v2 as an example. It's a [development "
-"board](https://tech.microbit.org/hardware/) based on the Nordic nRF51822 "
-"microcontroller with some LEDs and buttons, an I2C-connected accelerometer "
-"and compass, and an on-board SWD debugger."
+"For the microcontroller part of the course we will use the [BBC micro:bit]"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
+"an on-board SWD debugger."
 msgstr ""
 
 #: src/bare-metal.md:20
-msgid "To get started, install some tools we'll need later. On gLinux or Debian:"
+msgid ""
+"To get started, install some tools we'll need later. On gLinux or Debian:"
 msgstr ""
 
 #: src/bare-metal.md:30
-msgid "And give users in the `plugdev` group access to the micro:bit programmer:"
+msgid ""
+"And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
 
 #: src/bare-metal.md:32
@@ -12685,8 +12797,7 @@ msgstr ""
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:12
-#: src/bare-metal/alloc.md:1
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -12817,8 +12928,8 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a [global (heap) "
-"allocator](https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -12900,8 +13011,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"The `cortex_m_rt::entry` macro requires that the function have type `fn() -> "
-"!`, because returning to the reset handler doesn't make sense."
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:27
@@ -12999,8 +13110,8 @@ msgstr ""
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for memory-mapped peripherals from "
-"[CMSIS-SVD](https://www.keil.com/pack/doc/CMSIS/SVD/html/index.html) files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -13081,11 +13192,10 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
-"[HAL "
-"crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-implementation-crates) "
-"for many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits from "
-"[`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -13187,8 +13297,8 @@ msgid ""
 "        .p0_02\n"
 "        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
 "Level::Low);\n"
-"    let _pin3: P0_03<Output<PushPull>> = "
-"gpio0.p0_03.into_push_pull_output(Level::Low);\n"
+"    let _pin3: P0_03<Output<PushPull>> = gpio0.p0_03."
+"into_push_pull_output(Level::Low);\n"
 "\n"
 "    loop {}\n"
 "}\n"
@@ -13262,10 +13372,9 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement "
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-crates) "
-"in terms of these traits, e.g. an accelerometer driver might need an I2C or "
-"SPI bus implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
@@ -13356,9 +13465,9 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:23
 msgid ""
-"The [Microsoft Debug Adapter "
-"Protocol](https://microsoft.github.io/debug-adapter-protocol/) lets VSCode "
-"and other IDEs debug code running on any supported microcontroller."
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:25
@@ -13397,8 +13506,8 @@ msgstr ""
 #: src/bare-metal/microcontrollers/debugging.md:21
 msgid ""
 "```sh\n"
-"gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support "
-"--eval-command=\"target remote :1337\"\n"
+"gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support --eval-"
+"command=\"target remote :1337\"\n"
 "```"
 msgstr ""
 
@@ -13420,7 +13529,8 @@ msgid "\"Real-Time Interrupt-driven Concurrency\""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:5
-msgid "Shared resource management, message passing, task scheduling, timer queue"
+msgid ""
+"Shared resource management, message passing, task scheduling, timer queue"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:6
@@ -13457,8 +13567,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:13
 msgid ""
-"Some platforms have `std` implementations, e.g. "
-"[esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-library.html)."
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
@@ -13480,7 +13590,8 @@ msgid "Cortex-M only."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:23
-msgid "Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:24
@@ -13508,10 +13619,10 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"Check the documentation for the "
-"[`lsm303agr`](https://docs.rs/lsm303agr/latest/lsm303agr/) and "
-"[`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the [micro:bit hardware](https://tech.microbit.org/hardware/)."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:11
@@ -13520,29 +13631,28 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:12
-msgid "TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:13
 msgid ""
-"The LSM303AGR driver needs something implementing the "
-"`embedded_hal::blocking::i2c::WriteRead` trait. The "
-"[`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/struct.Twim.html) "
-"struct implements this."
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:17
 msgid ""
-"You have a "
-"[`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/struct.Board.html) "
-"struct with fields for the various pins and peripherals."
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:19
 msgid ""
-"You can also look at the [nRF52833 "
-"datasheet](https://infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.5.pdf) if "
-"you want, but it shouldn't be necessary for this exercise."
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23
@@ -13551,8 +13661,7 @@ msgid ""
 "look in the `compass` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:26
-#: src/exercises/bare-metal/rtc.md:19
+#: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 #, fuzzy
 msgid "_src/main.rs_:"
 msgstr "_hello_rust/src/main.rs_:"
@@ -13594,8 +13703,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:64
-#: src/exercises/bare-metal/rtc.md:385
+#: src/exercises/bare-metal/compass.md:64 src/exercises/bare-metal/rtc.md:385
 msgid "_Cargo.toml_ (you shouldn't need to change this):"
 msgstr ""
 
@@ -13637,8 +13745,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:100
-#: src/exercises/bare-metal/rtc.md:985
+#: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
 msgid "_.cargo/config.toml_ (you shouldn't need to change this):"
 msgstr ""
 
@@ -13658,7 +13765,8 @@ msgid "See the serial output on Linux with:"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:118
-msgid "Or on Mac OS something like (the device name may be slightly different):"
+msgid ""
+"Or on Mac OS something like (the device name may be slightly different):"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:124
@@ -13673,8 +13781,8 @@ msgstr ""
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
 "Now let's try writing something for Cortex-A. For simplicity we'll just work "
-"with QEMU's aarch64 "
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
@@ -13692,7 +13800,8 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:3
-msgid "Before we can start running Rust code, we need to do some initialisation."
+msgid ""
+"Before we can start running Rust code, we need to do some initialisation."
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:5
@@ -13800,10 +13909,10 @@ msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:86
 msgid ""
-"Unaligned accesses will fault. We build the Rust code for the "
-"`aarch64-unknown-none` target which sets `+strict-align` to prevent the "
-"compiler generating unaligned accesses, so it should be fine in this case, "
-"but this is not necessarily the case in general."
+"Unaligned accesses will fault. We build the Rust code for the `aarch64-"
+"unknown-none` target which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses, so it should be fine in this case, but this "
+"is not necessarily the case in general."
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:89
@@ -13894,9 +14003,8 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the "
-"[`smccc`](https://crates.io/crates/smccc) crate which has wrappers for all "
-"these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
@@ -13932,8 +14040,8 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:56
 msgid ""
-"Run the example in QEMU with `make qemu_psci` under "
-"`src/bare-metal/aps/examples`."
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
@@ -13986,9 +14094,8 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a "
-"[PL011](https://developer.arm.com/documentation/ddi0183/g) UART, so let's "
-"write a driver for that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -14039,8 +14146,8 @@ msgid ""
 "    fn read_flag_register(&self) -> u8 {\n"
 "        // Safe because we know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET).read_volatile() "
-"}\n"
+"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET)."
+"read_volatile() }\n"
 "    }\n"
 "}\n"
 "```"
@@ -14108,8 +14215,8 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:25
 msgid ""
-"Run the example in QEMU with `make qemu_minimal` under "
-"`src/bare-metal/aps/examples`."
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
@@ -14118,11 +14225,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more "
-"registers](https://developer.arm.com/documentation/ddi0183/g/programmers-model/summary-of-registers), "
-"and adding offsets to construct pointers to access them is error-prone and "
-"hard to read. Plus, some of them are bit fields which would be nice to "
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
@@ -14181,8 +14288,7 @@ msgstr ""
 msgid "ILPR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:12
-#: src/bare-metal/aps/better-uart.md:15
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
 msgid "8"
 msgstr ""
 
@@ -14194,8 +14300,7 @@ msgstr ""
 msgid "IBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:13
-#: src/bare-metal/aps/better-uart.md:16
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
 msgid "16"
 msgstr ""
 
@@ -14207,8 +14312,7 @@ msgstr ""
 msgid "FBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:14
-#: src/bare-metal/aps/better-uart.md:17
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
 msgid "6"
 msgstr ""
 
@@ -14244,10 +14348,8 @@ msgstr ""
 msgid "IMSC"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:18
-#: src/bare-metal/aps/better-uart.md:19
-#: src/bare-metal/aps/better-uart.md:20
-#: src/bare-metal/aps/better-uart.md:21
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
 msgid "11"
 msgstr ""
 
@@ -14347,11 +14449,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-representation) "
-"tells the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is necessary for our struct to have a predictable layout, "
-"as default Rust representation allows the compiler to (among other things) "
-"reorder fields however it sees fit."
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -14407,8 +14509,8 @@ msgid ""
 "        if self.read_flag_register().contains(Flags::RXFE) {\n"
 "            None\n"
 "        } else {\n"
-"            let data = unsafe { "
-"addr_of!((*self.registers).dr).read_volatile() };\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
 "            // TODO: Check for error conditions in bits 8-11.\n"
 "            Some(data as u8)\n"
 "        }\n"
@@ -14473,8 +14575,7 @@ msgid ""
 "            uart.write_byte(byte);\n"
 "            match byte {\n"
 "                b'\\r' => {\n"
-"                    uart.write_byte(b'\\n"
-"');\n"
+"                    uart.write_byte(b'\\n');\n"
 "                }\n"
 "                b'q' => break,\n"
 "                _ => {}\n"
@@ -14502,9 +14603,9 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the "
-"[`log`](https://crates.io/crates/log) crate. We can do this by implementing "
-"the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -14612,8 +14713,8 @@ msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:47
 msgid ""
-"Run the example in QEMU with `make qemu_logger` under "
-"`src/bare-metal/aps/examples`."
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:3
@@ -14701,12 +14802,11 @@ msgstr ""
 #: src/bare-metal/aps/exceptions.md:69
 msgid ""
 "We can think of exception handlers and our main execution context more or "
-"less like different threads. [`Send` and "
-"`Sync`](../../concurrency/send-sync.md) will control what we can share "
-"between them, just like with threads. For example, if we want to share some "
-"value between exception handlers and the rest of the program, and it's "
-"`Send` but not `Sync`, then we'll need to wrap it in something like a "
-"`Mutex` and put it in a static."
+"less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
+"md) will control what we can share between them, just like with threads. For "
+"example, if we want to share some value between exception handlers and the "
+"rest of the program, and it's `Send` but not `Sync`, then we'll need to wrap "
+"it in something like a `Mutex` and put it in a static."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
@@ -14727,8 +14827,8 @@ msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:7
 msgid ""
-"[Rust RaspberryPi OS "
-"tutorial](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)"
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:8
@@ -14814,14 +14914,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:49
-msgid "`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:50
 msgid ""
-"Run the example with `cargo run` under "
-"`src/bare-metal/useful-crates/zerocopy-example/`. (It won't run in the "
-"Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
@@ -14866,8 +14967,9 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:30
 msgid ""
-"This is used in Android for the [Protected VM "
-"Firmware](https://cs.android.com/android/platform/superproject/+/master:packages/modules/Virtualization/pvmfw/)."
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:31
@@ -14884,13 +14986,12 @@ msgstr ""
 msgid ""
 "[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
 "is a third-party crate implementing a basic buddy system allocator. It can "
-"be used both for "
-"[`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/buddy_system_allocator/struct.LockedHeap.html) "
-"implementing "
-"[`GlobalAlloc`](https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) "
-"so you can use the standard `alloc` crate (as we saw [before](../alloc.md)), "
-"or for allocating other address space. For example, we might want to "
-"allocate MMIO space for PCI BARs:"
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -14918,9 +15019,9 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"Run the example with `cargo run` under "
-"`src/bare-metal/useful-crates/allocator-example/`. (It won't run in the "
-"Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
@@ -15069,10 +15170,10 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the "
-"[vmbase](https://android.googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/master/vmbase/) "
-"library provides a linker script and useful defaults for the build rules, "
-"along with an entry point, UART console logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -15114,9 +15215,9 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a "
-"[PL031](https://developer.arm.com/documentation/ddi0224/c) real-time clock "
-"at 0x9010000. For this exercise, you should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:6
@@ -15128,17 +15229,15 @@ msgstr ""
 #: src/exercises/bare-metal/rtc.md:8
 msgid ""
 "Use the match register and raw interrupt status to busy-wait until a given "
-"time, e.g. 3 seconds in the future. (Call "
-"[`core::hint::spin_loop`](https://doc.rust-lang.org/core/hint/fn.spin_loop.html) "
-"inside the loop.)"
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:10
 msgid ""
 "_Extension if you have time:_ Enable and handle the interrupt generated by "
-"the RTC match. You can use the driver provided in the "
-"[`arm-gic`](https://docs.rs/arm-gic/) crate to configure the Arm Generic "
-"Interrupt Controller."
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:12
@@ -15147,9 +15246,8 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:13
 msgid ""
-"Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt."
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
@@ -15196,8 +15294,8 @@ msgid ""
 "base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) "
-"};\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
 "    gic.setup();\n"
 "\n"
 "    // TODO: Create instance of RTC driver and print current time.\n"
@@ -15514,8 +15612,8 @@ msgid ""
 "        if self.read_flag_register().contains(Flags::RXFE) {\n"
 "            None\n"
 "        } else {\n"
-"            let data = unsafe { "
-"addr_of!((*self.registers).dr).read_volatile() };\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
 "            // TODO: Check for error conditions in bits 8-11.\n"
 "            Some(data as u8)\n"
 "        }\n"
@@ -15669,10 +15767,10 @@ msgid ""
 ".set .L_TCR_RGN_IWB, 0x1 << 8\n"
 "/* Size offset for TTBR0_EL1 is 2**39 bytes (512 GiB). */\n"
 ".set .L_TCR_T0SZ_512, 64 - 39\n"
-".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | "
-".L_TCR_RGN_OWB\n"
-".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | "
-".L_TCR_T0SZ_512\n"
+".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | ."
+"L_TCR_RGN_OWB\n"
+".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | ."
+"L_TCR_T0SZ_512\n"
 "\n"
 "/* Stage 1 instruction access cacheability is unaffected. */\n"
 ".set .L_SCTLR_ELx_I, 0x1 << 12\n"
@@ -15690,10 +15788,10 @@ msgid ""
 ".set .L_SCTLR_EL1_ITD, 0x1 << 7\n"
 ".set .L_SCTLR_EL1_RES1, (0x1 << 11) | (0x1 << 20) | (0x1 << 22) | (0x1 << "
 "28) | (0x1 << 29)\n"
-".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | "
-".L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
-".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | "
-".L_SCTLR_EL1_RES1\n"
+".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | ."
+"L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
+".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | ."
+"L_SCTLR_EL1_RES1\n"
 "\n"
 "/**\n"
 " * This is a generic entry point for an image. It carries out the operations "
@@ -16217,7 +16315,8 @@ msgid ""
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
 "you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
-"Rust 类型系统能帮助我们把许多并发bug转换为编译期bug 发挥着重要作用。这通常称为“无畏并发”，因为你可以依靠编译器来确保 运行时的正确性。"
+"Rust 类型系统能帮助我们把许多并发bug转换为编译期bug 发挥着重要作用。这通常称"
+"为“无畏并发”，因为你可以依靠编译器来确保 运行时的正确性。"
 
 #: src/concurrency/threads.md:3
 msgid "Rust threads work similarly to threads in other languages:"
@@ -16285,7 +16384,9 @@ msgstr "请注意，线程在达到 10 之前就停止了，而主线程并 没�
 msgid ""
 "Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
 "the thread to finish."
-msgstr "使用 `let handle = thread::spawn(...)` 和后面的 `handle.join()` 等待 线程完成。"
+msgstr ""
+"使用 `let handle = thread::spawn(...)` 和后面的 `handle.join()` 等待 线程完"
+"成。"
 
 #: src/concurrency/threads.md:38
 msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
@@ -16294,11 +16395,11 @@ msgstr "在线程中触发紧急警报，并注意这为何不会影响到 `main
 #: src/concurrency/threads.md:40
 msgid ""
 "Use the `Result` return value from `handle.join()` to get access to the "
-"panic payload. This is a good time to talk about "
-"[`Any`](https://doc.rust-lang.org/std/any/index.html)."
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
 msgstr ""
-"使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报 载荷的访问权限。现在有必要介绍一下 "
-"[`Any`](https://doc.rust-lang.org/std/any/index.html) 了。"
+"使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报 载荷的访问权限。现在"
+"有必要介绍一下 [`Any`](https://doc.rust-lang.org/std/any/index.html) 了。"
 
 #: src/concurrency/scoped-threads.md:3
 msgid "Normal threads cannot borrow from their environment:"
@@ -16336,10 +16437,11 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:20
 msgid ""
-"However, you can use a [scoped "
-"thread](https://doc.rust-lang.org/std/thread/fn.scope.html) for this:"
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
 msgstr ""
-"不过，你可以使用[范围线程](https://doc.rust-lang.org/std/thread/fn.scope.html)来实现此目的："
+"不过，你可以使用[范围线程](https://doc.rust-lang.org/std/thread/fn.scope."
+"html)来实现此目的："
 
 #: src/concurrency/scoped-threads.md:22
 msgid ""
@@ -16375,20 +16477,25 @@ msgstr ""
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
-msgstr "其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使得线程能够返回借用的数据。"
+msgstr ""
+"其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使得"
+"线程能够返回借用的数据。"
 
 #: src/concurrency/scoped-threads.md:41
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."
-msgstr "此时须遵守常规 Rust 借用规则：你可以通过一个线程以可变的方式借用，也可以通过任意数量的线程以不可变的方式借用。"
+msgstr ""
+"此时须遵守常规 Rust 借用规则：你可以通过一个线程以可变的方式借用，也可以通过"
+"任意数量的线程以不可变的方式借用。"
 
 #: src/concurrency/channels.md:3
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
 "parts are connected via the channel, but you only see the end-points."
 msgstr ""
-"Rust 通道（Channel）包含两个部分：`Sender<T>` 和 `Receiver<T>`。这两个部分 通过通道进行连接，但你只能看到端点。"
+"Rust 通道（Channel）包含两个部分：`Sender<T>` 和 `Receiver<T>`。这两个部分 通"
+"过通道进行连接，但你只能看到端点。"
 
 #: src/concurrency/channels.md:6
 #, fuzzy
@@ -16436,16 +16543,16 @@ msgid ""
 "implement `Clone` (so you can make multiple producers) but `Receiver` does "
 "not."
 msgstr ""
-"`mpsc` 代表多个生产方，单个使用方。`Sender` 和 `SyncSender` 会实现 `Clone`（因此， 你可以设置多个生产方），但 "
-"`Receiver` 不会实现。"
+"`mpsc` 代表多个生产方，单个使用方。`Sender` 和 `SyncSender` 会实现 `Clone`"
+"（因此， 你可以设置多个生产方），但 `Receiver` 不会实现。"
 
 #: src/concurrency/channels.md:28
 msgid ""
 "`send()` and `recv()` return `Result`. If they return `Err`, it means the "
 "counterpart `Sender` or `Receiver` is dropped and the channel is closed."
 msgstr ""
-"`send()` 和 `recv()` 会返回 `Result`。如果它们返回 `Err`，则表示对应的 `Sender` 或 `Receiver` "
-"已被丢弃，且通道已关闭。"
+"`send()` 和 `recv()` 会返回 `Result`。如果它们返回 `Err`，则表示对应的 "
+"`Sender` 或 `Receiver` 已被丢弃，且通道已关闭。"
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
@@ -16503,7 +16610,8 @@ msgstr ""
 
 #: src/concurrency/channels/bounded.md:3
 #, fuzzy
-msgid "With bounded (synchronous) channels, `send` can block the current thread:"
+msgid ""
+"With bounded (synchronous) channels, `send` can block the current thread:"
 msgstr "有边界的同步通道会使 `send` 阻塞当前线程："
 
 #: src/concurrency/channels/bounded.md:5
@@ -16591,16 +16699,16 @@ msgid ""
 "[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
 "is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)：如果跨线程边界移动 `T` "
-"是安全的，则类型 `T` 为 `Send`。"
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)：如果跨线程边"
+"界移动 `T` 是安全的，则类型 `T` 为 `Send`。"
 
 #: src/concurrency/send-sync.md:7
 msgid ""
 "[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
 "is `Sync` if it is safe to move a `&T` across a thread boundary."
 msgstr ""
-"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)：如果跨线程边界移动 "
-"`&T` 是安全的，则类型 `T` 为 `Sync`。"
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)：如果跨线程边"
+"界移动 `&T` 是安全的，则类型 `T` 为 `Sync`。"
 
 #: src/concurrency/send-sync.md:10
 msgid ""
@@ -16609,13 +16717,14 @@ msgid ""
 "contain `Send` and `Sync` types. You can also implement them manually when "
 "you know it is valid."
 msgstr ""
-"`Send` 和 `Sync` 均为[不安全特征](../unsafe/unsafe-traits.md)。只要类型仅包含 `Send` 和 "
-"`Sync` 类型，编译器就会自动为类型派生 这两种特征。你也可以手动实现它们（如果你确定这样 有效的话）。"
+"`Send` 和 `Sync` 均为[不安全特征](../unsafe/unsafe-traits.md)。只要类型仅包"
+"含 `Send` 和 `Sync` 类型，编译器就会自动为类型派生 这两种特征。你也可以手动实"
+"现它们（如果你确定这样 有效的话）。"
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"One can think of these traits as markers that the type has certain "
-"thread-safety properties."
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr "不妨将这些特征视为类型包含某些线程安全属性的标记。"
 
 #: src/concurrency/send-sync.md:21
@@ -16631,8 +16740,8 @@ msgid ""
 "A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
 "if it is safe to move a `T` value to another thread."
 msgstr ""
-"如果将 `T` 值移动到另一个线程是安全的，则类型 `T` 为 "
-"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)。"
+"如果将 `T` 值移动到另一个线程是安全的，则类型 `T` 为 [`Send`](https://doc."
+"rust-lang.org/std/marker/trait.Send.html)。"
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
@@ -16640,7 +16749,8 @@ msgid ""
 "run in that thread. So the question is when you can allocate a value in one "
 "thread and deallocate it in another."
 msgstr ""
-"将所有权转移到另一个线程的影响是，“析构函数”将在相应线程中 运行。因此，问题在于你何时可以在一个线程中分配某个值，然后在 另一个线程中取消分配该值。"
+"将所有权转移到另一个线程的影响是，“析构函数”将在相应线程中 运行。因此，问题在"
+"于你何时可以在一个线程中分配某个值，然后在 另一个线程中取消分配该值。"
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
@@ -16657,8 +16767,8 @@ msgid ""
 "A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
 "if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"如果同时从多个线程访问 `T` 值是安全的，则类型 `T` 为 "
-"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)。"
+"如果同时从多个线程访问 `T` 值是安全的，则类型 `T` 为 [`Sync`](https://doc."
+"rust-lang.org/std/marker/trait.Sync.html)。"
 
 #: src/concurrency/send-sync/sync.md:6
 msgid "More precisely, the definition is:"
@@ -16673,7 +16783,9 @@ msgid ""
 "This statement is essentially a shorthand way of saying that if a type is "
 "thread-safe for shared use, it is also thread-safe to pass references of it "
 "across threads."
-msgstr "该语句实质上是一种简写形式，表示如果某个类型对于共享使用是线程安全的，那么跨线程传递对该类型的引用也是线程安全的。"
+msgstr ""
+"该语句实质上是一种简写形式，表示如果某个类型对于共享使用是线程安全的，那么跨"
+"线程传递对该类型的引用也是线程安全的。"
 
 #: src/concurrency/send-sync/sync.md:16
 msgid ""
@@ -16683,8 +16795,9 @@ msgid ""
 "is also safe to move to another thread, because the data it references can "
 "be accessed from any thread safely."
 msgstr ""
-"这是因为如果某个类型为 "
-"Sync，则意味着它可以在多个线程之间共享，而不存在数据争用或其他同步问题的风险，因此将其移动到另一个线程是安全的。对该类型的引用同样可以安全地移动到另一个线程，因为它引用的数据可以从任何线程安全地访问。"
+"这是因为如果某个类型为 Sync，则意味着它可以在多个线程之间共享，而不存在数据争"
+"用或其他同步问题的风险，因此将其移动到另一个线程是安全的。对该类型的引用同样"
+"可以安全地移动到另一个线程，因为它引用的数据可以从任何线程安全地访问。"
 
 #: src/concurrency/send-sync/examples.md:3
 msgid "`Send + Sync`"
@@ -16732,7 +16845,9 @@ msgstr "`Send + !Sync`"
 msgid ""
 "These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
-msgstr "这些类型可以移动到其他线程，但它们不是线程安全的。 这通常是由内部可变性造成的："
+msgstr ""
+"这些类型可以移动到其他线程，但它们不是线程安全的。 这通常是由内部可变性造成"
+"的："
 
 #: src/concurrency/send-sync/examples.md:22
 msgid "`mpsc::Sender<T>`"
@@ -16755,14 +16870,17 @@ msgid "`!Send + Sync`"
 msgstr "`!Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:29
-msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgid ""
+"These types are thread-safe, but they cannot be moved to another thread:"
 msgstr "这些类型是线程安全的，但它们不能移动到另一个线程："
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
 "`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
 "thread which created them."
-msgstr "`MutexGuard<T>`：使用操作系统级别的原语（必须在创建这些原语的线程上 取消分配）。"
+msgstr ""
+"`MutexGuard<T>`：使用操作系统级别的原语（必须在创建这些原语的线程上 取消分"
+"配）。"
 
 #: src/concurrency/send-sync/examples.md:34
 msgid "`!Send + !Sync`"
@@ -16774,15 +16892,17 @@ msgstr "这些类型不是线程安全的，不能移动到其他线程："
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a "
-"non-atomic reference count."
-msgstr "`Rc<T>`：每个 `Rc<T>` 都具有对 `RcBox<T>` 的引用，其中包含 非原子引用计数。"
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
+msgstr ""
+"`Rc<T>`：每个 `Rc<T>` 都具有对 `RcBox<T>` 的引用，其中包含 非原子引用计数。"
 
 #: src/concurrency/send-sync/examples.md:40
 msgid ""
 "`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
 "considerations."
-msgstr "`*const T`、`*mut T`：Rust 会假定原始指针可能 在并发方面有特殊的注意事项。"
+msgstr ""
+"`*const T`、`*mut T`：Rust 会假定原始指针可能 在并发方面有特殊的注意事项。"
 
 #: src/concurrency/shared_state.md:3
 msgid ""
@@ -16796,16 +16916,16 @@ msgid ""
 "reference counted `T`: handles sharing between threads and takes care to "
 "deallocate `T` when the last reference is dropped,"
 msgstr ""
-"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)，对 `T` "
-"进行原子计数：用于处理线程之间的共享，并负责 在最后一个引用被丢弃时取消分配 `T`。"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)，对 `T` 进行原"
+"子计数：用于处理线程之间的共享，并负责 在最后一个引用被丢弃时取消分配 `T`。"
 
 #: src/concurrency/shared_state.md:8
 msgid ""
 "[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
 "mutually exclusive access to the `T` value."
 msgstr ""
-"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)：确保对 `T` "
-"值的互斥访问。"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)：确保对 "
+"`T` 值的互斥访问。"
 
 #: src/concurrency/shared_state/arc.md:1
 msgid "`Arc`"
@@ -16873,14 +16993,16 @@ msgid ""
 "`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
 "and `Sync` if and only if `T` implements them both."
 msgstr ""
-"无论 `T` 是否实现 `Clone`，`Arc<T>` 都会实现 `Clone`。如果 `T` 实现了 `Send` 和 "
-"`Sync`，`Arc<T>` 便会 实现二者。"
+"无论 `T` 是否实现 `Clone`，`Arc<T>` 都会实现 `Clone`。如果 `T` 实现了 `Send` "
+"和 `Sync`，`Arc<T>` 便会 实现二者。"
 
 #: src/concurrency/shared_state/arc.md:33
 msgid ""
 "`Arc::clone()` has the cost of atomic operations that get executed, but "
 "after that the use of the `T` is free."
-msgstr "`Arc::clone()` 在执行原子操作方面有开销，但在此之后，`T` 便可 随意使用，而没有任何开销。"
+msgstr ""
+"`Arc::clone()` 在执行原子操作方面有开销，但在此之后，`T` 便可 随意使用，而没"
+"有任何开销。"
 
 #: src/concurrency/shared_state/arc.md:35
 msgid ""
@@ -16902,8 +17024,8 @@ msgid ""
 "mutual exclusion _and_ allows mutable access to `T` behind a read-only "
 "interface:"
 msgstr ""
-"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) "
-"能够确保互斥，并允许对只读接口 后面的 `T` 进行可变访问："
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) 能够确保互"
+"斥，并允许对只读接口 后面的 `T` 进行可变访问："
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -16941,19 +17063,19 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for "
-"Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) "
-"blanket implementation."
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
+"implementation."
 msgstr ""
-"请注意我们如何设置 [`impl<T: Send> Sync for "
-"Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) "
-"通用 实现。"
+"请注意我们如何设置 [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-lang."
+"org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) 通用 实现。"
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
 "`Mutex` in Rust looks like a collection with just one element - the "
 "protected data."
-msgstr "Rust 中的互斥器看起来就像只包含一个元素的集合，其中的元素就是受保护的数据。"
+msgstr ""
+"Rust 中的互斥器看起来就像只包含一个元素的集合，其中的元素就是受保护的数据。"
 
 #: src/concurrency/shared_state/mutex.md:32
 msgid ""
@@ -16966,8 +17088,8 @@ msgid ""
 "You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
 "`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
-"你可以通过获取锁，从 `&Mutex<T>` 中获取 `&mut T`。`MutexGuard` 能够确保 `&mut T` "
-"存在的时间不会比持有锁的时间更长。"
+"你可以通过获取锁，从 `&Mutex<T>` 中获取 `&mut T`。`MutexGuard` 能够确保 "
+"`&mut T` 存在的时间不会比持有锁的时间更长。"
 
 #: src/concurrency/shared_state/mutex.md:35
 #, fuzzy
@@ -16992,10 +17114,10 @@ msgid ""
 "[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
 "You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
-"如果持有 `Mutex` 的线程发生panic，`Mutex` 便会“中毒”并发出信号， 表明其所保护的数据可能处于不一致状态。对中毒的互斥量调用 "
-"`lock()` 将会失败， 并将显示 "
-"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html)。无论如何，你可以对该错误调用 "
-"`into_inner()` 来 恢复数据。"
+"如果持有 `Mutex` 的线程发生panic，`Mutex` 便会“中毒”并发出信号， 表明其所保护"
+"的数据可能处于不一致状态。对中毒的互斥量调用 `lock()` 将会失败， 并将显示 "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html)。"
+"无论如何，你可以对该错误调用 `into_inner()` 来 恢复数据。"
 
 #: src/concurrency/shared_state/example.md:3
 msgid "Let us see `Arc` and `Mutex` in action:"
@@ -17109,7 +17231,9 @@ msgstr "将 `Mutex` 封装在 `Arc` 中是一种在线程之间共享可变状�
 msgid ""
 "`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
 "thread. Note `move` was added to the lambda signature."
-msgstr "`v: Arc<_>` 必须先克隆为 `v2`，然后才能移动到另一个线程中。请注意，lambda 签名中添加了 `move`。"
+msgstr ""
+"`v: Arc<_>` 必须先克隆为 `v2`，然后才能移动到另一个线程中。请注意，lambda 签"
+"名中添加了 `move`。"
 
 #: src/concurrency/shared_state/example.md:54
 msgid ""
@@ -17223,9 +17347,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as "
-"[`reqwest`](https://docs.rs/reqwest/). Create a new Cargo project and "
-"`reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:17
@@ -17236,14 +17359,14 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:20
 msgid ""
-"You will also need a way to find links. We can use "
-"[`scraper`](https://docs.rs/scraper/) for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use "
-"[`thiserror`](https://docs.rs/thiserror/) for that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:33
@@ -17261,8 +17384,8 @@ msgid ""
 "publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] "
-"}\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -17270,8 +17393,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:50
 msgid ""
-"You can now download the start page. Try with a small site such as "
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:53
@@ -17337,8 +17460,8 @@ msgid ""
 "fn main() {\n"
 "    let client = Client::new();\n"
 "    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
-"    let crawl_command = CrawlCommand{ url: start_url, extract_links: true "
-"};\n"
+"    let crawl_command = CrawlCommand{ url: start_url, extract_links: "
+"true };\n"
 "    match visit_page(&client, &crawl_command) {\n"
 "        Ok(links) => println!(\"Links: {links:#?}\"),\n"
 "        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
@@ -17359,9 +17482,9 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:130
 msgid ""
-"Extend this to recursively extract links from all pages on the "
-"`www.google.org` domain. Put an upper limit of 100 pages or so so that you "
-"don't end up being blocked by the site."
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
 
 #: src/async.md:1
@@ -17444,7 +17567,9 @@ msgstr ""
 msgid ""
 "Note that this is a simplified example to show the syntax. There is no long "
 "running operation or any real concurrency in it!"
-msgstr "请注意，这只是一个简单的示例，用于展示语法。其中没有长时间运行的操作或任何真正的并发！"
+msgstr ""
+"请注意，这只是一个简单的示例，用于展示语法。其中没有长时间运行的操作或任何真"
+"正的并发！"
 
 #: src/async/async-await.md:30
 msgid "What is the return type of an async call?"
@@ -17464,19 +17589,25 @@ msgstr "\"async\" 关键字是语法糖。编译器会将返回类型替换为 f
 msgid ""
 "You cannot make `main` async, without additional instructions to the "
 "compiler on how to use the returned future."
-msgstr "你不能将 `main` 声明为异步函数，除非在编译器中加入额外的指令来告诉它如何使用返回的 future。"
+msgstr ""
+"你不能将 `main` 声明为异步函数，除非在编译器中加入额外的指令来告诉它如何使用"
+"返回的 future。"
 
 #: src/async/async-await.md:39
 msgid ""
 "You need an executor to run async code. `block_on` blocks the current thread "
 "until the provided future has run to completion. "
-msgstr "你需要一个执行器来运行异步代码。`block_on`会阻塞当前线程，直到提供的future完成为止。 "
+msgstr ""
+"你需要一个执行器来运行异步代码。`block_on`会阻塞当前线程，直到提供的future完"
+"成为止。 "
 
 #: src/async/async-await.md:42
 msgid ""
 "`.await` asynchronously waits for the completion of another operation. "
 "Unlike `block_on`, `.await` doesn't block the current thread."
-msgstr "`.await` 会异步地等待另一个操作的完成。与 `block_on` 不同，`.await` 不会阻塞当前线程。"
+msgstr ""
+"`.await` 会异步地等待另一个操作的完成。与 `block_on` 不同，`.await` 不会阻塞"
+"当前线程。"
 
 #: src/async/async-await.md:45
 msgid ""
@@ -17488,8 +17619,8 @@ msgstr "`.await` 只能在 `async` 函数（或块，这些稍后会介绍）中
 msgid ""
 "[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
 "trait, implemented by objects that represent an operation that may not be "
-"complete yet. A future can be polled, and `poll` returns a "
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
 #: src/async/futures.md:23
@@ -17541,8 +17672,8 @@ msgstr ""
 #: src/async/runtimes.md:7
 msgid ""
 "[Tokio](https://tokio.rs/): performant, with a well-developed ecosystem of "
-"functionality like [Hyper](https://hyper.rs/) for HTTP or "
-"[Tonic](https://github.com/hyperium/tonic) for gRPC."
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
 msgstr ""
 
 #: src/async/runtimes.md:10
@@ -17557,9 +17688,9 @@ msgstr ""
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example, "
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-async/src/lib.rs) "
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 
 #: src/async/runtimes.md:20
@@ -17678,8 +17809,7 @@ msgid ""
 "        println!(\"connection from {addr:?}\");\n"
 "\n"
 "        tokio::spawn(async move {\n"
-"            if let Err(e) = socket.write_all(b\"Who are you?\\n"
-"\").await {\n"
+"            if let Err(e) = socket.write_all(b\"Who are you?\\n\").await {\n"
 "                println!(\"socket error: {e:?}\");\n"
 "                return;\n"
 "            }\n"
@@ -17687,10 +17817,9 @@ msgid ""
 "            let mut buf = vec![0; 1024];\n"
 "            let reply = match socket.read(&mut buf).await {\n"
 "                Ok(n) => {\n"
-"                    let name = "
-"std::str::from_utf8(&buf[..n]).unwrap().trim();\n"
-"                    format!(\"Thanks for dialing in, {name}!\\n"
-"\")\n"
+"                    let name = std::str::from_utf8(&buf[..n]).unwrap()."
+"trim();\n"
+"                    format!(\"Thanks for dialing in, {name}!\\n\")\n"
 "                }\n"
 "                Err(e) => {\n"
 "                    println!(\"socket error: {e:?}\");\n"
@@ -17707,9 +17836,9 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/tasks.md:52
-#: src/async/control-flow/join.md:36
-msgid "Copy this example into your prepared `src/main.rs` and run it from there."
+#: src/async/tasks.md:52 src/async/control-flow/join.md:36
+msgid ""
+"Copy this example into your prepared `src/main.rs` and run it from there."
 msgstr ""
 
 #: src/async/tasks.md:54
@@ -17877,9 +18006,9 @@ msgstr ""
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to that future's result. In JavaScript, this is similar to "
-"`Promise.race`. In Python, it compares to `asyncio.wait(task_set, "
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
@@ -18044,8 +18173,8 @@ msgstr ""
 #: src/async/pitfalls/blocking-executor.md:32
 msgid ""
 "The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the effect more obvious, but the bug is still present in the "
-"multi-threaded flavor."
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:36
@@ -18173,8 +18302,8 @@ msgstr ""
 #: src/async/pitfalls/pin.md:88
 msgid ""
 "This still doesn't work. Follow the compiler errors, adding `&mut` to the "
-"`timeout_fut` in the `select!` to work around the move, then using "
-"`Box::pin`:"
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
 msgstr ""
 
 #: src/async/pitfalls/pin.md:102
@@ -18201,7 +18330,8 @@ msgstr ""
 msgid ""
 "Async methods in traits are not yet supported in the stable channel ([An "
 "experimental feature exists in nightly and should be stabilized in the mid "
-"term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html))"
+"term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-"
+"nightly.html))"
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:5
@@ -18266,18 +18396,21 @@ msgstr ""
 msgid ""
 "The challenges in language support for `async trait` are deep Rust and "
 "probably not worth describing in-depth. Niko Matsakis did a good job of "
-"explaining them in [this "
-"post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/) "
-"if you are interested in digging deeper."
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
 msgstr ""
-"对于 `async trait` 的语言支持中的挑战是深入  Rust的，并且可能不值得深入描述。如果您对深入了解感兴趣，Niko Matsakis "
-"在[这篇文章](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)中对它们做了很好的解释。"
+"对于 `async trait` 的语言支持中的挑战是深入  Rust的，并且可能不值得深入描述。"
+"如果您对深入了解感兴趣，Niko Matsakis 在[这篇文章](https://"
+"smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-"
+"hard/)中对它们做了很好的解释。"
 
 #: src/async/pitfalls/async-traits.md:60
 msgid ""
 "Try creating a new sleeper struct that will sleep for a random amount of "
 "time and adding it to the Vec."
-msgstr "尝试创建一个新的 sleeper 结构，使其随机休眠一段时间，并将其添加到 Vec 中。"
+msgstr ""
+"尝试创建一个新的 sleeper 结构，使其随机休眠一段时间，并将其添加到 Vec 中。"
 
 #: src/async/pitfalls/cancellation.md:3
 msgid ""
@@ -18308,8 +18441,7 @@ msgid ""
 "        let mut buf = [0];\n"
 "        while self.stream.read(&mut buf[..]).await? != 0 {\n"
 "            bytes.push(buf[0]);\n"
-"            if buf[0] == b'\\n"
-"' {\n"
+"            if buf[0] == b'\\n' {\n"
 "                break;\n"
 "            }\n"
 "        }\n"
@@ -18323,8 +18455,8 @@ msgid ""
 "    }\n"
 "}\n"
 "\n"
-"async fn slow_copy(source: String, mut dest: DuplexStream) -> "
-"std::io::Result<()> {\n"
+"async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::"
+"Result<()> {\n"
 "    for b in source.bytes() {\n"
 "        dest.write_u8(b).await?;\n"
 "        tokio::time::sleep(Duration::from_millis(10)).await\n"
@@ -18335,9 +18467,8 @@ msgid ""
 "#[tokio::main]\n"
 "async fn main() -> std::io::Result<()> {\n"
 "    let (client, server) = tokio::io::duplex(5);\n"
-"    let handle = tokio::spawn(slow_copy(\"hi\\n"
-"there\\n"
-"\".to_owned(), client));\n"
+"    let handle = tokio::spawn(slow_copy(\"hi\\nthere\\n\".to_owned(), "
+"client));\n"
 "\n"
 "    let mut lines = LinesReader::new(server);\n"
 "    let mut interval = tokio::time::interval(Duration::from_millis(60));\n"
@@ -18412,38 +18543,44 @@ msgstr ""
 #: src/async/pitfalls/cancellation.md:104
 #, fuzzy
 msgid ""
-"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick) "
-"is cancellation-safe because it keeps track of whether a tick has been "
-"'delivered'."
+"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
+"html#method.tick) is cancellation-safe because it keeps track of whether a "
+"tick has been 'delivered'."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/async/pitfalls/cancellation.md:107
 #, fuzzy
 msgid ""
-"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read) "
-"is cancellation-safe because it either returns or doesn't read data."
+"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncReadExt.html#method.read) is cancellation-safe because it either "
+"returns or doesn't read data."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/async/pitfalls/cancellation.md:110
 #, fuzzy
 msgid ""
-"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line) "
-"is similar to the example and _isn't_ cancellation-safe. See its "
-"documentation for details and alternatives."
+"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
+"cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/exercises/concurrency/afternoon.md:3
-msgid "To practice your Async Rust skills, we have again two exercises for you:"
+msgid ""
+"To practice your Async Rust skills, we have again two exercises for you:"
 msgstr "为了练习您的异步 Rust 技能，我们再次为您提供了两个练习："
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
 "Dining philosophers: we already saw this problem in the morning. This time "
 "you are going to implement it with Async Rust."
-msgstr "哲学家进餐：我们已经在上午看到了这个问题。这次你将使用异步 Rust 来实现它。"
+msgstr ""
+"哲学家进餐：我们已经在上午看到了这个问题。这次你将使用异步 Rust 来实现它。"
 
 #: src/exercises/concurrency/afternoon.md:8
 msgid ""
@@ -18464,14 +18601,13 @@ msgstr "查看[哲学家进餐](dining-philosophers.md)以获取问题的描述�
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 msgid ""
-"As before, you will need a local [Cargo "
-"installation](../../cargo/running-locally.md) for this exercise. Copy the "
-"code below to a file called `src/main.rs`, fill out the blanks, and test "
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
-"与之前一样，您需要一个本地的 [Cargo "
-"安装](../../cargo/running-locally.md)来进行这个练习。将下面的代码复制到一个名为 `src/main.rs` "
-"的文件中，填写空白部分，并测试确保 `cargo run` 不会死锁："
+"与之前一样，您需要一个本地的 [Cargo 安装](../../cargo/running-locally.md)来进"
+"行这个练习。将下面的代码复制到一个名为 `src/main.rs` 的文件中，填写空白部分，"
+"并测试确保 `cargo run` 不会死锁："
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
 msgid ""
@@ -18493,8 +18629,8 @@ msgid ""
 "impl Philosopher {\n"
 "    async fn think(&self) {\n"
 "        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", "
-"&self.name)).await\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
 "            .unwrap();\n"
 "    }\n"
 "\n"
@@ -18525,7 +18661,9 @@ msgstr ""
 msgid ""
 "Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
-msgstr "因为这次您正在使用异步Rust，您将需要一个 `tokio` 依赖。您可以使用以下的 `Cargo.toml`："
+msgstr ""
+"因为这次您正在使用异步Rust，您将需要一个 `tokio` 依赖。您可以使用以下的 "
+"`Cargo.toml`："
 
 #: src/exercises/concurrency/dining-philosophers-async.md:62
 msgid ""
@@ -18559,20 +18697,22 @@ msgid ""
 "input, and sends them to the server. The chat server broadcasts each message "
 "that it receives to all the clients."
 msgstr ""
-"在本练习中，我们想要使用我们的新知识来实现一个广播聊天应用。我们有一个聊天服务器，客户端连接到该服务器并发布他们的消息。客户端从标准输入读取用户消息，并将其发送到服务器。聊天服务器将收到的每条消息广播给所有客户端。"
+"在本练习中，我们想要使用我们的新知识来实现一个广播聊天应用。我们有一个聊天服"
+"务器，客户端连接到该服务器并发布他们的消息。客户端从标准输入读取用户消息，并"
+"将其发送到服务器。聊天服务器将收到的每条消息广播给所有客户端。"
 
 #: src/exercises/concurrency/chat-app.md:9
 #, fuzzy
 msgid ""
-"For this, we use [a broadcast "
-"channel](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html) "
-"on the server, and "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/) "
-"for the communication between the client and the server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
-"为此，我们在服务器上使用一个[广播 "
-"channel](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html)，并使用[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) "
-"来进行客户端与服务器之间的通信。"
+"为此，我们在服务器上使用一个[广播 channel](https://docs.rs/tokio/latest/"
+"tokio/sync/broadcast/fn.channel.html)，并使用[`tokio_websockets`](https://"
+"docs.rs/tokio-websockets/0.3.2/tokio_websockets/) 来进行客户端与服务器之间的"
+"通信。"
 
 #: src/exercises/concurrency/chat-app.md:13
 msgid "Create a new Cargo project and add the following dependencies:"
@@ -18608,46 +18748,51 @@ msgstr "所需的API"
 #, fuzzy
 msgid ""
 "You are going to need the following functions from `tokio` and "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/). "
-"Spend a few minutes to familiarize yourself with the API. "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
+"API. "
 msgstr ""
-"您将需要来自 `tokio` 和 "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) "
-"的以下函数。请花几分钟时间熟悉这些 API。"
+"您将需要来自 `tokio` 和 [`tokio_websockets`](https://docs.rs/tokio-"
+"websockets/0.3.2/tokio_websockets/) 的以下函数。请花几分钟时间熟悉这些 API。"
 
 #: src/exercises/concurrency/chat-app.md:37
 #, fuzzy
 msgid ""
-"[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/trait.StreamExt.html#method.next) "
-"implemented by `WebsocketStream`: for asynchronously reading messages from a "
-"Websocket Stream."
+"[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
+"trait.StreamExt.html#method.next) implemented by `WebsocketStream`: for "
+"asynchronously reading messages from a Websocket Stream."
 msgstr ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
-"由`WebsocketStream`实现：用于在Websocket流上异步发送消息。"
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) 由`WebsocketStream`实现：用于在Websocket流上"
+"异步发送消息。"
 
 #: src/exercises/concurrency/chat-app.md:39
 msgid ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
-"implemented by `WebsocketStream`: for asynchronously sending messages on a "
-"Websocket Stream."
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
 msgstr ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
-"由`WebsocketStream`实现：用于在Websocket流上异步发送消息。"
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) 由`WebsocketStream`实现：用于在Websocket流上"
+"异步发送消息。"
 
 #: src/exercises/concurrency/chat-app.md:41
 #, fuzzy
 msgid ""
-"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line): "
-"for asynchronously reading user messages from the standard input."
+"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/exercises/concurrency/chat-app.md:43
 msgid ""
-"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.subscribe): "
-"for subscribing to a broadcast channel."
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
-"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.subscribe)：用于订阅广播频道。"
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe)：用于订阅广播频道。"
 
 #: src/exercises/concurrency/chat-app.md:46
 msgid "Two binaries"
@@ -18655,24 +18800,29 @@ msgstr "两个可执行文件"
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one "
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client, and one for the server. You could potentially make them two separate "
-"Cargo projects, but we are going to put them in a single Cargo project with "
-"two binaries. For this to work, the client and the server code should go "
-"under `src/bin` (see the "
-"[documentation](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries)). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
-"通常在一个Cargo项目中，你只能有一个二进制文件，和一个`src/main.rs`文件。在这个项目中，我们需要两个二进制文件。一个用于客户端，另一个用于服务器。你可能会考虑将它们制作成两个单独的Cargo项目，但我们将它们放在一个包含两个二进制文件的Cargo项目中。为了使这个工作，客户端和服务器的代码应该放在`src/bin`下（参见[文档](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries)）。"
+"通常在一个Cargo项目中，你只能有一个二进制文件，和一个`src/main.rs`文件。在这"
+"个项目中，我们需要两个二进制文件。一个用于客户端，另一个用于服务器。你可能会"
+"考虑将它们制作成两个单独的Cargo项目，但我们将它们放在一个包含两个二进制文件的"
+"Cargo项目中。为了使这个工作，客户端和服务器的代码应该放在`src/bin`下（参见[文"
+"档](https://doc.rust-lang.org/cargo/reference/cargo-targets."
+"html#binaries)）。"
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and "
-"`src/bin/client.rs`, respectively. Your task is to complete these files as "
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
-"将以下服务器和客户端代码分别复制到 `src/bin/server.rs` 和 `src/bin/client.rs` "
-"中。您的任务是按照下面的描述完成这些文件。"
+"将以下服务器和客户端代码分别复制到 `src/bin/server.rs` 和 `src/bin/client."
+"rs` 中。您的任务是按照下面的描述完成这些文件。"
 
 #: src/exercises/concurrency/chat-app.md:59
 #: src/exercises/concurrency/solutions-afternoon.md:99
@@ -18777,8 +18927,8 @@ msgid ""
 "continuous loop. One task receives messages from the client and broadcasts "
 "them. The other sends messages received by the server to the client."
 msgstr ""
-"提示：使用 `tokio::select!` "
-"在一个连续的循环中并发执行两个任务。一个任务从客户端接收消息并广播它们。另一个任务将服务器接收到的消息发送给客户端。"
+"提示：使用 `tokio::select!` 在一个连续的循环中并发执行两个任务。一个任务从客"
+"户端接收消息并广播它们。另一个任务将服务器接收到的消息发送给客户端。"
 
 #: src/exercises/concurrency/chat-app.md:149
 msgid "Complete the main function in `src/bin/client.rs`."
@@ -18792,8 +18942,9 @@ msgid ""
 "sending them to the server, and (2) receiving messages from the server, and "
 "displaying them for the user."
 msgstr ""
-"提示：与之前一样，使用 `tokio::select!` 在一个连续的循环中并发执行两个任务：(1) 从标准输入读取用户消息并发送给服务器，以及 (2) "
-"从服务器接收消息并显示给用户。"
+"提示：与之前一样，使用 `tokio::select!` 在一个连续的循环中并发执行两个任务："
+"(1) 从标准输入读取用户消息并发送给服务器，以及 (2) 从服务器接收消息并显示给用"
+"户。"
 
 #: src/exercises/concurrency/chat-app.md:154
 #, fuzzy
@@ -18805,17 +18956,16 @@ msgstr "可选：完成后，将代码更改为将消息广播给除消息发送
 #: src/thanks.md:3
 #, fuzzy
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
-"it was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
 msgstr "_感谢您参与学习 Comprehensive Rust 🦀！_ 希望您喜欢并且觉得它有用。"
 
 #: src/thanks.md:6
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
 "perfect, so if you spotted any mistakes or have ideas for improvements, "
-"please get in [contact with us on "
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love to hear from you."
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 
 #: src/glossary.md:3
@@ -18904,7 +19054,8 @@ msgid "channel"
 msgstr "通道"
 
 #: src/glossary.md:21
-msgid "Used to safely pass messages [between threads](concurrency/channels.md)."
+msgid ""
+"Used to safely pass messages [between threads](concurrency/channels.md)."
 msgstr ""
 
 #: src/glossary.md:22
@@ -19253,9 +19404,9 @@ msgstr ""
 
 #: src/other-resources.md:39
 msgid ""
-"[Rust for Embedded C "
-"Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from the perspective of developers who write firmware in C."
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
 msgstr ""
 
 #: src/other-resources.md:42
@@ -19273,29 +19424,26 @@ msgstr ""
 
 #: src/other-resources.md:47
 msgid ""
-"[Ferrous Teaching "
-"Material](https://ferrous-systems.github.io/teaching-material/index.html): a "
-"series of small presentations covering both basic and advanced part of the "
-"Rust language. Other topics such as WebAssembly, and async/await are also "
-"covered."
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
 msgstr ""
 
 #: src/other-resources.md:52
 msgid ""
-"[Beginner's Series to "
-"Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) and "
-"[Take your first steps with "
-"Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): two "
-"Rust guides aimed at new developers. The first is a set of 35 videos and the "
-"second is a set of 11 modules which covers Rust syntax and basic constructs."
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
 msgstr ""
 
 #: src/other-resources.md:58
 msgid ""
-"[Learn Rust With Entirely Too Many Linked "
-"Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth "
-"exploration of Rust's memory management rules, through implementing a few "
-"different types of list structures."
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
 msgstr ""
 
 #: src/other-resources.md:63
@@ -19310,18 +19458,18 @@ msgid ""
 "documentation. See the page on [other resources](other-resources.md) for a "
 "full list of useful resources."
 msgstr ""
-"本课中的资料以众多优秀的 Rust 文档资源为基础。 如需查看实用资源的完整列表， 请参阅关于[其他资源](other-resources.md)的页面。"
+"本课中的资料以众多优秀的 Rust 文档资源为基础。 如需查看实用资源的完整列表， "
+"请参阅关于[其他资源](other-resources.md)的页面。"
 
 #: src/credits.md:7
 #, fuzzy
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0 license, please see "
-"[`LICENSE`](https://github.com/google/comprehensive-rust/blob/main/LICENSE) "
-"for details."
+"2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
+"rust/blob/main/LICENSE) for details."
 msgstr ""
-"我们根据 Apache 2.0 许可条款 授权你使用“全面了解 Rust”（Comprehensive "
-"Rust）的资料。如需了解详情，请参阅[`许可`](../LICENSE)。"
+"我们根据 Apache 2.0 许可条款 授权你使用“全面了解 Rust”（Comprehensive Rust）"
+"的资料。如需了解详情，请参阅[`许可`](../LICENSE)。"
 
 #: src/credits.md:12
 msgid "Rust by Example"
@@ -19334,9 +19482,9 @@ msgid ""
 "`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
-"部分示例和练习复制并 改编自[Rust by "
-"Example](https://doc.rust-lang.org/rust-by-example/)。如需了解详情（包括许可 条款），请参阅 "
-"`third_party/rust-by-example/` 目录。"
+"部分示例和练习复制并 改编自[Rust by Example](https://doc.rust-lang.org/rust-"
+"by-example/)。如需了解详情（包括许可 条款），请参阅 `third_party/rust-by-"
+"example/` 目录。"
 
 #: src/credits.md:19
 msgid "Rust on Exercism"
@@ -19344,13 +19492,12 @@ msgstr "Rust on Exercism"
 
 #: src/credits.md:21
 msgid ""
-"Some exercises have been copied and adapted from [Rust on "
-"Exercism](https://exercism.org/tracks/rust). Please see the "
-"`third_party/rust-on-exercism/` directory for details, including the license "
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"部分练习复制并 改编自 [Rust on Exercism](https://exercism.org/tracks/rust)。如需了解详情（包括许可 "
-"条款），请参阅 `third_party/rust-on-exercism/` 目录。"
+"部分练习复制并 改编自 [Rust on Exercism](https://exercism.org/tracks/rust)。"
+"如需了解详情（包括许可 条款），请参阅 `third_party/rust-on-exercism/` 目录。"
 
 #: src/credits.md:26
 msgid "CXX"
@@ -19363,13 +19510,14 @@ msgid ""
 "directory for details, including the license terms."
 msgstr ""
 "“[与 C++ 的互操作性](android/interoperability/cpp.md)”部分引用了一张 来自 "
-"[CXX](https://cxx.rs/) 的图片。如需了解详情（包括许可条款）， 请参阅 `third_party/cxx/` 目录。"
+"[CXX](https://cxx.rs/) 的图片。如需了解详情（包括许可条款）， 请参阅 "
+"`third_party/cxx/` 目录。"
 
 #: src/credits.md:34
 msgid ""
 "The [Why Rust? - An Example in C](why-rust/an-example-in-c.md) section has "
-"been taken from the presentation slides of [Colin Finck's Master "
-"Thesis](https://colinfinck.de/Master_Thesis_Colin_Finck.pdf). It has been "
+"been taken from the presentation slides of [Colin Finck's Master Thesis]"
+"(https://colinfinck.de/Master_Thesis_Colin_Finck.pdf). It has been "
 "relicensed under the terms of the Apache 2.0 license for this course by the "
 "author."
 msgstr ""
@@ -19380,12 +19528,13 @@ msgstr "您将在下面的页面找到练习的解答。"
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on "
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
 "欢迎您在 [GitHub](https://github.com/google/comprehensive-rust/discussions) "
-"上提问关于解决方案的问题。如果您有与此处呈现的不同或更好的解决方案，请告诉我们。"
+"上提问关于解决方案的问题。如果您有与此处呈现的不同或更好的解决方案，请告诉我"
+"们。"
 
 #: src/exercises/day-1/solutions-morning.md:1
 msgid "Day 1 Morning Exercises"
@@ -19455,14 +19604,14 @@ msgstr "附加问题"
 
 #: src/exercises/day-1/solutions-morning.md:59
 msgid ""
-"It requires more advanced concepts. It might seem that we could use a "
-"slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make "
-"our function handle any size of matrix. However, this quickly breaks down: "
-"the return type cannot be `&[&[i32]]` since it needs to own the data you "
-"return."
+"It requires more advanced concepts. It might seem that we could use a slice-"
+"of-slices (`&[&[i32]]`) as the input type to transpose and thus make our "
+"function handle any size of matrix. However, this quickly breaks down: the "
+"return type cannot be `&[&[i32]]` since it needs to own the data you return."
 msgstr ""
-"这需要更高级的概念。看起来，我们可以使用切片的切片（`&[&[i32]]`）作为输入类型来进行转置，从而使我们的函数能够处理任意大小的矩阵。然而，这很快就会崩溃：返回类型不能是 "
-"`&[&[i32]]`，因为它需要拥有您返回的数据。"
+"这需要更高级的概念。看起来，我们可以使用切片的切片（`&[&[i32]]`）作为输入类型"
+"来进行转置，从而使我们的函数能够处理任意大小的矩阵。然而，这很快就会崩溃：返"
+"回类型不能是 `&[&[i32]]`，因为它需要拥有您返回的数据。"
 
 #: src/exercises/day-1/solutions-morning.md:61
 msgid ""
@@ -19470,14 +19619,15 @@ msgid ""
 "out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to "
 "`&[&[i32]]` so now you cannot easily use `pretty_print` either."
 msgstr ""
-"您可以尝试使用类似 `Vec<Vec<i32>>` 的方式，但这也无法直接工作：从 `Vec<Vec<i32>>` 转换为 `&[&[i32]]` "
-"很困难，因此您现在也不能轻松使用 `pretty_print`。"
+"您可以尝试使用类似 `Vec<Vec<i32>>` 的方式，但这也无法直接工作：从 "
+"`Vec<Vec<i32>>` 转换为 `&[&[i32]]` 很困难，因此您现在也不能轻松使用 "
+"`pretty_print`。"
 
 #: src/exercises/day-1/solutions-morning.md:63
 msgid ""
-"Once we get to traits and generics, we'll be able to use the "
-"[`std::convert::AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) "
-"trait to abstract over anything that can be referenced as a slice."
+"Once we get to traits and generics, we'll be able to use the [`std::convert::"
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:65
@@ -19514,7 +19664,9 @@ msgstr ""
 msgid ""
 "In addition, the type itself would not enforce that the child slices are of "
 "the same length, so such variable could contain an invalid matrix."
-msgstr "此外，类型本身不会强制要求子切片具有相同的长度，因此这样的变量可能包含一个无效的矩阵。"
+msgstr ""
+"此外，类型本身不会强制要求子切片具有相同的长度，因此这样的变量可能包含一个无"
+"效的矩阵。"
 
 #: src/exercises/day-1/solutions-afternoon.md:1
 msgid "Day 1 Afternoon Exercises"
@@ -19530,8 +19682,8 @@ msgid ""
 "pub fn luhn(cc_number: &str) -> bool {\n"
 "    let mut digits_seen = 0;\n"
 "    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' "
-"').enumerate() {\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
 "        match ch.to_digit(10) {\n"
 "            Some(d) => {\n"
 "                sum += if i % 2 == 1 {\n"
@@ -20068,15 +20220,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", "
-"\"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -20094,8 +20246,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -20243,8 +20395,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
-"demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\"\n"
 "    )));\n"
@@ -20490,8 +20642,8 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, "
-"core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
 "    // Layout according to the Linux man page for readdir(3), where ino_t "
@@ -20629,19 +20781,17 @@ msgid ""
 "    #[test]\n"
 "    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
 "        let tmp = tempfile::TempDir::new()?;\n"
-"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo Diaries\\n"
-"\")?;\n"
-"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n"
-"\")?;\n"
-"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n"
-"\")?;\n"
+"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo "
+"Diaries\\n\")?;\n"
+"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n\")?;\n"
+"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n\")?;\n"
 "        let iter = DirectoryIterator::new(\n"
 "            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
 "        )?;\n"
 "        let mut entries = iter.collect::<Vec<_>>();\n"
 "        entries.sort();\n"
-"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", "
-"\"foo.txt\"]);\n"
+"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", \"foo."
+"txt\"]);\n"
 "        Ok(())\n"
 "    }\n"
 "}\n"
@@ -20693,8 +20843,8 @@ msgid ""
 "\n"
 "    // Set up the I2C controller and Inertial Measurement Unit.\n"
 "    writeln!(serial, \"Setting up IMU...\").unwrap();\n"
-"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), "
-"FREQUENCY_A::K100);\n"
+"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::"
+"K100);\n"
 "    let mut imu = Lsm303agr::new_with_i2c(i2c);\n"
 "    imu.init().unwrap();\n"
 "    imu.set_mag_odr(MagOutputDataRate::Hz50).unwrap();\n"
@@ -20786,8 +20936,8 @@ msgid ""
 "    }\n"
 "}\n"
 "\n"
-"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) "
-"-> i32 {\n"
+"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -"
+"> i32 {\n"
 "    let range_in = max_in - min_in;\n"
 "    let range_out = max_out - min_out;\n"
 "    cap(\n"
@@ -20861,8 +21011,8 @@ msgid ""
 "base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) "
-"};\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
 "    gic.setup();\n"
 "\n"
 "    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 "
@@ -21017,8 +21167,8 @@ msgid ""
 "    pub fn matched(&self) -> bool {\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).ris).read_volatile() "
-"};\n"
+"        let ris = unsafe { addr_of!((*self.registers).ris)."
+"read_volatile() };\n"
 "        (ris & 0x01) != 0\n"
 "    }\n"
 "\n"
@@ -21029,8 +21179,8 @@ msgid ""
 "    pub fn interrupt_pending(&self) -> bool {\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).mis).read_volatile() "
-"};\n"
+"        let ris = unsafe { addr_of!((*self.registers).mis)."
+"read_volatile() };\n"
 "        (ris & 0x01) != 0\n"
 "    }\n"
 "\n"
@@ -21043,8 +21193,8 @@ msgid ""
 "        let imsc = if mask { 0x01 } else { 0x00 };\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).imsc).write_volatile(imsc) "
-"}\n"
+"        unsafe { addr_of_mut!((*self.registers).imsc)."
+"write_volatile(imsc) }\n"
 "    }\n"
 "\n"
 "    /// Clears a pending interrupt, if any.\n"
@@ -21284,8 +21434,8 @@ msgid ""
 "    result_receiver: mpsc::Receiver<CrawlResult>,\n"
 ") -> Vec<Url> {\n"
 "    let mut crawl_state = CrawlState::new(&start_url);\n"
-"    let start_command = CrawlCommand { url: start_url, extract_links: true "
-"};\n"
+"    let start_command = CrawlCommand { url: start_url, extract_links: "
+"true };\n"
 "    command_sender.send(start_command).unwrap();\n"
 "    let mut pending_urls = 1;\n"
 "\n"
@@ -21298,8 +21448,8 @@ msgid ""
 "            Ok(link_urls) => {\n"
 "                for url in link_urls {\n"
 "                    if crawl_state.mark_visited(&url) {\n"
-"                        let extract_links = "
-"crawl_state.should_extract_links(&url);\n"
+"                        let extract_links = crawl_state."
+"should_extract_links(&url);\n"
 "                        let crawl_command = CrawlCommand { url, "
 "extract_links };\n"
 "                        command_sender.send(crawl_command).unwrap();\n"
@@ -21319,15 +21469,15 @@ msgid ""
 "\n"
 "fn check_links(start_url: Url) -> Vec<Url> {\n"
 "    let (result_sender, result_receiver) = mpsc::channel::<CrawlResult>();\n"
-"    let (command_sender, command_receiver) = "
-"mpsc::channel::<CrawlCommand>();\n"
+"    let (command_sender, command_receiver) = mpsc::channel::"
+"<CrawlCommand>();\n"
 "    spawn_crawler_threads(command_receiver, result_sender, 16);\n"
 "    control_crawl(start_url, command_sender, result_receiver)\n"
 "}\n"
 "\n"
 "fn main() {\n"
-"    let start_url = "
-"reqwest::Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let start_url = reqwest::Url::parse(\"https://www.google.org\")."
+"unwrap();\n"
 "    let bad_urls = check_links(start_url);\n"
 "    println!(\"Bad URLs: {:#?}\", bad_urls);\n"
 "}\n"
@@ -21362,8 +21512,8 @@ msgid ""
 "impl Philosopher {\n"
 "    async fn think(&self) {\n"
 "        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", "
-"&self.name)).await\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
 "            .unwrap();\n"
 "    }\n"
 "\n"
@@ -21390,8 +21540,8 @@ msgid ""
 "async fn main() {\n"
 "    // Create forks\n"
 "    let mut forks = vec![];\n"
-"    (0..PHILOSOPHERS.len()).for_each(|_| "
-"forks.push(Arc::new(Mutex::new(Fork))));\n"
+"    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::"
+"new(Fork))));\n"
 "\n"
 "    // Create philosophers\n"
 "    let (philosophers, mut rx) = {\n"
@@ -21399,8 +21549,8 @@ msgid ""
 "        let (tx, rx) = mpsc::channel(10);\n"
 "        for (i, name) in PHILOSOPHERS.iter().enumerate() {\n"
 "            let left_fork = Arc::clone(&forks[i]);\n"
-"            let right_fork = Arc::clone(&forks[(i + 1) % "
-"PHILOSOPHERS.len()]);\n"
+"            let right_fork = Arc::clone(&forks[(i + 1) % PHILOSOPHERS."
+"len()]);\n"
 "            // To avoid a deadlock, we have to break the symmetry\n"
 "            // somewhere. This will swap the forks without deinitializing\n"
 "            // either of them.\n"
@@ -21546,8 +21696,8 @@ msgid ""
 "            res = stdin.next_line() => {\n"
 "                match res {\n"
 "                    Ok(None) => return Ok(()),\n"
-"                    Ok(Some(line)) => "
-"ws_stream.send(Message::text(line.to_string())).await?,\n"
+"                    Ok(Some(line)) => ws_stream.send(Message::text(line."
+"to_string())).await?,\n"
 "                    Err(err) => return Err(err.into()),\n"
 "                }\n"
 "            }\n"
@@ -21557,4 +21707,3 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-

--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -1,38 +1,44 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: 2023-09-24 10:41-0300\n"
+"POT-Creation-Date: 2023-10-05T20:31:13-07:00\n"
+"PO-Revision-Date: 2023-06-12 21:28-0700\n"
 "Last-Translator: \n"
 "Language-Team: Language zh-Hans\n"
-"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: zh-Hans\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.2\n"
 
-#: src/SUMMARY.md:4 src/index.md:1
+#: src/SUMMARY.md:4
+#: src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "欢迎来到 Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:5 src/running-the-course.md:1
+#: src/SUMMARY.md:5
+#: src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "授课"
 
-#: src/SUMMARY.md:6 src/running-the-course/course-structure.md:1
+#: src/SUMMARY.md:6
+#: src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "课程结构"
 
-#: src/SUMMARY.md:7 src/running-the-course/keyboard-shortcuts.md:1
+#: src/SUMMARY.md:7
+#: src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "键盘快捷键"
 
-#: src/SUMMARY.md:8 src/running-the-course/translations.md:1
+#: src/SUMMARY.md:8
+#: src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "翻译"
 
-#: src/SUMMARY.md:9 src/cargo.md:1
+#: src/SUMMARY.md:9
+#: src/cargo.md:1
 msgid "Using Cargo"
 msgstr "使用 Cargo"
 
@@ -50,1026 +56,1189 @@ msgstr "在本地运行 Cargo"
 
 #: src/SUMMARY.md:15
 msgid "Day 1: Morning"
-msgstr "第一天:早上"
+msgstr "第一天：早上"
 
-#: src/SUMMARY.md:19 src/SUMMARY.md:79 src/SUMMARY.md:134 src/SUMMARY.md:192
-#: src/SUMMARY.md:218 src/SUMMARY.md:268
+#: src/SUMMARY.md:19
+#: src/SUMMARY.md:80
+#: src/SUMMARY.md:135
+#: src/SUMMARY.md:193
+#: src/SUMMARY.md:219
+#: src/SUMMARY.md:269
 msgid "Welcome"
 msgstr "欢迎"
 
-#: src/SUMMARY.md:20 src/welcome-day-1/what-is-rust.md:1
+#: src/SUMMARY.md:20
+#: src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
-msgstr "什么是 Rust?"
+msgstr "什么是 Rust？"
 
-#: src/SUMMARY.md:21 src/hello-world.md:1
+#: src/SUMMARY.md:21
+#: src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Hello World!"
 
-#: src/SUMMARY.md:22 src/hello-world/small-example.md:1
+#: src/SUMMARY.md:22
+#: src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "简短示例"
 
-#: src/SUMMARY.md:23 src/why-rust.md:1
+#: src/SUMMARY.md:23
+#: src/why-rust.md:1
 msgid "Why Rust?"
-msgstr "为什么选择 Rust?"
+msgstr "为什么选择 Rust？"
 
-#: src/SUMMARY.md:24 src/why-rust/compile-time.md:1
+#: src/SUMMARY.md:24
+#: src/why-rust/an-example-in-c.md:1
+#: src/credits.md:32
+#, fuzzy
+msgid "An Example in C"
+msgstr "C++ 示例"
+
+#: src/SUMMARY.md:25
+#: src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "编译期保障"
 
-#: src/SUMMARY.md:25 src/why-rust/runtime.md:1
+#: src/SUMMARY.md:26
+#: src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "运行时保障"
 
-#: src/SUMMARY.md:26 src/why-rust/modern.md:1
+#: src/SUMMARY.md:27
+#: src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "现代特性"
 
-#: src/SUMMARY.md:27 src/basic-syntax.md:1
+#: src/SUMMARY.md:28
+#: src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "基本语法"
 
-#: src/SUMMARY.md:28 src/basic-syntax/scalar-types.md:1
+#: src/SUMMARY.md:29
+#: src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "标量类型"
 
-#: src/SUMMARY.md:29 src/basic-syntax/compound-types.md:1
+#: src/SUMMARY.md:30
+#: src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "复合类型"
 
-#: src/SUMMARY.md:30 src/basic-syntax/references.md:1
+#: src/SUMMARY.md:31
+#: src/basic-syntax/references.md:1
 msgid "References"
 msgstr "引用"
 
-#: src/SUMMARY.md:31 src/basic-syntax/references-dangling.md:1
+#: src/SUMMARY.md:32
+#: src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "悬垂引用"
 
-#: src/SUMMARY.md:32 src/basic-syntax/slices.md:1
+#: src/SUMMARY.md:33
+#: src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "切片"
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:34
 msgid "String vs str"
 msgstr "String 和 str"
 
-#: src/SUMMARY.md:34 src/basic-syntax/functions.md:1
+#: src/SUMMARY.md:35
+#: src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "函数"
 
-#: src/SUMMARY.md:35 src/basic-syntax/rustdoc.md:1
+#: src/SUMMARY.md:36
+#: src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr "Rustdoc"
 
-#: src/SUMMARY.md:36 src/SUMMARY.md:102 src/basic-syntax/methods.md:1
+#: src/SUMMARY.md:37
+#: src/SUMMARY.md:103
+#: src/basic-syntax/methods.md:1
 #: src/methods.md:1
 msgid "Methods"
 msgstr "方法"
 
-#: src/SUMMARY.md:37
+#: src/SUMMARY.md:38
 msgid "Overloading"
 msgstr "重载"
 
-#: src/SUMMARY.md:38 src/SUMMARY.md:71 src/SUMMARY.md:105 src/SUMMARY.md:125
-#: src/SUMMARY.md:154 src/SUMMARY.md:184 src/SUMMARY.md:211 src/SUMMARY.md:232
-#: src/SUMMARY.md:260 src/SUMMARY.md:282 src/SUMMARY.md:303
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/SUMMARY.md:39
+#: src/SUMMARY.md:72
+#: src/SUMMARY.md:106
+#: src/SUMMARY.md:126
+#: src/SUMMARY.md:155
+#: src/SUMMARY.md:185
+#: src/SUMMARY.md:212
+#: src/SUMMARY.md:233
+#: src/SUMMARY.md:261
+#: src/SUMMARY.md:283
+#: src/SUMMARY.md:304
+#: src/exercises/android/morning.md:1
+#: src/exercises/bare-metal/morning.md:1
 #: src/exercises/bare-metal/afternoon.md:1
 #: src/exercises/concurrency/morning.md:1
 #: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "习题"
 
-#: src/SUMMARY.md:39 src/exercises/day-1/implicit-conversions.md:1
+#: src/SUMMARY.md:40
+#: src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "隐式类型转换"
 
-#: src/SUMMARY.md:40
+#: src/SUMMARY.md:41
 msgid "Arrays and for Loops"
 msgstr "数组与 for 循环"
 
-#: src/SUMMARY.md:42
+#: src/SUMMARY.md:43
 msgid "Day 1: Afternoon"
-msgstr "第 1 天:下午"
+msgstr "第 1 天：下午"
 
-#: src/SUMMARY.md:44 src/SUMMARY.md:295 src/control-flow.md:1
+#: src/SUMMARY.md:45
+#: src/SUMMARY.md:296
+#: src/control-flow.md:1
 msgid "Control Flow"
 msgstr "控制流"
 
-#: src/SUMMARY.md:45 src/control-flow/blocks.md:1
+#: src/SUMMARY.md:46
+#: src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "块"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:47
 msgid "if expressions"
 msgstr "if 表达式"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:48
 msgid "for expressions"
 msgstr "for 表达式"
 
-#: src/SUMMARY.md:48
+#: src/SUMMARY.md:49
 msgid "while expressions"
 msgstr "while 表达式"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:50
 msgid "break & continue"
 msgstr "break & continue"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:51
 msgid "loop expressions"
 msgstr "loop 表达式"
 
-#: src/SUMMARY.md:52 src/basic-syntax/variables.md:1
+#: src/SUMMARY.md:53
+#: src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "变量"
 
-#: src/SUMMARY.md:53 src/basic-syntax/type-inference.md:1
+#: src/SUMMARY.md:54
+#: src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "类型推导"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:55
 msgid "static & const"
 msgstr "静态与常量"
 
-#: src/SUMMARY.md:55 src/basic-syntax/scopes-shadowing.md:1
+#: src/SUMMARY.md:56
+#: src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "作用域和隐藏 (Shadowing)"
 
-#: src/SUMMARY.md:56 src/enums.md:1
+#: src/SUMMARY.md:57
+#: src/enums.md:1
 msgid "Enums"
 msgstr "枚举"
 
-#: src/SUMMARY.md:57 src/enums/variant-payloads.md:1
+#: src/SUMMARY.md:58
+#: src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "变体载荷"
 
-#: src/SUMMARY.md:58 src/enums/sizes.md:1
+#: src/SUMMARY.md:59
+#: src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "枚举大小"
 
-#: src/SUMMARY.md:60 src/control-flow/novel.md:1
+#: src/SUMMARY.md:61
+#: src/control-flow/novel.md:1
 #, fuzzy
 msgid "Novel Control Flow"
 msgstr "控制流"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:62
 msgid "if let expressions"
 msgstr "if let 表达式"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:63
 msgid "while let expressions"
 msgstr "while let 表达式"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:64
 msgid "match expressions"
 msgstr "match 表达式"
 
-#: src/SUMMARY.md:65 src/SUMMARY.md:73 src/pattern-matching.md:1
+#: src/SUMMARY.md:66
+#: src/SUMMARY.md:74
+#: src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "模式匹配"
 
-#: src/SUMMARY.md:66 src/pattern-matching/destructuring-enums.md:1
+#: src/SUMMARY.md:67
+#: src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "解构枚举"
 
-#: src/SUMMARY.md:67 src/pattern-matching/destructuring-structs.md:1
+#: src/SUMMARY.md:68
+#: src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "解构结构体"
 
-#: src/SUMMARY.md:68 src/pattern-matching/destructuring-arrays.md:1
+#: src/SUMMARY.md:69
+#: src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "解构数组"
 
-#: src/SUMMARY.md:69 src/pattern-matching/match-guards.md:1
+#: src/SUMMARY.md:70
+#: src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "匹配守卫"
 
-#: src/SUMMARY.md:72 src/exercises/day-1/luhn.md:1
+#: src/SUMMARY.md:73
+#: src/exercises/day-1/luhn.md:1
 #: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Luhn 算法"
 
-#: src/SUMMARY.md:75
+#: src/SUMMARY.md:76
 msgid "Day 2: Morning"
 msgstr "第二天：上午"
 
-#: src/SUMMARY.md:81 src/memory-management.md:1
+#: src/SUMMARY.md:82
+#: src/memory-management.md:1
 msgid "Memory Management"
 msgstr "内存管理"
 
-#: src/SUMMARY.md:82
+#: src/SUMMARY.md:83
 msgid "Stack vs Heap"
 msgstr "栈 vs 堆"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:84
 msgid "Stack Memory"
 msgstr "栈内存"
 
-#: src/SUMMARY.md:84 src/memory-management/manual.md:1
+#: src/SUMMARY.md:85
+#: src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "手动内存管理"
 
-#: src/SUMMARY.md:85 src/memory-management/scope-based.md:1
+#: src/SUMMARY.md:86
+#: src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "基于作用域的内存管理"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:87
 msgid "Garbage Collection"
 msgstr "垃圾回收"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:88
 msgid "Rust Memory Management"
 msgstr "Rust 内存管理"
 
-#: src/SUMMARY.md:88 src/ownership.md:1
+#: src/SUMMARY.md:89
+#: src/ownership.md:1
 msgid "Ownership"
 msgstr "所有权"
 
-#: src/SUMMARY.md:89 src/ownership/move-semantics.md:1
+#: src/SUMMARY.md:90
+#: src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "移动语义"
 
-#: src/SUMMARY.md:90 src/ownership/moved-strings-rust.md:1
+#: src/SUMMARY.md:91
+#: src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Rust 中移动的字符串"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:92
 msgid "Double Frees in Modern C++"
 msgstr "现代 C++ 中的双重释放"
 
-#: src/SUMMARY.md:92 src/ownership/moves-function-calls.md:1
+#: src/SUMMARY.md:93
+#: src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "函数调用中的移动"
 
-#: src/SUMMARY.md:93 src/ownership/copy-clone.md:1
+#: src/SUMMARY.md:94
+#: src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "复制和克隆"
 
-#: src/SUMMARY.md:94 src/ownership/borrowing.md:1
+#: src/SUMMARY.md:95
+#: src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "借用"
 
-#: src/SUMMARY.md:95 src/ownership/shared-unique-borrows.md:1
+#: src/SUMMARY.md:96
+#: src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "共享和唯一的借用"
 
-#: src/SUMMARY.md:96 src/ownership/lifetimes.md:1
+#: src/SUMMARY.md:97
+#: src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "生命周期"
 
-#: src/SUMMARY.md:97 src/ownership/lifetimes-function-calls.md:1
+#: src/SUMMARY.md:98
+#: src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "函数调用中的生命周期"
 
-#: src/SUMMARY.md:98 src/ownership/lifetimes-data-structures.md:1
+#: src/SUMMARY.md:99
+#: src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "数据结构中的生命周期"
 
-#: src/SUMMARY.md:99 src/structs.md:1
+#: src/SUMMARY.md:100
+#: src/structs.md:1
 msgid "Structs"
 msgstr "结构体"
 
-#: src/SUMMARY.md:100 src/structs/tuple-structs.md:1
+#: src/SUMMARY.md:101
+#: src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "元组结构体"
 
-#: src/SUMMARY.md:101 src/structs/field-shorthand.md:1
+#: src/SUMMARY.md:102
+#: src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "字段简写语法"
 
-#: src/SUMMARY.md:103 src/methods/receiver.md:1
+#: src/SUMMARY.md:104
+#: src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "方法接收者"
 
-#: src/SUMMARY.md:104 src/SUMMARY.md:166 src/SUMMARY.md:281
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
+#: src/SUMMARY.md:105
+#: src/SUMMARY.md:167
+#: src/SUMMARY.md:282
+#: src/methods/example.md:1
+#: src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "示例"
 
-#: src/SUMMARY.md:106 src/exercises/day-2/book-library.md:1
+#: src/SUMMARY.md:107
+#: src/exercises/day-2/book-library.md:1
 #, fuzzy
 msgid "Storing Books"
 msgstr "字符串"
 
-#: src/SUMMARY.md:107 src/exercises/day-2/health-statistics.md:1
+#: src/SUMMARY.md:108
+#: src/exercises/day-2/health-statistics.md:1
+#: src/exercises/day-2/solutions-morning.md:151
 msgid "Health Statistics"
 msgstr "健康统计"
 
-#: src/SUMMARY.md:109
+#: src/SUMMARY.md:110
 msgid "Day 2: Afternoon"
 msgstr "第二天：下午"
 
-#: src/SUMMARY.md:111 src/std.md:1
+#: src/SUMMARY.md:112
+#: src/std.md:1
 msgid "Standard Library"
 msgstr "标准库"
 
-#: src/SUMMARY.md:112
+#: src/SUMMARY.md:113
 msgid "Option and Result"
 msgstr "Option 和 Result"
 
-#: src/SUMMARY.md:113 src/std/string.md:1
+#: src/SUMMARY.md:114
+#: src/std/string.md:1
 msgid "String"
 msgstr "String"
 
-#: src/SUMMARY.md:114
+#: src/SUMMARY.md:115
 msgid "Vec"
 msgstr "Vec"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:116
 msgid "HashMap"
 msgstr "哈希表"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:117
 msgid "Box"
 msgstr "Box"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:118
 msgid "Recursive Data Types"
 msgstr "递归数据类型"
 
-#: src/SUMMARY.md:118 src/std/box-niche.md:1
+#: src/SUMMARY.md:119
+#: src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "小众优化"
 
-#: src/SUMMARY.md:119
+#: src/SUMMARY.md:120
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:121
 msgid "Cell/RefCell"
 msgstr "Cell/RefCell"
 
-#: src/SUMMARY.md:121 src/modules.md:1
+#: src/SUMMARY.md:122
+#: src/modules.md:1
 msgid "Modules"
 msgstr "模块"
 
-#: src/SUMMARY.md:122 src/modules/visibility.md:1
+#: src/SUMMARY.md:123
+#: src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "可见性"
 
-#: src/SUMMARY.md:123 src/modules/paths.md:1
+#: src/SUMMARY.md:124
+#: src/modules/paths.md:1
 msgid "Paths"
 msgstr "路径"
 
-#: src/SUMMARY.md:124 src/modules/filesystem.md:1
+#: src/SUMMARY.md:125
+#: src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "文件系统层级结构"
 
-#: src/SUMMARY.md:126 src/exercises/day-2/iterators-and-ownership.md:1
+#: src/SUMMARY.md:127
+#: src/exercises/day-2/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "迭代器和所有权"
 
-#: src/SUMMARY.md:127 src/exercises/day-2/strings-iterators.md:1
+#: src/SUMMARY.md:128
+#: src/exercises/day-2/strings-iterators.md:1
 #: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Strings and Iterators"
 msgstr "字符串和迭代器"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:131
 msgid "Day 3: Morning"
 msgstr "第三天：上午"
 
-#: src/SUMMARY.md:135 src/generics.md:1
+#: src/SUMMARY.md:136
+#: src/generics.md:1
 msgid "Generics"
 msgstr "泛型"
 
-#: src/SUMMARY.md:136 src/generics/data-types.md:1
+#: src/SUMMARY.md:137
+#: src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "通用数据类型"
 
-#: src/SUMMARY.md:137 src/generics/methods.md:1
+#: src/SUMMARY.md:138
+#: src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "泛型方法"
 
-#: src/SUMMARY.md:138 src/generics/monomorphization.md:1
+#: src/SUMMARY.md:139
+#: src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "单态化"
 
-#: src/SUMMARY.md:139 src/traits.md:1
+#: src/SUMMARY.md:140
+#: src/traits.md:1
 msgid "Traits"
 msgstr "特征"
 
-#: src/SUMMARY.md:140 src/traits/trait-objects.md:1
+#: src/SUMMARY.md:141
+#: src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "特征（Trait）对象"
 
-#: src/SUMMARY.md:141 src/traits/deriving-traits.md:1
+#: src/SUMMARY.md:142
+#: src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "派生特征"
 
-#: src/SUMMARY.md:142 src/traits/default-methods.md:1
+#: src/SUMMARY.md:143
+#: src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "默认方法"
 
-#: src/SUMMARY.md:143 src/traits/trait-bounds.md:1
+#: src/SUMMARY.md:144
+#: src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "特征边界"
 
-#: src/SUMMARY.md:144
+#: src/SUMMARY.md:145
 msgid "impl Trait"
 msgstr "impl Trait"
 
-#: src/SUMMARY.md:145 src/traits/important-traits.md:1
+#: src/SUMMARY.md:146
+#: src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "重要特征"
 
-#: src/SUMMARY.md:146
+#: src/SUMMARY.md:147
 msgid "Iterator"
 msgstr "迭代器"
 
-#: src/SUMMARY.md:147 src/traits/from-iterator.md:1
+#: src/SUMMARY.md:148
+#: src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
-#: src/SUMMARY.md:148
+#: src/SUMMARY.md:149
 msgid "From and Into"
 msgstr "From 和 Into"
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:150
 msgid "Read and Write"
 msgstr "读取和写入"
 
-#: src/SUMMARY.md:150
+#: src/SUMMARY.md:151
 msgid "Drop"
 msgstr "Drop"
 
-#: src/SUMMARY.md:151
+#: src/SUMMARY.md:152
 msgid "Default"
 msgstr "Default"
 
-#: src/SUMMARY.md:152
+#: src/SUMMARY.md:153
 msgid "Operators: Add, Mul, ..."
 msgstr "运算符：Add、Mul..."
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:154
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr "闭包：Fn、FnMut、FnOnce"
 
-#: src/SUMMARY.md:155 src/exercises/day-3/simple-gui.md:1
-#: src/exercises/day-3/solutions-morning.md:3
+#: src/SUMMARY.md:156
 msgid "A Simple GUI Library"
 msgstr "一个简单的 GUI 库"
 
-#: src/SUMMARY.md:156 src/exercises/day-3/solutions-morning.md:145
+#: src/SUMMARY.md:157
+#: src/exercises/day-3/solutions-morning.md:142
 msgid "Points and Polygons"
 msgstr "点和多边形"
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:159
 msgid "Day 3: Afternoon"
 msgstr "第三天：下午"
 
-#: src/SUMMARY.md:160 src/error-handling.md:1
+#: src/SUMMARY.md:161
+#: src/error-handling.md:1
 msgid "Error Handling"
 msgstr "错误处理"
 
-#: src/SUMMARY.md:161 src/error-handling/panics.md:1
+#: src/SUMMARY.md:162
+#: src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Panics"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Catching Stack Unwinding"
 msgstr "捕获堆栈展开"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:164
 msgid "Structured Error Handling"
 msgstr "结构化错误处理"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Propagating Errors with ?"
 msgstr "使用 ? 传播错误"
 
-#: src/SUMMARY.md:165 src/error-handling/converting-error-types.md:1
+#: src/SUMMARY.md:166
+#: src/error-handling/converting-error-types.md:1
 #: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "转换错误类型"
 
-#: src/SUMMARY.md:167 src/error-handling/deriving-error-enums.md:1
+#: src/SUMMARY.md:168
+#: src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "派生错误枚举"
 
-#: src/SUMMARY.md:168 src/error-handling/dynamic-errors.md:1
+#: src/SUMMARY.md:169
+#: src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "动态错误类型"
 
-#: src/SUMMARY.md:169 src/error-handling/error-contexts.md:1
+#: src/SUMMARY.md:170
+#: src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "为错误添加背景信息"
 
-#: src/SUMMARY.md:170 src/testing.md:1
+#: src/SUMMARY.md:171
+#: src/testing.md:1
 msgid "Testing"
 msgstr "测试"
 
-#: src/SUMMARY.md:171 src/testing/unit-tests.md:1
+#: src/SUMMARY.md:172
+#: src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "单元测试"
 
-#: src/SUMMARY.md:172 src/testing/test-modules.md:1
+#: src/SUMMARY.md:173
+#: src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "测试模块"
 
-#: src/SUMMARY.md:173 src/testing/doc-tests.md:1
+#: src/SUMMARY.md:174
+#: src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "文档测试"
 
-#: src/SUMMARY.md:174 src/testing/integration-tests.md:1
+#: src/SUMMARY.md:175
+#: src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "集成测试"
 
-#: src/SUMMARY.md:175 src/bare-metal/useful-crates.md:1
+#: src/SUMMARY.md:176
+#: src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr "实用 crate"
 
-#: src/SUMMARY.md:176 src/unsafe.md:1
+#: src/SUMMARY.md:177
+#: src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "不安全 Rust"
 
-#: src/SUMMARY.md:177 src/unsafe/raw-pointers.md:1
+#: src/SUMMARY.md:178
+#: src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "解引用裸指针"
 
-#: src/SUMMARY.md:178 src/unsafe/mutable-static-variables.md:1
+#: src/SUMMARY.md:179
+#: src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "可变的静态变量"
 
-#: src/SUMMARY.md:179 src/unsafe/unions.md:1
+#: src/SUMMARY.md:180
+#: src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "联合体"
 
-#: src/SUMMARY.md:180 src/unsafe/calling-unsafe-functions.md:1
+#: src/SUMMARY.md:181
+#: src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "调用 Unsafe 函数"
 
-#: src/SUMMARY.md:181 src/unsafe/writing-unsafe-functions.md:1
+#: src/SUMMARY.md:182
+#: src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "编写 Unsafe 函数"
 
-#: src/SUMMARY.md:182
+#: src/SUMMARY.md:183
 msgid "Extern Functions"
 msgstr "外部函数"
 
-#: src/SUMMARY.md:183 src/unsafe/unsafe-traits.md:1
+#: src/SUMMARY.md:184
+#: src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "实现 Unsafe Trait"
 
-#: src/SUMMARY.md:185 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/SUMMARY.md:186
+#: src/exercises/day-3/safe-ffi-wrapper.md:1
 #: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "安全 FFI 封装容器"
 
-#: src/SUMMARY.md:188 src/SUMMARY.md:258 src/bare-metal/android.md:1
+#: src/SUMMARY.md:189
+#: src/SUMMARY.md:259
+#: src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:193 src/android/setup.md:1
+#: src/SUMMARY.md:194
+#: src/android/setup.md:1
 msgid "Setup"
 msgstr "设置"
 
-#: src/SUMMARY.md:194 src/android/build-rules.md:1
+#: src/SUMMARY.md:195
+#: src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "构建规则"
 
-#: src/SUMMARY.md:195
+#: src/SUMMARY.md:196
 msgid "Binary"
 msgstr "可执行文件"
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:197
 msgid "Library"
 msgstr "库"
 
-#: src/SUMMARY.md:197 src/android/aidl.md:1
+#: src/SUMMARY.md:198
+#: src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:199
 msgid "Interface"
 msgstr "接口"
 
-#: src/SUMMARY.md:199
+#: src/SUMMARY.md:200
 msgid "Implementation"
 msgstr "实现"
 
-#: src/SUMMARY.md:200
+#: src/SUMMARY.md:201
 msgid "Server"
 msgstr "服务器"
 
-#: src/SUMMARY.md:201 src/android/aidl/deploy.md:1
+#: src/SUMMARY.md:202
+#: src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "部署"
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:203
 msgid "Client"
 msgstr "客户端"
 
-#: src/SUMMARY.md:203 src/android/aidl/changing.md:1
+#: src/SUMMARY.md:204
+#: src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "更改 API"
 
-#: src/SUMMARY.md:204 src/SUMMARY.md:248 src/android/logging.md:1
+#: src/SUMMARY.md:205
+#: src/SUMMARY.md:249
+#: src/android/logging.md:1
 #: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "日志记录"
 
-#: src/SUMMARY.md:205 src/android/interoperability.md:1
+#: src/SUMMARY.md:206
+#: src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "互操作性"
 
-#: src/SUMMARY.md:206
+#: src/SUMMARY.md:207
 msgid "With C"
 msgstr "与 C 语言交互"
 
-#: src/SUMMARY.md:207
+#: src/SUMMARY.md:208
 msgid "Calling C with Bindgen"
 msgstr "使用Bindgen调用C语言"
 
-#: src/SUMMARY.md:208
+#: src/SUMMARY.md:209
 msgid "Calling Rust from C"
 msgstr "从C语言调用Rust语言"
 
-#: src/SUMMARY.md:209 src/android/interoperability/cpp.md:1
+#: src/SUMMARY.md:210
+#: src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "与 C++ 交互"
 
-#: src/SUMMARY.md:210
+#: src/SUMMARY.md:211
 msgid "With Java"
 msgstr "与 Java 交互"
 
-#: src/SUMMARY.md:214
+#: src/SUMMARY.md:215
 msgid "Bare Metal: Morning"
 msgstr "裸机:上午"
 
-#: src/SUMMARY.md:219
+#: src/SUMMARY.md:220
 msgid "no_std"
 msgstr "no_std"
 
-#: src/SUMMARY.md:220
+#: src/SUMMARY.md:221
 msgid "A Minimal Example"
 msgstr "最小示例"
 
-#: src/SUMMARY.md:221
+#: src/SUMMARY.md:222
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:222 src/bare-metal/microcontrollers.md:1
+#: src/SUMMARY.md:223
+#: src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "微控制器"
 
-#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/mmio.md:1
+#: src/SUMMARY.md:224
+#: src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "原始 MMIO"
 
-#: src/SUMMARY.md:224
+#: src/SUMMARY.md:225
 msgid "PACs"
 msgstr "PAC"
 
-#: src/SUMMARY.md:225
+#: src/SUMMARY.md:226
 msgid "HAL Crates"
 msgstr "HAL crate"
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:227
 msgid "Board Support Crates"
 msgstr "板级支持 Crate"
 
-#: src/SUMMARY.md:227
+#: src/SUMMARY.md:228
 msgid "The Type State Pattern"
 msgstr "类型状态模式"
 
-#: src/SUMMARY.md:228
+#: src/SUMMARY.md:229
 msgid "embedded-hal"
 msgstr "embedded-hal"
 
-#: src/SUMMARY.md:229
+#: src/SUMMARY.md:230
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs、cargo-embed"
 
-#: src/SUMMARY.md:230 src/bare-metal/microcontrollers/debugging.md:1
+#: src/SUMMARY.md:231
+#: src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/SUMMARY.md:231 src/SUMMARY.md:251
+#: src/SUMMARY.md:232
+#: src/SUMMARY.md:252
 msgid "Other Projects"
 msgstr "其他项目"
 
-#: src/SUMMARY.md:233 src/exercises/bare-metal/compass.md:1
+#: src/SUMMARY.md:234
+#: src/exercises/bare-metal/compass.md:1
 #: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "罗盘"
 
-#: src/SUMMARY.md:235
+#: src/SUMMARY.md:236
 msgid "Bare Metal: Afternoon"
 msgstr "裸机:下午"
 
-#: src/SUMMARY.md:237
+#: src/SUMMARY.md:238
 msgid "Application Processors"
 msgstr "应用处理器"
 
-#: src/SUMMARY.md:238 src/bare-metal/aps/entry-point.md:1
+#: src/SUMMARY.md:239
+#: src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr "准备使用 Rust"
 
-#: src/SUMMARY.md:239
+#: src/SUMMARY.md:240
 msgid "Inline Assembly"
 msgstr "内嵌汇编"
 
-#: src/SUMMARY.md:240
+#: src/SUMMARY.md:241
 msgid "MMIO"
 msgstr "MMIO"
 
-#: src/SUMMARY.md:241
+#: src/SUMMARY.md:242
 msgid "Let's Write a UART Driver"
 msgstr "编写 UART 驱动程序"
 
-#: src/SUMMARY.md:242
+#: src/SUMMARY.md:243
 msgid "More Traits"
 msgstr "更多 trait"
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md:244
 msgid "A Better UART Driver"
 msgstr "一个更好的 UART 驱动程序"
 
-#: src/SUMMARY.md:244 src/bare-metal/aps/better-uart/bitflags.md:1
+#: src/SUMMARY.md:245
+#: src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "Bitflags"
 
-#: src/SUMMARY.md:245
+#: src/SUMMARY.md:246
 msgid "Multiple Registers"
 msgstr "多个寄存器"
 
-#: src/SUMMARY.md:246 src/bare-metal/aps/better-uart/driver.md:1
+#: src/SUMMARY.md:247
+#: src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "驱动程序"
 
-#: src/SUMMARY.md:247 src/SUMMARY.md:249
+#: src/SUMMARY.md:248
+#: src/SUMMARY.md:250
 msgid "Using It"
 msgstr "开始使用"
 
-#: src/SUMMARY.md:250 src/bare-metal/aps/exceptions.md:1
+#: src/SUMMARY.md:251
+#: src/bare-metal/aps/exceptions.md:1
 #, fuzzy
 msgid "Exceptions"
 msgstr "函数"
 
-#: src/SUMMARY.md:252
+#: src/SUMMARY.md:253
 msgid "Useful Crates"
 msgstr "实用 crate"
 
-#: src/SUMMARY.md:253
+#: src/SUMMARY.md:254
 msgid "zerocopy"
 msgstr "zerocopy"
 
-#: src/SUMMARY.md:254
+#: src/SUMMARY.md:255
 msgid "aarch64-paging"
 msgstr "aarch64-paging"
 
-#: src/SUMMARY.md:255
+#: src/SUMMARY.md:256
 msgid "buddy_system_allocator"
 msgstr "buddy_system_allocator"
 
-#: src/SUMMARY.md:256
+#: src/SUMMARY.md:257
 msgid "tinyvec"
 msgstr "tinyvec"
 
-#: src/SUMMARY.md:257
+#: src/SUMMARY.md:258
 msgid "spin"
 msgstr "转动"
 
-#: src/SUMMARY.md:259 src/bare-metal/android/vmbase.md:1
+#: src/SUMMARY.md:260
+#: src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
-#: src/SUMMARY.md:261
+#: src/SUMMARY.md:262
 msgid "RTC Driver"
 msgstr "RTC驱动"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:265
 msgid "Concurrency: Morning"
-msgstr "并发编程:入门篇"
+msgstr "并发编程：入门篇"
 
-#: src/SUMMARY.md:269 src/concurrency/threads.md:1
+#: src/SUMMARY.md:270
+#: src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "线程"
 
-#: src/SUMMARY.md:270 src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:271
+#: src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "范围线程"
 
-#: src/SUMMARY.md:271 src/concurrency/channels.md:1
+#: src/SUMMARY.md:272
+#: src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "通道"
 
-#: src/SUMMARY.md:272 src/concurrency/channels/unbounded.md:1
+#: src/SUMMARY.md:273
+#: src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "无界通道"
 
-#: src/SUMMARY.md:273 src/concurrency/channels/bounded.md:1
+#: src/SUMMARY.md:274
+#: src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "有界通道"
 
-#: src/SUMMARY.md:274
+#: src/SUMMARY.md:275
 msgid "Send and Sync"
 msgstr "Send 和 Sync"
 
-#: src/SUMMARY.md:274
+#: src/SUMMARY.md:275
 msgid "Send"
 msgstr "Send"
 
-#: src/SUMMARY.md:274
+#: src/SUMMARY.md:275
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:277 src/concurrency/send-sync/examples.md:1
+#: src/SUMMARY.md:278
+#: src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "示例"
 
-#: src/SUMMARY.md:278 src/concurrency/shared_state.md:1
+#: src/SUMMARY.md:279
+#: src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "共享状态"
 
-#: src/SUMMARY.md:279
+#: src/SUMMARY.md:280
 msgid "Arc"
 msgstr "Arc"
 
-#: src/SUMMARY.md:280
+#: src/SUMMARY.md:281
 msgid "Mutex"
 msgstr "Mutex"
 
-#: src/SUMMARY.md:283 src/SUMMARY.md:304
+#: src/SUMMARY.md:284
+#: src/SUMMARY.md:305
 #: src/exercises/concurrency/dining-philosophers.md:1
 #: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "哲学家就餐问题 (Dining philosophers problem)"
 
-#: src/SUMMARY.md:284 src/exercises/concurrency/link-checker.md:1
+#: src/SUMMARY.md:285
+#: src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "多线程链接检查器"
 
-#: src/SUMMARY.md:286
+#: src/SUMMARY.md:287
 msgid "Concurrency: Afternoon"
-msgstr "并发:下午"
+msgstr "并发：下午"
 
-#: src/SUMMARY.md:288
+#: src/SUMMARY.md:289
 msgid "Async Basics"
 msgstr "异步基础"
 
-#: src/SUMMARY.md:289
+#: src/SUMMARY.md:290
 msgid "async/await"
 msgstr "async/await"
 
-#: src/SUMMARY.md:290 src/async/futures.md:1
+#: src/SUMMARY.md:291
+#: src/async/futures.md:1
 msgid "Futures"
 msgstr "Futures"
 
-#: src/SUMMARY.md:291 src/async/runtimes.md:1
+#: src/SUMMARY.md:292
+#: src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "Runtimes"
 
-#: src/SUMMARY.md:292 src/async/runtimes/tokio.md:1
+#: src/SUMMARY.md:293
+#: src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:293 src/exercises/concurrency/link-checker.md:126
-#: src/async/tasks.md:1 src/exercises/concurrency/chat-app.md:143
+#: src/SUMMARY.md:294
+#: src/exercises/concurrency/link-checker.md:126
+#: src/async/tasks.md:1
+#: src/exercises/concurrency/chat-app.md:143
 msgid "Tasks"
 msgstr "任务"
 
-#: src/SUMMARY.md:294 src/async/channels.md:1
+#: src/SUMMARY.md:295
+#: src/async/channels.md:1
 msgid "Async Channels"
 msgstr "异步通道"
 
-#: src/SUMMARY.md:296 src/async/control-flow/join.md:1
+#: src/SUMMARY.md:297
+#: src/async/control-flow/join.md:1
 msgid "Join"
 msgstr "加入"
 
-#: src/SUMMARY.md:297 src/async/control-flow/select.md:1
+#: src/SUMMARY.md:298
+#: src/async/control-flow/select.md:1
 msgid "Select"
 msgstr "选择"
 
-#: src/SUMMARY.md:298
+#: src/SUMMARY.md:299
 msgid "Pitfalls"
 msgstr "误区"
 
-#: src/SUMMARY.md:299
+#: src/SUMMARY.md:300
 msgid "Blocking the Executor"
 msgstr "屏蔽执行器"
 
-#: src/SUMMARY.md:300 src/async/pitfalls/pin.md:1
+#: src/SUMMARY.md:301
+#: src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr "固定"
 
-#: src/SUMMARY.md:301 src/async/pitfalls/async-traits.md:1
+#: src/SUMMARY.md:302
+#: src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "异步特质"
 
-#: src/SUMMARY.md:302 src/async/pitfalls/cancellation.md:1
+#: src/SUMMARY.md:303
+#: src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
 msgstr "安装"
 
-#: src/SUMMARY.md:305 src/exercises/concurrency/chat-app.md:1
+#: src/SUMMARY.md:306
+#: src/exercises/concurrency/chat-app.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:95
 msgid "Broadcast Chat Application"
 msgstr "广播聊天应用程序"
 
-#: src/SUMMARY.md:308
+#: src/SUMMARY.md:309
 msgid "Final Words"
 msgstr "结束语"
 
-#: src/SUMMARY.md:312 src/thanks.md:1
-msgid "Thanks!"
-msgstr "谢谢!"
-
 #: src/SUMMARY.md:313
+#: src/thanks.md:1
+msgid "Thanks!"
+msgstr "谢谢！"
+
+#: src/SUMMARY.md:314
+#: src/glossary.md:1
+msgid "Glossary"
+msgstr ""
+
+#: src/SUMMARY.md:315
 msgid "Other Resources"
 msgstr "其他资源"
 
-#: src/SUMMARY.md:314 src/credits.md:1
+#: src/SUMMARY.md:316
+#: src/credits.md:1
 msgid "Credits"
 msgstr "鸣谢"
 
-#: src/SUMMARY.md:317 src/exercises/solutions.md:1
+#: src/SUMMARY.md:319
+#: src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "解答"
 
-#: src/SUMMARY.md:322
+#: src/SUMMARY.md:324
 msgid "Day 1 Morning"
 msgstr "第一天上午"
 
-#: src/SUMMARY.md:323
+#: src/SUMMARY.md:325
 msgid "Day 1 Afternoon"
 msgstr "第一天下午"
 
-#: src/SUMMARY.md:324
+#: src/SUMMARY.md:326
 msgid "Day 2 Morning"
 msgstr "第二天上午"
 
-#: src/SUMMARY.md:325
+#: src/SUMMARY.md:327
 msgid "Day 2 Afternoon"
 msgstr "第二天下午"
 
-#: src/SUMMARY.md:326
+#: src/SUMMARY.md:328
 msgid "Day 3 Morning"
 msgstr "第三天上午"
 
-#: src/SUMMARY.md:327
+#: src/SUMMARY.md:329
 msgid "Day 3 Afternoon"
 msgstr "第三天下午"
 
-#: src/SUMMARY.md:328
-msgid "Bare Metal Rust Morning"
-msgstr "嵌入式 Rust:入门篇"
-
-#: src/SUMMARY.md:329 src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "Bare Metal Rust Afternoon"
-msgstr "嵌入式 Rust:进阶篇"
-
 #: src/SUMMARY.md:330
-msgid "Concurrency Morning"
-msgstr "并发编程:入门篇"
+msgid "Bare Metal Rust Morning"
+msgstr "嵌入式 Rust：入门篇"
 
 #: src/SUMMARY.md:331
+#: src/exercises/bare-metal/solutions-afternoon.md:1
+msgid "Bare Metal Rust Afternoon"
+msgstr "嵌入式 Rust：进阶篇"
+
+#: src/SUMMARY.md:332
+msgid "Concurrency Morning"
+msgstr "并发编程：入门篇"
+
+#: src/SUMMARY.md:333
 msgid "Concurrency Afternoon"
-msgstr "并发编程:进阶篇"
+msgstr "并发编程：进阶篇"
 
 #: src/index.md:3
 #, fuzzy
 msgid ""
-"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
-"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
-"[GitHub contributors](https://img.shields.io/github/contributors/google/"
-"comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
-"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
-"com/google/comprehensive-rust/stargazers)"
+"[![Build "
+"workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) "
+"[![GitHub "
+"contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors) "
+"[![GitHub "
+"stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
 msgstr ""
-"[![构建工作流](https://img.shields.io/github/actions/workflow/status/google/"
-"comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
-"[GitHub 贡献者](https://img.shields.io/github/contributors/google/"
-"comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)"
+"[![构建工作流](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) "
+"[![GitHub "
+"贡献者](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
 
 #: src/index.md:7
 msgid ""
 "This is a free Rust course developed by the Android team at Google. The "
 "course covers the full spectrum of Rust, from basic syntax to advanced "
 "topics like generics and error handling."
-msgstr ""
-"这是由 Android 团队开发的免费 Rust 课程。该课程涵盖了 Rust 的全部范围,从基本"
-"语法到高级主题如泛型和错误处理。"
+msgstr "这是由 Android 团队开发的免费 Rust 课程。该课程涵盖了 Rust 的全部范围,从基本语法到高级主题如泛型和错误处理。"
 
 #: src/index.md:11
 msgid ""
-"The latest version of the course can be found at <https://google.github.io/"
-"comprehensive-rust/>. If you are reading somewhere else, please check there "
-"for updates."
+"The latest version of the course can be found at "
+"<https://google.github.io/comprehensive-rust/>. If you are reading somewhere "
+"else, please check there for updates."
 msgstr ""
-"如需查看课程的最新版本,请访问 <https://google.github.io/comprehensive-rust/"
-">。如果您是在其他地方阅读,请查看这个网址了解是否有更新。"
+"如需查看课程的最新版本,请访问 "
+"<https://google.github.io/comprehensive-rust/>。如果您是在其他地方阅读,请查看这个网址了解是否有更新。"
 
 #: src/index.md:15
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
 "anything about Rust and hope to:"
-msgstr "本课程的目标是教授你 Rust。我们假设你对 Rust 一无所知,并希望能够:"
+msgstr "本课程的目标是教授你 Rust。我们假设你对 Rust 一无所知，并希望能够："
 
 #: src/index.md:18
 msgid "Give you a comprehensive understanding of the Rust syntax and language."
@@ -1097,8 +1266,8 @@ msgid ""
 "[Android](android.md): a half-day course on using Rust for Android platform "
 "development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"[Android](android.md):一个半天的课程,介绍如何在 Android 平台开发中使用 "
-"Rust(AOSP)。课程内容包括与 C、C++ 和 Java 的互操作性。"
+"[Android](android.md)：一个半天的课程，介绍如何在 Android 平台开发中使用 Rust（AOSP）。课程内容包括与 C、C++ "
+"和 Java 的互操作性。"
 
 #: src/index.md:28
 msgid ""
@@ -1106,8 +1275,7 @@ msgid ""
 "(embedded) development. Both microcontrollers and application processors are "
 "covered."
 msgstr ""
-"[Bare-metal](bare-metal.md):为期一天的课程,介绍如何使用 Rust 进行裸机(嵌入式)"
-"开发。课程内容涵盖微控制器和应用处理器。"
+"[Bare-metal](bare-metal.md):为期一天的课程,介绍如何使用 Rust 进行裸机(嵌入式)开发。课程内容涵盖微控制器和应用处理器。"
 
 #: src/index.md:31
 #, fuzzy
@@ -1117,9 +1285,8 @@ msgid ""
 "mutexes) and async/await concurrency (cooperative multitasking using "
 "futures)."
 msgstr ""
-"[并发](concurrency.md):一天的课程,介绍 Rust 中的并发性。我们将涵盖传统并发(使"
-"用线程和互斥锁进行抢占式调度)和 async/await 并发(使用 futures 进行协作式多任"
-"务处理)。"
+"[并发](concurrency.md):一天的课程,介绍 Rust 中的并发性。我们将涵盖传统并发(使用线程和互斥锁进行抢占式调度)和 "
+"async/await 并发(使用 futures 进行协作式多任务处理)。"
 
 #: src/index.md:37
 msgid "Non-Goals"
@@ -1129,19 +1296,18 @@ msgstr "非目标"
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
 "days. Some non-goals of this course are:"
-msgstr ""
-"Rust 是一门庞大的语言,我们无法在几天内涵盖所有内容。本课程的一些非目标包括:"
+msgstr "Rust 是一门庞大的语言，我们无法在几天内涵盖所有内容。本课程的一些非目标包括："
 
 #: src/index.md:42
 #, fuzzy
 msgid ""
-"Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
-"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
-"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learning how to develop macros: please see [Chapter 19.5 in the Rust "
+"Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
-"了解如何开发宏,请参阅[本书中的第 19.5 章](https://doc.rust-lang.org/book/"
-"ch19-06-macros.html)和 [Rust by Examples](https://doc.rust-lang.org/rust-by-"
-"example/macros.html)。"
+"了解如何开发宏,请参阅[本书中的第 19.5 "
+"章](https://doc.rust-lang.org/book/ch19-06-macros.html)和 [Rust by "
+"Examples](https://doc.rust-lang.org/rust-by-example/macros.html)。"
 
 #: src/index.md:46
 msgid "Assumptions"
@@ -1153,18 +1319,14 @@ msgid ""
 "The course assumes that you already know how to program. Rust is a "
 "statically-typed language and we will sometimes make comparisons with C and "
 "C++ to better explain or contrast the Rust approach."
-msgstr ""
-"本课程假设你已经具备编程知识。Rust 是一种静态类型语言,我们有时会与 C 和 C++ "
-"进行比较,以更好地解释或对比 Rust 的方法。"
+msgstr "本课程假设你已经具备编程知识。Rust 是一种静态类型语言,我们有时会与 C 和 C++ 进行比较,以更好地解释或对比 Rust 的方法。"
 
 #: src/index.md:52
 #, fuzzy
 msgid ""
 "If you know how to program in a dynamically-typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
-msgstr ""
-"如果你已经了解如 Python 或 JavaScript 等动态类型语言的编程,那么你也能够很好地"
-"跟上本课程。"
+msgstr "如果你已经了解如 Python 或 JavaScript 等动态类型语言的编程,那么你也能够很好地跟上本课程。"
 
 #: src/index.md:57
 #, fuzzy
@@ -1172,11 +1334,10 @@ msgid ""
 "This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
 "should cover as well as answers to typical questions which come up in class."
-msgstr ""
-"这是演讲者备注的示例。我们将使用这些备注来为幻灯片添加额外的信息。这可能包括"
-"讲师应该涵盖的关键点,以及课堂上常见问题的答案。"
+msgstr "这是演讲者备注的示例。我们将使用这些备注来为幻灯片添加额外的信息。这可能包括讲师应该涵盖的关键点,以及课堂上常见问题的答案。"
 
-#: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
+#: src/running-the-course.md:3
+#: src/running-the-course/course-structure.md:3
 msgid "This page is for the course instructor."
 msgstr "本页面适用于课程教师。"
 
@@ -1195,14 +1356,13 @@ msgid ""
 "The downside of longer session is that people can become very tired after 6 "
 "full hours of class in the afternoon."
 msgstr ""
-"上课时间通常是从上午 10:00 到下午 4:00,中间有 1 小时的午餐休息时间。这样,上午"
-"和下午各留了 2.5 小时的上课时间。请注意,这仅是建议:您也可以上午上课 3 小时,让"
-"学员有更多的时间进行练习。上课时间较长的缺点是,学员上了整整 6 小时的课,到了下"
-"午可能会非常疲倦。"
+"上课时间通常是从上午 10:00 到下午 4:00,中间有 1 小时的午餐休息时间。这样,上午和下午各留了 2.5 "
+"小时的上课时间。请注意,这仅是建议:您也可以上午上课 3 小时,让学员有更多的时间进行练习。上课时间较长的缺点是,学员上了整整 6 "
+"小时的课,到了下午可能会非常疲倦。"
 
 #: src/running-the-course.md:16
 msgid "Before you run the course, you will want to:"
-msgstr "在授课之前,你需要完成以下事项:"
+msgstr "在授课之前，你需要完成以下事项："
 
 #: src/running-the-course.md:18
 msgid ""
@@ -1212,10 +1372,7 @@ msgid ""
 "notes in a popup (click the link with a little arrow next to \"Speaker "
 "Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"熟悉课程资料。我们添加了演讲者备注,借此强调要点(请帮个忙,多多贡献演讲者备"
-"注!)。演示幻灯片时,你应确保在弹出式窗口中打开演讲者备注(点击对应的链接,在`演"
-"讲者备注`旁边有一个小箭头)。这样,你就可以确保屏幕整洁有序,更好地向全班学员展"
-"示课程内容。"
+"熟悉课程资料。我们添加了演讲者备注，借此强调要点（请帮个忙，多多贡献演讲者备注！）。演示幻灯片时，你应确保在弹出式窗口中打开演讲者备注（点击对应的链接，在“演讲者备注”旁边有一个小箭头）。这样，你就可以确保屏幕整洁有序，更好地向全班学员展示课程内容。"
 
 #: src/running-the-course.md:24
 msgid ""
@@ -1224,9 +1381,7 @@ msgid ""
 "have said that they find it helpful to have a gap in the course since it "
 "helps them process all the information we give them."
 msgstr ""
-"确定培训日期。由于本课程至少需要三天的时间,因此我们建议你安排两周以上的时间。"
-"课程学员曾表示,在每堂课之间留一段间隔会很有帮助,因为这有利于他们吸收我们所提"
-"供的所有信息。"
+"确定培训日期。由于本课程至少需要三天的时间，因此我们建议你安排两周以上的时间。课程学员曾表示，在每堂课之间留一段间隔会很有帮助，因为这有利于他们吸收我们所提供的所有信息。"
 
 #: src/running-the-course.md:29
 msgid ""
@@ -1238,24 +1393,21 @@ msgid ""
 "laptops. In particular, you will be doing a lot of live-coding as an "
 "instructor, so a lectern won't be very helpful for you."
 msgstr ""
-"找一间足以容纳全体线下学员的大教室。我们建议你将课程人数控制在 15-25 人之间。"
-"这样,人数足够少,不仅便于学员提问问题,配备的一位教师也有时间答疑解惑。确保教室"
-"备有供你和学生使用的`课桌`:你们都需要能够坐下来并操作各自的笔记本电脑。特别是"
-"身为教师,你现场要进行大量编码,所以讲台对你来说用处不大。"
+"找一间足以容纳全体线下学员的大教室。我们建议你将课程人数控制在 15-25 "
+"人之间。这样，人数足够少，不仅便于学员提问问题，配备的一位教师也有时间答疑解惑。确保教室备有供你和学生使用的“课桌”：你们都需要能够坐下来并操作各自的笔记本电脑。特别是身为教师，你现场要进行大量编码，所以讲台对你来说用处不大。"
 
 #: src/running-the-course.md:37
 msgid ""
 "On the day of your course, show up to the room a little early to set things "
 "up. We recommend presenting directly using `mdbook serve` running on your "
-"laptop (see the [installation instructions](https://github.com/google/"
-"comprehensive-rust#building)). This ensures optimal performance with no lag "
-"as you change pages. Using your laptop will also allow you to fix typos as "
-"you or the course participants spot them."
+"laptop (see the [installation "
+"instructions](https://github.com/google/comprehensive-rust#building)). This "
+"ensures optimal performance with no lag as you change pages. Using your "
+"laptop will also allow you to fix typos as you or the course participants "
+"spot them."
 msgstr ""
-"在开课当天,请提前一点到教室,设置好教学设备。我们建议你直接在笔记本电脑上运行 "
-"`mdbook serve` 来演示课程内容(请参阅[安装说明](https://github.com/google/"
-"comprehensive-rust#building))。这样可以确保你在切换页面时没有延迟,演示效果更"
-"好。当你或课程学员发现拼写错误时,你也可以使用笔记本电脑及时更正。"
+"在开课当天，请提前一点到教室，设置好教学设备。我们建议你直接在笔记本电脑上运行 `mdbook serve` "
+"来演示课程内容（请参阅[安装说明](https://github.com/google/comprehensive-rust#building)）。这样可以确保你在切换页面时没有延迟，演示效果更好。当你或课程学员发现拼写错误时，你也可以使用笔记本电脑及时更正。"
 
 #: src/running-the-course.md:43
 msgid ""
@@ -1267,31 +1419,28 @@ msgid ""
 "offer a solution, e.g., by showing people where to find the relevant "
 "information in the standard library."
 msgstr ""
-"让学员采取小组形式或独立解题。通常,我们会在上午和下午各安排 30-45 分钟的练习"
-"时间(包括查看解决方案的时间)。请务必询问学员是否遇到困难,或是否需要任何帮助。"
-"如果你看到多位学员遇到同样的问题,请在班级集体进行讲解,并提供相应的解决方案,例"
-"如告诉大家在标准库的什么位置可以找到相关信息。"
+"让学员采取小组形式或独立解题。通常，我们会在上午和下午各安排 30-45 "
+"分钟的练习时间（包括查看解决方案的时间）。请务必询问学员是否遇到困难，或是否需要任何帮助。如果你看到多位学员遇到同样的问题，请在班级集体进行讲解，并提供相应的解决方案，例如告诉大家在标准库的什么位置可以找到相关信息。"
 
 #: src/running-the-course.md:51
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
 "for you as it has been for us!"
-msgstr "今天的分享就是这些,祝你授课顺利!希望你和我们一样,乐在其中!"
+msgstr "今天的分享就是这些，祝你授课顺利！希望你和我们一样，乐在其中！"
 
 #: src/running-the-course.md:54
 msgid ""
-"Please [provide feedback](https://github.com/google/comprehensive-rust/"
-"discussions/86) afterwards so that we can keep improving the course. We "
-"would love to hear what worked well for you and what can be made better. "
-"Your students are also very welcome to [send us feedback](https://github.com/"
-"google/comprehensive-rust/discussions/100)!"
+"Please [provide "
+"feedback](https://github.com/google/comprehensive-rust/discussions/86) "
+"afterwards so that we can keep improving the course. We would love to hear "
+"what worked well for you and what can be made better. Your students are also "
+"very welcome to [send us "
+"feedback](https://github.com/google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"欢迎你课后[提供反馈](https://github.com/google/comprehensive-rust/"
-"discussions/86),帮助我们不断改进课程。我们非常期待了解哪些方面做得不错,哪些方"
-"面还需要改进。同时非常欢迎学生们[向我们发送反馈](https://github.com/google/"
-"comprehensive-rust/discussions/100)!"
+"欢迎你课后[提供反馈](https://github.com/google/comprehensive-rust/discussions/86)，帮助我们不断改进课程。我们非常期待了解哪些方面做得不错，哪些方面还需要改进。同时非常欢迎学生们[向我们发送反馈](https://github.com/google/comprehensive-rust/discussions/100)！"
 
 #: src/running-the-course/course-structure.md:5
+#: src/glossary.md:58
 msgid "Rust Fundamentals"
 msgstr "Rust 二进制文件"
 
@@ -1299,9 +1448,7 @@ msgstr "Rust 二进制文件"
 msgid ""
 "The first three days make up [Rust Fundaments](../welcome-day-1.md). The "
 "days are fast paced and we cover a lot of ground:"
-msgstr ""
-"我们会在头三天介绍 [Rust 基础知识](../welcome-day-1.md)。这几天的步调会稍快,"
-"因为我们要探讨许多层面:"
+msgstr "我们会在头三天介绍 [Rust 基础知识](../welcome-day-1.md)。这几天的步调会稍快,因为我们要探讨许多层面:"
 
 #: src/running-the-course/course-structure.md:10
 msgid "Day 1: Basic Rust, syntax, control flow, creating and consuming values."
@@ -1327,9 +1474,10 @@ msgstr "深入探究"
 msgid ""
 "In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
-msgstr "除了为期 3 天的`Rust 基础知识`课程外,我们还推出了一些专题课程:"
+msgstr "除了为期 3 天的“Rust 基础知识”课程外，我们还推出了一些专题课程："
 
 #: src/running-the-course/course-structure.md:19
+#: src/glossary.md:59
 #, fuzzy
 msgid "Rust in Android"
 msgstr "欢迎来到Android 中的Rust"
@@ -1341,21 +1489,23 @@ msgid ""
 "Rust for Android platform development. This includes interoperability with "
 "C, C++, and Java."
 msgstr ""
-"`[深入探究 Android](../android.md)`课程为期半天,旨在介绍如何使用 Rust 进行 "
-"Android 平台开发。其中包括与 C、C++ 和 Java 的互操作性。"
+"`[深入探究 Android](../android.md)`课程为期半天,旨在介绍如何使用 Rust 进行 Android 平台开发。其中包括与 "
+"C、C++ 和 Java 的互操作性。"
 
 #: src/running-the-course/course-structure.md:25
 msgid ""
-"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
-"download/downloading). Make a checkout of the [course repository](https://"
-"github.com/google/comprehensive-rust) on the same machine and move the `src/"
-"android/` directory into the root of your AOSP checkout. This will ensure "
-"that the Android build system sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP "
+"checkout](https://source.android.com/docs/setup/download/downloading). Make "
+"a checkout of the [course "
+"repository](https://github.com/google/comprehensive-rust) on the same "
+"machine and move the `src/android/` directory into the root of your AOSP "
+"checkout. This will ensure that the Android build system sees the "
+"`Android.bp` files in `src/android/`."
 msgstr ""
-"你将需要[签出 AOSP](https://source.android.com/docs/setup/download/"
-"downloading)。在同一机器上签出[课程库](https://github.com/google/"
-"comprehensive-rust), 然后将 `src/android/` 目录移至所签出的 AOSP 的根目录。这"
-"将确保 Android 构建系统能检测到 `src/android/` 中的 `Android.bp` 文件。"
+"你将需要[签出 "
+"AOSP](https://source.android.com/docs/setup/download/downloading)。在同一机器上签出[课程库](https://github.com/google/comprehensive-rust)， "
+"然后将 `src/android/` 目录移至所签出的 AOSP 的根目录。这将确保 Android 构建系统能检测到 `src/android/` "
+"中的 `Android.bp` 文件。"
 
 #: src/running-the-course/course-structure.md:30
 msgid ""
@@ -1363,9 +1513,8 @@ msgid ""
 "all Android examples using `src/android/build_all.sh`. Read the script to "
 "see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"确保 `adb sync` 适用于你的模拟器或实际设备, 并使用 `src/android/build_all."
-"sh` 预构建所有 Android 示例。请阅读脚本, 查看它所运行的命令,并确保这些命令能"
-"在你手动运行时正确执行。"
+"确保 `adb sync` 适用于你的模拟器或实际设备， 并使用 `src/android/build_all.sh` 预构建所有 Android "
+"示例。请阅读脚本， 查看它所运行的命令，并确保这些命令能在你手动运行时正确执行。"
 
 #: src/running-the-course/course-structure.md:37
 #, fuzzy
@@ -1379,21 +1528,21 @@ msgid ""
 "using Rust for bare-metal (embedded) development. Both microcontrollers and "
 "application processors are covered."
 msgstr ""
-"`[深入探究裸机](../bare-metal.md)`课程为期一天,旨在介绍如何使用 Rust 进行裸机"
-"(嵌入式)开发。其中涵盖了微控制器和应用 处理器。"
+"`[深入探究裸机](../bare-metal.md)`课程为期一天,旨在介绍如何使用 Rust 进行裸机(嵌入式)开发。其中涵盖了微控制器和应用 "
+"处理器。"
 
 #: src/running-the-course/course-structure.md:43
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC micro:bit]"
-"(https://microbit.org/) v2 development board ahead of time. Everybody will "
-"need to install a number of packages as described on the [welcome page](../"
-"bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC "
+"micro:bit](https://microbit.org/) v2 development board ahead of time. "
+"Everybody will need to install a number of packages as described on the "
+"[welcome page](../bare-metal.md)."
 msgstr ""
-"对于微控制器部分,你需要提前购买 [BBC micro:bit](https://microbit.org/) 第 2 "
-"版开发板。每个人都需要安装多个软件包, 具体如[欢迎页面](../bare-metal.md)中所"
-"述。"
+"对于微控制器部分，你需要提前购买 [BBC micro:bit](https://microbit.org/) 第 2 "
+"版开发板。每个人都需要安装多个软件包， 具体如[欢迎页面](../bare-metal.md)中所述。"
 
 #: src/running-the-course/course-structure.md:48
+#: src/glossary.md:24
 msgid "Concurrency in Rust"
 msgstr "欢迎了解 Rust 中的并发"
 
@@ -1401,9 +1550,7 @@ msgstr "欢迎了解 Rust 中的并发"
 msgid ""
 "The [Concurrency in Rust](../concurrency.md) deep dive is a full day class "
 "on classical as well as `async`/`await` concurrency."
-msgstr ""
-"`[深入探究并发](../concurrency.md)`课程为期一天,旨在介绍传统并发和 `async`/"
-"`await` 并发。"
+msgstr "`[深入探究并发](../concurrency.md)`课程为期一天,旨在介绍传统并发和 `async`/`await` 并发。"
 
 #: src/running-the-course/course-structure.md:53
 msgid ""
@@ -1411,8 +1558,7 @@ msgid ""
 "to go. You can then copy/paste the examples into `src/main.rs` to experiment "
 "with them:"
 msgstr ""
-"你需要设置一个新 crate,下载所需的依赖项, 做好课前准备。然后,你可以将示例复制/"
-"粘贴到 `src/main.rs` 中, 以便对以下代码进行实验:"
+"你需要设置一个新 crate，下载所需的依赖项， 做好课前准备。然后，你可以将示例复制/粘贴到 `src/main.rs` 中， 以便对以下代码进行实验："
 
 #: src/running-the-course/course-structure.md:64
 msgid "Format"
@@ -1422,11 +1568,11 @@ msgstr "课程形式"
 msgid ""
 "The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
-msgstr "本课程的互动性非常强, 建议你以问题驱动探索 Rust!"
+msgstr "本课程的互动性非常强， 建议你以问题驱动探索 Rust！"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
-msgstr "mdBook 中有一些实用键盘快捷键:"
+msgstr "mdBook 中有一些实用键盘快捷键："
 
 #: src/running-the-course/keyboard-shortcuts.md:5
 msgid "Arrow-Left"
@@ -1434,7 +1580,7 @@ msgstr "向左箭头"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
 msgid ": Navigate to the previous page."
-msgstr ":转到上一页。"
+msgstr "：转到上一页。"
 
 #: src/running-the-course/keyboard-shortcuts.md:6
 msgid "Arrow-Right"
@@ -1442,15 +1588,16 @@ msgstr "向右箭头"
 
 #: src/running-the-course/keyboard-shortcuts.md:6
 msgid ": Navigate to the next page."
-msgstr ":转到下一页。"
+msgstr "：转到下一页。"
 
-#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+#: src/running-the-course/keyboard-shortcuts.md:7
+#: src/cargo/code-samples.md:19
 msgid "Ctrl + Enter"
 msgstr "Ctrl + Enter"
 
 #: src/running-the-course/keyboard-shortcuts.md:7
 msgid ": Execute the code sample that has focus."
-msgstr ":执行具有焦点的代码示例。"
+msgstr "：执行具有焦点的代码示例。"
 
 #: src/running-the-course/keyboard-shortcuts.md:8
 msgid "s"
@@ -1458,40 +1605,39 @@ msgstr "s"
 
 #: src/running-the-course/keyboard-shortcuts.md:8
 msgid ": Activate the search bar."
-msgstr ":激活搜索栏。"
+msgstr "：激活搜索栏。"
 
 #: src/running-the-course/translations.md:3
 msgid ""
 "The course has been translated into other languages by a set of wonderful "
 "volunteers:"
-msgstr "一批优秀的志愿者已将本课程翻译成其他语言:"
+msgstr "一批优秀的志愿者已将本课程翻译成其他语言："
 
 #: src/running-the-course/translations.md:6
 msgid ""
 "[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
-"by [@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
-"com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), and "
+"by [@rastringer](https://github.com/rastringer), "
+"[@hugojacob](https://github.com/hugojacob), "
+"[@joaovicmendes](https://github.com/joaovicmendes), and "
 "[@henrif75](https://github.com/henrif75)."
 msgstr ""
-"[巴西葡萄牙语版本](https://google.github.io/comprehensive-rust/pt-BR/)译者:"
-"[@rastringer](https://github.com/rastringer)、[@hugojacob](https://github."
-"com/hugojacob)、[@joaovicmendes](https://github.com/joaovicmendes) 和 "
-"[@henrif75](https://github.com/henrif75)。"
+"[巴西葡萄牙语版本](https://google.github.io/comprehensive-rust/pt-BR/)译者:[@rastringer](https://github.com/rastringer)、[@hugojacob](https://github.com/hugojacob)、[@joaovicmendes](https://github.com/joaovicmendes) "
+"和 [@henrif75](https://github.com/henrif75)。"
 
 #: src/running-the-course/translations.md:7
 msgid ""
-"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
-"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by "
+"[@keispace](https://github.com/keispace), "
+"[@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
-"[韩语版本](https://google.github.io/comprehensive-rust/ko/)译者:[@keispace]"
-"(https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp) 和 "
-"[@jooyunghan](https://github.com/jooyunghan)。"
+"[韩语版本](https://google.github.io/comprehensive-rust/ko/)译者:[@keispace](https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp) "
+"和 [@jooyunghan](https://github.com/jooyunghan)。"
 
 #: src/running-the-course/translations.md:8
 msgid ""
-"[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
-"(https://github.com/deavid)."
+"[Spanish](https://google.github.io/comprehensive-rust/es/) by "
+"[@deavid](https://github.com/deavid)."
 msgstr ""
 
 #: src/running-the-course/translations.md:10
@@ -1507,82 +1653,80 @@ msgstr "未完成的翻译"
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
-msgstr "多数语言版本仍在翻译中。我们会提供最近更新的翻译的链接:"
+msgstr "多数语言版本仍在翻译中。我们会提供最近更新的翻译的链接："
 
 #: src/running-the-course/translations.md:17
 msgid ""
-"[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
-"(https://github.com/raselmandol)."
+"[Bengali](https://google.github.io/comprehensive-rust/bn/) by "
+"[@raselmandol](https://github.com/raselmandol)."
 msgstr ""
-"[孟加拉语版本](https://google.github.io/comprehensive-rust/bn/)译者:"
-"[@raselmandol](https://github.com/raselmandol)。"
+"[孟加拉语版本](https://google.github.io/comprehensive-rust/bn/)译者:[@raselmandol](https://github.com/raselmandol)。"
 
 #: src/running-the-course/translations.md:18
 msgid ""
 "[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
-"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
-"victorhsieh), [@mingyc](https://github.com/mingyc), and [@johnathan79717]"
-"(https://github.com/johnathan79717)."
+"by [@hueich](https://github.com/hueich), "
+"[@victorhsieh](https://github.com/victorhsieh), "
+"[@mingyc](https://github.com/mingyc), and "
+"[@johnathan79717](https://github.com/johnathan79717)."
 msgstr ""
 
 #: src/running-the-course/translations.md:19
 msgid ""
 "[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
-"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
-"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
-"kongy), [@noahdragon](https://github.com/noahdragon), and [@superwhd]"
-"(https://github.com/superwhd)."
+"by [@suetfei](https://github.com/suetfei), "
+"[@wnghl](https://github.com/wnghl), [@anlunx](https://github.com/anlunx), "
+"[@kongy](https://github.com/kongy), "
+"[@noahdragon](https://github.com/noahdragon), and "
+"[@superwhd](https://github.com/superwhd)."
 msgstr ""
 
 #: src/running-the-course/translations.md:20
 msgid ""
-"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
-"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+"[French](https://google.github.io/comprehensive-rust/fr/) by "
+"[@KookaS](https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
-"[法语版本](https://google.github.io/comprehensive-rust/fr/)译者:[@KookaS]"
-"(https://github.com/KookaS) 和 [@vcaen](https://github.com/vcaen)。"
+"[法语版本](https://google.github.io/comprehensive-rust/fr/)译者:[@KookaS](https://github.com/KookaS) "
+"和 [@vcaen](https://github.com/vcaen)。"
 
 #: src/running-the-course/translations.md:21
 msgid ""
-"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
-"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+"[German](https://google.github.io/comprehensive-rust/de/) by "
+"[@Throvn](https://github.com/Throvn) and "
+"[@ronaldfw](https://github.com/ronaldfw)."
 msgstr ""
-"[德语版本](https://google.github.io/comprehensive-rust/de/)译者:[@Throvn]"
-"(https://github.com/Throvn) 和 [@ronaldfw](https://github.com/ronaldfw)。"
+"[德语版本](https://google.github.io/comprehensive-rust/de/)译者:[@Throvn](https://github.com/Throvn) "
+"和 [@ronaldfw](https://github.com/ronaldfw)。"
 
 #: src/running-the-course/translations.md:22
 msgid ""
-"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
-"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
-"momotaro1105)."
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by "
+"[@CoinEZ-JPN](https://github.com/CoinEZ) and "
+"[@momotaro1105](https://github.com/momotaro1105)."
 msgstr ""
-"[日语版本](https://google.github.io/comprehensive-rust/ja/)译者:[@CoinEZ-JPN]"
-"(https://github.com/CoinEZ) 和 [@momotaro1105](https://github.com/"
-"momotaro1105)。"
+"[日语版本](https://google.github.io/comprehensive-rust/ja/)译者:[@CoinEZ-JPN](https://github.com/CoinEZ) "
+"和 [@momotaro1105](https://github.com/momotaro1105)。"
 
 #: src/running-the-course/translations.md:24
 msgid ""
-"If you want to help with this effort, please see [our instructions](https://"
-"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
-"get going. Translations are coordinated on the [issue tracker](https://"
-"github.com/google/comprehensive-rust/issues/282)."
+"If you want to help with this effort, please see [our "
+"instructions](https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) "
+"for how to get going. Translations are coordinated on the [issue "
+"tracker](https://github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"如果你想帮助我们,请参阅[我们的说明](htts://github.com/google/comprehensive-"
-"rust/blob/main/TRANSLATIONS.md),了解如何开始翻译。翻译工作将通过[问题跟踪器]"
-"(https://github.com/google/comprehensive-rust/issues/282)."
+"如果你想帮助我们,请参阅[我们的说明](htts://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md),了解如何开始翻译。翻译工作将通过[问题跟踪器](https://github.com/google/comprehensive-rust/issues/282)."
 
 #: src/cargo.md:3
 msgid ""
-"When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
-"and run Rust applications. Here we want to give a brief overview of what "
-"Cargo is and how it fits into the wider ecosystem and how it fits into this "
-"training."
+"When you start reading about Rust, you will soon meet "
+"[Cargo](https://doc.rust-lang.org/cargo/), the standard tool used in the "
+"Rust ecosystem to build and run Rust applications. Here we want to give a "
+"brief overview of what Cargo is and how it fits into the wider ecosystem and "
+"how it fits into this training."
 msgstr ""
-"开始了解 Rust 后,你很快就会遇到 [Cargo](https://doc.rust-lang.org/cargo/),这"
-"是 Rust 生态系统中 用于构建和运行 Rust 应用的标准工具。在这里,我们希望 简要介"
-"绍一下什么是 Cargo,它如何融入更广泛的生态系统, 以及我们如何在本培训中合理利"
-"用 Cargo。"
+"开始了解 Rust 后，你很快就会遇到 [Cargo](https://doc.rust-lang.org/cargo/)，这是 Rust 生态系统中 "
+"用于构建和运行 Rust 应用的标准工具。在这里，我们希望 简要介绍一下什么是 Cargo，它如何融入更广泛的生态系统， 以及我们如何在本培训中合理利用 "
+"Cargo。"
 
 #: src/cargo.md:8
 msgid "Installation"
@@ -1604,12 +1748,14 @@ msgstr ""
 #: src/cargo.md:14
 msgid ""
 "After installing Rust, you should configure your editor or IDE to work with "
-"Rust. Most editors do this by talking to [rust-analyzer](https://rust-"
-"analyzer.github.io/), which provides auto-completion and jump-to-definition "
-"functionality for [VS Code](https://code.visualstudio.com/), [Emacs](https://"
-"rust-analyzer.github.io/manual.html#emacs), [Vim/Neovim](https://rust-"
-"analyzer.github.io/manual.html#vimneovim), and many others. There is also a "
-"different IDE available called [RustRover](https://www.jetbrains.com/rust/)."
+"Rust. Most editors do this by talking to "
+"[rust-analyzer](https://rust-analyzer.github.io/), which provides "
+"auto-completion and jump-to-definition functionality for [VS "
+"Code](https://code.visualstudio.com/), "
+"[Emacs](https://rust-analyzer.github.io/manual.html#emacs), "
+"[Vim/Neovim](https://rust-analyzer.github.io/manual.html#vimneovim), and "
+"many others. There is also a different IDE available called "
+"[RustRover](https://www.jetbrains.com/rust/)."
 msgstr ""
 
 #: src/cargo.md:18
@@ -1619,9 +1765,9 @@ msgid ""
 "gets you an outdated rust version and may lead to unexpected behavior. The "
 "command would be:"
 msgstr ""
-"在 Debian/Ubuntu 上,你也可以通过 `apt` 安装 Cargo、Rust 源代码和 [Rust 格式设"
-"置工具](https://github.com/rust-lang/rustfmt)。但是,这样会得到一个过时的 "
-"Rust 版本,可能会导致意外的行为。命令如下:"
+"在 Debian/Ubuntu 上,你也可以通过 `apt` 安装 Cargo、Rust 源代码和 [Rust "
+"格式设置工具](https://github.com/rust-lang/rustfmt)。但是,这样会得到一个过时的 Rust "
+"版本,可能会导致意外的行为。命令如下:"
 
 #: src/cargo/rust-ecosystem.md:1
 msgid "The Rust Ecosystem"
@@ -1630,13 +1776,13 @@ msgstr "Rust 生态系统"
 #: src/cargo/rust-ecosystem.md:3
 msgid ""
 "The Rust ecosystem consists of a number of tools, of which the main ones are:"
-msgstr "Rust 生态系统由许多工具组成,其中的主要工具包括:"
+msgstr "Rust 生态系统由许多工具组成，其中的主要工具包括："
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
 "`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
 "intermediate formats."
-msgstr "`rustc`:Rust 编译器,可将 `.rs` 文件转换为二进制文件和其他 中间格式。"
+msgstr "`rustc`：Rust 编译器，可将 `.rs` 文件转换为二进制文件和其他 中间格式。"
 
 #: src/cargo/rust-ecosystem.md:8
 msgid ""
@@ -1645,9 +1791,8 @@ msgid ""
 "pass them to `rustc` when building your project. Cargo also comes with a "
 "built-in test runner which is used to execute unit tests."
 msgstr ""
-"`cargo`:Rust 依赖项管理器和构建工具。Cargo 知道如何 下载托管在 <https://"
-"crates.io> 上的依赖项,并在构建项目时将它们 传递给 `rustc`。Cargo 还附带一个内"
-"置的 测试运行程序,用于执行单元测试。"
+"`cargo`:Rust 依赖项管理器和构建工具。Cargo 知道如何 下载托管在 <https://crates.io> "
+"上的依赖项,并在构建项目时将它们 传递给 `rustc`。Cargo 还附带一个内置的 测试运行程序,用于执行单元测试。"
 
 #: src/cargo/rust-ecosystem.md:13
 msgid ""
@@ -1657,51 +1802,202 @@ msgid ""
 "standard library. You can have multiple versions of Rust installed at once "
 "and `rustup` will let you switch between them as needed."
 msgstr ""
-"`rustup`:Rust 工具链安装程序和更新程序。发布新版本 Rust 时,此工具用于 安装并"
-"更新 `rustc` 和 `cargo`。 此外,`rustup` 还可以下载标准 库的文档。你可以同时安"
-"装多个版本的 Rust,并且 `rustup` 可让你根据需要在这些版本之间切换。"
+"`rustup`：Rust 工具链安装程序和更新程序。发布新版本 Rust 时，此工具用于 安装并更新 `rustc` 和 `cargo`。 "
+"此外，`rustup` 还可以下载标准 库的文档。你可以同时安装多个版本的 Rust，并且 `rustup` 可让你根据需要在这些版本之间切换。"
 
-#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
-#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
-#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:30
-#: src/basic-syntax/references.md:23
+#: src/cargo/rust-ecosystem.md:21
+#: src/hello-world.md:25
+#: src/hello-world/small-example.md:27
+#: src/why-rust/runtime.md:10
+#: src/why-rust/modern.md:21
+#: src/basic-syntax/compound-types.md:32
+#: src/basic-syntax/references.md:24
 #: src/pattern-matching/destructuring-enums.md:35
 #: src/ownership/double-free-modern-cpp.md:55
 #: src/error-handling/try-operator.md:48
 #: src/error-handling/converting-error-types-example.md:50
-#: src/concurrency/threads.md:30 src/async/async-await.md:25
+#: src/concurrency/threads.md:30
+#: src/async/async-await.md:25
 msgid "Key points:"
-msgstr "关键点:"
+msgstr "关键点："
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
 "Rust has a rapid release schedule with a new release coming out every six "
 "weeks. New releases maintain backwards compatibility with old releases --- "
 "plus they enable new functionality."
-msgstr ""
-"Rust 有一个快速发布时间表,每六周就会发布一次 新版本。新版本保持与 旧版本的向"
-"后兼容性,还添加了新功能。"
+msgstr "Rust 有一个快速发布时间表，每六周就会发布一次 新版本。新版本保持与 旧版本的向后兼容性，还添加了新功能。"
 
 #: src/cargo/rust-ecosystem.md:27
-#, fuzzy
-msgid ""
-"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
-msgstr "共有三个发布阶段:`稳定版``Beta 版`和`夜间版`。"
+msgid "There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "共有三个发布阶段：“稳定版”“Beta 版”和“夜间版”。"
 
 #: src/cargo/rust-ecosystem.md:29
-#, fuzzy
 msgid ""
 "New features are being tested on \"nightly\", \"beta\" is what becomes "
 "\"stable\" every six weeks."
-msgstr "我们会在`夜间版`上测试新功能,每六周将`Beta 版`升级为 `稳定版`。"
+msgstr "我们会在“夜间版”上测试新功能，每六周将“Beta 版”升级为 “稳定版”。"
 
 #: src/cargo/rust-ecosystem.md:32
 msgid ""
-"Dependencies can also be resolved from alternative [registries](https://doc."
-"rust-lang.org/cargo/reference/registries.html), git, folders, and more."
+"Dependencies can also be resolved from alternative "
+"[registries](https://doc.rust-lang.org/cargo/reference/registries.html), "
+"git, folders, and more."
 msgstr ""
-"您也可以通过备用的[注册数据库](https://doc.rust-lang.org/cargo/reference/"
-"registries.html)、git、文件夹等资源来解析依赖项。"
+"您也可以通过备用的[注册数据库](https://doc.rust-lang.org/cargo/reference/registries.html)、git、文件夹等资源来解析依赖项。"
+
+#: src/cargo/rust-ecosystem.md:34
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr "Rust 也有三个\\[版本\\]：当前版本是 Rust 2021。之前的 版本是 Rust 2015 和 Rust 2018。"
+
+#: src/cargo/rust-ecosystem.md:37
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "这些版本支持对语言进行向后不兼容的 更改。"
+
+#: src/cargo/rust-ecosystem.md:40
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr "为防止破坏代码，你可以自行选择版本： 通过 `Cargo.toml` 文件为 crate 选择合适的版本。"
+
+#: src/cargo/rust-ecosystem.md:43
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr "为免分割生态系统，Rust 编译器可以混合使用 为不同版本编写的代码。"
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr "提及不通过 `cargo` 而直接使用编译器的情况相当少见（大多数用户从不这样做）。"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr "值得注意的是，Cargo 本身就是一个功能强大且全面的工具。它能够实现许多高级功能，包括但不限于："
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Project/package structure"
+msgstr "项目/软件包结构"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr "\\[工作区\\]"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr "开发依赖项和运行时依赖项管理/缓存"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"[build "
+"scripting](https://doc.rust-lang.org/cargo/reference/build-scripts.html)"
+msgstr "\\[构建脚本\\]"
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"[global "
+"installation](https://doc.rust-lang.org/cargo/commands/cargo-install.html)"
+msgstr "\\[全局安装\\] \\]"
+
+#: src/cargo/rust-ecosystem.md:54
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"它还可以使用子命令插件（例如 [cargo clippy](https://github.com/rust-lang/rust-clippy)）进行扩展。"
+
+#: src/cargo/rust-ecosystem.md:55
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr "如需了解详情，请参阅\\[ Cargo 官方图书\\]"
+
+#: src/cargo/code-samples.md:1
+msgid "Code Samples in This Training"
+msgstr "本培训中的代码示例"
+
+#: src/cargo/code-samples.md:3
+msgid ""
+"For this training, we will mostly explore the Rust language through examples "
+"which can be executed through your browser. This makes the setup much easier "
+"and ensures a consistent experience for everyone."
+msgstr "在本培训中，我们将主要通过示例 探索 Rust 语言，这些示例可通过浏览器执行。这能大大简化设置过程， 并确保所有人都能获得一致的体验。"
+
+#: src/cargo/code-samples.md:7
+msgid ""
+"Installing Cargo is still encouraged: it will make it easier for you to do "
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
+msgstr ""
+"我们仍然建议你安装 Cargo：它有助于你更轻松地完成 练习。在最后一天，我们要做一个更大的练习， 向你展示如何使用依赖项，因此你需要安装 Cargo。"
+
+#: src/cargo/code-samples.md:11
+msgid "The code blocks in this course are fully interactive:"
+msgstr "本课程中的代码块是完全交互式的："
+
+#: src/cargo/code-samples.md:13
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/code-samples.md:19
+msgid "You can use "
+msgstr "当文本框为 焦点时，你可以使用 "
+
+#: src/cargo/code-samples.md:19
+msgid "to execute the code when focus is in the text box."
+msgstr "来执行代码。"
+
+#: src/cargo/code-samples.md:24
+msgid ""
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
+msgstr "大多数代码示例都可修改（如上图所示）。少数代码示例 可能会因各种原因而不可修改："
+
+#: src/cargo/code-samples.md:27
+msgid ""
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
+msgstr "嵌入式 Playground 无法执行单元测试。将代码复制并粘贴 到实际 Playground 中，以演示单元测试。"
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr "嵌入式 Playground 会在你离开页面后立即 丢失其状态！正因如此，学员应使用本地安装的 Rust 或通过 Playground 解题。"
+
+#: src/cargo/running-locally.md:1
+msgid "Running Code Locally with Cargo"
+msgstr "使用 Cargo 在本地运行代码"
+
+#: src/cargo/running-locally.md:3
+msgid ""
+"If you want to experiment with the code on your own system, then you will "
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
+msgstr ""
+"如果你想在自己的系统上对代码进行实验， 则需要先安装 Rust。为此，请按照 [Rust 图书中的 "
+"说明](https://doc.rust-lang.org/book/ch01-01-installation.html)操作。这应会为你提供一个有效的 "
+"`rustc` 和 `cargo`。在撰写 本文时，最新的 Rust 稳定版具有以下版本号："
 
 #: src/cargo/running-locally.md:15
 msgid ""
@@ -1713,30 +2009,27 @@ msgstr "您也可以使用任何更高版本,因为 Rust 保持向后兼容性�
 msgid ""
 "With this in place, follow these steps to build a Rust binary from one of "
 "the examples in this training:"
-msgstr ""
-"了解这些信息后,请按照以下步骤从本培训中的 一个示例中构建 Rust 二进制文件:"
+msgstr "了解这些信息后，请按照以下步骤从本培训中的 一个示例中构建 Rust 二进制文件："
 
 #: src/cargo/running-locally.md:20
 msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
-msgstr "在你要复制的示例上点击`复制到剪贴板`按钮。"
+msgstr "在你要复制的示例上点击“复制到剪贴板”按钮。"
 
 #: src/cargo/running-locally.md:22
 msgid ""
 "Use `cargo new exercise` to create a new `exercise/` directory for your code:"
-msgstr "使用 `cargo new exercise` 为你的代码新建一个 `exercise/` 目录:"
+msgstr "使用 `cargo new exercise` 为你的代码新建一个 `exercise/` 目录："
 
 #: src/cargo/running-locally.md:29
 msgid ""
 "Navigate into `exercise/` and use `cargo run` to build and run your binary:"
-msgstr "导航至 `exercise/` 并使用 `cargo run` 构建并运行你的二进制文件:"
+msgstr "导航至 `exercise/` 并使用 `cargo run` 构建并运行你的二进制文件："
 
 #: src/cargo/running-locally.md:40
 msgid ""
 "Replace the boiler-plate code in `src/main.rs` with your own code. For "
 "example, using the example on the previous page, make `src/main.rs` look like"
-msgstr ""
-"将 `src/main.rs` 中的样板代码替换为你自己的代码。例如, 使用上一页中的示例,将 "
-"`src/main.rs` 改为:"
+msgstr "将 `src/main.rs` 中的样板代码替换为你自己的代码。例如， 使用上一页中的示例，将 `src/main.rs` 改为："
 
 #: src/cargo/running-locally.md:43
 msgid ""
@@ -1754,33 +2047,19514 @@ msgstr ""
 
 #: src/cargo/running-locally.md:49
 msgid "Use `cargo run` to build and run your updated binary:"
-msgstr "使用 `cargo run` 构建并运行你更新后的二进制文件:"
+msgstr "使用 `cargo run` 构建并运行你更新后的二进制文件："
 
 #: src/cargo/running-locally.md:59
 msgid ""
 "Use `cargo check` to quickly check your project for errors, use `cargo "
-"build` to compile it without running it. You will find the output in `target/"
-"debug/` for a normal debug build. Use `cargo build --release` to produce an "
-"optimized release build in `target/release/`."
+"build` to compile it without running it. You will find the output in "
+"`target/debug/` for a normal debug build. Use `cargo build --release` to "
+"produce an optimized release build in `target/release/`."
 msgstr ""
-"使用 `cargo check` 快速检查项目是否存在错误;使用 `cargo build` 只进行编译,而"
-"不运行。你可以在 `target/debug/` 中找到常规调试 build 的输出。使用 `cargo "
-"build --release` 在 `target/release/` 中生成经过优化的 发布 build。"
+"使用 `cargo check` 快速检查项目是否存在错误；使用 `cargo build` 只进行编译，而不运行。你可以在 "
+"`target/debug/` 中找到常规调试 build 的输出。使用 `cargo build --release` 在 "
+"`target/release/` 中生成经过优化的 发布 build。"
 
 #: src/cargo/running-locally.md:64
 msgid ""
 "You can add dependencies for your project by editing `Cargo.toml`. When you "
 "run `cargo` commands, it will automatically download and compile missing "
 "dependencies for you."
-msgstr ""
-"你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你 运行 `cargo` 命令时,系统会"
-"自动为你下载和编译缺失 的依赖项。"
+msgstr "你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你 运行 `cargo` 命令时，系统会自动为你下载和编译缺失 的依赖项。"
 
 #: src/cargo/running-locally.md:72
 msgid ""
 "Try to encourage the class participants to install Cargo and use a local "
 "editor. It will make their life easier since they will have a normal "
 "development environment."
+msgstr "尽量鼓励全班学员安装 Cargo 并使用 本地编辑器。这能为他们营造常规 开发环境，让工作变得更加轻松。"
+
+#: src/welcome-day-1.md:1
+msgid "Welcome to Day 1"
+msgstr "欢迎来到第一天"
+
+#: src/welcome-day-1.md:3
+#, fuzzy
+msgid ""
+"This is the first day of Rust Fundamentals. We will cover a lot of ground "
+"today:"
+msgstr "现在是学习 Comprehensive Rust 的第一天。今天我们会涉及很多内容："
+
+#: src/welcome-day-1.md:6
+msgid ""
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
+msgstr "Rust 基本语法：变量，标量（scalar）和复合（compound）类型，枚举（enum），结构体（struct），引用，函数和方法。"
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr "控制流的构造: `if`, `if let`, `while`, `while let`, `break`, 和 `continue`。"
+
+#: src/welcome-day-1.md:12
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr "模式匹配: 解构枚举, 结构体和数组（array）。"
+
+#: src/welcome-day-1.md:16
+msgid "Please remind the students that:"
+msgstr "请提醒学生："
+
+#: src/welcome-day-1.md:18
+msgid "They should ask questions when they get them, don't save them to the end."
+msgstr "他们可以随时提问，不需要留到最后。"
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr "这个课程本应该是互动的，我们鼓励大家积极讨论。"
+
+#: src/welcome-day-1.md:20
+#, fuzzy
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the discussions related to how Rust does things vs some other language. "
+" It can be hard to find the right balance, but err on the side of allowing  "
+"discussions since they engage people much more than one-way communication."
 msgstr ""
-"尽量鼓励全班学员安装 Cargo 并使用 本地编辑器。这能为他们营造常规 开发环境,让"
-"工作变得更加轻松。"
+"作为讲师，你应该尽量保证讨论话题的相关性，例如，讨论围绕Rust是如何做某些事情，而不是其他的语言如何如何。 这个平衡点不容易找到，但是尽量倾向于允许  "
+"讨论，因为讨论比起单方面的灌输更有利于让大家投入。"
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr "有些问题会导致我们提前谈到后面的内容"
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr "这完全没有问题! 重复是学习的一个重要方法。请记得 这些幻灯片只是一个辅助，你可以选择性地跳过。"
+
+#: src/welcome-day-1.md:29
+msgid ""
+"The idea for the first day is to show _just enough_ of Rust to be able to "
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
+msgstr ""
+"第一天的主要目标是要谈到著名的 borrow checker，其他方面点到为止。Rust 处理内存的方式是其主要特点，这点我们应该尽早展示给学生。"
+
+#: src/welcome-day-1.md:33
+msgid ""
+"If you're teaching this in a classroom, this is a good place to go over the "
+"schedule. We suggest splitting the day into two parts (following the slides):"
+msgstr "如果你是在教室里教授此课程，不妨在这里介绍一下时间安排。 这边建议是把每天分成两部分（跟着幻灯片来）："
+
+#: src/welcome-day-1.md:36
+msgid "Morning: 9:00 to 12:00,"
+msgstr "早上：9:00 到 12:00，"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "下午：13:00 到 16:00。"
+
+#: src/welcome-day-1.md:39
+msgid ""
+"You can of course adjust this as necessary. Please make sure to include "
+"breaks, we recommend a break every hour!"
+msgstr "当然你也可以看情况调整时间。但是请务必记得提供休息时间。我们建议每个小时休息一次！"
+
+#: src/welcome-day-1/what-is-rust.md:3
+msgid ""
+"Rust is a new programming language which had its [1.0 release in "
+"2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
+msgstr ""
+"Rust 是一种新的编程语言，它的[1.0 版本于 2015 "
+"年发布](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html)："
+
+#: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "Rust 是一种静态编译语言，其功能定位与 C++ 相似"
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` 使用 LLVM 作为它的后端。"
+
+#: src/welcome-day-1/what-is-rust.md:7
+msgid ""
+"Rust supports many [platforms and "
+"architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):"
+msgstr ""
+"Rust "
+"支持多种[平台和架构](https://doc.rust-lang.org/nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, ..."
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rust 被广泛用于各种设备中："
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "固件和引导程序，"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "智能显示器，"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "手机，"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "桌面，"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "服务器。"
+
+#: src/welcome-day-1/what-is-rust.md:21
+msgid "Rust fits in the same area as C++:"
+msgstr "Rust 和 C++ 适用于类似的场景："
+
+#: src/welcome-day-1/what-is-rust.md:23
+msgid "High flexibility."
+msgstr "极高的灵活性。"
+
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "高度的控制能力。"
+
+#: src/welcome-day-1/what-is-rust.md:25
+#, fuzzy
+msgid "Can be scaled down to very constrained devices such as microcontrollers."
+msgstr "能够在资源极度有限的设备（如手机）上运行。"
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "没有运行时和垃圾收集。"
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr "关注程序可靠性和安全性，而不会牺牲任何性能。"
+
+#: src/hello-world.md:3
+msgid ""
+"Let us jump into the simplest possible Rust program, a classic Hello World "
+"program:"
+msgstr "让我们进入最简单的 Rust 程序，一个经典的 Hello World 程序："
+
+#: src/hello-world.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Hello 🌍!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Hello 🌍!\");\n"
+"}\n"
+"```"
+
+#: src/hello-world.md:12
+msgid "What you see:"
+msgstr "你看到的："
+
+#: src/hello-world.md:14
+msgid "Functions are introduced with `fn`."
+msgstr "函数以 `fn` 开头。"
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "像 C 和 C++ 一样，块由花括号分隔。"
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "`main` 函数是程序的入口。"
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr "Rust 有卫生宏 (hygienic macros)，`println!` 就是一个例子。"
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr "Rust 字符串是 UTF-8 编码的，可以包含任何 Unicode 字符。"
+
+#: src/hello-world.md:22
+#, fuzzy
+msgid ""
+"This slide tries to make the students comfortable with Rust code. They will "
+"see a ton of it over the next three days so we start small with something "
+"familiar."
+msgstr "这张幻灯片试图让学生们熟悉 Rust 代码。在接下来的四天里，他们会看到很多 Rust 代码, 所以我们从一些熟悉的东西开始。"
+
+#: src/hello-world.md:27
+#, fuzzy
+msgid ""
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative and it doesn't try to reinvent things unless absolutely necessary."
+msgstr "Rust 非常像 C/C++/Java 等其他传统语言。它是指令式语言（而非函数式），而且除非绝对必要，它不会尝试重新发明新的概念。"
+
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "Rust 是一种现代编程语言，它完全支持 Unicode 等特性。"
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"在需要处理可变数量的参数的情况下，Rust 使用宏（没有函数[重载](basic-syntax/functions-interlude.md)）。"
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+msgstr ""
+"宏是“卫生的”意味着它们不会意外地捕获它们所在作用域中的标识符。Rust "
+"的宏实际上只是[部分卫生](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)。"
+
+#: src/hello-world.md:40
+msgid ""
+"Rust is multi-paradigm. For example, it has powerful [object-oriented "
+"programming features](https://doc.rust-lang.org/book/ch17-00-oop.html), and, "
+"while it is not a functional language, it includes a range of [functional "
+"concepts](https://doc.rust-lang.org/book/ch13-00-functional-features.html)."
+msgstr ""
+
+#: src/hello-world/small-example.md:3
+msgid "Here is a small example program in Rust:"
+msgstr "以下是一个简短的 Rust 示例程序"
+
+#: src/hello-world/small-example.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {              // Program entry point\n"
+"    let mut x: i32 = 6;  // Mutable variable binding\n"
+"    print!(\"{x}\");       // Macro for printing, like printf\n"
+"    while x != 1 {       // No parenthesis around expression\n"
+"        if x % 2 == 0 {  // Math like in other languages\n"
+"            x = x / 2;\n"
+"        } else {\n"
+"            x = 3 * x + 1;\n"
+"        }\n"
+"        print!(\" -> {x}\");\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {              // 程序入口\n"
+"    let mut x: i32 = 6;  // 可变变量绑定\n"
+"    print!(\"{x}\");       // 与 printf 类似的输出宏\n"
+"    while x != 1 {       // 表达式周围没有括号\n"
+"        if x % 2 == 0 {  // 与其他语言类似的数值计算\n"
+"            x = x / 2;\n"
+"        } else {\n"
+"            x = 3 * x + 1;\n"
+"        }\n"
+"        print!(\" -> {x}\");\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+
+#: src/hello-world/small-example.md:23
+msgid ""
+"The code implements the Collatz conjecture: it is believed that the loop "
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
+msgstr "这段代码实现了 Collatz 猜想：猜想认为该循环总是会结束，但该猜想还没有被证明。可以编辑代码来尝试不同的输入。"
+
+#: src/hello-world/small-example.md:29
+msgid ""
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
+msgstr "说明所有变量的类型都是静态的。尝试删除 `i32` 来触发类型推断。尝试使用 `i8` 来触发运行时整数溢出。"
+
+#: src/hello-world/small-example.md:32
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "将 `let mut x` 改为 `let x`，讨论出现的编译错误。"
+
+#: src/hello-world/small-example.md:34
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr "展示 `print!` 在参数与格式字符串不匹配时产生的编译错误。"
+
+#: src/hello-world/small-example.md:37
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr "展示如何使用 `{}` 作为占位符，来输出比单个变量更复杂的表达式。"
+
+#: src/hello-world/small-example.md:40
+msgid ""
+"Show the students the standard library, show them how to search for "
+"`std::fmt` which has the rules of the formatting mini-language. It's "
+"important that the students become familiar with searching in the standard "
+"library."
+msgstr "向学生展示标准库，展示如何搜索 `std::fmt`，其中包含用于格式化字符串的微型语言规则。要点是让学生熟悉在标准库中搜索的过程。"
+
+#: src/hello-world/small-example.md:44
+msgid ""
+"In a shell `rustup doc std::fmt` will open a browser on the local std::fmt "
+"documentation"
+msgstr ""
+
+#: src/why-rust.md:3
+msgid "Some unique selling points of Rust:"
+msgstr "Rust 有一些独特的卖点："
+
+#: src/why-rust.md:5
+msgid "Compile time memory safety."
+msgstr "编译期内存安全。"
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "没有运行时未定义行为。"
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "现代的编程语言特性。"
+
+#: src/why-rust.md:11
+msgid ""
+"Make sure to ask the class which languages they have experience with. "
+"Depending on the answer you can highlight different features of Rust:"
+msgstr "应该问问学生们都使用过哪些语言。根据答案侧重讲解 Rust 的不同特性："
+
+#: src/why-rust.md:14
+msgid ""
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
+msgstr ""
+"使用过 C 或 C++：Rust 利用\"借用检查\"消除了一类 _运行时错误_ 。你可以达到堪比 C 和 C++ "
+"的性能，而没有内存不安全的问题。并且你还可以得到些现代的语言构造，比如模式匹配和内置依赖管理。"
+
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"使用过 Java, Go, Python, "
+"JavaScript...：你可以得到和这些语言相同的内存安全特性，并拥有类似的使用高级语言的感受。同时你可以得到类似 C 和 C++ "
+"的高速且可预测的执行性能（无垃圾回收机制），以及在需要时对底层硬件的访问。"
+
+#: src/why-rust/an-example-in-c.md:4
+msgid "Let's consider the following \"minimum wrong example\" program in C:"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:6
+msgid ""
+"```c,editable\n"
+"#include <stdio.h>\n"
+"#include <stdlib.h>\n"
+"#include <sys/stat.h>\n"
+"\n"
+"int main(int argc, char* argv[]) {\n"
+"\tchar *buf, *filename;\n"
+"\tFILE *fp;\n"
+"\tsize_t bytes, len;\n"
+"\tstruct stat st;\n"
+"\n"
+"\tswitch (argc) {\n"
+"\t\tcase 1:\n"
+"\t\t\tprintf(\"Too few arguments!\\n"
+"\");\n"
+"\t\t\treturn 1;\n"
+"\n"
+"\t\tcase 2:\n"
+"\t\t\tfilename = argv[argc];\n"
+"\t\t\tstat(filename, &st);\n"
+"\t\t\tlen = st.st_size;\n"
+"\t\t\t\n"
+"\t\t\tbuf = (char*)malloc(len);\n"
+"\t\t\tif (!buf)\n"
+"\t\t\t\tprintf(\"malloc failed!\\n"
+"\", len);\n"
+"\t\t\t\treturn 1;\n"
+"\n"
+"\t\t\tfp = fopen(filename, \"rb\");\n"
+"\t\t\tbytes = fread(buf, 1, len, fp);\n"
+"\t\t\tif (bytes = st.st_size)\n"
+"\t\t\t\tprintf(\"%s\", buf);\n"
+"\t\t\telse\n"
+"\t\t\t\tprintf(\"fread failed!\\n"
+"\");\n"
+"\n"
+"\t\tcase 3:\n"
+"\t\t\tprintf(\"Too many arguments!\\n"
+"\");\n"
+"\t\t\treturn 1;\n"
+"\t}\n"
+"\n"
+"\treturn 0;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:48
+msgid "How many bugs do you spot?"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:52
+msgid ""
+"Despite just 29 lines of code, this C example contains serious bugs in at "
+"least 11:"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:54
+msgid "Assignment `=` instead of equality comparison `==` (line 28)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:55
+msgid "Excess argument to `printf` (line 23)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:56
+msgid "File descriptor leak (after line 26)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:57
+msgid "Forgotten braces in multi-line `if` (line 22)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:58
+msgid "Forgotten `break` in a `switch` statement (line 32)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:59
+msgid ""
+"Forgotten NUL-termination of the `buf` string, leading to a buffer overflow "
+"(line 29)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:60
+msgid "Memory leak by not freeing the `malloc`\\-allocated buffer (line 21)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:61
+msgid "Out-of-bounds access (line 17)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:62
+msgid "Unchecked cases in the `switch` statement (line 11)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:63
+msgid "Unchecked return values of `stat` and `fopen` (lines 18 and 26)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:65
+msgid ""
+"_Shouldn't these bugs be obvious even for a C compiler?_  \n"
+"No, surprisingly this code compiles warning-free at the default warning "
+"level, even in the latest GCC version (13.2 as of writing)."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:68
+msgid ""
+"_Isn't this a highly unrealistic example?_  \n"
+"Absolutely not, these kind of bugs have lead to serious security "
+"vulnerabilities in the past. Some examples:"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:71
+msgid ""
+"Assignment `=` instead of equality comparison `==`: [The Linux Backdoor "
+"Attempt of "
+"2003](https://freedom-to-tinker.com/2013/10/09/the-linux-backdoor-attempt-of-2003)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:72
+msgid ""
+"Forgotten braces in multi-line `if`: [The Apple goto fail "
+"vulnerability](https://dwheeler.com/essays/apple-goto-fail.html)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:73
+msgid ""
+"Forgotten `break` in a `switch` statement: [The break that broke "
+"sudo](https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-break-that-broke-sudo)"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:75
+msgid ""
+"_How is Rust any better here?_  \n"
+"Safe Rust makes all of these bugs impossible:"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:78
+msgid "Assignments inside an `if` clause are not supported."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:79
+msgid "Format strings are checked at compile-time."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:80
+msgid "Resources are freed at the end of scope via the `Drop` trait."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:81
+msgid "All `if` clauses require braces."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:82
+msgid ""
+"`match` (as the Rust equivalent to `switch`) does not fall-through, hence "
+"you can't accidentally forget a `break`."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:83
+msgid "Buffer slices carry their size and don't rely on a NUL terminator."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:84
+msgid ""
+"Heap-allocated memory is freed via the `Drop` trait when the corresponding "
+"`Box` leaves the scope."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:85
+msgid ""
+"Out-of-bounds accesses cause a panic or can be checked via the `get` method "
+"of a slice."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:86
+msgid "`match` mandates that all cases are handled."
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:87
+msgid ""
+"Fallible Rust functions return `Result` values that need to be unwrapped and "
+"thereby checked for success. Additionally, the compiler emits a warning if "
+"you miss to check the return value of a function marked with `#[must_use]`."
+msgstr ""
+
+#: src/why-rust/compile-time.md:3
+msgid "Static memory management at compile time:"
+msgstr "编译期静态内存管理："
+
+#: src/why-rust/compile-time.md:5
+msgid "No uninitialized variables."
+msgstr "不存在未初始化的变量。"
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "不存在内存泄漏（_通常情况下_，见注释）。"
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "不存在“双重释放”。"
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "不存在“释放后使用”。"
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "不存在 `NULL` 指针。"
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "不存在被遗忘的互斥锁。"
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "不存在线程之间的数据竞争。"
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "不存在迭代器失效。"
+
+#: src/why-rust/compile-time.md:16
+msgid "It is possible to produce memory leaks in (safe) Rust. Some examples are:"
+msgstr "在（安全的）Rust 中也有可能产生内存泄漏。例如："
+
+#: src/why-rust/compile-time.md:19
+#, fuzzy
+msgid ""
+"You can use "
+"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) "
+"to leak a pointer. A use of this could be to get runtime-initialized and "
+"runtime-sized static variables"
+msgstr ""
+"可以使用 "
+"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) "
+"来泄漏一个指针。该方法可以用于得到在运行时决定大小和初始化的静态变量"
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use "
+"[`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html) to "
+"make the compiler \"forget\" about a value (meaning the destructor is never "
+"run)."
+msgstr ""
+"可以使用 [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html) "
+"来让编译器“忘记”一个值（即其析构函数不会被执行）。"
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference "
+"cycle](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html) with "
+"`Rc` or `Arc`."
+msgstr ""
+"可以使用 `Rc` 或 `Arc` 意外创建一个循环引用（[reference "
+"cycle](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html)）。"
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr "实际上，有人认为无限填充一个集合也是一种内存泄漏，Rust 对此没有保护。"
+
+#: src/why-rust/compile-time.md:28
+msgid ""
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
+msgstr "就本课程而言，“不存在内存泄漏”应理解为“几乎没有 _意外_ 内存泄漏”。"
+
+#: src/why-rust/runtime.md:3
+msgid "No undefined behavior at runtime:"
+msgstr "Rust 没有运行时未定义行为："
+
+#: src/why-rust/runtime.md:5
+msgid "Array access is bounds checked."
+msgstr "数组访问有边界检查。"
+
+#: src/why-rust/runtime.md:6
+#, fuzzy
+msgid "Integer overflow is defined (panic or wrap-around)."
+msgstr "整数溢出的行为有明确定义。"
+
+#: src/why-rust/runtime.md:12
+#, fuzzy
+msgid ""
+"Integer overflow is defined via the "
+"[`overflow-checks`](https://doc.rust-lang.org/rustc/codegen-options/index.html#overflow-checks) "
+"compile-time flag. If enabled, the program will panic (a controlled crash of "
+"the program), otherwise you get wrap-around semantics. By default, you get "
+"panics in debug mode (`cargo build`) and wrap-around in release mode (`cargo "
+"build --release`)."
+msgstr ""
+"整数溢出的行为由编译时的标志指定。可以选择 "
+"panic（一种受控的程序崩溃）或使用“绕回（wrap-around）”语义。默认情况下，使用调试模式编译（`cargo build`）的行为为 "
+"panic，使用发布模式编译（`cargo build --release`）的行为为“绕回”。"
+
+#: src/why-rust/runtime.md:18
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"边界检查不能使用编译标志禁用，也不能直接通过 `unsafe` 关键字禁用。然而， `unsafe` 允许你调用 "
+"`slice::get_unchecked` 等不做边界检查的函数。"
+
+#: src/why-rust/modern.md:3
+#, fuzzy
+msgid "Rust is built with all the experience gained in the last decades."
+msgstr "Rust 建立于过去 40 年来所获得的经验之上。"
+
+#: src/why-rust/modern.md:5
+msgid "Language Features"
+msgstr "语言特性"
+
+#: src/why-rust/modern.md:7
+msgid "Enums and pattern matching."
+msgstr "枚举和模式匹配。"
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "泛型。"
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "无额外开销外部函数接口（FFI）。"
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "零成本抽象。"
+
+#: src/why-rust/modern.md:12
+msgid "Tooling"
+msgstr "工具"
+
+#: src/why-rust/modern.md:14
+msgid "Great compiler errors."
+msgstr "强大的编译器错误提示。"
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "内置依赖管理器。"
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "对测试的内置支持。"
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "优秀的语言服务协议（Language Server Protocol）支持。"
+
+#: src/why-rust/modern.md:23
+msgid ""
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
+msgstr ""
+"与 C++ 类似的零成本抽象，意味着你不需要为高级程序语言的结构“付出”更多的内存和 CPU。例如使用 `for` 循环与使用 "
+"`.iter().fold()` 结构应该会生成大致相同的底层指令。"
+
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+"值得一提的是，Rust 的枚举是“代数数据类型”（也叫“和类型”）。它使得类型系统可以表示 `Option<T>` 和 `Result<T, E>` "
+"等结构。"
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"提醒学生去阅读编译错误 --- 许多开发者已经习惯去忽略冗长的编译器输出。Rust 编译器会比其它编译器更健谈。它通常会提供 _可操作的_ "
+"反馈，可以直接复制粘贴到代码中。"
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr "相比 Java, Python 和 Go 等语言，Rust 标准库较为精简。Rust 并没有内置一些你可能认为标准和必要的功能："
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr "随机数生成器，可以使用 [rand](https://docs.rs/rand/) 替代。"
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr "SSL 和 TLS 支持，可以使用 [rusttls](https://docs.rs/rustls/) 替代。"
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr "JSON 支持，可以使用 [serde_json](https://docs.rs/serde_json/) 替代。"
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+"Rust 这么做的原因是标准库中的功能是无法去除的，因此该功能必须非常稳定。对于以上例子，Rust 社区仍在寻找最佳解决方案 --- "
+"甚至对一些情况可能没有单一的“最佳解决方案”。"
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr "Rust 内置了一个包管理器 Cargo，使得下载和编译第三方 crate 变得简单。这也导致标准库可以更加精简。"
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like "
+"<https://lib.rs/> help with this by letting you compare health metrics for "
+"crates to find a good and trusted one."
+msgstr ""
+"发现高质量的第三方 crate 也许是一个问题。 <https://lib.rs/> 等网站对此问题有所帮助。它能帮你比较 crate "
+"的健康指标，以找到一个高质量并受信任的 crate。"
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/) 是一个受到广泛支持的 LSP 实现，被主流的 IDE "
+"和文本编辑器所使用。"
+
+#: src/basic-syntax.md:3
+msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
+msgstr "Rust 的许多语法与 C, C++ 和 Java 的语法相似"
+
+#: src/basic-syntax.md:5
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "代码块和作用域都是由花括号来界定的。"
+
+#: src/basic-syntax.md:6
+msgid ""
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
+msgstr "行内注释以 `//` 起始，块注释使用 `/* ... */` 来界定。"
+
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "`if` 和 `while` 等关键词作用与以上语言一致。"
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr "变量赋值使用 `=`，值之间比较使用 `==`。"
+
+#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Types"
+msgstr "类型"
+
+#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr "字面量"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr "有符号整数"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+#, fuzzy
+msgid "`-10`, `0`, `1_000`, `123_i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr "无符号整数"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+#, fuzzy
+msgid "`0`, `123`, `10_u16`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr "浮点数"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+#, fuzzy
+msgid "`3.14`, `-10.0e20`, `2_f32`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr "字符串"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr "`\"foo\"`, `\"two\\nlines\"`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr "Unicode 标量类型"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr "`char`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Booleans"
+msgstr "布尔值"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`bool`"
+msgstr "`bool`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`true`, `false`"
+msgstr "`true`, `false`"
+
+#: src/basic-syntax/scalar-types.md:12
+msgid "The types have widths as follows:"
+msgstr "各类型占用的空间为："
+
+#: src/basic-syntax/scalar-types.md:14
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN` 和 `fN` 占用 _N_ 位，"
+
+#: src/basic-syntax/scalar-types.md:15
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` 和 `usize` 占用一个指针大小的空间，"
+
+#: src/basic-syntax/scalar-types.md:16
+#, fuzzy
+msgid "`char` is 32 bits wide,"
+msgstr "`char` 占用 32 位空间，"
+
+#: src/basic-syntax/scalar-types.md:17
+#, fuzzy
+msgid "`bool` is 8 bits wide."
+msgstr "`bool` 占用 8 位空间。"
+
+#: src/basic-syntax/scalar-types.md:21
+msgid "There are a few syntaxes which are not shown above:"
+msgstr "上表中还有一些未提及的语法："
+
+#: src/basic-syntax/scalar-types.md:23
+msgid ""
+"Raw strings allow you to create a `&str` value with escapes disabled: `r\"\\n"
+"\" == \"\\\\n"
+"\"`. You can embed double-quotes by using an equal amount of `#` on either "
+"side of the quotes:"
+msgstr ""
+"原始字符串可在创建 `&str` 时禁用转义：`r\"\\n"
+"\" == \"\\\\n"
+"\"`。可以在外层引号两侧添加相同数量的 `#`，以在字符串中嵌入双引号："
+
+#: src/basic-syntax/scalar-types.md:35
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr "字节串可以用于直接创建 `&[u8]` 类型的值："
+
+#: src/basic-syntax/scalar-types.md:45
+msgid ""
+"All underscores in numbers can be left out, they are for legibility only. So "
+"`1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written "
+"as `123i64`."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr "数组（Arrays）"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr "`[T; N]`"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr "`[20, 30, 40]`, `[0; 3]`"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr "元组（Tuples）"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
+
+#: src/basic-syntax/compound-types.md:8
+msgid "Array assignment and access:"
+msgstr "数组的赋值和访问操作："
+
+#: src/basic-syntax/compound-types.md:19
+msgid "Tuple assignment and access:"
+msgstr "元组的赋值和访问操作："
+
+#: src/basic-syntax/compound-types.md:34
+msgid "Arrays:"
+msgstr "数组："
+
+#: src/basic-syntax/compound-types.md:36
+#, fuzzy
+msgid ""
+"A value of the array type `[T; N]` holds `N` (a compile-time constant) "
+"elements of the same type `T`. Note that the length of the array is _part of "
+"its type_, which means that `[u8; 3]` and `[u8; 4]` are considered two "
+"different types."
+msgstr ""
+"数组中的元素具有相同的类型 `T`，数组的长度为 `N`，`N` 是一个编译期常量。 需要注意的是数组的长度是它_类型的一部分\\_, 这意味着 "
+"`[u8; 3]` 和 `[u8; 4]` 在 Rust 中被认为是不同的类型。"
+
+#: src/basic-syntax/compound-types.md:40
+msgid "We can use literals to assign values to arrays."
+msgstr "我们可以使用字面量来为数组赋值。"
+
+#: src/basic-syntax/compound-types.md:42
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+"在主函数中，打印（print）语句使用 `?` 格式请求调试实现。 使用参数 `{}` 打印默认输出，`{:?}` 表示以调试格式输出。 "
+"我们也可以不在格式化字符串后面指定变量值，直接使用 `{a}` 和 `{a:?}` 进行输出。"
+
+#: src/basic-syntax/compound-types.md:47
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
+msgstr "添加 `#`, 比如 `{a:#?}`, 会输出“美观打印（pretty printing）” 格式, 这种格式可能会更加易读。"
+
+#: src/basic-syntax/compound-types.md:49
+msgid "Tuples:"
+msgstr "元组："
+
+#: src/basic-syntax/compound-types.md:51
+msgid "Like arrays, tuples have a fixed length."
+msgstr "和数组一样，元组也具有固定的长度。"
+
+#: src/basic-syntax/compound-types.md:53
+msgid "Tuples group together values of different types into a compound type."
+msgstr "元组将不同类型的值组成一个复合类型。"
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr "元组中的字段可以通过英文句号加上值的下标进行访问比如：`t.0`, `t.1`。"
+
+#: src/basic-syntax/compound-types.md:57
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+"空元组 `()` 也被称作 “单元（unit）类型”. 它既是一个类型， 也是这种类型的唯一值——也就是说它的类型和它的  值都被表示为 "
+"`()`。它通常用于表示，比如，一个  函数或表达式没有返回值，我们会在后续的幻灯片种见到这种用法。"
+
+#: src/basic-syntax/compound-types.md:61
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr "你可以将其理解为你可能在其他编程语言中比较熟悉的  `void` 类型"
+
+#: src/basic-syntax/references.md:3
+msgid "Like C++, Rust has references:"
+msgstr "如同 C++ 一样，Rust 也提供了引用类型。"
+
+#: src/basic-syntax/references.md:15
+msgid "Some notes:"
+msgstr "一些注意事项："
+
+#: src/basic-syntax/references.md:17
+msgid ""
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
+msgstr "就像 C 与 C++ 中的指针一样，对引用 `ref_x` 进行赋值时，我们必须对其解引用。"
+
+#: src/basic-syntax/references.md:18
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr "Rust 有时会进行自动解引用。比如调用方法 `ref_x.count_ones()` 时，ref_x 会被解引用。"
+
+#: src/basic-syntax/references.md:20
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr "如果引用值被声明为 `mut`（可变引用），那么这个引用值可以在它的生命周期内被绑定为不同的值。"
+
+#: src/basic-syntax/references.md:26
+msgid ""
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
+"value."
+msgstr ""
+"注意 `let mut ref_x: &i32` 与 `let ref_x: &mut i32` "
+"之间的区别。第一条语句声明了一个可变引用，所以我们可以修改这个引用所绑定的值；第二条语句声明了一个指向可变变量的引用。"
+
+#: src/basic-syntax/references-dangling.md:3
+msgid "Rust will statically forbid dangling references:"
+msgstr "Rust 会静态地禁止悬垂引用："
+
+#: src/basic-syntax/references-dangling.md:17
+msgid "A reference is said to \"borrow\" the value it refers to."
+msgstr "一个引用被认为是“借用（borrow）”了它指向的值。"
+
+#: src/basic-syntax/references-dangling.md:18
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr "Rust 会跟踪所有引用的生命周期，以确保这些值的存活时间足够长。"
+
+#: src/basic-syntax/references-dangling.md:20
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr "我们会在讲到所有权（ownership）时详细讨论借用（borrow）。"
+
+#: src/basic-syntax/slices.md:3
+msgid "A slice gives you a view into a larger collection:"
+msgstr "切片 (slice) 的作用是提供对集合 (collection) 的视图 (view):"
+
+#: src/basic-syntax/slices.md:17
+msgid "Slices borrow data from the sliced type."
+msgstr "切片从被切片的类型中借用 (borrow) 数据。"
+
+#: src/basic-syntax/slices.md:18
+#, fuzzy
+msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
+msgstr "请思考：如果我们改变 `a[3]`，将会产生怎样的后果？"
+
+#: src/basic-syntax/slices.md:22
+#, fuzzy
+msgid ""
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr "创建切片时，我们借用了 `a` ，并在方括号中标明了起始和结尾下标。"
+
+#: src/basic-syntax/slices.md:24
+#, fuzzy
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"如果切片的起始下标为 0， Rust 语法允许我们省略起始下标。比如说 `&a[0..a.len()]` 与 `&a[..a.len()]` 是等价的。"
+
+#: src/basic-syntax/slices.md:26
+#, fuzzy
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr "结尾下标也可以用相同方式省略。比如说 `&a[2..a.len()]` 和 `&a[2..]` 是等价的。"
+
+#: src/basic-syntax/slices.md:28
+#, fuzzy
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr "因此，我们可以用 `&a[..]` 来创建包含整个数组的切片。"
+
+#: src/basic-syntax/slices.md:30
+#, fuzzy
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr "切片会从另外一个对象中借用数据。在这个例子中， `a` 必须在其切片存活时保持存活（处于作用域中）。"
+
+#: src/basic-syntax/slices.md:32
+#, fuzzy
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"关于修改 `a[3]` 的问题可能会引发精彩的讨论。正确答案是：为了保证内存安全，在创建切片后，我们不能通过 `a` 来修改数据。不过我们可以通过 "
+"`a` 或者 `s` 来读取数据。我们将会在“借用”章节着重介绍这个内容。"
+
+#: src/basic-syntax/slices.md:34
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` at "
+"this point in the execution, but you can read the data from both `a` and `s` "
+"safely. It works before you created the slice, and again after the "
+"`println`, when the slice is no longer used. More details will be explained "
+"in the borrow checker section."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:1
+msgid "`String` vs `str`"
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:3
+msgid "We can now understand the two string types in Rust:"
+msgstr "现在我们就可以理解 Rust 中的两种字符串类型："
+
+#: src/basic-syntax/string-slices.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: &str = \"World\";\n"
+"    println!(\"s1: {s1}\");\n"
+"\n"
+"    let mut s2: String = String::from(\"Hello \");\n"
+"    println!(\"s2: {s2}\");\n"
+"    s2.push_str(s1);\n"
+"    println!(\"s2: {s2}\");\n"
+"    \n"
+"    let s3: &str = &s2[6..];\n"
+"    println!(\"s3: {s3}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:20
+msgid "Rust terminology:"
+msgstr "Rust 术语："
+
+#: src/basic-syntax/string-slices.md:22
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str` 是一个指向字符串片段的不可变引用。"
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String` 是一个可变字符串缓冲区。"
+
+#: src/basic-syntax/string-slices.md:27
+msgid ""
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
+msgstr ""
+"`&str` 引入了一个字符串切片，它是一个指向保存在内存块中的 UTF-8 编码字符串数据的不可变引用。   "
+"字符串字面量（`”Hello”`）会保存在程序的二进制文件中。"
+
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr "Rust 的 `String` 类型是一个字节 vector 的封装。和 `Vec<T>` 一样，它是拥有所有权的。"
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"和其他类型一样，`String::from()` 会从字符串字面量创建一个字符串；`String::new()` 会创建一个新的空字符串，   "
+"之后可以使用 `push()` 和 `push_str()` 方法向其中添加字符串数据。"
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr "`format!()` 宏可以方便地动态生成拥有所有权的字符串。它接受和 `println!()` 相同的格式规范。"
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr "你可以通过 `&` 和可选的范围选择从 `String` 中借用 `&str` 切片。"
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"对于 C++ 程序员：可以把 `&str` 当作 C++ 中的 `const char*`，但是它总是指向内存中的一个有效字符串。   Rust 的 "
+"`String` 大致相当于 C++ 中 `std::string` （主要区别：它只能包含 UTF-8 编码的字节，   "
+"并且永远不会使用小字符串优化（small-string optimization））。"
+
+#: src/basic-syntax/functions.md:3
+msgid ""
+"A Rust version of the famous "
+"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
+msgstr "一个 Rust 版本的著名 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 面试题："
+
+#: src/basic-syntax/functions.md:36
+msgid ""
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
+msgstr "我们在 `main` 中引用了下面编写的一个函数。不需要提前声明或添加头文件。 "
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr "类型跟随在声明的参数后（与某些编程语言相反），然后是返回类型。"
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr "函数体（或任何块）中的最后一个表达式将成为返回值。只需省略表达式末尾的 `;` 即可。"
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr "有些函数没有返回值，会返回“单元类型（unit type）”`()`。如果省略了`-> ()`的返回类型，编译器将会自动推断。"
+
+#: src/basic-syntax/functions.md:40
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"`=n`, which causes it to include the upper bound."
+msgstr "`print_fizzbuzz_to()`函数中`for`循环的范围表达式（range expression）包含`=n`，这会导致它包括上限。"
+
+#: src/basic-syntax/rustdoc.md:3
+msgid "All language items in Rust can be documented using special `///` syntax."
+msgstr "Rust 中的所有语言元素都可以通过特殊的 `///` 语法进行文档化。"
+
+#: src/basic-syntax/rustdoc.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"/// Determine whether the first argument is divisible by the second "
+"argument.\n"
+"///\n"
+"/// If the second argument is zero, the result is false.\n"
+"///\n"
+"/// # Example\n"
+"/// ```\n"
+"/// assert!(is_divisible_by(42, 2));\n"
+"/// ```\n"
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
+"    if rhs == 0 {\n"
+"        return false;  // Corner case, early return\n"
+"    }\n"
+"    lhs % rhs == 0     // The last expression in a block is the return "
+"value\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"/// 判断第一个参数是否可以被第二个参数整除。\n"
+"///\n"
+"/// 如果第二个参数是 0，则返回结果为 false。\n"
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
+"    if rhs == 0 {\n"
+"        return false;  // 边界条件，直接返回\n"
+"    }\n"
+"    lhs % rhs == 0     // 代码块中的最后一个表达式就是它的返回值\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/rustdoc.md:22
+#, fuzzy
+msgid ""
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the "
+"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
+"is idiomatic to document all public items in an API using this pattern. Code "
+"snippets can document usage and will be used as unit tests."
+msgstr ""
+"文档的内容会被当做 Markdown 处理。所有已发布 Rust 库 crate "
+"都会自动被[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 工具在 "
+"[`docs.rs`](https://docs.rs)存档。 按照这种方式来为 API 中的所有公开项编写文档是 Rust 中惯用的做法。"
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Show students the generated docs for the `rand` crate at "
+"[`docs.rs/rand`](https://docs.rs/rand)."
+msgstr "向学生展示在 [`docs.rs/rand`](https://docs.rs/rand) 中为 `rand` crate 生成的文档。"
+
+#: src/basic-syntax/rustdoc.md:33
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr "本课程的幻灯片中不包含 rustdoc，这是为了节省空间，但是在实际的代码中，应当编写相关的程序文档。"
+
+#: src/basic-syntax/rustdoc.md:36
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr "内部文档注释将在稍后（在讲解模块的页面）讨论，这里无需进行说明。"
+
+#: src/basic-syntax/rustdoc.md:39
+msgid ""
+"Rustdoc comments can contain code snippets that we can run and test using "
+"`cargo test`. We will discuss these tests in the [Testing "
+"section](../testing/doc-tests.html)."
+msgstr ""
+
+#: src/basic-syntax/methods.md:3
+msgid ""
+"Methods are functions associated with a type. The `self` argument of a "
+"method is an instance of the type it is associated with:"
+msgstr "方法是与某种类型关联的函数。方法的 `self` 参数是与其关联类型的一个实例："
+
+#: src/basic-syntax/methods.md:6
+msgid ""
+"```rust,editable\n"
+"struct Rectangle {\n"
+"    width: u32,\n"
+"    height: u32,\n"
+"}\n"
+"\n"
+"impl Rectangle {\n"
+"    fn area(&self) -> u32 {\n"
+"        self.width * self.height\n"
+"    }\n"
+"\n"
+"    fn inc_width(&mut self, delta: u32) {\n"
+"        self.width += delta;\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut rect = Rectangle { width: 10, height: 5 };\n"
+"    println!(\"old area: {}\", rect.area());\n"
+"    rect.inc_width(5);\n"
+"    println!(\"new area: {}\", rect.area());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/methods.md:30
+msgid ""
+"We will look much more at methods in today's exercise and in tomorrow's "
+"class."
+msgstr "我们将在今天的练习和明天的课程中更深入地学习方法相关的概念。"
+
+#: src/basic-syntax/methods.md:34
+#, fuzzy
+msgid "Add a static method called `Rectangle::new` and call this from `main`:"
+msgstr "新增一个 `Rectangle::new` 构造函数并在 `main` 函数中调用它:"
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"While _technically_, Rust does not have custom constructors, static methods "
+"are commonly used to initialize structs (but don't have to). The actual "
+"constructor, `Rectangle { width, height }`, could be called directly. See "
+"the [Rustnomicon](https://doc.rust-lang.org/nomicon/constructors.html)."
+msgstr ""
+
+#: src/basic-syntax/methods.md:45
+#, fuzzy
+msgid ""
+"Add a `Rectangle::square(width: u32)` constructor to illustrate that such "
+"static methods can take arbitrary parameters."
+msgstr "新增一个 `Rectangle::new_square(width: u32)` 构造函数来说明构造函数可以接受任意参数。"
+
+#: src/basic-syntax/functions-interlude.md:1
+msgid "Function Overloading"
+msgstr "函数重载"
+
+#: src/basic-syntax/functions-interlude.md:3
+msgid "Overloading is not supported:"
+msgstr "不支持重载："
+
+#: src/basic-syntax/functions-interlude.md:5
+msgid "Each function has a single implementation:"
+msgstr "每一个函数都只有一种实现："
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "始终接受固定个数的形参。"
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "始终接受一组形参类型。"
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "不支持提供默认值："
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr "实参的数量在所有调用的地方都是一样的。"
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "有时可以用宏（Macro）作为替代。"
+
+#: src/basic-syntax/functions-interlude.md:12
+msgid "However, function parameters can be generic:"
+msgstr "然而，函数形参可以是泛型（generics）："
+
+#: src/basic-syntax/functions-interlude.md:14
+msgid ""
+"```rust,editable\n"
+"fn pick_one<T>(a: T, b: T) -> T {\n"
+"    if std::process::id() % 2 == 0 { a } else { b }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
+"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn pick_one<T>(a: T, b: T) -> T {\n"
+"    if std::process::id() % 2 == 0 { a } else { b }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
+"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/functions-interlude.md:27
+msgid ""
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
+"section."
+msgstr "标准库中的 `Into<T>` 通过泛型参数提供了一种具有有限多态性的参数类型。详见之后的章节。"
+
+#: src/exercises/day-1/morning.md:1
+msgid "Day 1: Morning Exercises"
+msgstr "第一天上午习题"
+
+#: src/exercises/day-1/morning.md:3
+msgid "In these exercises, we will explore two parts of Rust:"
+msgstr "在这些习题中，我们将探索 Rust 的两个部分："
+
+#: src/exercises/day-1/morning.md:5
+msgid "Implicit conversions between types."
+msgstr "类型之间的隐式转换。"
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
+msgstr "数组和 `for` 循环。"
+
+#: src/exercises/day-1/morning.md:11
+msgid "A few things to consider while solving the exercises:"
+msgstr "在解题时要考虑几件事："
+
+#: src/exercises/day-1/morning.md:13
+msgid ""
+"Use a local Rust installation, if possible. This way you can get "
+"auto-completion in your editor. See the page about [Using "
+"Cargo](../../cargo.md) for details on installing Rust."
+msgstr "最好使用本地安装的 Rust，以实现在编辑器中自动补全。关于安装 Rust 的细节，请参见 \\[使用 Cargo\\] 页面。"
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
+msgstr "也可以使用 Rust Playground 作为替代。"
+
+#: src/exercises/day-1/morning.md:19
+msgid ""
+"The code snippets are not editable on purpose: the inline code snippets lose "
+"their state if you navigate away from the page."
+msgstr "页面内嵌的代码片段是不可编辑的：因为离开页面后内嵌代码片段中的修改会丢失。"
+
+#: src/exercises/day-1/morning.md:22
+#: src/exercises/day-2/morning.md:11
+#: src/exercises/day-3/morning.md:9
+#: src/exercises/bare-metal/morning.md:7
+#: src/exercises/concurrency/morning.md:12
+#, fuzzy
+msgid ""
+"After looking at the exercises, you can look at the "
+"[solutions](solutions-morning.md) provided."
+msgstr "读完习题后，可以阅读本书提供的 \\[题解\\]。"
+
+#: src/exercises/day-1/implicit-conversions.md:3
+msgid ""
+"Rust will not automatically apply _implicit conversions_ between types "
+"([unlike "
+"C++](https://en.cppreference.com/w/cpp/language/implicit_conversion)). You "
+"can see this in a program like this:"
+msgstr ""
+"[与 C++ "
+"不同](https://en.cppreference.com/w/cpp/language/implicit_conversion)，Rust "
+"不会自动进行 _隐式类型转换_。例如，下面的程序中不存在隐式类型转换："
+
+#: src/exercises/day-1/implicit-conversions.md:20
+msgid ""
+"The Rust integer types all implement the "
+"[`From<T>`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Into<T>`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits to "
+"let us convert between them. The `From<T>` trait has a single `from()` "
+"method and similarly, the `Into<T>` trait has a single `into()` method. "
+"Implementing these traits is how a type expresses that it can be converted "
+"into another type."
+msgstr ""
+"Rust 的整数类型都实现了 "
+"[`From<T>`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
+"[`Into<T>`](https://doc.rust-lang.org/std/convert/trait.Into.html) "
+"trait，使得我们可以在它们之间进行转换。`From<T>` trait 包含 `from()` 方法，`Into<T>` trait 包含 "
+"`into()` 方法。类型通过实现这些 trait 来表达它将被如何转换为另一个类型。"
+
+#: src/exercises/day-1/implicit-conversions.md:26
+msgid ""
+"The standard library has an implementation of `From<i8> for i16`, which "
+"means that we can convert a variable `x` of type `i8` to an `i16` by calling "
+" `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16` "
+"implementation automatically create an implementation of `Into<i16> for i8`."
+msgstr ""
+"标准库中包含 `From<i8> for i16` 的实现，即我们可以通过调用 `i16::from(x)` 来将 `i8` 类型的变量 `x` 转换为 "
+"`i16`。或者也可以简单地使用 `x.into()`，因为 `From<i8> for i16` 的实现会自动创建 `Into<i16> for "
+"i8` 的实现。"
+
+#: src/exercises/day-1/implicit-conversions.md:31
+msgid ""
+"The same applies for your own `From` implementations for your own types, so "
+"it is sufficient to only implement `From` to get a respective `Into` "
+"implementation automatically."
+msgstr "这同样也适用于自定义类型的 `From` 实现，只需实现 `From` 就可以自动得到对应的 `Into` 实现。"
+
+#: src/exercises/day-1/implicit-conversions.md:34
+msgid "Execute the above program and look at the compiler error."
+msgstr "执行上述程序，并查看对应的编译错误。"
+
+#: src/exercises/day-1/implicit-conversions.md:36
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr "修改代码，使用 `into()` 进行类型转换。"
+
+#: src/exercises/day-1/implicit-conversions.md:38
+msgid ""
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library "
+"documentation](https://doc.rust-lang.org/std/convert/trait.From.html) to see "
+"if `From<T>` is implemented for the pairs you check."
+msgstr ""
+"修改 `x` 和 `y` 的类型（例如 `f32`, `bool`, `i128` "
+"等）来了解哪些类型之间可以相互转换。尝试将较小的类型转换为较大的类型和将较大的类型转换为较小的类型。阅读 "
+"[标准库文档](https://doc.rust-lang.org/std/convert/trait.From.html) "
+"来了解对于你所尝试的两个类型 `From<T>` 是否已被实现。"
+
+#: src/exercises/day-1/for-loops.md:1
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "数组与 `for` 循环"
+
+#: src/exercises/day-1/for-loops.md:3
+msgid "We saw that an array can be declared like this:"
+msgstr "我们可以这样声明一个数组："
+
+#: src/exercises/day-1/for-loops.md:9
+msgid ""
+"You can print such an array by asking for its debug representation with "
+"`{:?}`:"
+msgstr "你可以使用 `{:?}` 来打印这种数组的调试格式："
+
+#: src/exercises/day-1/for-loops.md:19
+msgid ""
+"Rust lets you iterate over things like arrays and ranges using the `for` "
+"keyword:"
+msgstr "在 Rust 中，可以使用 `for` 关键词遍历数组和区间等元素："
+
+#: src/exercises/day-1/for-loops.md:22
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    print!(\"Iterating over array:\");\n"
+"    for n in &array {\n"
+"        print!(\" {n}\");\n"
+"    }\n"
+"    println!();\n"
+"\n"
+"    print!(\"Iterating over range:\");\n"
+"    for i in 0..3 {\n"
+"        print!(\" {}\", array[i]);\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    print!(\"Iterating over array:\");\n"
+"    for n in array {\n"
+"        print!(\" {n}\");\n"
+"    }\n"
+"    println!();\n"
+"\n"
+"    print!(\"Iterating over range:\");\n"
+"    for i in 0..3 {\n"
+"        print!(\" {}\", array[i]);\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:39
+msgid ""
+"Use the above to write a function `pretty_print` which pretty-print a matrix "
+"and a function `transpose` which will transpose a matrix (turn rows into "
+"columns):"
+msgstr ""
+"使用以上知识，写一个用易读的格式输出矩阵的 `pretty_print` 函数，以及一个对矩阵进行转置（将行和列互换）的 `transpose` 函数："
+
+#: src/exercises/day-1/for-loops.md:49
+msgid "Hard-code both functions to operate on 3 × 3 matrices."
+msgstr "硬编码这两个函数，让它们处理 3 × 3 的矩阵。"
+
+#: src/exercises/day-1/for-loops.md:51
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
+"functions:"
+msgstr "将下面的代码复制到 <https://play.rust-lang.org/> 并实现上述函数："
+
+#: src/exercises/day-1/for-loops.md:54
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"\n"
+"    println!(\"matrix:\");\n"
+"    pretty_print(&matrix);\n"
+"\n"
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,should_panic\n"
+"// TODO: 完成你的实现后移除此行。\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- 这个注释会让 rustfmt 添加一个新行\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"\n"
+"    println!(\"matrix:\");\n"
+"    pretty_print(&matrix);\n"
+"\n"
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:82
+msgid "Bonus Question"
+msgstr "附加题"
+
+#: src/exercises/day-1/for-loops.md:84
+msgid ""
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
+"slice-of-slices. Why or why not?"
+msgstr ""
+"是否可以使用 `&[i32]` 切片而不是硬编码的 3 × 3 矩阵作为函数的参数和返回类型？例如使用 `&[&[i32]]` "
+"表示一个二维的切片的切片。为什么这样做是可行或不可行的？"
+
+#: src/exercises/day-1/for-loops.md:89
+msgid ""
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
+"implementation."
+msgstr "参考 [`ndarray` crate](https://docs.rs/ndarray/) 以了解该功能满足生产环境质量的实现。"
+
+#: src/exercises/day-1/for-loops.md:94
+msgid ""
+"The solution and the answer to the bonus section are available in the  "
+"[Solution](solutions-morning.md#arrays-and-for-loops) section."
+msgstr "题目解答和附加题的答案在 [题解](solutions-morning.md#arrays-and-for-loops) 章节中。"
+
+#: src/exercises/day-1/for-loops.md:97
+msgid ""
+"The use of the reference `&array` within `for n in &array` is a subtle "
+"preview of issues of ownership that will come later in the afternoon."
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:100
+msgid "Without the `&`..."
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:101
+msgid ""
+"The loop would have been one that consumes the array.  This is a change "
+"[introduced in the 2021 "
+"Edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)."
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:104
+msgid ""
+"An implicit array copy would have occurred.  Since `i32` is a copy type, "
+"then `[i32; 3]` is also a copy type."
+msgstr ""
+
+#: src/control-flow.md:3
+msgid ""
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
+"evaluate one of two blocks, but the blocks can have a value which then "
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
+msgstr ""
+"正如我们所知，`if` 是 Rust 中的一个表达式。它用于有条件地 评估两个块中的一个，但这些块可以有一个值， 然后成为 `if` "
+"表达式的值。其他控制流表达式在 Rust 中也有类似 的运作方式。"
+
+#: src/control-flow/blocks.md:3
+#, fuzzy
+msgid ""
+"A block in Rust contains a sequence of expressions. Each block has a value "
+"and a type, which are those of the last expression of the block:"
+msgstr "Rust 中的块包含值和类型：值是 块的最后一个表达式："
+
+#: src/control-flow/blocks.md:27
+#, fuzzy
+msgid ""
+"If the last expression ends with `;`, then the resulting value and type is "
+"`()`."
+msgstr "不过，如果最后一个表达式以 `;` 结尾，那么生成的值和类型为 `()`。"
+
+#: src/control-flow/blocks.md:29
+msgid ""
+"The same rule is used for functions: the value of the function body is the "
+"return value:"
+msgstr "同样的规则也适用于函数：函数主体的值 是返回值："
+
+#: src/control-flow/blocks.md:45
+#: src/enums.md:34
+#: src/enums/sizes.md:28
+#: src/pattern-matching.md:25
+#: src/pattern-matching/match-guards.md:22
+#: src/structs.md:31
+#: src/methods.md:30
+#: src/methods/example.md:46
+msgid "Key Points:"
+msgstr "关键点："
+
+#: src/control-flow/blocks.md:46
+msgid ""
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr "这张幻灯片的重点是说明在 Rust 中，块有类型和值。"
+
+#: src/control-flow/blocks.md:47
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
+msgstr "你可以通过更改块的最后一行，来展示块值的变化情况。例如，添加/移除分号或使用 `return`。"
+
+#: src/control-flow/if-expressions.md:1
+msgid "`if` expressions"
+msgstr "`if` 表达式"
+
+#: src/control-flow/if-expressions.md:3
+msgid ""
+"You use [`if` "
+"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions) "
+"exactly like `if` statements in other languages:"
+msgstr ""
+"[`if` "
+"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions) "
+"的用法与其他语言中的 `if` 语句完全一样。"
+
+#: src/control-flow/if-expressions.md:18
+msgid ""
+"In addition, you can use `if` as an expression. The last expression of each "
+"block becomes the value of the `if` expression:"
+msgstr "此外，你还可以将 `if` 用作一个表达式。每个块的最后一个表达式 将成为 `if` 表达式的值："
+
+#: src/control-flow/if-expressions.md:35
+msgid ""
+"Because `if` is an expression and must have a particular type, both of its "
+"branch blocks must have the same type. Consider showing what happens if you "
+"add `;` after `x / 2` in the second example."
+msgstr ""
+"由于 `if` 是一个表达式且必须有一个特定的类型，因此它的两个分支块必须有相同的类型。考虑在第二个示例中将 `;` 添加到 `x / 2` "
+"的后面，看看会出现什么情况。"
+
+#: src/control-flow/for-expressions.md:1
+msgid "`for` loops"
+msgstr "`for` 循环"
+
+#: src/control-flow/for-expressions.md:3
+#, fuzzy
+msgid ""
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expressions.md). It will "
+"automatically call `into_iter()` on the expression and then iterate over it:"
+msgstr ""
+"[`for` 循环](https://doc.rust-lang.org/std/keyword.for.html) 与 [`when let` "
+"循环](when-let-expression.md)密切相关。它会 自动对表达式调用 `into_iter()`，然后对其进行迭代："
+
+#: src/control-flow/for-expressions.md:22
+msgid "You can use `break` and `continue` here as usual."
+msgstr "你可以在此照常使用 `break` 和 `continue`。"
+
+#: src/control-flow/for-expressions.md:26
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr "在这种情况下，索引迭代在 Rust 中并不是一个特殊的语法。"
+
+#: src/control-flow/for-expressions.md:27
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "`(0..10)` 是实现 `Iterator` trait 的范围。"
+
+#: src/control-flow/for-expressions.md:28
+msgid ""
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr "`step_by` 是返回另一个 `Iterator` 的方法，用于逐一跳过所有其他元素。"
+
+#: src/control-flow/for-expressions.md:29
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
+"vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
+msgstr "修改矢量中的元素并说明编译器错误。将矢量 `v` 改为可变，并将 for 循环改为 `for x in v.iter_mut()`。"
+
+#: src/control-flow/while-expressions.md:1
+msgid "`while` loops"
+msgstr "`while` 循环"
+
+#: src/control-flow/while-expressions.md:3
+msgid ""
+"The [`while` "
+"keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops) "
+"works very similar to other languages:"
+msgstr ""
+"[`while` "
+"关键字](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops) "
+"的工作方式与其他语言非常相似："
+
+#: src/control-flow/break-continue.md:1
+msgid "`break` and `continue`"
+msgstr "`break` 和 `continue`"
+
+#: src/control-flow/break-continue.md:3
+msgid ""
+"If you want to exit a loop early, use "
+"[`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions),"
+msgstr ""
+"如果你想提前退出循环，请使用 "
+"[`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions)，"
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use "
+"[`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+msgstr ""
+"如果需要立即启动 下一次迭代，请使用 "
+"[`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)。"
+
+#: src/control-flow/break-continue.md:7
+msgid ""
+"Both `continue` and `break` can optionally take a label argument which is "
+"used to break out of nested loops:"
+msgstr "`continue` 和 `break` 都可以选择接受一个标签参数，用来 终止嵌套循环："
+
+#: src/control-flow/break-continue.md:29
+msgid ""
+"In this case we break the outer loop after 3 iterations of the inner loop."
+msgstr "在本示例中，我们会在内循环 3 次迭代后终止外循环。"
+
+#: src/control-flow/loop-expressions.md:1
+msgid "`loop` expressions"
+msgstr "`loop` 表达式"
+
+#: src/control-flow/loop-expressions.md:3
+msgid ""
+"Finally, there is a [`loop` "
+"keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops) "
+"which creates an endless loop."
+msgstr ""
+"最后是用于创建无限循环的 [`loop` "
+"关键字](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops) "
+"。"
+
+#: src/control-flow/loop-expressions.md:6
+msgid "Here you must either `break` or `return` to stop the loop:"
+msgstr "在下例中，你必须 `break` 或 `return` 才能停止循环："
+
+#: src/control-flow/loop-expressions.md:28
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr "用一个值（例如 `break 8`）来中断 `loop` 并将其输出。"
+
+#: src/control-flow/loop-expressions.md:29
+msgid ""
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
+msgstr "请注意，`loop` 是唯一返回有意义的值的循环结构。 这是因为它保证至少被输入一次（与 `while` 和 `for` 循环不同）。"
+
+#: src/basic-syntax/variables.md:3
+msgid ""
+"Rust provides type safety via static typing. Variable bindings are immutable "
+"by default:"
+msgstr "Rust 通过静态类型实现了类型安全。变量绑定默认是不可变的："
+
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
+msgstr "由于类型推导，`i32` 可以省略。随着课程推进，我们会越来越少地看到类型声明。"
+
+#: src/basic-syntax/type-inference.md:3
+msgid "Rust will look at how the variable is _used_ to determine the type:"
+msgstr "Rust 会根据变量的使用来确定其类型："
+
+#: src/basic-syntax/type-inference.md:27
+msgid ""
+"This slide demonstrates how the Rust compiler infers types based on "
+"constraints given by variable declarations and usages."
+msgstr "这张幻灯片演示了 Rust 编译器是如何根据变量声明和用法来推导其类型的。"
+
+#: src/basic-syntax/type-inference.md:29
+msgid ""
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
+msgstr ""
+"需要重点强调的是这样声明的变量并非像那种动态类型语言中可以持有任何数据的“任何类型”。这种声明所生成的机器码与明确类型声明完全相同。编译器进行类型推导能够让我们编写更简略的代码。"
+
+#: src/basic-syntax/type-inference.md:33
+#, fuzzy
+msgid ""
+"The following code tells the compiler to copy into a certain generic "
+"container without the code ever explicitly specifying the contained type, "
+"using `_` as a placeholder:"
+msgstr "下面的代码通过使用 `_` 占位符来告诉编译器无需明确指定其类型就可以将对应数据拷贝到该容器： "
+
+#: src/basic-syntax/type-inference.md:48
+#, fuzzy
+msgid ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
+"relies on "
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html), "
+"which "
+"[`HashSet`](https://doc.rust-lang.org/std/collections/struct.HashSet.html#impl-FromIterator%3CT%3E-for-HashSet%3CT,+S%3E) "
+"implements."
+msgstr ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
+"依赖 [`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"实现的 `FromIterator`。"
+
+#: src/basic-syntax/static-and-const.md:1
+msgid "Static and Constant Variables"
+msgstr "静态 (Static) 变量和常数 (Constant) 变量"
+
+#: src/basic-syntax/static-and-const.md:3
+msgid ""
+"Static and constant variables are two different ways to create "
+"globally-scoped values that cannot be moved or reallocated during the "
+"execution of the program. "
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:6
+msgid "`const`"
+msgstr "`const`"
+
+#: src/basic-syntax/static-and-const.md:8
+msgid ""
+"Constant variables are evaluated at compile time and their values are "
+"inlined wherever they are used:"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:30
+msgid ""
+"According to the [Rust RFC "
+"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) these are "
+"inlined upon use."
+msgstr ""
+"根据 [Rust RFC "
+"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
+"这些变量在使用时是内联 (inlined) 的。"
+
+#: src/basic-syntax/static-and-const.md:32
+msgid ""
+"Only functions marked `const` can be called at compile time to generate "
+"`const` values. `const` functions can however be called at runtime."
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:34
+msgid "`static`"
+msgstr "`static`"
+
+#: src/basic-syntax/static-and-const.md:36
+msgid ""
+"Static variables will live during the whole execution of the program, and "
+"therefore will not move:"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:38
+msgid ""
+"```rust,editable\n"
+"static BANNER: &str = \"Welcome to RustOS 3.14\";\n"
+"\n"
+"fn main() {\n"
+"    println!(\"{BANNER}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"static BANNER: &str = \"Welcome to RustOS 3.14\";\n"
+"\n"
+"fn main() {\n"
+"    println!(\"{BANNER}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/static-and-const.md:46
+#, fuzzy
+msgid ""
+"As noted in the [Rust RFC "
+"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html), these are "
+"not inlined upon use and have an actual associated memory location.  This is "
+"useful for unsafe and  embedded code, and the variable lives through the "
+"entirety of the program execution. When a globally-scoped value does not "
+"have a reason to need object identity, `const` is generally preferred."
+msgstr ""
+"正如 [Rust RFC "
+"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
+"中所述，这些变量在使用时并不是内联的，而且还具有实际相关联的内存位置。这对于不安全的嵌入式代码是有用的，并且这些变量存在于整个程序的执行过程之中。"
+
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"Because `static` variables are accessible from any thread, they must be "
+"`Sync`. Interior mutability is possible through a "
+"[`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html), atomic or "
+"similar. It is also possible to have mutable statics, but they require "
+"manual synchronisation so any access to them requires `unsafe` code. We will "
+"look at [mutable statics](../unsafe/mutable-static-variables.md) in the "
+"chapter on Unsafe Rust."
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:58
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
+msgstr "值得一提的是，`const` 在语义上与C++的 `constexpr` 类似。"
+
+#: src/basic-syntax/static-and-const.md:59
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr "另一方面，`static` 远远更类似于C++中的 `const` 或可改变的全局变量。"
+
+#: src/basic-syntax/static-and-const.md:60
+msgid ""
+"`static` provides object identity: an address in memory and state as "
+"required by types with interior mutability such as `Mutex<T>`."
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:61
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr "虽然需要使用在运行中求值的常量的情况并不是很常见，但是它是有帮助的，而且比使用静态变量更安全。"
+
+#: src/basic-syntax/static-and-const.md:62
+msgid "`thread_local` data can be created with the macro `std::thread_local`."
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:64
+msgid "Properties table:"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:66
+msgid "Property"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:66
+#, fuzzy
+msgid "Static"
+msgstr "`static`"
+
+#: src/basic-syntax/static-and-const.md:66
+msgid "Constant"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:68
+msgid "Has an address in memory"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:68
+#: src/basic-syntax/static-and-const.md:69
+#: src/basic-syntax/static-and-const.md:71
+#: src/basic-syntax/static-and-const.md:72
+msgid "Yes"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:68
+msgid "No (inlined)"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:69
+#, fuzzy
+msgid "Lives for the entire duration of the program"
+msgstr "`main` 函数是程序的入口。"
+
+#: src/basic-syntax/static-and-const.md:69
+#: src/basic-syntax/static-and-const.md:70
+#: src/basic-syntax/static-and-const.md:72
+msgid "No"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:70
+msgid "Can be mutable"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:70
+msgid "Yes (unsafe)"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:71
+#, fuzzy
+msgid "Evaluated at compile time"
+msgstr "值在编译时具有已知的固定大小。"
+
+#: src/basic-syntax/static-and-const.md:71
+msgid "Yes (initialised at compile time)"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:72
+msgid "Inlined wherever it is used"
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:3
+msgid ""
+"You can shadow variables, both those from outer scopes and variables from "
+"the same scope:"
+msgstr "你可以隐藏变量，位于外部作用域的变量和 相同作用域的变量都可以："
+
+#: src/basic-syntax/scopes-shadowing.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a = 10;\n"
+"    println!(\"before: {a}\");\n"
+"\n"
+"    {\n"
+"        let a = \"hello\";\n"
+"        println!(\"inner scope: {a}\");\n"
+"\n"
+"        let a = true;\n"
+"        println!(\"shadowed in inner scope: {a}\");\n"
+"    }\n"
+"\n"
+"    println!(\"after: {a}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a = 10;\n"
+"    println!(\"before: {a}\");\n"
+"\n"
+"    {\n"
+"        let a = \"hello\";\n"
+"        println!(\"inner scope: {a}\");\n"
+"\n"
+"        let a = true;\n"
+"        println!(\"shadowed in inner scope: {a}\");\n"
+"    }\n"
+"\n"
+"    println!(\"after: {a}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/scopes-shadowing.md:25
+msgid ""
+"Definition: Shadowing is different from mutation, because after shadowing "
+"both variable's memory locations exist at the same time. Both are available "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"定义: 隐藏和变更 (mutation) "
+"不同，因为在隐藏之后，两个变量都会同时存在于内存的不同位置中。在同一个名字下的两个变量都是可以被使用的，但是你在代码的哪里使用会最终决定你使用哪一个变量。"
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr "一个隐藏变量可以具有不同的类型。"
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr "隐藏起初看起来会有些晦涩，但是它很便于存 `.unwrap()` 之后的得到的值。"
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
+"locations when shadowing an immutable variable in a scope, even if the type "
+"does not change."
+msgstr "以下代码说明了为什么在作用域内隐藏一个不可变的变量时，即使是在变量类型没有改变的情况下，编译器也不能简单地重复利用之前的内存位置。"
+
+#: src/enums.md:3
+msgid ""
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
+msgstr "`enum` 关键字允许创建具有几个 不同变体的类型："
+
+#: src/enums.md:6
+msgid ""
+"```rust,editable\n"
+"fn generate_random_number() -> i32 {\n"
+"    // Implementation based on https://xkcd.com/221/\n"
+"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"enum CoinFlip {\n"
+"    Heads,\n"
+"    Tails,\n"
+"}\n"
+"\n"
+"fn flip_coin() -> CoinFlip {\n"
+"    let random_number = generate_random_number();\n"
+"    if random_number % 2 == 0 {\n"
+"        return CoinFlip::Heads;\n"
+"    } else {\n"
+"        return CoinFlip::Tails;\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    println!(\"You got: {:?}\", flip_coin());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums.md:36
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr "枚举允许你从一种类型下收集一组值"
+
+#: src/enums.md:37
+#, fuzzy
+msgid ""
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tails`. You might note the namespace when using variants."
+msgstr "本页提供了一个枚举类型 `CoinFlip`，其中包含 `Heads` 和`Tail`两个变体。在使用变体时，你可能会注意到命名空间。"
+
+#: src/enums.md:38
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr "这可能是比较结构体和枚举的好时机："
+
+#: src/enums.md:39
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr "在这两者中，你可以获得一个不含字段的简单版本（单位结构体），或一个包含不同类型字段的版本（变体载荷）。"
+
+#: src/enums.md:40
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr "在这两者中，关联的函数都在 `impl` 块中定义。"
+
+#: src/enums.md:41
+msgid ""
+"You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. "
+msgstr "你甚至可以使用单独的结构体实现枚举的不同变体，但这样一来，如果它们都已在枚举中定义，类型与之前也不一样。"
+
+#: src/enums/variant-payloads.md:3
+msgid ""
+"You can define richer enums where the variants carry data. You can then use "
+"the `match` statement to extract the data from each variant:"
+msgstr "你可以定义更丰富的枚举，其中变体会携带数据。然后，你可以使用 `match` 语句从每个变体中提取数据："
+
+#: src/enums/variant-payloads.md:6
+msgid ""
+"```rust,editable\n"
+"enum WebEvent {\n"
+"    PageLoad,                 // Variant without payload\n"
+"    KeyPress(char),           // Tuple struct variant\n"
+"    Click { x: i64, y: i64 }, // Full struct variant\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(event: WebEvent) {\n"
+"    match event {\n"
+"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
+"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
+"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let load = WebEvent::PageLoad;\n"
+"    let press = WebEvent::KeyPress('x');\n"
+"    let click = WebEvent::Click { x: 20, y: 80 };\n"
+"\n"
+"    inspect(load);\n"
+"    inspect(press);\n"
+"    inspect(click);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"enum WebEvent {\n"
+"    PageLoad,                 // Variant without payload\n"
+"    KeyPress(char),           // Tuple struct variant\n"
+"    Click { x: i64, y: i64 }, // Full struct variant\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(event: WebEvent) {\n"
+"    match event {\n"
+"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
+"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
+"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let load = WebEvent::PageLoad;\n"
+"    let press = WebEvent::KeyPress('x');\n"
+"    let click = WebEvent::Click { x: 20, y: 80 };\n"
+"\n"
+"    inspect(load);\n"
+"    inspect(press);\n"
+"    inspect(click);\n"
+"}\n"
+"```"
+
+#: src/enums/variant-payloads.md:35
+msgid ""
+"The values in the enum variants can only be accessed after being pattern "
+"matched. The pattern binds references to the fields in the \"match arm\" "
+"after the `=>`."
+msgstr "枚举变体中的值只有在被模式匹配后，才可访问。模式将引用绑定到 `=>` 之后的“match 分支”中的字段。"
+
+#: src/enums/variant-payloads.md:36
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr "表达式会从上到下与模式匹配。没有像 C 或 C++ 中那样的跳转。"
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr "匹配表达式拥有一个值。值是 match 分支中被执行的最后一个表达式。"
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr "从顶部开始，查找与该值匹配的模式，然后沿箭头运行代码。一旦找到匹配，我们便会停止。"
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr "展示搜索不详尽时会发生的情况。请注意 Rust 编译器的优势，即确认所有情况何时都得到了处理。"
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr "`match` 会检查 `enum` 中的隐藏的判别字段。"
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling "
+"`std::mem::discriminant()`"
+msgstr "可以通过调用 `std::mem::discriminant()` 来检索判别"
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr "这很有用，例如如果为结构体实现 `PartialEq`，比较字段值不会影响等式。"
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as "
+"`WebEvent::Click(Click)` with a top level `struct Click { ... }`. The "
+"inlined version cannot implement traits, for example."
+msgstr ""
+"`WebEvent::Click { ... }` 与含顶层 `struct Click { ... }` 的 "
+"`WebEvent::Click(Click)` 不完全相同。例如，内嵌版本无法实现 trait。"
+
+#: src/enums/sizes.md:3
+msgid ""
+"Rust enums are packed tightly, taking constraints due to alignment into "
+"account:"
+msgstr "Rust 枚举被紧密地打包，考虑到了对齐的影响，因此存在一些限制："
+
+#: src/enums/sizes.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::any::type_name;\n"
+"use std::mem::{align_of, size_of};\n"
+"\n"
+"fn dbg_size<T>() {\n"
+"    println!(\"{}: size {} bytes, align: {} bytes\",\n"
+"        type_name::<T>(), size_of::<T>(), align_of::<T>());\n"
+"}\n"
+"\n"
+"enum Foo {\n"
+"    A,\n"
+"    B,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    dbg_size::<Foo>();\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::mem::{align_of, size_of};\n"
+"\n"
+"macro_rules! dbg_size {\n"
+"    ($t:ty) => {\n"
+"        println!(\"{}: size {} bytes, align: {} bytes\",\n"
+"                 stringify!($t), size_of::<$t>(), align_of::<$t>());\n"
+"    };\n"
+"}\n"
+"\n"
+"enum Foo {\n"
+"    A,\n"
+"    B,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    dbg_size!(Foo);\n"
+"}\n"
+"```"
+
+#: src/enums/sizes.md:24
+msgid ""
+"See the [Rust "
+"Reference](https://doc.rust-lang.org/reference/type-layout.html)."
+msgstr "请参阅 [Rust 引用](https://doc.rust-lang.org/reference/type-layout.html)。"
+
+#: src/enums/sizes.md:30
+#, fuzzy
+msgid ""
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr "在内部，Rust 使用字段（判别）来跟踪枚举变体。"
+
+#: src/enums/sizes.md:32
+#, fuzzy
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr "你可以根据需要控制判别（例如，与 C 的兼容性）："
+
+#: src/enums/sizes.md:50
+#, fuzzy
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr "如果不使用 `repr`，判别类型会占用 2 个字节，因为 10001 是一个 2 个字节的数值。"
+
+#: src/enums/sizes.md:54
+#, fuzzy
+msgid "Try out other types such as"
+msgstr "试试其他类型，例如："
+
+#: src/enums/sizes.md:56
+#, fuzzy
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr "`dbg_size!(bool)`：大小占用 1 个字节，对齐占用 1 个字节；"
+
+#: src/enums/sizes.md:57
+#, fuzzy
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr "`dbg_size!(Option<bool>)`：大小占用 1 个字节，对齐占用 1 个字节（小众优化，请参阅下文）；"
+
+#: src/enums/sizes.md:58
+#, fuzzy
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr "`dbg_size!(&i32)`：大小占用 8 个字节，对齐占用 8 个字节（在 64 位设备上）；"
+
+#: src/enums/sizes.md:59
+#, fuzzy
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr "`dbg_size!(Option<&i32>)`：大小占用 8 个字节，对齐占用 8 个字节（Null 指针优化，请参阅下文）。"
+
+#: src/enums/sizes.md:61
+#, fuzzy
+msgid ""
+"Niche optimization: Rust will merge unused bit patterns for the enum "
+"discriminant."
+msgstr "小众优化：Rust 将对枚举判别合并使用 未使用的位模式。"
+
+#: src/enums/sizes.md:64
+#, fuzzy
+msgid ""
+"Null pointer optimization: For [some "
+"types](https://doc.rust-lang.org/std/option/#representation), Rust "
+"guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`."
+msgstr ""
+"Null 指针优化：对于[某些 "
+"类型](https://doc.rust-lang.org/std/option/#representation)，Rust 保证 "
+"`size_of::<T>()` 等效于 `size_of::<Option<T>>()`。"
+
+#: src/enums/sizes.md:68
+#, fuzzy
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr "如果你想展示位表示方式在实践中“可能”会是什么样子，请参考示例代码。 请务必注意，编译器对此表示法不提供任何保证，因此这是完全不安全的。"
+
+#: src/enums/sizes.md:105
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/control-flow/novel.md:3
+msgid ""
+"Rust has a few control flow constructs which differ from other languages. "
+"They are used for pattern matching:"
+msgstr ""
+
+#: src/control-flow/novel.md:6
+#: src/control-flow/if-let-expressions.md:1
+msgid "`if let` expressions"
+msgstr "`if let` 表达式"
+
+#: src/control-flow/novel.md:7
+#, fuzzy
+msgid "`while let` expressions"
+msgstr "while let 表达式"
+
+#: src/control-flow/novel.md:8
+#: src/control-flow/match-expressions.md:1
+msgid "`match` expressions"
+msgstr "`match` 表达式"
+
+#: src/control-flow/if-let-expressions.md:3
+msgid ""
+"The [`if let` "
+"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions) "
+"lets you execute different code depending on whether a value matches a "
+"pattern:"
+msgstr ""
+"[`if let` "
+"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions) "
+"能让你根据某个值是否与模式相匹配来执行不同的代码："
+
+#: src/control-flow/if-let-expressions.md:7
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let arg = std::env::args().next();\n"
+"    if let Some(value) = arg {\n"
+"        println!(\"Program name: {value}\");\n"
+"    } else {\n"
+"        println!(\"Missing name?\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let arg = std::env::args().next();\n"
+"    if let Some(value) = arg {\n"
+"        println!(\"Program name: {value}\");\n"
+"    } else {\n"
+"        println!(\"Missing name?\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/if-let-expressions.md:18
+#: src/control-flow/while-let-expressions.md:22
+#: src/control-flow/match-expressions.md:23
+msgid ""
+"See [pattern matching](../pattern-matching.md) for more details on patterns "
+"in Rust."
+msgstr "如需详细了解 Rust 中 的模式，请参阅[模式匹配](../pattern-matching.md)。"
+
+#: src/control-flow/if-let-expressions.md:23
+#, fuzzy
+msgid ""
+"Unlike `match`, `if let` does not have to cover all branches. This can make "
+"it more concise than `match`."
+msgstr "与 `match` 不同的是，`if let` 不支持模式匹配的 guard 子句。"
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr "使用 `Option` 时，常见的做法是处理 `Some` 值。"
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr "与 `match` 不同的是，`if let` 不支持模式匹配的 guard 子句。"
+
+#: src/control-flow/if-let-expressions.md:26
+#, fuzzy
+msgid ""
+"Since 1.65, a similar "
+"[let-else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) "
+"construct allows to do a destructuring assignment, or if it fails, execute a "
+"block which is required to abort normal control flow (with "
+"`panic`/`return`/`break`/`continue`):"
+msgstr ""
+"自 1.65 版以来，类似的 "
+"[let-else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) "
+"结构允许执行解构赋值，或者如果不满足条件，则有一个非返回块分支 (panic/return/break/continue)："
+
+#: src/control-flow/while-let-expressions.md:1
+msgid "`while let` loops"
+msgstr "`while let` 循环"
+
+#: src/control-flow/while-let-expressions.md:3
+msgid ""
+"Like with `if let`, there is a [`while "
+"let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops) "
+"variant which repeatedly tests a value against a pattern:"
+msgstr ""
+"与 `if let` 一样，[`with "
+"let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops) "
+"变体会针对一个模式重复测试一个值："
+
+#: src/control-flow/while-let-expressions.md:18
+#, fuzzy
+msgid ""
+"Here the iterator returned by `v.into_iter()` will return a `Option<i32>` on "
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
+msgstr ""
+"在这里，每次 调用 `next()` 时，`v.iter()` 返回的迭代器都会返回一个 `Option<i32>`。它将一直返回 "
+"`Some(x)`，直到完成。 之后它将返回 `None`。`while let`能让我们持续迭代所有项。"
+
+#: src/control-flow/while-let-expressions.md:27
+msgid ""
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
+msgstr "指出只要值与模式匹配，`while let` 循环就会一直进行下去。"
+
+#: src/control-flow/while-let-expressions.md:28
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
+msgstr ""
+"你可以使用 if 语句将 `while let` 循环重写为无限循环，当 `iter.next()` 没有值可以解封时中断。`while let` "
+"为上述情况提供了语法糖。"
+
+#: src/control-flow/match-expressions.md:3
+msgid ""
+"The [`match` "
+"keyword](https://doc.rust-lang.org/reference/expressions/match-expr.html) is "
+"used to match a value against one or more patterns. In that sense, it works "
+"like a series of `if let` expressions:"
+msgstr ""
+"[`match` "
+"关键字](https://doc.rust-lang.org/reference/expressions/match-expr.html) "
+"用于将一个值与一个或多个模式进行匹配。从这个意义上讲，它的工作方式 类似于一系列的 `if let` 表达式："
+
+#: src/control-flow/match-expressions.md:7
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    match std::env::args().next().as_deref() {\n"
+"        Some(\"cat\") => println!(\"Will do cat things\"),\n"
+"        Some(\"ls\")  => println!(\"Will ls some files\"),\n"
+"        Some(\"mv\")  => println!(\"Let's move some files\"),\n"
+"        Some(\"rm\")  => println!(\"Uh, dangerous!\"),\n"
+"        None        => println!(\"Hmm, no program name?\"),\n"
+"        _           => println!(\"Unknown program name!\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    match std::env::args().next().as_deref() {\n"
+"        Some(\"cat\") => println!(\"Will do cat things\"),\n"
+"        Some(\"ls\")  => println!(\"Will ls some files\"),\n"
+"        Some(\"mv\")  => println!(\"Let's move some files\"),\n"
+"        Some(\"rm\")  => println!(\"Uh, dangerous!\"),\n"
+"        None        => println!(\"Hmm, no program name?\"),\n"
+"        _           => println!(\"Unknown program name!\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/match-expressions.md:20
+msgid ""
+"Like `if let`, each match arm must have the same type. The type is the last "
+"expression of the block, if any. In the example above, the type is `()`."
+msgstr "与 `if let` 类似，每个匹配分支必须有相同的类型。该类型是块的最后一个 表达式（如有）。在上例中，类型是 `()`。"
+
+#: src/control-flow/match-expressions.md:28
+msgid "Save the match expression to a variable and print it out."
+msgstr "将 match 表达式保存到一个变量中并输出结果。"
+
+#: src/control-flow/match-expressions.md:29
+msgid "Remove `.as_deref()` and explain the error."
+msgstr "移除 `.as_deref()` 并说明错误。"
+
+#: src/control-flow/match-expressions.md:30
+msgid ""
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
+msgstr "`std::env::args().next()` 会返回  `Option<String>`，但无法与 `String` 进行匹配。"
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+"`as_deref()` 会将 `Option<T>` 转换为 `Option<&T::Target>`。在我们的示例中，这会将 "
+"`Option<String>` 转换为 `Option<&str>`。"
+
+#: src/control-flow/match-expressions.md:32
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
+msgstr "现在，我们可以使用模式匹配来匹配 `Option` 中的 `&str`。"
+
+#: src/pattern-matching.md:3
+msgid ""
+"The `match` keyword let you match a value against one or more _patterns_. "
+"The comparisons are done from top to bottom and the first match wins."
+msgstr "使用关键词 `match` 对一个值进行模式匹配。进行匹配时，会从上至下依次进行比较，并选定第一个匹配成功的结果。"
+
+#: src/pattern-matching.md:6
+msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
+msgstr "模式 (pattern) 可以是简单的值，其用法类似于 C 与 C++ 中的 `switch` 。"
+
+#: src/pattern-matching.md:8
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let input = 'x';\n"
+"\n"
+"    match input {\n"
+"        'q'                   => println!(\"Quitting\"),\n"
+"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
+"        '0'..='9'             => println!(\"Number input\"),\n"
+"        _                     => println!(\"Something else\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching.md:21
+msgid "The `_` pattern is a wildcard pattern which matches any value."
+msgstr "模式 `_` 是外卡 (wildcard) 模式。它可以匹配任何值。"
+
+#: src/pattern-matching.md:26
+#, fuzzy
+msgid ""
+"You might point out how some specific characters are being used when in a "
+"pattern"
+msgstr ""
+"你可以解释一些用于表达模式的特殊字符的用法 \\*`|` 表示或 (or) \\*`..` 可以展开为任意一个或多个值 \\*`1..=5` "
+"代表了一个闭区间范围"
+
+#: src/pattern-matching.md:27
+#, fuzzy
+msgid "`|` as an `or`"
+msgstr "解释模式匹配中的绑定的原理可能会很有帮助。比如可以用一个变量替代外卡，或者去除 `q` 外面的引号。"
+
+#: src/pattern-matching.md:28
+#, fuzzy
+msgid "`..` can expand as much as it needs to be"
+msgstr "你可以展示如何匹配一个引用。"
+
+#: src/pattern-matching.md:29
+#, fuzzy
+msgid "`1..=5` represents an inclusive range"
+msgstr "现在是一个讲解不可反驳 (irrefutable) 模式的好时机。因为这个术语可能会出现在错误信息中。"
+
+#: src/pattern-matching.md:30
+msgid "`_` is a wild card"
+msgstr ""
+
+#: src/pattern-matching.md:31
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+
+#: src/pattern-matching.md:32
+msgid "You can demonstrate matching on a reference."
+msgstr ""
+
+#: src/pattern-matching.md:33
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:3
+msgid ""
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:6
+msgid ""
+"```rust,editable\n"
+"enum Result {\n"
+"    Ok(i32),\n"
+"    Err(String),\n"
+"}\n"
+"\n"
+"fn divide_in_two(n: i32) -> Result {\n"
+"    if n % 2 == 0 {\n"
+"        Result::Ok(n / 2)\n"
+"    } else {\n"
+"        Result::Err(format!(\"cannot divide {n} into two equal parts\"))\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let n = 100;\n"
+"    match divide_in_two(n) {\n"
+"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
+"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:29
+msgid ""
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm, `msg` is bound to the error message."
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:36
+msgid ""
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:37
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:3
+msgid "You can also destructure `structs`:"
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Foo {\n"
+"    x: (u32, u32),\n"
+"    y: u32,\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let foo = Foo { x: (1, 2), y: 3 };\n"
+"    match foo {\n"
+"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
+"        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:23
+msgid "Change the literal values in `foo` to match with the other patterns."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:25
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:3
+msgid ""
+"You can destructure arrays, tuples, and slices by matching on their elements:"
+msgstr "你可以通过元素匹配来解构数组、元组和切片："
+
+#: src/pattern-matching/destructuring-arrays.md:5
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let triple = [0, -2, 3];\n"
+"    println!(\"Tell me about {triple:?}\");\n"
+"    match triple {\n"
+"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _         => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:21
+msgid ""
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
+msgstr "对未知长度的切片进行解构也可以使用固定长度的模式。"
+
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr "使用 `_` 创建一个新的模式来代表一个元素。"
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr "向数组中添加更多的值。"
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr "指出 `..` 是如何扩展以适应不同数量的元素的。 "
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr "展示使用模式 `[.., b]` 和 `[a@..,b]` 来匹配切片的尾部。"
+
+#: src/pattern-matching/match-guards.md:3
+msgid ""
+"When matching, you can add a _guard_ to a pattern. This is an arbitrary "
+"Boolean expression which will be executed if the pattern matches:"
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:6
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let pair = (2, -2);\n"
+"    println!(\"Tell me about {pair:?}\");\n"
+"    match pair {\n"
+"        (x, y) if x == y     => println!(\"These are twins\"),\n"
+"        (x, y) if x + y == 0 => println!(\"Antimatter, kaboom!\"),\n"
+"        (x, _) if x % 2 == 1 => println!(\"The first one is odd\"),\n"
+"        _                    => println!(\"No correlation...\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:23
+msgid ""
+"Match guards as a separate syntax feature are important and necessary when "
+"we wish to concisely express more complex ideas than patterns alone would "
+"allow."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:24
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
+"An `if` expression inside of the branch block (after `=>`) happens after the "
+"match arm is selected. Failing the `if` condition inside of that block won't "
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:26
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:27
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr ""
+
+#: src/exercises/day-1/afternoon.md:1
+msgid "Day 1: Afternoon Exercises"
+msgstr ""
+
+#: src/exercises/day-1/afternoon.md:3
+msgid "We will look at two things:"
+msgstr ""
+
+#: src/exercises/day-1/afternoon.md:5
+#, fuzzy
+msgid "The Luhn algorithm,"
+msgstr "Luhn 算法"
+
+#: src/exercises/day-1/afternoon.md:7
+#, fuzzy
+msgid "An exercise on pattern matching."
+msgstr "枚举和模式匹配。"
+
+#: src/exercises/day-1/afternoon.md:11
+#: src/exercises/day-2/afternoon.md:7
+#: src/exercises/bare-metal/afternoon.md:7
+#: src/exercises/concurrency/afternoon.md:13
+#, fuzzy
+msgid ""
+"After looking at the exercises, you can look at the "
+"[solutions](solutions-afternoon.md) provided."
+msgstr "读完习题后，可以阅读本书提供的 \\[题解\\]。"
+
+#: src/exercises/day-1/luhn.md:3
+msgid ""
+"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:9
+msgid ""
+"Moving from **right to left**, double every second digit: for the number "
+"`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits if the result is greater than 9. So "
+"doubling `7` becomes `14` which becomes `1 + 4 = 5`."
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:19
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
+"function."
+msgstr "将下面的代码复制到 <https://play.rust-lang.org/> 并实现上述函数："
+
+#: src/exercises/day-1/luhn.md:21
+msgid ""
+"Try to solve the problem the \"simple\" way first, using `for` loops and "
+"integers. Then, revisit the solution and try to implement it with iterators."
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:25
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"    assert!(!luhn(\"foo 0 0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"\n"
+"#[allow(dead_code)]\n"
+"fn main() {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:1
+msgid "Exercise: Expression Evaluation"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:3
+msgid "Let's write a simple recursive evaluator for arithmetic expressions. "
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:5
+msgid ""
+"```rust\n"
+"/// An operation to perform on two subexpressions.\n"
+"#[derive(Debug)]\n"
+"enum Operation {\n"
+"    Add,\n"
+"    Sub,\n"
+"    Mul,\n"
+"    Div,\n"
+"}\n"
+"\n"
+"/// An expression, in tree form.\n"
+"#[derive(Debug)]\n"
+"enum Expression {\n"
+"    /// An operation on two subexpressions.\n"
+"    Op {\n"
+"        op: Operation,\n"
+"        left: Box<Expression>,\n"
+"        right: Box<Expression>,\n"
+"    },\n"
+"\n"
+"    /// A literal value\n"
+"    Value(i64),\n"
+"}\n"
+"\n"
+"/// The result of evaluating an expression.\n"
+"#[derive(Debug, PartialEq, Eq)]\n"
+"enum Res {\n"
+"    /// Evaluation was successful, with the given result.\n"
+"    Ok(i64),\n"
+"    /// Evaluation failed, with the given error message.\n"
+"    Err(String),\n"
+"}\n"
+"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
+"use Res::{Err, Ok};\n"
+"\n"
+"fn eval(e: Expression) -> Res {\n"
+"    todo!()\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_value() {\n"
+"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_sum() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(Expression::Value(10)),\n"
+"            right: Box::new(Expression::Value(20)),\n"
+"        }),\n"
+"        Ok(30)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_recursion() {\n"
+"    let term1 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Value(10)),\n"
+"        right: Box::new(Expression::Value(9)),\n"
+"    };\n"
+"    let term2 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Op {\n"
+"            op: Operation::Sub,\n"
+"            left: Box::new(Expression::Value(3)),\n"
+"            right: Box::new(Expression::Value(4)),\n"
+"        }),\n"
+"        right: Box::new(Expression::Value(5)),\n"
+"    };\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(term1),\n"
+"            right: Box::new(term2),\n"
+"        }),\n"
+"        Ok(85)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_error() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Div,\n"
+"            left: Box::new(Expression::Value(99)),\n"
+"            right: Box::new(Expression::Value(0)),\n"
+"        }),\n"
+"        Err(String::from(\"division by zero\"))\n"
+"    );\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:100
+msgid ""
+"The `Box` type here is a smart pointer, and will be covered in detail later "
+"in the course. An expression can be \"boxed\" with `Box::new` as seen in the "
+"tests. To evaluate a boxed expression, use the deref operator to \"unbox\" "
+"it: `eval(*boxed_expr)`."
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:105
+msgid ""
+"Some expressions cannot be evaluated and will return an error. The `Res` "
+"type represents either a successful value or an error with a message. This "
+"is very similar to the standard-library `Result` which we will see later."
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:109
+msgid ""
+"Copy and paste the code into the Rust playground, and begin implementing "
+"`eval`. The final product should pass the tests. It may be helpful to use "
+"`todo!()` and get the tests to pass one-by-one."
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:113
+msgid ""
+"If you finish early, try writing a test that results in an integer overflow. "
+"How could you handle this with `Res::Err` instead of a panic?"
+msgstr ""
+
+#: src/welcome-day-2.md:1
+msgid "Welcome to Day 2"
+msgstr "欢迎来到第二天"
+
+#: src/welcome-day-2.md:3
+msgid "Now that we have seen a fair amount of Rust, we will continue with:"
+msgstr "现在我们已经了解了相当多的Rust，接下来我们将学习："
+
+#: src/welcome-day-2.md:5
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr "内存管理：栈与堆，手动内存管理，基于作用域的内存管理，以及垃圾回收。"
+
+#: src/welcome-day-2.md:8
+msgid "Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr "所有权：移动（move）的语义，复制（copy）和克隆（clone），借用（borrow），以及生命周期。"
+
+#: src/welcome-day-2.md:10
+#, fuzzy
+msgid "Structs and methods."
+msgstr "结构体（struct）, 枚举（enum）, 方法（method）。"
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+"标准库: `字符串（String）`, `选项（Option）` 和 `结果（Result）`, `动态数组（Vec）`, "
+"`散列表（HashMap）`, `引用计数（Rc）` 和 `共享引用计数（Arc）`。"
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr "模块: 可见性, 路径和文件系统的层次结构。"
+
+#: src/memory-management.md:3
+msgid "Traditionally, languages have fallen into two broad categories:"
+msgstr "传统上，语言分为两大类："
+
+#: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr "通过手动内存管理实现完全控制：C、C++、Pascal…"
+
+#: src/memory-management.md:6
+msgid ""
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Haskell, ..."
+msgstr "运行时通过自动内存管理实现完全安全：Java、Python、Go、Haskell…"
+
+#: src/memory-management.md:8
+msgid "Rust offers a new mix:"
+msgstr "Rust 提供了一个全新的组合："
+
+#: src/memory-management.md:10
+msgid ""
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
+msgstr "通过编译时强制执行正确的内存>管理来实现完全控制与安全。"
+
+#: src/memory-management.md:13
+msgid "It does this with an explicit ownership concept."
+msgstr "它通过一个明确的所有权（ownership）概念来实现此目的。"
+
+#: src/memory-management.md:15
+msgid "First, let's refresh how memory management works."
+msgstr "首先，我们回顾一下内存管理的工作原理。"
+
+#: src/memory-management/stack-vs-heap.md:1
+msgid "The Stack vs The Heap"
+msgstr "栈与堆"
+
+#: src/memory-management/stack-vs-heap.md:3
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "栈：局部变量的连续内存区域。"
+
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr "值在编译时具有已知的固定大小。"
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr "速度极快：只需移动一个栈指针。"
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr "易于管理：遵循函数调用规则。"
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr "优秀的内存局部性。"
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr "堆：函数调用之外的值的存储。"
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr "值具有动态大小，具体大小需在运行时确定。"
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "比栈稍慢：需要向系统申请空间。"
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr "不保证内存局部性。"
+
+#: src/memory-management/stack.md:1
+#, fuzzy
+msgid "Stack and Heap Example"
+msgstr "栈 vs 堆"
+
+#: src/memory-management/stack.md:3
+#, fuzzy
+msgid ""
+"Creating a `String` puts fixed-sized metadata on the stack and dynamically "
+"sized data, the actual string, on the heap:"
+msgstr "创建 `String` 时将固定大小的数据存储在栈上， 并将动态大小的数据存储在堆上："
+
+#: src/memory-management/stack.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1 = String::from(\"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1 = String::from(\"Hello\");\n"
+"}\n"
+"```"
+
+#: src/memory-management/stack.md:28
+msgid ""
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
+msgstr "指出 `String` 底层由 `Vec` 实现，因此它具有容量和长度，如果值可变，则可以通过在堆上重新分配存储空间进行增长。"
+
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System "
+"Allocator](https://doc.rust-lang.org/std/alloc/struct.System.html) and "
+"custom allocators can be implemented using the [Allocator "
+"API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+"如果学员提出相关问题，你可以提及我们不仅能使用\\[系统分配器\\]在堆上分配底层内存，还能使用 [Allocator "
+"API](https://doc.rust-lang.org/std/alloc/index.html) 实现自定义分配器"
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr "我们可以使用 `unsafe` 代码检查内存布局。不过，你应该指出，这种做法不安全！"
+
+#: src/memory-management/stack.md:34
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (ptr, capacity, len): (usize, usize, usize) = "
+"std::mem::transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = "
+"std::mem::transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/memory-management/manual.md:3
+msgid "You allocate and deallocate heap memory yourself."
+msgstr "你自己实现堆内存分配和释放。"
+
+#: src/memory-management/manual.md:5
+msgid ""
+"If not done with care, this can lead to crashes, bugs, security "
+"vulnerabilities, and memory leaks."
+msgstr "稍有不慎，这可能会导致崩溃、bug、安全漏洞和内存泄漏。"
+
+#: src/memory-management/manual.md:7
+msgid "C Example"
+msgstr "C++ 示例"
+
+#: src/memory-management/manual.md:9
+msgid "You must call `free` on every pointer you allocate with `malloc`:"
+msgstr "你必须对使用 `malloc` 分配的每个指针调用 `free`："
+
+#: src/memory-management/manual.md:11
+#, fuzzy
+msgid ""
+"```c\n"
+"void foo(size_t n) {\n"
+"    int* int_array = malloc(n * sizeof(int));\n"
+"    //\n"
+"    // ... lots of code\n"
+"    //\n"
+"    free(int_array);\n"
+"}\n"
+"```"
+msgstr ""
+"```c\n"
+"void foo(size_t n) {\n"
+"    int* int_array = (int*)malloc(n * sizeof(int));\n"
+"    //\n"
+"    // ... lots of code\n"
+"    //\n"
+"    free(int_array);\n"
+"}\n"
+"```"
+
+#: src/memory-management/manual.md:21
+#, fuzzy
+msgid ""
+"Memory is leaked if the function returns early between `malloc` and `free`: "
+"the pointer is lost and we cannot deallocate the memory. Worse, freeing the "
+"pointer twice, or accessing a freed pointer can lead to exploitable security "
+"vulnerabilities."
+msgstr "如果函数在 `malloc` 和 `free` 之间提前返回，则会导致内存泄漏： 指针丢失，而我们无法释放对应的内存。"
+
+#: src/memory-management/scope-based.md:3
+msgid "Constructors and destructors let you hook into the lifetime of an object."
+msgstr "构造函数和析构函数让你可以钩入对象的生命周期。"
+
+#: src/memory-management/scope-based.md:5
+msgid ""
+"By wrapping a pointer in an object, you can free memory when the object is "
+"destroyed. The compiler guarantees that this happens, even if an exception "
+"is raised."
+msgstr "通过将指针封装在对象中，你可以在该对象 被销毁时释放内存。编译器可保证这一点的实现，即使引发了异常也不例外。"
+
+#: src/memory-management/scope-based.md:9
+msgid ""
+"This is often called _resource acquisition is initialization_ (RAII) and "
+"gives you smart pointers."
+msgstr ""
+"这通常称为“资源获取即初始化 (resource acquisition is initialization, RAII)”， 并为你提供智能指针。"
+
+#: src/memory-management/scope-based.md:12
+msgid "C++ Example"
+msgstr "C++ 示例"
+
+#: src/memory-management/scope-based.md:14
+msgid ""
+"```c++\n"
+"void say_hello(std::unique_ptr<Person> person) {\n"
+"  std::cout << \"Hello \" << person->name << std::endl;\n"
+"}\n"
+"```"
+msgstr ""
+"```c++\n"
+"void say_hello(std::unique_ptr<Person> person) {\n"
+"  std::cout << \"Hello \" << person->name << std::endl;\n"
+"}\n"
+"```"
+
+#: src/memory-management/scope-based.md:20
+msgid ""
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
+msgstr "`std::unique_ptr` 对象在栈上分配内存，并指向在堆上分配的内存。"
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr "在 `say_hello` 结束时，`std::unique_ptr` 析构函数将运行。"
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
+msgstr "析构函数释放它所指向的 `Person` 对象。"
+
+#: src/memory-management/scope-based.md:25
+msgid "Special move constructors are used when passing ownership to a function:"
+msgstr "将所有权传递给函数时，使用特殊的 move 构造函数："
+
+#: src/memory-management/garbage-collection.md:1
+msgid "Automatic Memory Management"
+msgstr "自动内存管理"
+
+#: src/memory-management/garbage-collection.md:3
+msgid ""
+"An alternative to manual and scope-based memory management is automatic "
+"memory management:"
+msgstr "自动内存管理是手动和基于作用域的内存管理 的替代方案："
+
+#: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "程序员从不显式分配或取消分配内存。"
+
+#: src/memory-management/garbage-collection.md:7
+msgid ""
+"A garbage collector finds unused memory and deallocates it for the "
+"programmer."
+msgstr "垃圾回收器找到未使用的内存，并为程序员将其取消分配。"
+
+#: src/memory-management/garbage-collection.md:9
+msgid "Java Example"
+msgstr "Java 示例"
+
+#: src/memory-management/garbage-collection.md:11
+msgid "The `person` object is not deallocated after `sayHello` returns:"
+msgstr "`sayHello` 返回后，`person` 对象未被取消分配："
+
+#: src/memory-management/garbage-collection.md:13
+msgid ""
+"```java\n"
+"void sayHello(Person person) {\n"
+"  System.out.println(\"Hello \" + person.getName());\n"
+"}\n"
+"```"
+msgstr ""
+"```java\n"
+"void sayHello(Person person) {\n"
+"  System.out.println(\"Hello \" + person.getName());\n"
+"}\n"
+"```"
+
+#: src/memory-management/rust.md:1
+msgid "Memory Management in Rust"
+msgstr "Rust 中的内存管理"
+
+#: src/memory-management/rust.md:3
+msgid "Memory management in Rust is a mix:"
+msgstr "Rust 中的内存管理是一种混合模式："
+
+#: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "像 Java 一样安全又正确，但没有垃圾回收器。"
+
+#: src/memory-management/rust.md:6
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr "像 C++ 一样基于作用域，但编译器会强制完全遵循规则。"
+
+#: src/memory-management/rust.md:7
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
+"have no cost at runtime like C."
+msgstr "Rust 用户可以根据具体情况选择合适的抽象，有些甚至没有像 C 那样的运行时开销。"
+
+#: src/memory-management/rust.md:9
+#, fuzzy
+msgid "Rust achieves this by modeling _ownership_ explicitly."
+msgstr "它通过对“所有权”进行显式建模来实现这一点。"
+
+#: src/memory-management/rust.md:13
+msgid ""
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as "
+"[Box](https://doc.rust-lang.org/std/boxed/struct.Box.html), "
+"[Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html), "
+"[Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or "
+"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
+msgstr ""
+"如果此时被问及如何操作，你可以提及在 Rust 中，这通常由 RAII 封装容器类型（例如 "
+"[Box](https://doc.rust-lang.org/std/boxed/struct.Box.html)、[Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html)、[Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html) "
+"或 "
+"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html)）处理。这些类型通过各种方式封装了所有权和内存分配，并防止了 "
+"C 中潜在错误的发生。"
+
+#: src/memory-management/rust.md:15
+msgid ""
+"You may be asked about destructors here, the "
+"[Drop](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait is the Rust "
+"equivalent."
+msgstr ""
+"你可能会被问及析构函数，此处 [Drop](https://doc.rust-lang.org/std/ops/trait.Drop.html) "
+"trait 是 Rust 等效项。"
+
+#: src/ownership.md:3
+msgid ""
+"All variable bindings have a _scope_ where they are valid and it is an error "
+"to use a variable outside its scope:"
+msgstr "所有变量绑定都有一个有效的“作用域”，使用 超出其作用域的变量是错误的："
+
+#: src/ownership.md:19
+msgid "At the end of the scope, the variable is _dropped_ and the data is freed."
+msgstr "作用域结束时，变量会“被丢弃”，数据会被释放。"
+
+#: src/ownership.md:20
+msgid "A destructor can run here to free up resources."
+msgstr "析构函数可在此运行以释放资源。"
+
+#: src/ownership.md:21
+msgid "We say that the variable _owns_ the value."
+msgstr "指出变量“拥有”值。"
+
+#: src/ownership/move-semantics.md:3
+#, fuzzy
+msgid "An assignment will transfer _ownership_ between variables:"
+msgstr "赋值操作将在变量之间转移所有权："
+
+#: src/ownership/move-semantics.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Hello!\");\n"
+"    let s2: String = s1;\n"
+"    println!(\"s2: {s2}\");\n"
+"    // println!(\"s1: {s1}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Hello!\");\n"
+"    let s2: String = s1;\n"
+"    println!(\"s2: {s2}\");\n"
+"    // println!(\"s1: {s1}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/move-semantics.md:14
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "将 `s1` 赋值给 `s2`，即转移了所有权。"
+
+#: src/ownership/move-semantics.md:15
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens: it does not own anything."
+msgstr "当 `s1` 离开作用域时，什么都不会发生：它没有所有权。"
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr "当 `s2` 离开作用域时，字符串数据被释放。"
+
+#: src/ownership/move-semantics.md:17
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr "变量绑定在任一时刻有且“只有”一个值。"
+
+#: src/ownership/move-semantics.md:21
+msgid ""
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
+msgstr "指出这与 C++ 中的默认值相反。除非你使用 `std::move`（并已定义 move 构造函数！），否则 C++ 中的默认值是按值复制的。"
+
+#: src/ownership/move-semantics.md:23
+msgid ""
+"It is only the ownership that moves. Whether any machine code is generated "
+"to manipulate the data itself is a matter of optimization, and such copies "
+"are aggressively optimized away."
+msgstr ""
+
+#: src/ownership/move-semantics.md:25
+msgid "Simple values (such as integers) can be marked `Copy` (see later slides)."
+msgstr ""
+
+#: src/ownership/move-semantics.md:27
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "在 Rust 中，克隆是显式的（通过使用 `clone`）。"
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "`s1` 中的堆数据会被 `s2` 重复使用。"
+
+#: src/ownership/moved-strings-rust.md:12
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgstr "当 `s1` 离开作用域时，什么都不会发生（它已被移出）。"
+
+#: src/ownership/moved-strings-rust.md:14
+msgid "Before move to `s2`:"
+msgstr "移动到 `s2` 中之前："
+
+#: src/ownership/moved-strings-rust.md:31
+msgid "After move to `s2`:"
+msgstr "移动到 `s2` 中之后："
+
+#: src/ownership/moved-strings-rust.md:33
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1 \"(inaccessible)\"    :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :  |  :                           :\n"
+":   +-----------+-------+   :  |  :                           :\n"
+":                           :  |  `- - - - - - - - - - - - - -'\n"
+":    s2                     :  |\n"
+":   +-----------+-------+   :  |\n"
+":   | ptr       |   o---+---+--'\n"
+":   | len       |     4 |   :\n"
+":   | capacity  |     4 |   :\n"
+":   +-----------+-------+   :\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" 栈                             堆\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1 \"（无法访问）\"    :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :  |  :                           :\n"
+":   +-----------+-------+   :  |  :                           :\n"
+":                           :  |  `- - - - - - - - - - - - - -'\n"
+":    s2                     :  |\n"
+":   +-----------+-------+   :  |\n"
+":   | ptr       |   o---+---+--'\n"
+":   | len       |     4 |   :\n"
+":   | capacity  |     4 |   :\n"
+":   +-----------+-------+   :\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+
+#: src/ownership/double-free-modern-cpp.md:1
+#, fuzzy
+msgid "Defensive Copies in Modern C++"
+msgstr "现代 C++ 中的双重释放"
+
+#: src/ownership/double-free-modern-cpp.md:3
+msgid "Modern C++ solves this differently:"
+msgstr "现代 C++ 以不同的方式解决此问题："
+
+#: src/ownership/double-free-modern-cpp.md:5
+msgid ""
+"```c++\n"
+"std::string s1 = \"Cpp\";\n"
+"std::string s2 = s1;  // Duplicate the data in s1.\n"
+"```"
+msgstr ""
+"```c++\n"
+"std::string s1 = \"Cpp\";\n"
+"std::string s2 = s1;  // 复制 s1 中的数据。\n"
+"```"
+
+#: src/ownership/double-free-modern-cpp.md:10
+msgid ""
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+msgstr "`s1` 中的堆数据被复制，`s2` 获得自己的独立副本。"
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr "当 `s1` 和 `s2` 离开作用域时，它们会各自释放自己的内存。"
+
+#: src/ownership/double-free-modern-cpp.md:13
+msgid "Before copy-assignment:"
+msgstr "复制-赋值之前："
+
+#: src/ownership/double-free-modern-cpp.md:30
+msgid "After copy-assignment:"
+msgstr "复制-赋值之后："
+
+#: src/ownership/double-free-modern-cpp.md:57
+msgid ""
+"C++ has made a slightly different choice than Rust. Because `=` copies data, "
+"the string data has to be cloned. Otherwise we would get a double-free when "
+"either string goes out of scope."
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:61
+msgid ""
+"C++ also has [`std::move`](https://en.cppreference.com/w/cpp/utility/move), "
+"which is used to indicate when a value may be moved from. If the example had "
+"been `s2 = std::move(s1)`, no heap allocation would take place. After the "
+"move, `s1` would be in a valid but unspecified state. Unlike Rust, the "
+"programmer is allowed to keep using `s1`."
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:66
+msgid ""
+"Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
+"which is being copied or moved."
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:3
+msgid ""
+"When you pass a value to a function, the value is assigned to the function "
+"parameter. This transfers ownership:"
+msgstr "你将值传递给函数时，该值会被赋给函数 参数。这就转移了所有权："
+
+#: src/ownership/moves-function-calls.md:6
+msgid ""
+"```rust,editable\n"
+"fn say_hello(name: String) {\n"
+"    println!(\"Hello {name}\")\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let name = String::from(\"Alice\");\n"
+"    say_hello(name);\n"
+"    // say_hello(name);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn say_hello(name: String) {\n"
+"    println!(\"Hello {name}\")\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let name = String::from(\"Alice\");\n"
+"    say_hello(name);\n"
+"    // say_hello(name);\n"
+"}\n"
+"```"
+
+#: src/ownership/moves-function-calls.md:20
+msgid ""
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
+msgstr "首次调用 `say_hello` 时，`main` 便放弃了 `name` 的所有权。此后，`main` 中不能再使用 `name`。"
+
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr "在 `say_hello` 函数结束时，系统会释放为 `name` 分配的堆内存。"
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr "如果 `main` 将 `name` 作为引用 (`&name`) 传递过去，且 `say_hello` 接受作为参数的引用，则可保留所有权。"
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call "
+"(`name.clone()`)."
+msgstr "此外，`main` 也可以在首次调用时传递 `name` 的克隆 (`name.clone()`)。"
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr "相较于 C++，Rust 通过将移动语义设为默认值，并强制程序员进行显式克隆，更难以无意中创建副本。"
+
+#: src/ownership/copy-clone.md:3
+msgid ""
+"While move semantics are the default, certain types are copied by default:"
+msgstr "虽然移动语义是默认的，但默认情况下会复制某些类型："
+
+#: src/ownership/copy-clone.md:15
+msgid "These types implement the `Copy` trait."
+msgstr "这些类型实现了 `Copy` trait。"
+
+#: src/ownership/copy-clone.md:17
+msgid "You can opt-in your own types to use copy semantics:"
+msgstr "你可以选择自己的类型来使用复制语义："
+
+#: src/ownership/copy-clone.md:32
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr "赋值之后，`p1` 和 `p2` 都拥有自己的数据。"
+
+#: src/ownership/copy-clone.md:33
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr "我们还可以使用 `p1.clone()` 显式复制数据。"
+
+#: src/ownership/copy-clone.md:37
+msgid "Copying and cloning are not the same thing:"
+msgstr "复制和克隆是两码事："
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
+msgstr "复制是指内存区域的按位复制，不适用于任意对象。"
+
+#: src/ownership/copy-clone.md:40
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr "复制不允许自定义逻辑（不同于 C++ 中的复制构造函数）。"
+
+#: src/ownership/copy-clone.md:41
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr "克隆是一种更通用的操作，也允许通过实现 `Clone` trait 来自定义行为。"
+
+#: src/ownership/copy-clone.md:42
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr "复制不适用于实现 `Drop` trait 的类型。"
+
+#: src/ownership/copy-clone.md:44
+#: src/ownership/lifetimes-function-calls.md:30
+msgid "In the above example, try the following:"
+msgstr "在上述示例中，请尝试以下操作："
+
+#: src/ownership/copy-clone.md:46
+msgid ""
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
+msgstr "在 `struct Point` 中添加 `String` 字段。由于 `String` 不属于 `Copy` 类型，因此无法编译。"
+
+#: src/ownership/copy-clone.md:47
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr "从 `derive` 属性中移除 `Copy`。现在，编译器错误位于 `p1`的 `println!` 中。"
+
+#: src/ownership/copy-clone.md:48
+msgid "Show that it works if you clone `p1` instead."
+msgstr "指出如果你改为克隆 `p1`，则可按预期运行。"
+
+#: src/ownership/copy-clone.md:50
+msgid ""
+"If students ask about `derive`, it is sufficient to say that this is a way "
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
+msgstr ""
+"如果学员问起 `derive`，只需说这是一种 在编译时生成 Rust 代码的方法。在这种情况下，系统会生成 `Copy` 和 `Clone` "
+"trait 的默认实现。"
+
+#: src/ownership/borrowing.md:3
+msgid ""
+"Instead of transferring ownership when calling a function, you can let a "
+"function _borrow_ the value:"
+msgstr "调用函数时，你可以让 函数“借用”值，而不是转移所有权："
+
+#: src/ownership/borrowing.md:23
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr "`add` 函数“借用”两个点并返回一个新点。"
+
+#: src/ownership/borrowing.md:24
+msgid "The caller retains ownership of the inputs."
+msgstr "调用方会保留输入的所有权。"
+
+#: src/ownership/borrowing.md:28
+msgid "Notes on stack returns:"
+msgstr "关于栈返回的说明："
+
+#: src/ownership/borrowing.md:29
+#, fuzzy
+msgid ""
+"Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground](https://play.rust-lang.org/) or look at the "
+"assembly in [Godbolt](https://rust.godbolt.org/). In the \"DEBUG\" "
+"optimization level, the addresses should change, while they stay the same "
+"when changing to the \"RELEASE\" setting:"
+msgstr ""
+"证明从 `add` 返回的开销很低，因为编译器可以消除复制操作。更改上述代码以输出栈地址，并在 "
+"[Playground](https://play.rust-lang.org/) "
+"上运行它。在“调试”优化级别中，地址应发生变化，而在改成“发布”设置时保持不变："
+
+#: src/ownership/borrowing.md:50
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr "Rust 编译器能够执行返回值优化 (RVO)。"
+
+#: src/ownership/borrowing.md:51
+#, fuzzy
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
+"copy."
+msgstr ""
+"在 C++ 中，必须在语言规范中定义复制省略，因为构造函数可能会有附带效应。在 Rust 中，这完全不是问题。如果 RVO 未发生，Rust "
+"将始终执行简单且高效的 `memcpy` 复制。"
+
+#: src/ownership/shared-unique-borrows.md:3
+msgid "Rust puts constraints on the ways you can borrow values:"
+msgstr "Rust 限制了借用值的方式："
+
+#: src/ownership/shared-unique-borrows.md:5
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "在任何给定时间，你都可以有一个或多个 `&T` 值，或者"
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
+msgstr "你可以有且只有一个 `&mut T` 值。"
+
+#: src/ownership/shared-unique-borrows.md:26
+msgid ""
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr "上述代码无法编译，因为 `a` 同时作为可变值（通过 `c`）和不可变值（通过 `b`）被借用。"
+
+#: src/ownership/shared-unique-borrows.md:27
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr "将`b` 的 `println!` 语句移到引入 `c` 的作用域之前，这段代码就可以编译。"
+
+#: src/ownership/shared-unique-borrows.md:28
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
+msgstr ""
+"这样更改后，编译器会发现 `b` 只在通过 `c` 对 `a` 进行新可变借用之前使用过。这是借用检查器的一个功能，名为“非词法作用域生命周期”。"
+
+#: src/ownership/lifetimes.md:3
+msgid "A borrowed value has a _lifetime_:"
+msgstr "借用的值是有“生命周期”的："
+
+#: src/ownership/lifetimes.md:5
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
+msgstr "生命周期可以是隐式的：add(p1: &Point, p2: &Point) -> Point\\`。"
+
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr "生命周期也可以是显式的：`&'a Point`、`&'document str`。"
+
+#: src/ownership/lifetimes.md:7
+#: src/ownership/lifetimes-function-calls.md:24
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr "将 `&'a Point` 读取为“借用的 `Point，至少 在 `a\\` 生命周期内有效。"
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr "生命周期始终由编译器推断出来：你不能自行 分配生命周期。"
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr "生命周期注释会创建约束条件；编译器会验证 是否存在有效的解决方案。"
+
+#: src/ownership/lifetimes.md:13
+#, fuzzy
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows lifetimes to be elided in most cases with [a few simple "
+"rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgstr ""
+"必须完全指定函数参数和返回值的生命周期， 但 Rust 允许在大多数情况下通过\\[一些简单的 "
+"规则\\](https://doc.rust-lang.org/nomicon/lifetime-elision.html）来省略此操作。"
+
+#: src/ownership/lifetimes-function-calls.md:3
+msgid ""
+"In addition to borrowing its arguments, a function can return a borrowed "
+"value:"
+msgstr "除了借用其参数之外，函数还可以返回借用的值："
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`'a` 是一个泛型形参，由编译器推断出来。"
+
+#: src/ownership/lifetimes-function-calls.md:23
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr "以 `'` 和 `'a` 开头的生命周期是典型的默认名称。"
+
+#: src/ownership/lifetimes-function-calls.md:26
+msgid "The _at least_ part is important when parameters are in different scopes."
+msgstr "当参数在不同的作用域时，“至少”部分至关重要。"
+
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
+"resulting in the following code:"
+msgstr "将 `p2` 和 `p3` 的声明移至新作用域 (`{ ... }`)，以产生以下代码："
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr "请注意：由于 `p3` 的生命周期比 `p2` 长，因此无法编译。"
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+"重置工作区，然后将函数签名更改为 `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b "
+"Point`。这不会被编译，因为 `'a` 和 `'b` 生命周期之间的关系不明确。"
+
+#: src/ownership/lifetimes-function-calls.md:55
+msgid "Another way to explain it:"
+msgstr "另一种解释方式："
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr "对两个值的两个引用被一个函数借用，该函数返回 另一个引用。"
+
+#: src/ownership/lifetimes-function-calls.md:58
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr "它必须是来自这两个输入中的一个（或来自一个全局变量）。"
+
+#: src/ownership/lifetimes-function-calls.md:59
+msgid ""
+"Which one is it? The compiler needs to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr "是哪一个呢？编译器需要知道这一点，因此在调用点，返回的引用 的使用时间不会超过引用的来源中的变量。"
+
+#: src/ownership/lifetimes-data-structures.md:3
+msgid ""
+"If a data type stores borrowed data, it must be annotated with a lifetime:"
+msgstr "如果数据类型存储了借用的数据，则必须对其添加生命周期注释："
+
+#: src/ownership/lifetimes-data-structures.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy "
+"dog.\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(text);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy "
+"dog.\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(text);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/lifetimes-data-structures.md:25
+msgid ""
+"In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data."
+msgstr ""
+"在上述示例中，`Highlight` 注释会强制包含 `&str` 的底层数据的生命周期至少与使用该数据的任何 `Highlight` 实例一样长。"
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr "如果 `text` 在 `fox`（或 `dog`）的生命周期结束前被消耗，借用检查器将抛出一个错误。"
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr "借用数据的类型会迫使用户保留原始数据。这对于创建轻量级视图很有用，但通常会使它们更难使用。"
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr "如有可能，让数据结构直接拥有自己的数据。"
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"一些包含多个引用的结构可以有多个生命周期注释。除了结构体本身的生命周期之外，如果需要描述引用之间的生命周期关系，则可能需要这样做。这些都是非常高级的用例。"
+
+#: src/structs.md:3
+msgid "Like C and C++, Rust has support for custom structs:"
+msgstr "与 C 和 C++ 一样，Rust 支持自定义结构体："
+
+#: src/structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    peter.age = 28;\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    let jackie = Person {\n"
+"        name: String::from(\"Jackie\"),\n"
+"        ..peter\n"
+"    };\n"
+"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs.md:33
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
+msgid ""
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
+"old struct without having to explicitly type it all out. It must always be "
+"the last element."
+msgstr ""
+
+#: src/structs/tuple-structs.md:3
+msgid "If the field names are unimportant, you can use a tuple struct:"
+msgstr "如果字段名称不重要，您可以使用元组结构体："
+
+#: src/structs/tuple-structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn main() {\n"
+"    let p = Point(17, 23);\n"
+"    println!(\"({}, {})\", p.0, p.1);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/tuple-structs.md:14
+msgid "This is often used for single-field wrappers (called newtypes):"
+msgstr "这通常用于单字段封装容器（称为 newtype）："
+
+#: src/structs/tuple-structs.md:16
+msgid ""
+"```rust,editable,compile_fail\n"
+"struct PoundsOfForce(f64);\n"
+"struct Newtons(f64);\n"
+"\n"
+"fn compute_thruster_force() -> PoundsOfForce {\n"
+"    todo!(\"Ask a rocket scientist at NASA\")\n"
+"}\n"
+"\n"
+"fn set_thruster_force(force: Newtons) {\n"
+"    // ...\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let force = compute_thruster_force();\n"
+"    set_thruster_force(force);\n"
+"}\n"
+"\n"
+"```"
+msgstr ""
+
+#: src/structs/tuple-structs.md:37
+msgid ""
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
+msgstr "如需对基元类型中的值的额外信息进行编码，使用 newtype 是一种非常好的方式，例如："
+
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr "数字会以某些单位来衡量：上方示例中为 `Newtons`。"
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"值在创建时已通过一些验证，因此您不再需要在每次使用时都再次验证它：`PhoneNumber(String)` 或 `OddNumber(u32)`。"
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr "展示如何通过访问 newtype 中的单个字段，将 `f64` 值添加到 `Newtons` 类型。"
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr "Rust 通常不喜欢不明确的内容，例如自动解封或将布尔值用作整数。"
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics)."
+msgstr "运算符过载在第 3 天（泛型）讨论。"
+
+#: src/structs/tuple-structs.md:43
+msgid ""
+"The example is a subtle reference to the [Mars Climate "
+"Orbiter](https://en.wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
+msgstr ""
+"此示例巧妙地引用了[火星气候探测者号](https://zh.wikipedia.org/wiki/%E7%81%AB%E6%98%9F%E6%B0%A3%E5%80%99%E6%8E%A2%E6%B8%AC%E8%80%85%E8%99%9F) "
+"的失败事故。"
+
+#: src/structs/field-shorthand.md:3
+msgid ""
+"If you already have variables with the right names, then you can create the "
+"struct using a shorthand:"
+msgstr "如果您已有名称正确的变量，则可以使用简写形式创建结构体："
+
+#: src/structs/field-shorthand.md:6
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Person {\n"
+"        Person { name, age }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
+"    println!(\"{peter:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:27
+msgid ""
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Person::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Person::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid "Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
+
+#: src/methods.md:3
+msgid ""
+"Rust allows you to associate functions with your new types. You do this with "
+"an `impl` block:"
+msgstr ""
+
+#: src/methods.md:6
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"\n"
+"impl Person {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Hello, my name is {}\", self.name);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    peter.say_hello();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/methods.md:31
+msgid "It can be helpful to introduce methods by comparing them to functions."
+msgstr ""
+
+#: src/methods.md:32
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+
+#: src/methods.md:33
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+
+#: src/methods.md:34
+msgid "Point out the use of the keyword `self`, a method receiver."
+msgstr ""
+
+#: src/methods.md:35
+msgid ""
+"Show that it is an abbreviated term for `self: Self` and perhaps show how "
+"the struct name could also be used."
+msgstr ""
+
+#: src/methods.md:36
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+
+#: src/methods.md:37
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+
+#: src/methods.md:38
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+
+#: src/methods.md:39
+msgid "We describe the distinction between method receivers next."
+msgstr ""
+
+#: src/methods/receiver.md:3
+msgid ""
+"The `&self` above indicates that the method borrows the object immutably. "
+"There are other possible receivers for a method:"
+msgstr ""
+
+#: src/methods/receiver.md:6
+msgid ""
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:8
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:10
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+
+#: src/methods/receiver.md:14
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+
+#: src/methods/receiver.md:15
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
+msgstr ""
+
+#: src/methods/receiver.md:18
+msgid ""
+"Beyond variants on `self`, there are also [special wrapper "
+"types](https://doc.rust-lang.org/reference/special-types-and-traits.html) "
+"allowed to be receiver types, such as `Box<Self>`."
+msgstr ""
+
+#: src/methods/receiver.md:24
+msgid ""
+"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
+msgstr ""
+
+#: src/methods/example.md:3
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Race {\n"
+"    name: String,\n"
+"    laps: Vec<i32>,\n"
+"}\n"
+"\n"
+"impl Race {\n"
+"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
+"        Race { name: String::from(name), laps: Vec::new() }\n"
+"    }\n"
+"\n"
+"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
+"access to self\n"
+"        self.laps.push(lap);\n"
+"    }\n"
+"\n"
+"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
+"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
+"        for (idx, lap) in self.laps.iter().enumerate() {\n"
+"            println!(\"Lap {idx}: {lap} sec\");\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn finish(self) {  // Exclusive ownership of self\n"
+"        let total = self.laps.iter().sum::<i32>();\n"
+"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"total);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
+"    race.add_lap(70);\n"
+"    race.add_lap(68);\n"
+"    race.print_laps();\n"
+"    race.add_lap(71);\n"
+"    race.print_laps();\n"
+"    race.finish();\n"
+"    // race.add_lap(42);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/methods/example.md:47
+msgid "All four methods here use a different method receiver."
+msgstr ""
+
+#: src/methods/example.md:48
+msgid ""
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+
+#: src/methods/example.md:49
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+
+#: src/methods/example.md:50
+msgid ""
+"Note that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+
+#: src/methods/example.md:51
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
+msgstr ""
+
+#: src/exercises/day-2/morning.md:1
+msgid "Day 2: Morning Exercises"
+msgstr "第二天上午习题"
+
+#: src/exercises/day-2/morning.md:3
+msgid "We will look at implementing methods in two contexts:"
+msgstr "我们将考虑以下两种场景："
+
+#: src/exercises/day-2/morning.md:5
+msgid "Storing books and querying the collection"
+msgstr ""
+
+#: src/exercises/day-2/morning.md:7
+msgid "Keeping track of health statistics for patients"
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:3
+msgid ""
+"We will learn much more about structs and the `Vec<T>` type tomorrow. For "
+"now, you just need to know part of its API:"
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut vec = vec![10, 20];\n"
+"    vec.push(30);\n"
+"    let midpoint = vec.len() / 2;\n"
+"    println!(\"middle value: {}\", vec[midpoint]);\n"
+"    for item in &vec {\n"
+"        println!(\"item: {item}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:18
+#, fuzzy
+msgid ""
+"Use this to model a library's book collection. Copy the code below to "
+"<https://play.rust-lang.org/> and update the types to make it compile:"
+msgstr "将下面的代码复制到 <https://play.rust-lang.org/> 并实现上述函数："
+
+#: src/exercises/day-2/book-library.md:21
+msgid ""
+"```rust,should_panic\n"
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}\n"
+"\n"
+"struct Book {\n"
+"    title: String,\n"
+"    year: u16,\n"
+"}\n"
+"\n"
+"impl Book {\n"
+"    // This is a constructor, used below.\n"
+"    fn new(title: &str, year: u16) -> Book {\n"
+"        Book {\n"
+"            title: String::from(title),\n"
+"            year,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// Implement the methods below. Notice how the `self` parameter\n"
+"// changes type to indicate the method's required level of ownership\n"
+"// over the object:\n"
+"//\n"
+"// - `&self` for shared read-only access,\n"
+"// - `&mut self` for unique and mutable access,\n"
+"// - `self` for unique access by value.\n"
+"impl Library {\n"
+"    fn new() -> Library {\n"
+"        todo!(\"Initialize and return a `Library` value\")\n"
+"    }\n"
+"\n"
+"    fn len(&self) -> usize {\n"
+"        todo!(\"Return the length of `self.books`\")\n"
+"    }\n"
+"\n"
+"    fn is_empty(&self) -> bool {\n"
+"        todo!(\"Return `true` if `self.books` is empty\")\n"
+"    }\n"
+"\n"
+"    fn add_book(&mut self, book: Book) {\n"
+"        todo!(\"Add a new book to `self.books`\")\n"
+"    }\n"
+"\n"
+"    fn print_books(&self) {\n"
+"        todo!(\"Iterate over `self.books` and print each book's title and "
+"year\")\n"
+"    }\n"
+"\n"
+"    fn oldest_book(&self) -> Option<&Book> {\n"
+"        todo!(\"Return a reference to the oldest book (if any)\")\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut library = Library::new();\n"
+"\n"
+"    println!(\n"
+"        \"The library is empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"\n"
+"    println!(\n"
+"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.print_books();\n"
+"\n"
+"    match library.oldest_book() {\n"
+"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
+"        None => println!(\"The library is empty!\"),\n"
+"    }\n"
+"\n"
+"    println!(\"The library has {} books\", library.len());\n"
+"    library.print_books();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:3
+msgid ""
+"You're working on implementing a health-monitoring system. As part of that, "
+"you need to keep track of users' health statistics."
+msgstr "你正在实现一个健康监控系统。作为其中的一部分，你需要对用户的健康统计数据进行追踪。"
+
+#: src/exercises/day-2/health-statistics.md:6
+msgid ""
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
+msgstr ""
+"`User` 结构体的定义和 `impl` 块中一些函数的框架已经给出。你的目标是实现在 `impl` 块中定义的 `User` `struct` "
+"的方法。"
+
+#: src/exercises/day-2/health-statistics.md:10
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
+"methods:"
+msgstr "将以下代码复制到 <https://play.rust-lang.org/>，并填充缺失的方法："
+
+#: src/exercises/day-2/health-statistics.md:13
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    height: f32,\n"
+"    visit_count: usize,\n"
+"    last_blood_pressure: Option<(u32, u32)>,\n"
+"}\n"
+"\n"
+"pub struct Measurements {\n"
+"    height: f32,\n"
+"    blood_pressure: (u32, u32),\n"
+"}\n"
+"\n"
+"pub struct HealthReport<'a> {\n"
+"    patient_name: &'a str,\n"
+"    visit_count: u32,\n"
+"    height_change: f32,\n"
+"    blood_pressure_change: Option<(i32, i32)>,\n"
+"}\n"
+"\n"
+"impl User {\n"
+"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
+"        todo!(\"Create a new User instance\")\n"
+"    }\n"
+"\n"
+"    pub fn name(&self) -> &str {\n"
+"        todo!(\"Return the user's name\")\n"
+"    }\n"
+"\n"
+"    pub fn age(&self) -> u32 {\n"
+"        todo!(\"Return the user's age\")\n"
+"    }\n"
+"\n"
+"    pub fn height(&self) -> f32 {\n"
+"        todo!(\"Return the user's height\")\n"
+"    }\n"
+"\n"
+"    pub fn doctor_visits(&self) -> u32 {\n"
+"        todo!(\"Return the number of time the user has visited the "
+"doctor\")\n"
+"    }\n"
+"\n"
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        todo!(\"Set the user's age\")\n"
+"    }\n"
+"\n"
+"    pub fn set_height(&mut self, new_height: f32) {\n"
+"        todo!(\"Set the user's height\")\n"
+"    }\n"
+"\n"
+"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
+"HealthReport {\n"
+"        todo!(\"Update a user's statistics based on measurements from a "
+"visit to the doctor\")\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_height() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.height(), 155.2);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_set_age() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.age(), 32);\n"
+"    bob.set_age(33);\n"
+"    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_visit() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.doctor_visits(), 0);\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (120, 80),\n"
+"    });\n"
+"    assert_eq!(report.patient_name, \"Bob\");\n"
+"    assert_eq!(report.visit_count, 1);\n"
+"    assert_eq!(report.blood_pressure_change, None);\n"
+"\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (115, 76),\n"
+"    });\n"
+"\n"
+"    assert_eq!(report.visit_count, 2);\n"
+"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std.md:3
+msgid ""
+"Rust comes with a standard library which helps establish a set of common "
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
+msgstr ""
+"Rust 附带一个标准库，此库有助于建立一个供 Rust 库和程序 使用的常用类型集。这样一来，两个库便可顺畅地搭配运作， 因为它们使用相同的 "
+"`String` 类型。"
+
+#: src/std.md:7
+msgid "The common vocabulary types include:"
+msgstr "常见的词汇类型包括："
+
+#: src/std.md:9
+msgid ""
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
+msgstr ""
+"[`Option` 和 `Result`](std/option-result.md) 类型：用于可选值和 "
+"[错误处理](error-handling.md)。"
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr "[`String`](std/string.md)：用于自有数据的默认字符串类型。"
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr "[`Vec`](std/vec.md)：标准的可扩展矢量。"
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr "[`HashMap`](std/hashmap.md)：采用可配置哈希算法的哈希映射 类型。"
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr "[`Box`](std/box.md)：适用于堆分配数据的自有指针。"
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
+msgstr "[`Rc`](std/rc.md)：适用于堆分配数据的共享引用计数指针。"
+
+#: src/std.md:25
+msgid ""
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
+msgstr "Rust 实际上含有多个层级的标准库，分别是 `core`、`alloc` 和 `std`。"
+
+#: src/std.md:26
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr "`core` 包括最基本的类型与函数，这些类型与函数不依赖于 `libc`、分配器 或是否存在操作系统。"
+
+#: src/std.md:28
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr "`alloc` 包括需要全局堆分配器的类型，例如 `Vec`、`Box` 和 `Arc`。"
+
+#: src/std.md:29
+msgid "Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr "嵌入式 Rust 应用通常只使用 `core`，偶尔会使用 `alloc`。"
+
+#: src/std/option-result.md:1
+msgid "`Option` and `Result`"
+msgstr "`Option` 和 `Result`"
+
+#: src/std/option-result.md:3
+msgid "The types represent optional data:"
+msgstr "这些类型表示可选数据："
+
+#: src/std/option-result.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let numbers = vec![10, 20, 30];\n"
+"    let first: Option<&i8> = numbers.first();\n"
+"    println!(\"first: {first:?}\");\n"
+"\n"
+"    let arr: Result<[i8; 3], Vec<i8>> = numbers.try_into();\n"
+"    println!(\"arr: {arr:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();\n"
+"\n"
+"    while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/std/option-result.md:18
+msgid "`Option` and `Result` are widely used not just in the standard library."
+msgstr "`Option` 和 `Result` 的使用范围很广，不局限于标准库。"
+
+#: src/std/option-result.md:19
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "相较于 `&T`，`Option<&T>` 的空间开销为零。"
+
+#: src/std/option-result.md:20
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr "`Result` 是用于实现错误处理的标准类型，我们将在第 3 天的课程中介绍。"
+
+#: src/std/option-result.md:21
+msgid ""
+"`try_into` attempts to convert the vector into a fixed-sized array. This can "
+"fail:"
+msgstr ""
+
+#: src/std/option-result.md:22
+msgid ""
+"If the vector has the right size, `Result::Ok` is returned with the array."
+msgstr ""
+
+#: src/std/option-result.md:23
+msgid "Otherwise, `Result::Err` is returned with the original vector."
+msgstr ""
+
+#: src/std/string.md:3
+msgid ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
+msgstr ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) "
+"是标准堆分配的可扩容 UTF-8 字符串缓冲区："
+
+#: src/std/string.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::new();\n"
+"    s1.push_str(\"Hello\");\n"
+"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());\n"
+"\n"
+"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
+"    s2.push_str(&s1);\n"
+"    s2.push('!');\n"
+"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());\n"
+"\n"
+"    let s3 = String::from(\"🇨🇭\");\n"
+"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
+"             s3.chars().count());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/string.md:22
+msgid ""
+"`String` implements [`Deref<Target = "
+"str>`](https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str), "
+"which means that you can call all `str` methods on a `String`."
+msgstr ""
+"`String` 会实现 [`Deref<Target = "
+"str>`](https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str)，这意味着您可以 "
+"对 `String` 调用所有 `str` 方法。"
+
+#: src/std/string.md:30
+msgid ""
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme "
+"clusters](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
+"operations you see supported on vectors are also supported on `String`, but "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
+"boundaries or not."
+msgstr ""
+
+#: src/std/vec.md:1
+msgid "`Vec`"
+msgstr "`Vec`"
+
+#: src/std/vec.md:3
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
+msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 是标准的可调整大小堆分配缓冲区："
+
+#: src/std/vec.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut v1 = Vec::new();\n"
+"    v1.push(42);\n"
+"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());\n"
+"\n"
+"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
+"    v2.extend(v1.iter());\n"
+"    v2.push(9999);\n"
+"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
+"\n"
+"    // Canonical macro to initialize a vector with elements.\n"
+"    let mut v3 = vec![0, 0, 1, 2, 3, 4];\n"
+"\n"
+"    // Retain only the even elements.\n"
+"    v3.retain(|x| x % 2 == 0);\n"
+"    println!(\"{v3:?}\");\n"
+"\n"
+"    // Remove consecutive duplicates.\n"
+"    v3.dedup();\n"
+"    println!(\"{v3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/vec.md:29
+msgid ""
+"`Vec` implements [`Deref<Target = "
+"[T]>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-%5BT%5D), "
+"which means that you can call slice methods on a `Vec`."
+msgstr ""
+"`Vec` 会实现 [`Deref<Target = "
+"[T]>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-%5BT%5D)，这意味着您可以对 "
+"`Vec` 调用 slice 方法。"
+
+#: src/std/vec.md:37
+msgid ""
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
+msgstr ""
+
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1
+#: src/bare-metal/no_std.md:46
+msgid "`HashMap`"
+msgstr "`HashMap`"
+
+#: src/std/hashmap.md:3
+msgid "Standard hash map with protection against HashDoS attacks:"
+msgstr "标准的哈希映射，内含针对 HashDoS 攻击的保护措施："
+
+#: src/std/hashmap.md:5
+msgid ""
+"```rust,editable\n"
+"use std::collections::HashMap;\n"
+"\n"
+"fn main() {\n"
+"    let mut page_counts = HashMap::new();\n"
+"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
+"207);\n"
+"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
+"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);\n"
+"\n"
+"    if !page_counts.contains_key(\"Les Misérables\") {\n"
+"        println!(\"We know about {} books, but not Les Misérables.\",\n"
+"                 page_counts.len());\n"
+"    }\n"
+"\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        match page_counts.get(book) {\n"
+"            Some(count) => println!(\"{book}: {count} pages\"),\n"
+"            None => println!(\"{book} is unknown.\")\n"
+"        }\n"
+"    }\n"
+"\n"
+"    // Use the .entry() method to insert a value if nothing is found.\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        let page_count: &mut i32 = "
+"page_counts.entry(book.to_string()).or_insert(0);\n"
+"        *page_count += 1;\n"
+"    }\n"
+"\n"
+"    println!(\"{page_counts:#?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:38
+msgid ""
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); "
+"N]>`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), "
+"which allows us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields "
+"key-value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
+"compiles. Where do you think we might run into issues?"
+msgstr ""
+
+#: src/std/hashmap.md:64
+msgid ""
+"This type has several \"method-specific\" return types, such as "
+"`std::collections::hash_map::Keys`. These types often appear in searches of "
+"the Rust docs. Show students the docs for this type, and the helpful link "
+"back to the `keys` method."
+msgstr ""
+
+#: src/std/box.md:1
+msgid "`Box`"
+msgstr "`Box`"
+
+#: src/std/box.md:3
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 是指向堆上数据的自有指针："
+
+#: src/std/box.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let five = Box::new(5);\n"
+"    println!(\"five: {}\", *five);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/box.md:26
+msgid ""
+"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
+"methods from `T` directly on a "
+"`Box<T>`](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion)."
+msgstr ""
+"`Box<T>` 会实现 `Deref<Target = T>`，这意味着您可以[直接在 `Box<T>` 上通过 `T` "
+"调用相应方法](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion)。"
+
+#: src/std/box.md:34
+msgid ""
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
+msgstr "在 C++ 中，`Box` 与 `std::unique_ptr` 类似，除了它一定会不为 null 以外。"
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr "在上面的示例中，因为有 `Deref`，您甚至可以在 `println!` 语句中省略 `*`。"
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr "在以下情况下，`Box` 可能会很实用："
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr "在编译时间遇到无法知晓大小的类型，但 Rust 编译器需要知道确切大小。"
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr "想要转让大量数据的所有权。为避免在堆栈上复制大量数据，请改为将数据存储在 `Box` 中的堆上，以便仅移动指针。"
+
+#: src/std/box-recursive.md:1
+msgid "Box with Recursive Data Structures"
+msgstr "包含递归数据结构的 Box"
+
+#: src/std/box-recursive.md:3
+msgid ""
+"Recursive data types or data types with dynamic sizes need to use a `Box`:"
+msgstr "递归数据类型或具有动态大小的数据类型需要使用 `Box`："
+
+#: src/std/box-recursive.md:5
+#: src/std/box-niche.md:3
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"enum List<T> {\n"
+"    Cons(T, Box<List<T>>),\n"
+"    Nil,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, "
+"Box::new(List::Nil))));\n"
+"    println!(\"{list:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/box-recursive.md:18
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                         :     :                                            "
+"   :\n"
+":    list                 :     :                                            "
+"   :\n"
+":   +------+----+----+    :     :    +------+----+----+    "
+"+------+----+----+   :\n"
+":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
+"|   :\n"
+":   +------+----+----+    :     :    +------+----+----+    "
+"+------+----+----+   :\n"
+":                         :     :                                            "
+"   :\n"
+":                         :     :                                            "
+"   :\n"
+"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
+msgstr ""
+
+#: src/std/box-recursive.md:33
+#, fuzzy
+msgid ""
+"If `Box` was not used and we attempted to embed a `List` directly into the "
+"`List`, the compiler would not compute a fixed size of the struct in memory "
+"(`List` would be of infinite size)."
+msgstr ""
+"如果这里未使用 `Box`，且我们曾尝试将一个 `List` 直接嵌入 `List`， 编译器就不会计算内存中结构体的固定大小，结构体看起来会像是无限大。"
+
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr "`Box` 大小与一般指针相同，并且只会指向堆中的下一个 `List` 元素， 因此可以解决这个问题。"
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
+"将 `Box` 从 List 定义中移除后，画面上会显示编译器错误。如果您看到“Recursive with "
+"indirection”错误消息，这是在提示您使用 Box 或其他类型的引用，而不是直接储存值。"
+
+#: src/std/box-niche.md:16
+msgid ""
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
+"allows the compiler to optimize the memory layout:"
+msgstr "`Box` 不得为空，因此指针始终有效且非 `null`。这样， 编译器就可以优化内存布局："
+
+#: src/std/box-niche.md:19
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"-.\n"
+":                         :     :                                            "
+" :\n"
+":    list                 :     :                                            "
+" :\n"
+":   +----+----+           :     :    +----+----+    +----+------+            "
+" :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |            "
+" :\n"
+":   +----+----+           :     :    +----+----+    +----+------+            "
+" :\n"
+":                         :     :                                            "
+" :\n"
+":                         :     :                                            "
+" :\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
+"```"
+msgstr ""
+
+#: src/std/rc.md:1
+msgid "`Rc`"
+msgstr "`Rc`"
+
+#: src/std/rc.md:3
+msgid ""
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a "
+"reference-counted shared pointer. Use this when you need to refer to the "
+"same data from multiple places:"
+msgstr ""
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) "
+"是引用计数的共享指针。如果您需要从多个位置 引用相同的数据，请使用此指针："
+
+#: src/std/rc.md:6
+msgid ""
+"```rust,editable\n"
+"use std::rc::Rc;\n"
+"\n"
+"fn main() {\n"
+"    let mut a = Rc::new(10);\n"
+"    let mut b = Rc::clone(&a);\n"
+"\n"
+"    println!(\"a: {a}\");\n"
+"    println!(\"b: {b}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/rc.md:18
+#, fuzzy
+msgid ""
+"See [`Arc`](../concurrency/shared_state/arc.md) and "
+"[`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+"如果您在多线程情境中，请参阅 [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)。"
+
+#: src/std/rc.md:19
+msgid ""
+"You can _downgrade_ a shared pointer into a "
+"[`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) pointer to "
+"create cycles that will get dropped."
+msgstr ""
+"您可以将共享指针_降级_为 [`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) "
+"指针， 以便创建之后会被舍弃的循环引用。"
+
+#: src/std/rc.md:29
+msgid ""
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr "`Rc` 的计数可确保只要有引用，内含的值就会保持有效。"
+
+#: src/std/rc.md:30
+msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
+msgstr ""
+
+#: src/std/rc.md:31
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"increases the reference count. Does not make a deep clone and can generally "
+"be ignored when looking for performance issues in code."
+msgstr "`Rc::clone` 的成本很低：这个做法会创建指向相同分配的指针，并增加引用计数，而不会产生深层的克隆，排查代码性能问题时通常可以忽略。"
+
+#: src/std/rc.md:32
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr "`make_mut` 实际上会在必要时克隆内部值（“clone-on-write”），并返回可变的引用。"
+
+#: src/std/rc.md:33
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr "使用 `Rc::strong_count` 可查看引用计数。"
+
+#: src/std/rc.md:34
+#, fuzzy
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`, "
+"on the next slide)."
+msgstr "`Rc::downgrade` 会向您提供 _弱引用计数_ 对象， 以便创建之后会被适当舍弃的周期（可能会与 `RefCell` 组合）。"
+
+#: src/std/cell.md:1
+#, fuzzy
+msgid "`Cell` and `RefCell`"
+msgstr "Cell/RefCell"
+
+#: src/std/cell.md:3
+#, fuzzy
+msgid ""
+"[`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and "
+"[`RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html) "
+"implement what Rust calls _interior mutability:_ mutation of values in an "
+"immutable context."
+msgstr ""
+"您可以使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` "
+"来源进行抽象化处理："
+
+#: src/std/cell.md:8
+msgid ""
+"`Cell` is typically used for simple types, as it requires copying or moving "
+"values. More complex interior types typically use `RefCell`, which tracks "
+"shared and exclusive references at runtime and panics if they are misused."
+msgstr ""
+
+#: src/std/cell.md:12
+msgid ""
+"```rust,editable\n"
+"use std::cell::RefCell;\n"
+"use std::rc::Rc;\n"
+"\n"
+"#[derive(Debug, Default)]\n"
+"struct Node {\n"
+"    value: i64,\n"
+"    children: Vec<Rc<RefCell<Node>>>,\n"
+"}\n"
+"\n"
+"impl Node {\n"
+"    fn new(value: i64) -> Rc<RefCell<Node>> {\n"
+"        Rc::new(RefCell::new(Node { value, ..Node::default() }))\n"
+"    }\n"
+"\n"
+"    fn sum(&self) -> i64 {\n"
+"        self.value + self.children.iter().map(|c| "
+"c.borrow().sum()).sum::<i64>()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let root = Node::new(1);\n"
+"    root.borrow_mut().children.push(Node::new(5));\n"
+"    let subtree = Node::new(10);\n"
+"    subtree.borrow_mut().children.push(Node::new(11));\n"
+"    subtree.borrow_mut().children.push(Node::new(12));\n"
+"    root.borrow_mut().children.push(subtree);\n"
+"\n"
+"    println!(\"graph: {root:#?}\");\n"
+"    println!(\"graph sum: {}\", root.borrow().sum());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/cell.md:47
+msgid ""
+"If we were using `Cell` instead of `RefCell` in this example, we would have "
+"to move the `Node` out of the `Rc` to push children, then move it back in. "
+"This is safe because there's always one, un-referenced value in the cell, "
+"but it's not ergonomic."
+msgstr ""
+
+#: src/std/cell.md:48
+msgid ""
+"To do anything with a Node, you must call a `RefCell` method, usually "
+"`borrow` or `borrow_mut`."
+msgstr ""
+
+#: src/std/cell.md:49
+msgid ""
+"Demonstrate that reference loops can be created by adding `root` to "
+"`subtree.children` (don't try to print it!)."
+msgstr ""
+
+#: src/std/cell.md:50
+msgid ""
+"To demonstrate a runtime panic, add a `fn inc(&mut self)` that increments "
+"`self.value` and calls the same method on its children. This will panic in "
+"the presence of the reference loop, with `thread 'main' panicked at 'already "
+"borrowed: BorrowMutError'`."
+msgstr ""
+
+#: src/modules.md:3
+msgid "We have seen how `impl` blocks let us namespace functions to a type."
+msgstr ""
+
+#: src/modules.md:5
+msgid "Similarly, `mod` lets us namespace types and functions:"
+msgstr ""
+
+#: src/modules.md:7
+msgid ""
+"```rust,editable\n"
+"mod foo {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the foo module\");\n"
+"    }\n"
+"}\n"
+"\n"
+"mod bar {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the bar module\");\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    foo::do_something();\n"
+"    bar::do_something();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/modules.md:28
+msgid ""
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
+msgstr ""
+
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr ""
+
+#: src/modules/visibility.md:3
+msgid "Modules are a privacy boundary:"
+msgstr ""
+
+#: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr ""
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr ""
+
+#: src/modules/visibility.md:7
+msgid ""
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
+msgstr ""
+
+#: src/modules/visibility.md:10
+msgid ""
+"```rust,editable\n"
+"mod outer {\n"
+"    fn private() {\n"
+"        println!(\"outer::private\");\n"
+"    }\n"
+"\n"
+"    pub fn public() {\n"
+"        println!(\"outer::public\");\n"
+"    }\n"
+"\n"
+"    mod inner {\n"
+"        fn private() {\n"
+"            println!(\"outer::inner::private\");\n"
+"        }\n"
+"\n"
+"        pub fn public() {\n"
+"            println!(\"outer::inner::public\");\n"
+"            super::private();\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    outer::public();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/modules/visibility.md:39
+msgid "Use the `pub` keyword to make modules public."
+msgstr ""
+
+#: src/modules/visibility.md:41
+msgid ""
+"Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
+"of public visibility."
+msgstr ""
+
+#: src/modules/visibility.md:43
+msgid ""
+"See the [Rust "
+"Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+msgstr ""
+
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
+msgstr ""
+
+#: src/modules/paths.md:3
+msgid "Paths are resolved as follows:"
+msgstr ""
+
+#: src/modules/paths.md:5
+msgid "As a relative path:"
+msgstr ""
+
+#: src/modules/paths.md:6
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+
+#: src/modules/paths.md:7
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr ""
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr ""
+
+#: src/modules/paths.md:13
+msgid ""
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
+msgstr ""
+
+#: src/modules/filesystem.md:3
+msgid ""
+"Omitting the module content will tell Rust to look for it in another file:"
+msgstr ""
+
+#: src/modules/filesystem.md:9
+msgid ""
+"This tells rust that the `garden` module content is found at "
+"`src/garden.rs`. Similarly, a `garden::vegetables` module can be found at "
+"`src/garden/vegetables.rs`."
+msgstr ""
+
+#: src/modules/filesystem.md:12
+msgid "The `crate` root is in:"
+msgstr ""
+
+#: src/modules/filesystem.md:14
+msgid "`src/lib.rs` (for a library crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:15
+msgid "`src/main.rs` (for a binary crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:17
+msgid ""
+"Modules defined in files can be documented, too, using \"inner doc "
+"comments\". These document the item that contains them -- in this case, a "
+"module."
+msgstr ""
+
+#: src/modules/filesystem.md:20
+msgid ""
+"```rust,editable,compile_fail\n"
+"//! This module implements the garden, including a highly performant "
+"germination\n"
+"//! implementation.\n"
+"\n"
+"// Re-export types from this module.\n"
+"pub use seeds::SeedPacket;\n"
+"pub use garden::Garden;\n"
+"\n"
+"/// Sow the given seed packets.\n"
+"pub fn sow(seeds: Vec<SeedPacket>) { todo!() }\n"
+"\n"
+"/// Harvest the produce in the garden that is ready.\n"
+"pub fn harvest(garden: &mut Garden) { todo!() }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:37
+msgid ""
+"Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
+"`module.rs`, and this is still a working alternative for editions after 2018."
+msgstr ""
+
+#: src/modules/filesystem.md:39
+msgid ""
+"The main reason to introduce `filename.rs` as alternative to "
+"`filename/mod.rs` was because many files named `mod.rs` can be hard to "
+"distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:42
+msgid "Deeper nesting can use folders, even if the main module is a file:"
+msgstr ""
+
+#: src/modules/filesystem.md:52
+msgid ""
+"The place rust will look for modules can be changed with a compiler "
+"directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:54
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module;\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:59
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
+msgstr ""
+
+#: src/exercises/day-2/afternoon.md:1
+msgid "Day 2: Afternoon Exercises"
+msgstr "第二天下午习题"
+
+#: src/exercises/day-2/afternoon.md:3
+msgid "The exercises for this afternoon will focus on strings and iterators."
+msgstr "今天下午的习题将重点关注字符串（string）和迭代器（iterator）。"
+
+#: src/exercises/day-2/iterators-and-ownership.md:3
+msgid ""
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"traits."
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:8
+#: src/bare-metal/no_std.md:28
+msgid "`Iterator`"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:10
+msgid ""
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
+"`Iterator` trait simply says that you can call `next` until you get `None` "
+"back:"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:20
+msgid "You use this trait like this:"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:22
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();\n"
+"\n"
+"    println!(\"v[0]: {:?}\", iter.next());\n"
+"    println!(\"v[1]: {:?}\", iter.next());\n"
+"    println!(\"v[2]: {:?}\", iter.next());\n"
+"    println!(\"No more items: {:?}\", iter.next());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:34
+msgid "What is the type returned by the iterator? Test your answer here:"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:36
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();\n"
+"\n"
+"    let v0: Option<..> = iter.next();\n"
+"    println!(\"v0: {v0:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:46
+msgid "Why is this type used?"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:48
+msgid "`IntoIterator`"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:50
+msgid ""
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
+"iterator. The related trait `IntoIterator` tells you how to create the "
+"iterator:"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:62
+msgid ""
+"The syntax here means that every implementation of `IntoIterator` must "
+"declare two types:"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:65
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:66
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:68
+msgid ""
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
+"`Item` type, which means that it returns `Option<Item>`"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:71
+msgid "Like before, what  is the type returned by the iterator?"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:73
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), "
+"String::from(\"bar\")];\n"
+"    let mut iter = v.into_iter();\n"
+"\n"
+"    let v0: Option<..> = iter.next();\n"
+"    println!(\"v0: {v0:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:83
+msgid "`for` Loops"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:85
+msgid ""
+"Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:89
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), "
+"String::from(\"bar\")];\n"
+"\n"
+"    for word in &v {\n"
+"        println!(\"word: {word}\");\n"
+"    }\n"
+"\n"
+"    for word in v {\n"
+"        println!(\"word: {word}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:103
+msgid "What is the type of `word` in each loop?"
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:105
+msgid ""
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for "
+"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E) "
+"and [`impl IntoIterator for "
+"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT,+A%3E) "
+"to check your answers."
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:3
+msgid ""
+"In this exercise, you are implementing a routing component of a web server. "
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:8
+msgid ""
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
+"pass. Try avoiding allocating a `Vec` for your intermediate results:"
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:12
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", "
+"\"/v1/parent/publishers\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/welcome-day-3.md:1
+msgid "Welcome to Day 3"
+msgstr ""
+
+#: src/welcome-day-3.md:3
+msgid "Today, we will cover some more advanced topics of Rust:"
+msgstr ""
+
+#: src/welcome-day-3.md:5
+msgid ""
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
+msgstr ""
+
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
+
+#: src/generics.md:3
+#, fuzzy
+msgid ""
+"Rust support generics, which lets you abstract algorithms or data structures "
+"(such as sorting or a binary tree) over the types used or stored."
+msgstr "Rust 支持泛型，允许您根据算法（例如排序）中使用的类型对算法进行抽象化处理。"
+
+#: src/generics/data-types.md:3
+msgid "You can use generics to abstract over the concrete field type:"
+msgstr "您可以使用泛型对具体字段类型进行抽象化处理："
+
+#: src/generics/data-types.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T> {\n"
+"    x: T,\n"
+"    y: T,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let integer = Point { x: 5, y: 10 };\n"
+"    let float = Point { x: 1.0, y: 4.0 };\n"
+"    println!(\"{integer:?} and {float:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/data-types.md:21
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
+msgstr ""
+
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
+msgstr ""
+
+#: src/generics/methods.md:3
+msgid "You can declare a generic type on your `impl` block:"
+msgstr "您可以在 `impl` 块中声明通用类型："
+
+#: src/generics/methods.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T>(T, T);\n"
+"\n"
+"impl<T> Point<T> {\n"
+"    fn x(&self) -> &T {\n"
+"        &self.0  // + 10\n"
+"    }\n"
+"\n"
+"    // fn set_x(&mut self, x: T)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p = Point(5, 10);\n"
+"    println!(\"p.x = {}\", p.x());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/methods.md:25
+msgid ""
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
+msgstr "\\*问：\\*为什么 `T` 在 `impl<T> Point<T> {}` 中指定了两次？这不是多余的吗？"
+
+#: src/generics/methods.md:26
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr "这是因为它是泛型类型的泛型实现部分。它们是独立的泛型内容。"
+
+#: src/generics/methods.md:27
+msgid "It means these methods are defined for any `T`."
+msgstr "这意味着这些方法是针对所有 `T` 定义的。"
+
+#: src/generics/methods.md:28
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "可以编写 `impl Point<u32> { .. }`。"
+
+#: src/generics/methods.md:29
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr "`Point` 依然是一个泛型，并且您可以使用 `Point<f64>`，但此块中的方法将仅适用于 `Point<u32>`。"
+
+#: src/generics/monomorphization.md:3
+msgid "Generic code is turned into non-generic code based on the call sites:"
+msgstr "泛型代码根据调用位置转换为非泛型代码："
+
+#: src/generics/monomorphization.md:12
+msgid "behaves as if you wrote"
+msgstr "具体行为与您所编写的一样"
+
+#: src/generics/monomorphization.md:31
+msgid ""
+"This is a zero-cost abstraction: you get exactly the same result as if you "
+"had hand-coded the data structures without the abstraction."
+msgstr "这是零成本的抽象化处理：您得到的结果不会受到影响，也就是说，与在没有进行抽象化处理的情况下，对数据结构进行手动编码时的结果一样。"
+
+#: src/traits.md:3
+msgid ""
+"Rust lets you abstract over types with traits. They're similar to interfaces:"
+msgstr "Rust 让您可以依据特征对类型进行抽象化处理。特征与接口类似："
+
+#: src/traits.md:5
+msgid ""
+"```rust,editable\n"
+"struct Dog { name: String, age: i8 }\n"
+"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
+"\n"
+"trait Pet {\n"
+"    fn talk(&self) -> String;\n"
+"}\n"
+"\n"
+"impl Pet for Dog {\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self.name) "
+"}\n"
+"}\n"
+"\n"
+"impl Pet for Cat {\n"
+"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
+"}\n"
+"\n"
+"fn greet<P: Pet>(pet: &P) {\n"
+"    println!(\"Oh you're a cutie! What's your name? {}\", pet.talk());\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let captain_floof = Cat { lives: 9 };\n"
+"    let fido = Dog { name: String::from(\"Fido\"), age: 5 };\n"
+"\n"
+"    greet(&captain_floof);\n"
+"    greet(&fido);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/trait-objects.md:3
+msgid ""
+"Trait objects allow for values of different types, for instance in a "
+"collection:"
+msgstr "特征（Trait）对象可接受不同类型的值，举例来说，在集合中会是这样："
+
+#: src/traits/trait-objects.md:5
+msgid ""
+"```rust,editable\n"
+"struct Dog { name: String, age: i8 }\n"
+"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
+"\n"
+"trait Pet {\n"
+"    fn talk(&self) -> String;\n"
+"}\n"
+"\n"
+"impl Pet for Dog {\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self.name) "
+"}\n"
+"}\n"
+"\n"
+"impl Pet for Cat {\n"
+"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let pets: Vec<Box<dyn Pet>> = vec![\n"
+"        Box::new(Cat { lives: 9 }),\n"
+"        Box::new(Dog { name: String::from(\"Fido\"), age: 5 }),\n"
+"    ];\n"
+"    for pet in pets {\n"
+"        println!(\"Hello, who are you? {}\", pet.talk());\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/trait-objects.md:32
+msgid "Memory layout after allocating `pets`:"
+msgstr "以下是分配 `pets` 后的内存布局："
+
+#: src/traits/trait-objects.md:34
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                           :     :                                          "
+"   :\n"
+":    pets                   :     :                     "
+"+----+----+----+----+   :\n"
+":   +-----------+-------+   :     :   +-----+-----+  .->| F  | i  | d  | o  "
+"|   :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o |  |  "
+"+----+----+----+----+   :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-+  `---------.             "
+"   :\n"
+":   | capacity  |     2 |   :     :     | |   | |    data      |             "
+"   :\n"
+":   +-----------+-------+   :     :     | |   | |   +-------+--|-------+     "
+"   :\n"
+":                           :     :     | |   | '-->| name  |  o, 4, 4 |     "
+"   :\n"
+":                           :     :     | |   |     | age   |        5 |     "
+"   :\n"
+"`- - - - - - - - - - - - - -'     :     | |   |     +-------+----------+     "
+"   :\n"
+"                                  :     | |   |                              "
+"   :\n"
+"                                  :     | |   |      vtable                  "
+"   :\n"
+"                                  :     | |   |     +----------------------+ "
+"   :\n"
+"                                  :     | |   '---->| \"<Dog as Pet>::talk\" "
+"|    :\n"
+"                                  :     | |         +----------------------+ "
+"   :\n"
+"                                  :     | |                                  "
+"   :\n"
+"                                  :     | |    data                          "
+"   :\n"
+"                                  :     | |   +-------+-------+              "
+"   :\n"
+"                                  :     | '-->| lives |     9 |              "
+"   :\n"
+"                                  :     |     +-------+-------+              "
+"   :\n"
+"                                  :     |                                    "
+"   :\n"
+"                                  :     |      vtable                        "
+"   :\n"
+"                                  :     |     +----------------------+       "
+"   :\n"
+"                                  :     '---->| \"<Cat as Pet>::talk\" |     "
+"     :\n"
+"                                  :           +----------------------+       "
+"   :\n"
+"                                  :                                          "
+"   :\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
+msgstr ""
+
+#: src/traits/trait-objects.md:68
+msgid ""
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<dyn Pet>` in the example above."
+msgstr ""
+
+#: src/traits/trait-objects.md:70
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/traits/trait-objects.md:72
+msgid ""
+"In the example, `pets` is allocated on the stack and the vector data is on "
+"the heap. The two vector elements are _fat pointers_:"
+msgstr ""
+
+#: src/traits/trait-objects.md:74
+msgid ""
+"A fat pointer is a double-width pointer. It has two components: a pointer to "
+"the actual object and a pointer to the [virtual method "
+"table](https://en.wikipedia.org/wiki/Virtual_method_table) (vtable) for the "
+"`Pet` implementation of that particular object."
+msgstr ""
+
+#: src/traits/trait-objects.md:77
+msgid ""
+"The data for the `Dog` named Fido is the `name` and `age` fields. The `Cat` "
+"has a `lives` field."
+msgstr ""
+
+#: src/traits/trait-objects.md:79
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits/trait-objects.md:80
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), "
+"std::mem::size_of::<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), "
+"std::mem::size_of::<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
+msgstr ""
+
+#: src/traits/deriving-traits.md:3
+msgid ""
+"Rust derive macros work by automatically generating code that implements the "
+"specified traits for a data structure."
+msgstr ""
+
+#: src/traits/deriving-traits.md:5
+#, fuzzy
+msgid "You can let the compiler derive a number of traits as follows:"
+msgstr "您可以让编译器派生多个特征："
+
+#: src/traits/deriving-traits.md:7
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Clone, PartialEq, Eq, Default)]\n"
+"struct Player {\n"
+"    name: String,\n"
+"    strength: u8,\n"
+"    hit_points: u8,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Player::default();\n"
+"    let p2 = p1.clone();\n"
+"    println!(\"Is {:?}\\n"
+"equal to {:?}?\\n"
+"The answer is {}!\", &p1, &p2,\n"
+"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:3
+msgid "Traits can implement behavior in terms of other trait methods:"
+msgstr "特征可以依照其他特征方法来实现行为："
+
+#: src/traits/default-methods.md:5
+msgid ""
+"```rust,editable\n"
+"trait Equals {\n"
+"    fn equals(&self, other: &Self) -> bool;\n"
+"    fn not_equals(&self, other: &Self) -> bool {\n"
+"        !self.equals(other)\n"
+"    }\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct Centimeter(i16);\n"
+"\n"
+"impl Equals for Centimeter {\n"
+"    fn equals(&self, other: &Centimeter) -> bool {\n"
+"        self.0 == other.0\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let a = Centimeter(10);\n"
+"    let b = Centimeter(20);\n"
+"    println!(\"{a:?} equals {b:?}: {}\", a.equals(&b));\n"
+"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equals(&b));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:32
+msgid ""
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
+msgstr ""
+
+#: src/traits/default-methods.md:35
+msgid "Move method `not_equals` to a new trait `NotEquals`."
+msgstr ""
+
+#: src/traits/default-methods.md:37
+msgid "Make `Equals` a super trait for `NotEquals`."
+msgstr ""
+
+#: src/traits/default-methods.md:46
+msgid "Provide a blanket implementation of `NotEquals` for `Equals`."
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `Equals` as a super "
+"trait for `NotEqual`."
+msgstr ""
+
+#: src/traits/trait-bounds.md:3
+msgid ""
+"When working with generics, you often want to require the types to implement "
+"some trait, so that you can call this trait's methods."
+msgstr "使用泛型时，您通常会想要利用类型来实现某些特性， 这样才能调用此特征的方法。"
+
+#: src/traits/trait-bounds.md:6
+msgid "You can do this with `T: Trait` or `impl Trait`:"
+msgstr "您可以使用 `T: Trait` 或 `impl Trait` 执行此操作："
+
+#: src/traits/trait-bounds.md:8
+msgid ""
+"```rust,editable\n"
+"fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
+"    (a.clone(), a.clone())\n"
+"}\n"
+"\n"
+"// Syntactic sugar for:\n"
+"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
+"fn add_42_millions(x: impl Into<i32>) -> i32 {\n"
+"    x.into() + 42_000_000\n"
+"}\n"
+"\n"
+"// struct NotClonable;\n"
+"\n"
+"fn main() {\n"
+"    let foo = String::from(\"foo\");\n"
+"    let pair = duplicate(foo);\n"
+"    println!(\"{pair:?}\");\n"
+"\n"
+"    let many = add_42_millions(42_i8);\n"
+"    println!(\"{many}\");\n"
+"    let many_more = add_42_millions(10_000_000);\n"
+"    println!(\"{many_more}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/trait-bounds.md:35
+msgid "Show a `where` clause, students will encounter it when reading code."
+msgstr "显示 `where` 子句，学员在阅读代码时会看到它。"
+
+#: src/traits/trait-bounds.md:46
+msgid "It declutters the function signature if you have many parameters."
+msgstr "它会在您有多个形参的情况下整理函数签名。"
+
+#: src/traits/trait-bounds.md:47
+msgid "It has additional features making it more powerful."
+msgstr "它具有额外功能，因此也更强大。"
+
+#: src/traits/trait-bounds.md:48
+msgid ""
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
+msgstr "如果有人提问，便阐明额外功能是指“:”左侧的类别可为任意值，例如 `Option<T>`。"
+
+#: src/traits/impl-trait.md:1
+msgid "`impl Trait`"
+msgstr "`impl Trait`"
+
+#: src/traits/impl-trait.md:3
+msgid ""
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
+"arguments and return values:"
+msgstr "与特征边界类似，`impl Trait` 语法可以在函数实参 和返回值中使用："
+
+#: src/traits/impl-trait.md:6
+msgid ""
+"```rust,editable\n"
+"use std::fmt::Display;\n"
+"\n"
+"fn get_x(name: impl Display) -> impl Display {\n"
+"    format!(\"Hello {name}\")\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let x = get_x(\"foo\");\n"
+"    println!(\"{x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/impl-trait.md:19
+msgid "`impl Trait` allows you to work with types which you cannot name."
+msgstr "`impl Trait` 让您可使用无法命名的类型。"
+
+#: src/traits/impl-trait.md:23
+msgid ""
+"The meaning of `impl Trait` is a bit different in the different positions."
+msgstr "`impl Trait` 的意义因使用位置而略有不同。"
+
+#: src/traits/impl-trait.md:25
+msgid ""
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
+msgstr "对形参来说，`impl Trait` 就像是具有特征边界的匿名泛型形参。"
+
+#: src/traits/impl-trait.md:27
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+"对返回值类型来说，它则意味着返回值类型就是实现该特征的某具体类型， 无需为该类型命名。如果您不想在公共 API 中公开该具体类型，便可 使用此方法。"
+
+#: src/traits/impl-trait.md:31
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, "
+"`foo.collect::<Vec<_>>()`."
+msgstr ""
+"在返回位置处进行推断有一定难度。会返回 `impl Foo` 的函数会挑选 自身返回的具体类型，而不必在来源中写出此信息。会返回 泛型类型（例如 "
+"`collect<B>() -> B`）的函数则可返回符合 `B` 的任何类型，而调用方可能需要选择一个类型，例如使用 `let x: Vec<_> = "
+"foo.collect()` 或使用以下 Turbofish：`foo.collect::<Vec<_>>()`。"
+
+#: src/traits/impl-trait.md:37
+msgid ""
+"This example is great, because it uses `impl Display` twice. It helps to "
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
+msgstr ""
+"这是一个非常棒的示例，因为它使用了两次 `impl Display`。这有助于说明 此处没有任何项目会强制使用相同的 `impl Display` "
+"类型。如果我们使用单个 `T: Display`，它会强制限制输入 `T` 和返回 `T` 均为同一类型。 "
+"这并不适用于这个特定函数，因为我们预期作为输入的类型可能 不会是 `format!` 返回的值。如果我们希望通过 `: Display` "
+"语法执行相同的操作，则需要两个 独立的泛型形参。"
+
+#: src/traits/important-traits.md:3
+msgid ""
+"We will now look at some of the most common traits of the Rust standard "
+"library:"
+msgstr "现在，我们来看看 Rust 标准库的一些最常见的特征："
+
+#: src/traits/important-traits.md:5
+msgid ""
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
+msgstr ""
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) 和 "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"用于 `for` 循环中，"
+
+#: src/traits/important-traits.md:6
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) used to "
+"convert values,"
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 用于转换值，"
+
+#: src/traits/important-traits.md:7
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
+"[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 用于实现 IO。"
+
+#: src/traits/important-traits.md:8
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), "
+"[`Mul`](https://doc.rust-lang.org/std/ops/trait.Mul.html), ... used for "
+"operator overloading, and"
+msgstr ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html)、[`Mul`](https://doc.rust-lang.org/std/ops/trait.Mul.html) "
+"等用于实现运算符重载，"
+
+#: src/traits/important-traits.md:9
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 用于定义析构函数。"
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
+"用于构建相应类型的默认实例。"
+
+#: src/traits/iterator.md:1
+msgid "Iterators"
+msgstr "迭代器"
+
+#: src/traits/iterator.md:3
+msgid ""
+"You can implement the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) trait "
+"on your own types:"
+msgstr ""
+"您可以自行实现 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
+"特征："
+
+#: src/traits/iterator.md:5
+msgid ""
+"```rust,editable\n"
+"struct Fibonacci {\n"
+"    curr: u32,\n"
+"    next: u32,\n"
+"}\n"
+"\n"
+"impl Iterator for Fibonacci {\n"
+"    type Item = u32;\n"
+"\n"
+"    fn next(&mut self) -> Option<Self::Item> {\n"
+"        let new_next = self.curr + self.next;\n"
+"        self.curr = self.next;\n"
+"        self.next = new_next;\n"
+"        Some(self.curr)\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let fib = Fibonacci { curr: 0, next: 1 };\n"
+"    for (i, n) in fib.enumerate().take(5) {\n"
+"        println!(\"fib({i}): {n}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/iterator.md:32
+msgid ""
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
+msgstr ""
+"`Iterator` 特征会对集合实现许多常见的函数程序操作， 例如 ` map`filter \\``和`reduce` "
+"等。您可以通过此特征找到有关它们的所有 文档。在 Rust 中，这些函数应生成代码，且生成的代码应与等效命令式实现一样 高效。"
+
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
+"`IntoIterator` 是迫使 for 循环运作的特征。此特征由集合类型 （例如 `Vec<T>`）和相关引用（例如 `&Vec<T>` 和 "
+"`&[T]`）而实现。此外，范围也会实现这项特征。因此， 您可以使用 `for i in some_vec { .. }` 来遍历某矢量，但 "
+"`some_vec.next()` 不存在。"
+
+#: src/traits/from-iterator.md:3
+msgid ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html)."
+msgstr ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"让您可通过 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
+"构建一个集合。"
+
+#: src/traits/from-iterator.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let primes = vec![2, 3, 5, 7];\n"
+"    let prime_squares = primes\n"
+"        .into_iter()\n"
+"        .map(|prime| prime * prime)\n"
+"        .collect::<Vec<_>>();\n"
+"    println!(\"prime_squares: {prime_squares:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();\n"
+"\n"
+"    while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/traits/from-iterator.md:18
+msgid ""
+"`Iterator` implements `fn collect<B>(self) -> B where B: "
+"FromIterator<Self::Item>, Self: Sized`"
+msgstr ""
+"`Iterator` 会实现 `fn collect<B>(self) -> B where B: FromIterator<Self::Item>, "
+"Self: Sized`"
+
+#: src/traits/from-iterator.md:24
+msgid ""
+"There are also implementations which let you do cool things like convert an "
+"`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
+msgstr ""
+"还有一些实现，让您可执行一些很酷的操作，比如 将 `Iterator<Item = Result<V, E>>` 转换成 `Result<Vec<V>, "
+"E>`。"
+
+#: src/traits/from-into.md:1
+msgid "`From` and `Into`"
+msgstr "`From` 和 `Into`"
+
+#: src/traits/from-into.md:3
+msgid ""
+"Types implement "
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
+msgstr ""
+"类型会实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 以加快类型转换："
+
+#: src/traits/from-into.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s = String::from(\"hello\");\n"
+"    let addr = std::net::Ipv4Addr::from([127, 0, 0, 1]);\n"
+"    let one = i16::from(true);\n"
+"    let bigger = i32::from(123i16);\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/from-into.md:15
+msgid ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when "
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) is "
+"implemented:"
+msgstr ""
+"实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 后，系统会自动实现 "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)："
+
+#: src/traits/from-into.md:17
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s: String = \"hello\".into();\n"
+"    let addr: std::net::Ipv4Addr = [127, 0, 0, 1].into();\n"
+"    let one: i16 = true.into();\n"
+"    let bigger: i32 = 123i16.into();\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/from-into.md:29
+msgid ""
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
+msgstr "这就是为什么通常只需实现 `From`，因为您的类型也会实现 `Into`。"
+
+#: src/traits/from-into.md:30
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
+msgstr ""
+"若要声明某个函数实参输入类型（例如“任何可转换成 `String` 的类型”），规则便会相反，此时应使用 `Into`。 您的函数会接受可实现 "
+"`From` 的类型，以及那些仅实现 `Into` 的类型。"
+
+#: src/traits/read-write.md:1
+msgid "`Read` and `Write`"
+msgstr "`Read` 和 `Write`"
+
+#: src/traits/read-write.md:3
+msgid ""
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr ""
+"您可以使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` "
+"来源进行抽象化处理："
+
+#: src/traits/read-write.md:5
+msgid ""
+"```rust,editable\n"
+"use std::io::{BufRead, BufReader, Read, Result};\n"
+"\n"
+"fn count_lines<R: Read>(reader: R) -> usize {\n"
+"    let buf_reader = BufReader::new(reader);\n"
+"    buf_reader.lines().count()\n"
+"}\n"
+"\n"
+"fn main() -> Result<()> {\n"
+"    let slice: &[u8] = b\"foo\\n"
+"bar\\n"
+"baz\\n"
+"\";\n"
+"    println!(\"lines in slice: {}\", count_lines(slice));\n"
+"\n"
+"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
+"    println!(\"lines in file: {}\", count_lines(file));\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/read-write.md:23
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
+msgstr ""
+"您同样可使用 [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 对 `u8` "
+"接收器进行抽象化处理："
+
+#: src/traits/read-write.md:25
+msgid ""
+"```rust,editable\n"
+"use std::io::{Result, Write};\n"
+"\n"
+"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
+"    writer.write_all(msg.as_bytes())?;\n"
+"    writer.write_all(\"\\n"
+"\".as_bytes())\n"
+"}\n"
+"\n"
+"fn main() -> Result<()> {\n"
+"    let mut buffer = Vec::new();\n"
+"    log(&mut buffer, \"Hello\")?;\n"
+"    log(&mut buffer, \"World\")?;\n"
+"    println!(\"Logged: {:?}\", buffer);\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/drop.md:1
+msgid "The `Drop` Trait"
+msgstr "`Drop` 特征"
+
+#: src/traits/drop.md:3
+msgid ""
+"Values which implement "
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) can specify code "
+"to run when they go out of scope:"
+msgstr ""
+"用于实现 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) "
+"的值可以指定在超出范围时运行的代码："
+
+#: src/traits/drop.md:5
+msgid ""
+"```rust,editable\n"
+"struct Droppable {\n"
+"    name: &'static str,\n"
+"}\n"
+"\n"
+"impl Drop for Droppable {\n"
+"    fn drop(&mut self) {\n"
+"        println!(\"Dropping {}\", self.name);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let a = Droppable { name: \"a\" };\n"
+"    {\n"
+"        let b = Droppable { name: \"b\" };\n"
+"        {\n"
+"            let c = Droppable { name: \"c\" };\n"
+"            let d = Droppable { name: \"d\" };\n"
+"            println!(\"Exiting block B\");\n"
+"        }\n"
+"        println!(\"Exiting block A\");\n"
+"    }\n"
+"    drop(a);\n"
+"    println!(\"Exiting main\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/drop.md:34
+msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
+msgstr ""
+
+#: src/traits/drop.md:35
+msgid "Values are automatically dropped when they go out of scope."
+msgstr ""
+
+#: src/traits/drop.md:36
+msgid ""
+"When a value is dropped, if it implements `std::ops::Drop` then its "
+"`Drop::drop` implementation will be called."
+msgstr ""
+
+#: src/traits/drop.md:38
+msgid ""
+"All its fields will then be dropped too, whether or not it implements `Drop`."
+msgstr ""
+
+#: src/traits/drop.md:39
+msgid ""
+"`std::mem::drop` is just an empty function that takes any value. The "
+"significance is that it takes ownership of the value, so at the end of its "
+"scope it gets dropped. This makes it a convenient way to explicitly drop "
+"values earlier than they would otherwise go out of scope."
+msgstr ""
+
+#: src/traits/drop.md:42
+msgid ""
+"This can be useful for objects that do some work on `drop`: releasing locks, "
+"closing files, etc."
+msgstr ""
+
+#: src/traits/drop.md:45
+#: src/traits/operators.md:26
+msgid "Discussion points:"
+msgstr "讨论点："
+
+#: src/traits/drop.md:47
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "为什么 `Drop::drop` 不使用 `self`？"
+
+#: src/traits/drop.md:48
+msgid ""
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
+msgstr "简答：如果这样的话，系统会在代码块结尾 调用 `std::mem::drop`，进而引发再一次调用 `Drop::drop`，并引发堆栈 溢出！"
+
+#: src/traits/drop.md:51
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "尝试用 `a.drop()` 替换 `drop(a)`。"
+
+#: src/traits/default.md:1
+msgid "The `Default` Trait"
+msgstr "`Default` 特征"
+
+#: src/traits/default.md:3
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
+"特征会为类型生成默认值。"
+
+#: src/traits/default.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Default)]\n"
+"struct Derived {\n"
+"    x: u32,\n"
+"    y: String,\n"
+"    z: Implemented,\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct Implemented(String);\n"
+"\n"
+"impl Default for Implemented {\n"
+"    fn default() -> Self {\n"
+"        Self(\"John Smith\".into())\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let default_struct = Derived::default();\n"
+"    println!(\"{default_struct:#?}\");\n"
+"\n"
+"    let almost_default_struct = Derived {\n"
+"        y: \"Y is set!\".into(),\n"
+"        ..Derived::default()\n"
+"    };\n"
+"    println!(\"{almost_default_struct:#?}\");\n"
+"\n"
+"    let nothing: Option<Derived> = None;\n"
+"    println!(\"{:#?}\", nothing.unwrap_or_default());\n"
+"}\n"
+"\n"
+"```"
+msgstr ""
+
+#: src/traits/default.md:40
+msgid ""
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr "系统可以直接实现它，也可以通过 `#[derive(Default)]` 派生出它。"
+
+#: src/traits/default.md:41
+#, fuzzy
+msgid ""
+"A derived implementation will produce a value where all fields are set to "
+"their default values."
+msgstr "派生的实现会生成一个实例，其中字段全都设为其默认值。"
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr "这意味着，该结构体中的所有类型也都必须实现 `Default`。"
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr "标准的 Rust 类型通常会以合理的值（例如 ` 0`\"\" \\`` 等）实现 `Default`。"
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr "部分结构体副本可与默认值完美搭配运作。"
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
+"provides convenience methods that use it."
+msgstr "Rust 标准库了解类型可能会实现 `Default`，因此提供了便利的使用方式。"
+
+#: src/traits/default.md:46
+msgid ""
+"the `..` syntax is called [struct update "
+"syntax](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax)"
+msgstr ""
+
+#: src/traits/operators.md:1
+msgid "`Add`, `Mul`, ..."
+msgstr "` Add`Mul \\``…"
+
+#: src/traits/operators.md:3
+msgid ""
+"Operator overloading is implemented via traits in "
+"[`std::ops`](https://doc.rust-lang.org/std/ops/index.html):"
+msgstr ""
+"运算符重载是通过 [`std::ops`](https://doc.rust-lang.org/std/ops/index.html) 中的特征实现的："
+
+#: src/traits/operators.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Copy, Clone)]\n"
+"struct Point { x: i32, y: i32 }\n"
+"\n"
+"impl std::ops::Add for Point {\n"
+"    type Output = Self;\n"
+"\n"
+"    fn add(self, other: Self) -> Self {\n"
+"        Self {x: self.x + other.x, y: self.y + other.y}\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point { x: 10, y: 20 };\n"
+"    let p2 = Point { x: 100, y: 200 };\n"
+"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/operators.md:28
+msgid ""
+"You could implement `Add` for `&Point`. In which situations is that useful? "
+msgstr "您可以针对 `&Point` 实现 `Add`。此做法在哪些情况下可派上用场？"
+
+#: src/traits/operators.md:29
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"回答：`Add:add` 会耗用 `self`。如果您的运算符重载对象 （即类型 `T`）不是 `Copy`，建议您也为 `&T` "
+"重载运算符。这可避免调用点上存在不必要的 克隆任务。"
+
+#: src/traits/operators.md:33
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr "为什么 `Output` 是关联类型？可将它用作该方法的类型形参吗？"
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementor of a "
+"trait."
+msgstr "简答：函数类型形参是由调用方控管，但 `Output` 这类关联类型则由特征实现人员 控管。"
+
+#: src/traits/operators.md:37
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
+msgstr ""
+"您可以针对两种不同类型实现 `Add`，例如， `impl Add<(i32, i32)> for Point` 会向 `Point` 中添加元组。"
+
+#: src/traits/closures.md:1
+msgid "Closures"
+msgstr "闭包"
+
+#: src/traits/closures.md:3
+msgid ""
+"Closures or lambda expressions have types which cannot be named. However, "
+"they implement special "
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), "
+"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
+"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
+msgstr ""
+"闭包或 lambda 表达式具有无法命名的类型。不过，它们会 实现特殊的 "
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)， "
+"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和 "
+"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) 特征："
+
+#: src/traits/closures.md:8
+msgid ""
+"```rust,editable\n"
+"fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
+"    println!(\"Calling function on {input}\");\n"
+"    func(input)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let add_3 = |x| x + 3;\n"
+"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
+"    println!(\"add_3: {}\", apply_with_log(add_3, 20));\n"
+"\n"
+"    let mut v = Vec::new();\n"
+"    let mut accumulate = |x: i32| {\n"
+"        v.push(x);\n"
+"        v.iter().sum::<i32>()\n"
+"    };\n"
+"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 4));\n"
+"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 5));\n"
+"\n"
+"    let multiply_sum = |x| x * v.into_iter().sum::<i32>();\n"
+"    println!(\"multiply_sum: {}\", apply_with_log(multiply_sum, 3));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/closures.md:34
+msgid ""
+"An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
+"perhaps captures nothing at all. It can be called multiple times "
+"concurrently."
+msgstr "`Fn`（例如 `add_3`）既不会耗用也不会修改捕获的值，或许 也不会捕获任何值。它可被并发调用多次。"
+
+#: src/traits/closures.md:37
+msgid ""
+"An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
+"multiple times, but not concurrently."
+msgstr "`FnMut`（例如 `accumulate`）可能会改变捕获的值。您可以多次调用它， 但不能并发调用它。"
+
+#: src/traits/closures.md:40
+msgid ""
+"If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
+"might consume captured values."
+msgstr "如果您使用 `FnOnce`（例如 `multiply_sum`），或许只能调用它一次。它可能会耗用 所捕获的值。"
+
+#: src/traits/closures.md:43
+msgid ""
+"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
+msgstr ""
+"`FnMut` 是 `FnOnce` 的子类型。`Fn` 是 `FnMut` 和 `FnOnce` 的子类型。也就是说，您可以在任何 需要调用 "
+"`FnOnce` 的地方使用 `FnMut`，还可在任何需要调用 `FnMut` 或 `FnOnce` 的地方 使用 `Fn`。"
+
+#: src/traits/closures.md:47
+msgid ""
+"The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
+"`multiply_sum`), depending on what the closure captures."
+msgstr "编译器也会推断 `Copy`（例如针对 `add_3`）和 `Clone`（例如 `multiply_sum`）， 具体取决于闭包捕获的数据。"
+
+#: src/traits/closures.md:50
+msgid ""
+"By default, closures will capture by reference if they can. The `move` "
+"keyword makes them capture by value."
+msgstr "默认情况下，闭包会依据引用来捕获数据（如果可以的话）。`move` 关键字则可让闭包依据值 来捕获数据。"
+
+#: src/traits/closures.md:52
+msgid ""
+"```rust,editable\n"
+"fn make_greeter(prefix: String) -> impl Fn(&str) {\n"
+"    return move |name| println!(\"{} {}\", prefix, name)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let hi = make_greeter(\"Hi\".to_string());\n"
+"    hi(\"there\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/morning.md:1
+msgid "Day 3: Morning Exercises"
+msgstr ""
+
+#: src/exercises/day-3/morning.md:3
+msgid "We will design a classical GUI library using traits and trait objects."
+msgstr ""
+
+#: src/exercises/day-3/morning.md:5
+msgid ""
+"We will also look at enum dispatch with an exercise involving points and "
+"polygons."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
+#, fuzzy
+msgid "Drawing A Simple GUI"
+msgstr "一个简单的 GUI 库"
+
+#: src/exercises/day-3/simple-gui.md:3
+msgid ""
+"Let us design a classical GUI library using our new knowledge of traits and "
+"trait objects. We'll only implement the drawing of it (as text) for "
+"simplicity."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:6
+msgid "We will have a number of widgets in our library:"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:8
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:9
+msgid ""
+"`Button`: has a `label`. In reality, it would also take a callback function "
+"to allow the program to do something when the button is clicked but we won't "
+"include that since we're only drawing the GUI."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:12
+msgid "`Label`: has a `label`."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:14
+msgid "The widgets will implement a `Widget` trait, see below."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:16
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
+"`draw_into` methods so that you implement the `Widget` trait:"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:19
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_imports, unused_variables, dead_code)]\n"
+"\n"
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;\n"
+"\n"
+"    /// Draw the widget into a buffer.\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
+"\n"
+"    /// Draw the widget on standard output.\n"
+"    fn draw(&self) {\n"
+"        let mut buffer = String::new();\n"
+"        self.draw_into(&mut buffer);\n"
+"        println!(\"{buffer}\");\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Label {\n"
+"    label: String,\n"
+"}\n"
+"\n"
+"impl Label {\n"
+"    fn new(label: &str) -> Label {\n"
+"        Label {\n"
+"            label: label.to_owned(),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Button {\n"
+"    label: Label,\n"
+"}\n"
+"\n"
+"impl Button {\n"
+"    fn new(label: &str) -> Button {\n"
+"        Button {\n"
+"            label: Label::new(label),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Window {\n"
+"    title: String,\n"
+"    widgets: Vec<Box<dyn Widget>>,\n"
+"}\n"
+"\n"
+"impl Window {\n"
+"    fn new(title: &str) -> Window {\n"
+"        Window {\n"
+"            title: title.to_owned(),\n"
+"            widgets: Vec::new(),\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"        self.widgets.push(widget);\n"
+"    }\n"
+"\n"
+"    fn inner_width(&self) -> usize {\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }\n"
+"}\n"
+"\n"
+"\n"
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\"\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:128
+msgid "The output of the above program can be something simple like this:"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:140
+msgid ""
+"If you want to draw aligned text, you can use the "
+"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment) "
+"formatting operators. In particular, notice how you can pad with different "
+"characters (here a `'/'`) and how you can control alignment:"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:145
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let width = 10;\n"
+"    println!(\"left aligned:  |{:/<width$}|\", \"foo\");\n"
+"    println!(\"centered:      |{:/^width$}|\", \"foo\");\n"
+"    println!(\"right aligned: |{:/>width$}|\", \"foo\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:154
+msgid ""
+"Using such alignment tricks, you can for example produce output like this:"
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:1
+msgid "Polygon Struct"
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:3
+msgid ""
+"We will create a `Polygon` struct which contain some points. Copy the code "
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:7
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub struct Point {\n"
+"    // add fields\n"
+"}\n"
+"\n"
+"impl Point {\n"
+"    // add methods\n"
+"}\n"
+"\n"
+"pub struct Polygon {\n"
+"    // add fields\n"
+"}\n"
+"\n"
+"impl Polygon {\n"
+"    // add methods\n"
+"}\n"
+"\n"
+"pub struct Circle {\n"
+"    // add fields\n"
+"}\n"
+"\n"
+"impl Circle {\n"
+"    // add methods\n"
+"}\n"
+"\n"
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"\n"
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100.0).round() / 100.0\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_magnitude() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_dist() {\n"
+"        let p1 = Point::new(10, 10);\n"
+"        let p2 = Point::new(14, 13);\n"
+"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_add() {\n"
+"        let p1 = Point::new(16, 16);\n"
+"        let p2 = p1 + Point::new(-4, 3);\n"
+"        assert_eq!(p2, Point::new(12, 19));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_left_most_point() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"        assert_eq!(poly.left_most_point(), Some(p1));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_iter() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"\n"
+"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}\n"
+"\n"
+"#[allow(dead_code)]\n"
+"fn main() {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:117
+msgid ""
+"Since the method signatures are missing from the problem statements, the key "
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:120
+msgid "Other interesting parts of the exercise:"
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:122
+msgid ""
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:123
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
+
+#: src/error-handling.md:3
+msgid "Error handling in Rust is done using explicit control flow:"
+msgstr "Rust 中的错误处理是使用显式控制流来进行的："
+
+#: src/error-handling.md:5
+msgid "Functions that can have errors list this in their return type,"
+msgstr "包含错误的函数会在返回类型中列出相关信息。"
+
+#: src/error-handling.md:6
+msgid "There are no exceptions."
+msgstr "此规则没有例外。"
+
+#: src/error-handling/panics.md:3
+msgid "Rust will trigger a panic if a fatal error happens at runtime:"
+msgstr "如果运行时发生严重错误，Rust 会触发 panic："
+
+#: src/error-handling/panics.md:5
+msgid ""
+"```rust,editable,should_panic\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    println!(\"v[100]: {}\", v[100]);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/panics.md:12
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "Panic 用于指示不可恢复的意外错误。"
+
+#: src/error-handling/panics.md:13
+msgid "Panics are symptoms of bugs in the program."
+msgstr "Panic反映了程序中的 bug 问题。"
+
+#: src/error-handling/panics.md:14
+msgid ""
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+msgstr "如果崩溃不可接受，请使用不会触发 panic 的 API（例如 `Vec::get`）。"
+
+#: src/error-handling/panic-unwind.md:1
+msgid "Catching the Stack Unwinding"
+msgstr "捕获堆栈展开"
+
+#: src/error-handling/panic-unwind.md:3
+msgid ""
+"By default, a panic will cause the stack to unwind. The unwinding can be "
+"caught:"
+msgstr "默认情况下，panic 会导致堆栈展开。您可以捕获展开信息："
+
+#: src/error-handling/panic-unwind.md:5
+msgid ""
+"```rust,editable\n"
+"use std::panic;\n"
+"\n"
+"fn main() {\n"
+"    let result = panic::catch_unwind(|| {\n"
+"        println!(\"hello!\");\n"
+"    });\n"
+"    assert!(result.is_ok());\n"
+"    \n"
+"    let result = panic::catch_unwind(|| {\n"
+"        panic!(\"oh no!\");\n"
+"    });\n"
+"    assert!(result.is_err());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:21
+msgid ""
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
+msgstr "如果服务器需要持续运行（即使是在请求发生崩溃的情况下）， 此方法十分有用。"
+
+#: src/error-handling/panic-unwind.md:23
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr "如果您在 `Cargo.toml` 中设置了 `panic = 'abort'`，此方法不会生效。"
+
+#: src/error-handling/result.md:1
+msgid "Structured Error Handling with `Result`"
+msgstr "使用 `Result` 进行结构化错误处理"
+
+#: src/error-handling/result.md:3
+msgid ""
+"We have already seen the `Result` enum. This is used pervasively when errors "
+"are expected as part of normal operation:"
+msgstr "在前面，我们看到了 `Result` 枚举。在遇到正常操作产生的预期错误时， 我们常会用到此方法："
+
+#: src/error-handling/result.md:6
+msgid ""
+"```rust,editable\n"
+"use std::fs;\n"
+"use std::io::Read;\n"
+"\n"
+"fn main() {\n"
+"    let file = fs::File::open(\"diary.txt\");\n"
+"    match file {\n"
+"        Ok(mut file) => {\n"
+"            let mut contents = String::new();\n"
+"            file.read_to_string(&mut contents);\n"
+"            println!(\"Dear diary: {contents}\");\n"
+"        },\n"
+"        Err(err) => {\n"
+"            println!(\"The diary could not be opened: {err}\");\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/result.md:27
+msgid ""
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
+msgstr ""
+"与 `Option` 方法相同，成功值位于 `Result` 方法内部， 开发者必须显示提取成功值。因此，建议进行错误检查。在绝不应出现错误的情况下， "
+"可以调用 `unwrap()` 或 `expect()` 方法，这也是一种开发者意向信号。"
+
+#: src/error-handling/result.md:30
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr "我们建议阅读 `Result` 文档。虽然课程中不会涉及该文档，但是有必要提到它。 该文档中包含许多便捷的方法和函数，对于函数式编程很有帮助。"
+
+#: src/error-handling/try-operator.md:1
+msgid "Propagating Errors with `?`"
+msgstr "使用 `?` 传播错误"
+
+#: src/error-handling/try-operator.md:3
+msgid ""
+"The try-operator `?` is used to return errors to the caller. It lets you "
+"turn the common"
+msgstr "try 操作符 `?` 用于将错误返回给调用方。它能把常用命令"
+
+#: src/error-handling/try-operator.md:13
+msgid "into the much simpler"
+msgstr "转换成更简单的命令"
+
+#: src/error-handling/try-operator.md:19
+#, fuzzy
+msgid "We can use this to simplify our error handling code:"
+msgstr "我们可以用它来简化错误处理代码："
+
+#: src/error-handling/try-operator.md:21
+msgid ""
+"```rust,editable\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, io::Error> {\n"
+"    let username_file_result = fs::File::open(path);\n"
+"    let mut username_file = match username_file_result {\n"
+"        Ok(file) => file,\n"
+"        Err(err) => return Err(err),\n"
+"    };\n"
+"\n"
+"    let mut username = String::new();\n"
+"    match username_file.read_to_string(&mut username) {\n"
+"        Ok(_) => Ok(username),\n"
+"        Err(err) => Err(err),\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/try-operator.md:50
+#: src/error-handling/converting-error-types-example.md:52
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr "`username` 变量可以是 `Ok(string)` 或 `Err(error)`。"
+
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr "可以使用 `fs::write` 调用来测试不同的场景：没有文件、空文件、包含用户名的文件。"
+
+#: src/error-handling/try-operator.md:52
+msgid ""
+"The return type of the function has to be compatible with the nested "
+"functions it calls. For instance, a function returning a `Result<T, Err>` "
+"can only apply the `?` operator on a function returning a  `Result<AnyT, "
+"Err>`. It cannot apply the `?` operator on a function returning an "
+"`Option<AnyT>` or `Result<T, OtherErr>` unless `OtherErr` implements "
+"`From<Err>`. Reciprocally, a function returning an `Option<T>` can only "
+"apply the `?` operator  on a function returning an `Option<AnyT>`."
+msgstr ""
+
+#: src/error-handling/try-operator.md:57
+msgid ""
+"You can convert incompatible types into one another with the different "
+"`Option` and `Result` methods  such as `Option::ok_or`, `Result::ok`, "
+"`Result::err`."
+msgstr ""
+
+#: src/error-handling/converting-error-types.md:3
+msgid ""
+"The effective expansion of `?` is a little more complicated than previously "
+"indicated:"
+msgstr "`?` 的有效展开比前面介绍的内容略微复杂一些："
+
+#: src/error-handling/converting-error-types.md:9
+msgid "works the same as"
+msgstr "效果等同于"
+
+#: src/error-handling/converting-error-types.md:18
+msgid ""
+"The `From::from` call here means we attempt to convert the error type to the "
+"type returned by the function:"
+msgstr "此处的 `From::from` 调用表示，我们尝试将错误类型转换为 函数返回的类型："
+
+#: src/error-handling/converting-error-types-example.md:3
+msgid ""
+"```rust,editable\n"
+"use std::error::Error;\n"
+"use std::fmt::{self, Display, Formatter};\n"
+"use std::fs::{self, File};\n"
+"use std::io::{self, Read};\n"
+"\n"
+"#[derive(Debug)]\n"
+"enum ReadUsernameError {\n"
+"    IoError(io::Error),\n"
+"    EmptyUsername(String),\n"
+"}\n"
+"\n"
+"impl Error for ReadUsernameError {}\n"
+"\n"
+"impl Display for ReadUsernameError {\n"
+"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
+"        match self {\n"
+"            Self::IoError(e) => write!(f, \"IO error: {e}\"),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
+"in {filename}\"),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"impl From<io::Error> for ReadUsernameError {\n"
+"    fn from(err: io::Error) -> ReadUsernameError {\n"
+"        ReadUsernameError::IoError(err)\n"
+"    }\n"
+"}\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/converting-error-types-example.md:55
+msgid ""
+"It is good practice for all error types that don't need to be `no_std` to "
+"implement `std::error::Error`, which requires `Debug` and `Display`. The "
+"`Error` crate for `core` is only available in "
+"[nightly](https://github.com/rust-lang/rust/issues/103765), so not fully "
+"`no_std` compatible yet."
+msgstr ""
+
+#: src/error-handling/converting-error-types-example.md:57
+#, fuzzy
+msgid ""
+"It's generally helpful for them to implement `Clone` and `Eq` too where "
+"possible, to make life easier for tests and consumers of your library. In "
+"this case we can't easily do so, because `io::Error` doesn't implement them."
+msgstr ""
+"对所有错误类型实现 `std::error::Error` 是一种很好的做法，而这需要结合使用 `Debug` 和 `Display` 方法。 "
+"通常，在可能的情况下实现 `Clone` 和 `Eq` 也十分有益， 可以让库的测试和使用变得更加简单。在本例中，我们无法轻松做到这一点， 因为 "
+"`io::Error` 不能实现这些方法。"
+
+#: src/error-handling/deriving-error-enums.md:3
+msgid ""
+"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
+"an error enum like we did on the previous page:"
+msgstr ""
+"[thiserror](https://docs.rs/thiserror/) crate 是创建错误枚举的常用方法， 就像前一页中提供的示例一样："
+
+#: src/error-handling/deriving-error-enums.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use thiserror::Error;\n"
+"\n"
+"#[derive(Debug, Error)]\n"
+"enum ReadUsernameError {\n"
+"    #[error(\"Could not read: {0}\")]\n"
+"    IoError(#[from] io::Error),\n"
+"    #[error(\"Found no username in {0}\")]\n"
+"    EmptyUsername(String),\n"
+"}\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
+"    let mut username = String::new();\n"
+"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:39
+msgid ""
+"`thiserror`'s derive macro automatically implements `std::error::Error`, and "
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
+msgstr ""
+"`thiserror` 的派生宏会自动实现 `std::error::Error`，并且可以选择性地实现 `Display` （如果提供了 "
+"`#[error(...)]` 属性）和 `From`（如果添加了 `#[from]` 属性）。 此规则也适用于结构体。"
+
+#: src/error-handling/deriving-error-enums.md:43
+msgid "It doesn't affect your public API, which makes it good for libraries."
+msgstr "但是，此规则不会影响公共 API，对于库而言，这非常理想。"
+
+#: src/error-handling/dynamic-errors.md:3
+msgid ""
+"Sometimes we want to allow any type of error to be returned without writing "
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
+msgstr ""
+"有时，我们需要允许返回任意类型的错误，但又不想自己手动编写枚举来涵盖所有不同的可能性。 `std::error::Error` 可以让我们轻松做到这一点。"
+
+#: src/error-handling/dynamic-errors.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::fs;\n"
+"use std::io::Read;\n"
+"use thiserror::Error;\n"
+"use std::error::Error;\n"
+"\n"
+"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
+"#[error(\"Found no username in {0}\")]\n"
+"struct EmptyUsernameError(String);\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
+"    let mut username = String::new();\n"
+"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(EmptyUsernameError(String::from(path)).into());\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/dynamic-errors.md:36
+msgid ""
+"This saves on code, but gives up the ability to cleanly handle different "
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
+"somewhere."
+msgstr ""
+"虽然这可以省却编写代码的麻烦，但也会导致我们无法在程序中以不同的方式正常处理不同的 错误情况。因此，在库的公共 API 中使用 `Box<dyn "
+"Error>` 通常不是一个好主意。 但是对于您只需要在某处显示错误消息的程序来说，这不失为一个 很好的选择。"
+
+#: src/error-handling/error-contexts.md:3
+msgid ""
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
+msgstr ""
+"广泛使用的 [anyhow](https://docs.rs/anyhow/) crate 可以帮助我们为错误添加 背景信息，并减少自定义错误类型的 "
+"数量。"
+
+#: src/error-handling/error-contexts.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use anyhow::{Context, Result, bail};\n"
+"\n"
+"fn read_username(path: &str) -> Result<String> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::File::open(path)\n"
+"        .with_context(|| format!(\"Failed to open {path}\"))?\n"
+"        .read_to_string(&mut username)\n"
+"        .context(\"Failed to read\")?;\n"
+"    if username.is_empty() {\n"
+"        bail!(\"Found no username in {path}\");\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err:?}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/error-contexts.md:35
+#, fuzzy
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
+msgstr "“anyhow::Result"
+
+#: src/error-handling/error-contexts.md:36
+#, fuzzy
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr "”是“Result\\<V, anyhow::Error>”的类型别名。"
+
+#: src/error-handling/error-contexts.md:38
+#, fuzzy
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr "“anyhow::Error”本质上是“Box"
+
+#: src/error-handling/error-contexts.md:39
+#, fuzzy
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"”的封装容器。因此，就像前面提到的那样，在库的公共 API 中 使用它通常不是一个好主意。但是它广泛用于应用中。\n"
+"\n"
+"如果需要，可以提取其内部的实际错误类型进行检查。\n"
+"\n"
+"Go 开发者可能会十分熟悉 `anyhow::Result<T>` 提供的功能， 因为它的使用模式和工效学设计与 Go 的 `(T, error)` "
+"方法十分相似。"
+
+#: src/testing.md:3
+msgid "Rust and Cargo come with a simple unit test framework:"
+msgstr "Rust 和 Cargo 随附了一个简单的单元测试框架："
+
+#: src/testing.md:5
+msgid "Unit tests are supported throughout your code."
+msgstr "单元测试在您的整个代码中都受支持。"
+
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr "您可以通过 `tests/` 目录来支持集成测试。"
+
+#: src/testing/unit-tests.md:3
+msgid "Mark unit tests with `#[test]`:"
+msgstr "使用 `#[test]` 标记单元测试："
+
+#: src/testing/unit-tests.md:5
+msgid ""
+"```rust,editable,ignore\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_multiple_words() {\n"
+"    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/testing/unit-tests.md:29
+msgid "Use `cargo test` to find and run the unit tests."
+msgstr "使用 `cargo test` 查找并运行单元测试。"
+
+#: src/testing/test-modules.md:3
+msgid ""
+"Unit tests are often put in a nested module (run tests on the "
+"[Playground](https://play.rust-lang.org/)):"
+msgstr "单元测试通常会放在嵌套模块中（在 [Playground](https://play.rust-lang.org/) 上运行测试）："
+
+#: src/testing/test-modules.md:6
+msgid ""
+"```rust,editable\n"
+"fn helper(a: &str, b: &str) -> String {\n"
+"    format!(\"{a} {b}\")\n"
+"}\n"
+"\n"
+"pub fn main() {\n"
+"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"\n"
+"    #[test]\n"
+"    fn test_helper() {\n"
+"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/testing/test-modules.md:26
+msgid "This lets you unit test private helpers."
+msgstr "这样一来，您可以对专用帮助程序进行单元测试。"
+
+#: src/testing/test-modules.md:27
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr "仅当您运行 `cargo test` 时，`#[cfg(test)]` 属性才有效。"
+
+#: src/testing/doc-tests.md:3
+msgid "Rust has built-in support for documentation tests:"
+msgstr "Rust 本身就支持文档测试："
+
+#: src/testing/doc-tests.md:5
+msgid ""
+"```rust\n"
+"/// Shortens a string to the given length.\n"
+"///\n"
+"/// ```\n"
+"/// # use playground::shorten_string;\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
+"/// ```\n"
+"pub fn shorten_string(s: &str, length: usize) -> &str {\n"
+"    &s[..std::cmp::min(length, s.len())]\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/testing/doc-tests.md:18
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr "`///` 注释中的代码块会自动被视为 Rust 代码。"
+
+#: src/testing/doc-tests.md:19
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "代码会作为 `cargo test` 的一部分进行编译和执行。"
+
+#: src/testing/doc-tests.md:20
+msgid ""
+"Adding `# ` in the code will hide it from the docs, but will still "
+"compile/run it."
+msgstr ""
+
+#: src/testing/doc-tests.md:21
+msgid ""
+"Test the above code on the [Rust "
+"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgstr ""
+"在 [Rust "
+"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
+"上测试上述代码。"
+
+#: src/testing/integration-tests.md:3
+msgid "If you want to test your library as a client, use an integration test."
+msgstr "如果您想要以客户的身份测试您的库，请使用集成测试。"
+
+#: src/testing/integration-tests.md:5
+msgid "Create a `.rs` file under `tests/`:"
+msgstr "在 `tests/` 下方创建一个 `.rs` 文件："
+
+#: src/testing/integration-tests.md:16
+msgid "These tests only have access to the public API of your crate."
+msgstr "这些测试只能使用您的 crate 的公共 API。"
+
+#: src/testing/useful-crates.md:1
+msgid "Useful crates for writing tests"
+msgstr "用于编写测试的实用 crate"
+
+#: src/testing/useful-crates.md:3
+msgid "Rust comes with only basic support for writing tests."
+msgstr "Rust 仅为编写测试提供基本支持。"
+
+#: src/testing/useful-crates.md:5
+msgid "Here are some additional crates which we recommend for writing tests:"
+msgstr "下面列出了我们建议在编写测试时使用的一些其他 crate："
+
+#: src/testing/useful-crates.md:7
+msgid ""
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
+msgstr ""
+"[googletest](https://docs.rs/googletest)：遵从 GoogleTest for C++ 传统的综合测试断言库。"
+
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr "[proptest](https://docs.rs/proptest)：基于属性的测试，适用于 Rust。"
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
+msgstr "[rstest](https://docs.rs/rstest)：支持固件和参数化测试。"
+
+#: src/unsafe.md:3
+msgid "The Rust language has two parts:"
+msgstr "Rust 语言包含两个部分："
+
+#: src/unsafe.md:5
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr "\\*\\*安全 Rust：\\*\\*内存安全，没有潜在的未定义行为。"
+
+#: src/unsafe.md:6
+msgid ""
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"violated."
+msgstr "\\*\\*不安全 Rust：\\*\\*如果违反了前提条件，可能会触发未定义的行为。"
+
+#: src/unsafe.md:8
+msgid ""
+"We will be seeing mostly safe Rust in this course, but it's important to "
+"know what Unsafe Rust is."
+msgstr "本课程中出现的大多为“安全 Rust”，但是了解“不安全 Rust”的定义 非常重要。"
+
+#: src/unsafe.md:11
+msgid ""
+"Unsafe code is usually small and isolated, and its correctness should be "
+"carefully documented. It is usually wrapped in a safe abstraction layer."
+msgstr "不安全的代码通常内容很少而且与其他代码隔离， 其正确性也应得到仔细记录。这类代码通常封装在安全的抽象层中。"
+
+#: src/unsafe.md:14
+msgid "Unsafe Rust gives you access to five new capabilities:"
+msgstr "不安全 Rust 提供了五种新功能："
+
+#: src/unsafe.md:16
+msgid "Dereference raw pointers."
+msgstr "解引用原始指针。"
+
+#: src/unsafe.md:17
+msgid "Access or modify mutable static variables."
+msgstr "访问或修改可变的静态变量。"
+
+#: src/unsafe.md:18
+msgid "Access `union` fields."
+msgstr "访问 `union` 字段。"
+
+#: src/unsafe.md:19
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr "调用 `unsafe` 函数，包括 `extern` 函数。"
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
+msgstr "实现 `unsafe` trait。"
+
+#: src/unsafe.md:22
+msgid ""
+"We will briefly cover unsafe capabilities next. For full details, please see "
+"[Chapter 19.1 in the Rust "
+"Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) and the "
+"[Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+msgstr ""
+"下面，我们将简要介绍这些不安全功能。如需了解完整详情，请参阅 [《Rust 手册》第 19.1 "
+"章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) 和 "
+"[Rustonomicon](https://doc.rust-lang.org/nomicon/)。"
+
+#: src/unsafe.md:28
+msgid ""
+"Unsafe Rust does not mean the code is incorrect. It means that developers "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
+"rules."
+msgstr ""
+"不安全 Rust 并不意味着代码不正确，而是这意味着开发者已停用 编译器的安全功能，必须自行编写正确的 代码。也就是说，编译器不再强制执行 Rust "
+"的内存安全规则。"
+
+#: src/unsafe/raw-pointers.md:3
+msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
+msgstr "创建指针是安全的操作，但解引用指针需要使用 `unsafe` 方法："
+
+#: src/unsafe/raw-pointers.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut num = 5;\n"
+"\n"
+"    let r1 = &mut num as *mut i32;\n"
+"    let r2 = r1 as *const i32;\n"
+"\n"
+"    // Safe because r1 and r2 were obtained from references and so are\n"
+"    // guaranteed to be non-null and properly aligned, the objects "
+"underlying\n"
+"    // the references from which they were obtained are live throughout the\n"
+"    // whole unsafe block, and they are not accessed either through the\n"
+"    // references or concurrently through any other pointers.\n"
+"    unsafe {\n"
+"        println!(\"r1 is: {}\", *r1);\n"
+"        *r1 = 10;\n"
+"        println!(\"r2 is: {}\", *r2);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:27
+msgid ""
+"It is good practice (and required by the Android Rust style guide) to write "
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
+msgstr ""
+"我们建议（而且 Android Rust 样式指南要求）为每个 `unsafe` 代码块编写一条注释， "
+"说明该代码块中的代码如何满足其所执行的不安全操作的 安全要求。"
+
+#: src/unsafe/raw-pointers.md:31
+msgid ""
+"In the case of pointer dereferences, this means that the pointers must be "
+"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
+msgstr ""
+"对于指针解除引用，这意味着指针必须为 "
+"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety)，即："
+
+#: src/unsafe/raw-pointers.md:34
+msgid "The pointer must be non-null."
+msgstr "指针必须为非 null。"
+
+#: src/unsafe/raw-pointers.md:35
+msgid ""
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
+msgstr "指针必须是 _dereferenceable_（在单个已分配对象的边界内）。"
+
+#: src/unsafe/raw-pointers.md:36
+msgid "The object must not have been deallocated."
+msgstr "对象不得已取消分配。"
+
+#: src/unsafe/raw-pointers.md:37
+msgid "There must not be concurrent accesses to the same location."
+msgstr "不得并发访问相同位置。"
+
+#: src/unsafe/raw-pointers.md:38
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr "如果通过转换引用类型来获取指针，则底层对象必须处于活跃状态， 而且不得使用任何引用来访问内存。"
+
+#: src/unsafe/raw-pointers.md:41
+msgid "In most cases the pointer must also be properly aligned."
+msgstr "在大多数情况下，指针还必须正确对齐。"
+
+#: src/unsafe/mutable-static-variables.md:3
+msgid "It is safe to read an immutable static variable:"
+msgstr "读取不可变的静态变量是安全的操作："
+
+#: src/unsafe/mutable-static-variables.md:5
+msgid ""
+"```rust,editable\n"
+"static HELLO_WORLD: &str = \"Hello, world!\";\n"
+"\n"
+"fn main() {\n"
+"    println!(\"HELLO_WORLD: {HELLO_WORLD}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:13
+msgid ""
+"However, since data races can occur, it is unsafe to read and write mutable "
+"static variables:"
+msgstr "但是，读取和写入可变的静态变量是不安全的，因为这可能会 造成数据争用："
+
+#: src/unsafe/mutable-static-variables.md:16
+msgid ""
+"```rust,editable\n"
+"static mut COUNTER: u32 = 0;\n"
+"\n"
+"fn add_to_counter(inc: u32) {\n"
+"    unsafe { COUNTER += inc; }  // Potential data race!\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    add_to_counter(42);\n"
+"\n"
+"    unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:32
+msgid ""
+"Using a mutable static is generally a bad idea, but there are some cases "
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
+msgstr "通常，我们不建议使用可变的静态变量，但在某些情况下，在低层级 `no_std` 代码中可能需要这样做， 例如实现堆分配器或使用某些 C API。"
+
+#: src/unsafe/unions.md:3
+msgid "Unions are like enums, but you need to track the active field yourself:"
+msgstr "联合体与枚举类似，但您需要自行跟踪活跃字段："
+
+#: src/unsafe/unions.md:5
+msgid ""
+"```rust,editable\n"
+"#[repr(C)]\n"
+"union MyUnion {\n"
+"    i: u8,\n"
+"    b: bool,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let u = MyUnion { i: 42 };\n"
+"    println!(\"int: {}\", unsafe { u.i });\n"
+"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/unions.md:21
+msgid ""
+"Unions are very rarely needed in Rust as you can usually use an enum. They "
+"are occasionally needed for interacting with C library APIs."
+msgstr "在 Rust 中很少需要用到联合体，因为您通常可以使用枚举。联合体只是偶尔用于 与 C 库 API 进行交互。"
+
+#: src/unsafe/unions.md:24
+msgid ""
+"If you just want to reinterpret bytes as a different type, you probably want "
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
+"or a safe wrapper such as the "
+"[`zerocopy`](https://crates.io/crates/zerocopy) crate."
+msgstr ""
+"如果您只是想将字节重新解释为其他类型，则可能需要使用 "
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
+"或 安全的封装容器，例如 [`zerocopy`](https://crates.io/crates/zerocopy) crate。"
+
+#: src/unsafe/calling-unsafe-functions.md:3
+msgid ""
+"A function or method can be marked `unsafe` if it has extra preconditions "
+"you must uphold to avoid undefined behaviour:"
+msgstr "如果函数或方法具有额外的前提条件，您必须遵守这些前提条件来避免未定义的行为， 则可以将该函数或方法标记为 `unsafe`："
+
+#: src/unsafe/calling-unsafe-functions.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let emojis = \"🗻∈🌏\";\n"
+"\n"
+"    // Safe because the indices are in the correct order, within the bounds "
+"of\n"
+"    // the string slice, and lie on UTF-8 sequence boundaries.\n"
+"    unsafe {\n"
+"        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
+"        println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
+"        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
+"    }\n"
+"\n"
+"    println!(\"char count: {}\", count_chars(unsafe { "
+"emojis.get_unchecked(0..7) }));\n"
+"\n"
+"    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
+"    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
+"    // println!(\"char count: {}\", count_chars(unsafe { "
+"emojis.get_unchecked(0..3) }));\n"
+"}\n"
+"\n"
+"fn count_chars(s: &str) -> usize {\n"
+"    s.chars().map(|_| 1).sum()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:3
+msgid ""
+"You can mark your own functions as `unsafe` if they require particular "
+"conditions to avoid undefined behaviour."
+msgstr "如果您自己编写的函数需要满足特定条件以避免未定义的行为， 您可以将这些函数标记为 `unsafe`。"
+
+#: src/unsafe/writing-unsafe-functions.md:6
+msgid ""
+"```rust,editable\n"
+"/// Swaps the values pointed to by the given pointers.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// The pointers must be valid and properly aligned.\n"
+"unsafe fn swap(a: *mut u8, b: *mut u8) {\n"
+"    let temp = *a;\n"
+"    *a = *b;\n"
+"    *b = temp;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut a = 42;\n"
+"    let mut b = 66;\n"
+"\n"
+"    // Safe because ...\n"
+"    unsafe {\n"
+"        swap(&mut a, &mut b);\n"
+"    }\n"
+"\n"
+"    println!(\"a = {}, b = {}\", a, b);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:33
+msgid ""
+"We wouldn't actually use pointers for this because it can be done safely "
+"with references."
+msgstr "实际上，我们不会这样使用指针，因为使用引用可以安全地达到相同的目的。"
+
+#: src/unsafe/writing-unsafe-functions.md:35
+msgid ""
+"Note that unsafe code is allowed within an unsafe function without an "
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
+msgstr ""
+"请注意，在不安全函数中，可以在没有 `unsafe` 代码块的情况下使用不安全代码。我们可以 使用 "
+"`#[deny(unsafe_op_in_unsafe_fn)]` 来禁止此行为。请尝试添加该命令，看看会出现什么情况。"
+
+#: src/unsafe/extern-functions.md:1
+msgid "Calling External Code"
+msgstr "调用外部代码"
+
+#: src/unsafe/extern-functions.md:3
+msgid ""
+"Functions from other languages might violate the guarantees of Rust. Calling "
+"them is thus unsafe:"
+msgstr "基于其他语言的函数可能会违反 Rust 的保证。因此， 调用这类函数是不安全的："
+
+#: src/unsafe/extern-functions.md:6
+msgid ""
+"```rust,editable\n"
+"extern \"C\" {\n"
+"    fn abs(input: i32) -> i32;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    unsafe {\n"
+"        // Undefined behavior if abs misbehaves.\n"
+"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/extern-functions.md:21
+msgid ""
+"This is usually only a problem for extern functions which do things with "
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
+msgstr "这个问题通常仅存在于使用指针执行违反 Rust 内存模型的操作的外部函数中。 但一般而言，任何 C 函数都有可能在任意情况下出现未定义行为。"
+
+#: src/unsafe/extern-functions.md:25
+msgid ""
+"The `\"C\"` in this example is the ABI; [other ABIs are available "
+"too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
+msgstr ""
+
+#: src/unsafe/unsafe-traits.md:3
+msgid ""
+"Like with functions, you can mark a trait as `unsafe` if the implementation "
+"must guarantee particular conditions to avoid undefined behaviour."
+msgstr "与函数一样，如果您在实现某个 trait 时必须保证特定条件来避免未定义的行为， 您也可以将该 trait 标记为 `unsafe`。"
+
+#: src/unsafe/unsafe-traits.md:6
+msgid ""
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+msgstr ""
+"例如，`zerocopy` crate 包含一个不安全的 trait， "
+"[大致内容是这样的](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html)："
+
+#: src/unsafe/unsafe-traits.md:9
+msgid ""
+"```rust,editable\n"
+"use std::mem::size_of_val;\n"
+"use std::slice;\n"
+"\n"
+"/// ...\n"
+"/// # Safety\n"
+"/// The type must have a defined representation and no padding.\n"
+"pub unsafe trait AsBytes {\n"
+"    fn as_bytes(&self) -> &[u8] {\n"
+"        unsafe {\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// Safe because u32 has a defined representation and no padding.\n"
+"unsafe impl AsBytes for u32 {}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/unsafe-traits.md:30
+msgid ""
+"There should be a `# Safety` section on the Rustdoc for the trait explaining "
+"the requirements for the trait to be safely implemented."
+msgstr "在 Rustdoc 中有关 trait 的章节下，有一个标题为 `# 安全` 的部分介绍了 安全实现 trait 的要求。"
+
+#: src/unsafe/unsafe-traits.md:33
+msgid ""
+"The actual safety section for `AsBytes` is rather longer and more "
+"complicated."
+msgstr "实际上，与 `AsBytes` 相关的安全说明远比这里展示的更详尽、更复杂。"
+
+#: src/unsafe/unsafe-traits.md:35
+msgid "The built-in `Send` and `Sync` traits are unsafe."
+msgstr "内置的 `Send` 和 `Sync` trait 都是不安全的。"
+
+#: src/exercises/day-3/afternoon.md:1
+msgid "Day 3: Afternoon Exercises"
+msgstr ""
+
+#: src/exercises/day-3/afternoon.md:3
+msgid "Let us build a safe wrapper for reading directory content!"
+msgstr ""
+
+#: src/exercises/day-3/afternoon.md:5
+msgid ""
+"For this exercise, we suggest using a local dev environment instead of the "
+"Playground. This will allow you to run your binary on your own machine."
+msgstr ""
+
+#: src/exercises/day-3/afternoon.md:8
+msgid ""
+"To get started, follow the [running locally](../../cargo/running-locally.md) "
+"instructions."
+msgstr ""
+
+#: src/exercises/day-3/afternoon.md:14
+msgid ""
+"After looking at the exercise, you can look at the "
+"[solution](solutions-afternoon.md) provided."
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:3
+msgid ""
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
+"functions you would use from C to read the names of files in a directory."
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:7
+msgid "You will want to consult the manual pages:"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:9
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:13
+msgid ""
+"You will also want to browse the "
+"[`std::ffi`](https://doc.rust-lang.org/std/ffi/) module. There you find a "
+"number of string types which you need for the exercise:"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Encoding"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Use"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid ""
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and "
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "UTF-8"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "Text processing in Rust"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and "
+"[`CString`](https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "NUL-terminated"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "Communicating with C functions"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "OS-specific"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "Communicating with the OS"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:22
+msgid "You will convert between all these types:"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:24
+msgid ""
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use "
+"[`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) "
+"to create it,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:34
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:45
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
+"functions and methods:"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:48
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_imports, unused_variables, dead_code)]\n"
+"\n"
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int};\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
+"\n"
+"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"    #[repr(C)]\n"
+"    pub struct DIR {\n"
+"        _data: [u8; 0],\n"
+"        _marker: core::marker::PhantomData<(*mut u8, "
+"core::marker::PhantomPinned)>,\n"
+"    }\n"
+"\n"
+"    // Layout according to the Linux man page for readdir(3), where ino_t "
+"and\n"
+"    // off_t are resolved according to the definitions in\n"
+"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_ino: c_ulong,\n"
+"        pub d_off: c_long,\n"
+"        pub d_reclen: c_ushort,\n"
+"        pub d_type: c_uchar,\n"
+"        pub d_name: [c_char; 256],\n"
+"    }\n"
+"\n"
+"    // Layout according to the macOS man page for dir(5).\n"
+"    #[cfg(all(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_fileno: u64,\n"
+"        pub d_seekoff: u64,\n"
+"        pub d_reclen: u16,\n"
+"        pub d_namlen: u16,\n"
+"        pub d_type: u8,\n"
+"        pub d_name: [c_char; 1024],\n"
+"    }\n"
+"\n"
+"    extern \"C\" {\n"
+"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"\n"
+"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        // See https://github.com/rust-lang/libc/issues/414 and the section "
+"on\n"
+"        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
+"        //\n"
+"        // \"Platforms that existed before these updates were available\" "
+"refers\n"
+"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
+"PowerPC.\n"
+"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
+"        #[link_name = \"readdir$INODE64\"]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        pub fn closedir(s: *mut DIR) -> c_int;\n"
+"    }\n"
+"}\n"
+"\n"
+"use std::ffi::{CStr, CString, OsStr, OsString};\n"
+"use std::os::unix::ffi::OsStrExt;\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"\n"
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
+"        // otherwise return Err with a message.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android.md:1
+msgid "Welcome to Rust in Android"
+msgstr "欢迎来到Android 中的Rust"
+
+#: src/android.md:3
+msgid ""
+"Rust is supported for native platform development on Android. This means "
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
+msgstr "Rust 支持Android 的原生平台开发。这意味着您可以在Rust 中编写新的操作系统服务，以及扩展现有服务。"
+
+#: src/android.md:7
+msgid ""
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
+msgstr ""
+"今天我们会尝试在你自己的项目中调用Rust。 所以试着在你的代码中找一小段来改成Rust。 "
+"代码中越少依赖(dependencies)，越少“独特”的类型，越好。比如 一段解析原始字符的代码就很理想。"
+
+#: src/android/setup.md:3
+msgid ""
+"We will be using an Android Virtual Device to test our code. Make sure you "
+"have access to one or create a new one with:"
+msgstr ""
+"我们将会使用Android 虚拟设备（Android Virtual Device）来测试我们的代码。 确保你有权限访问一个，或者用以下命令创建一个新的："
+
+#: src/android/setup.md:12
+msgid ""
+"Please see the [Android Developer "
+"Codelab](https://source.android.com/docs/setup/start) for details."
+msgstr ""
+"更多细节请参考 [Android Developer "
+"Codelab](https://source.android.com/docs/setup/start)."
+
+#: src/android/build-rules.md:3
+msgid "The Android build system (Soong) supports Rust via a number of modules:"
+msgstr "Android 构建系统（Soong）通过一系列模块来支持Rust："
+
+#: src/android/build-rules.md:5
+#, fuzzy
+msgid "Module Type"
+msgstr ""
+"\\| 模块类型      | 描述                                                           "
+"                             | "
+"\\|—————————|——————————————————————————————————————————————————| \\| "
+"`rust_binary`     | Rust 二进制文件。                                              "
+"                             | \\| `rust_library`    | 生成Rust 库，并且提供 `rlib` "
+"和 `dylib` 变体。                       | \\| `rust_ffi`        | 生成可由 cc 模块使用的 "
+"Rust C 库，并提供静态和共享变体。    | \\| `rust_proc_macro` | 生成 proc-macro Rust 库。 "
+"这些宏与编译器插件类似。                     | \\| `rust_test`       | 生成使用标准 Rust "
+"自动化测试框架的 Rust 测试二进制文件。                             | \\| `rust_fuzz`       | "
+"生成使用 libfuzzer 的 Rust 模糊测试二进制文件。                                         | "
+"\\| `rust_protobuf`   | 生成源代码，并生成为特定 protobuf 提供接口的 Rust 库。| \\| "
+"`rust_bindgen`    | 生成源代码，并生成包含与 C 库的 Rust 绑定的 Rust 库。｜"
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr "描述"
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr "`rust_binary`"
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr "生成一个Rust二进制文件。"
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr "`rust_library`"
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr "生成一个 Rust 库，并提供 `rlib` 和 `dylib` 两种变体。"
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr "`rust_ffi`"
+
+#: src/android/build-rules.md:9
+msgid ""
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr "生成一个可由 `cc` 模块使用的 Rust C 库，并提供静态和共享两种变体。"
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr "`rust_proc_macro`"
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr "`rust_test`"
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr "生成使用标准 Rust 测试框架的 Rust 测试二进制文件。"
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr "`rust_fuzz`"
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr "`rust_protobuf`"
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr "生成源代码并生成为特定 protobuf 提供接口的 Rust 库。"
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr "生成源代码并生成包含 Rust 绑定到 C 库的 Rust 库。"
+
+#: src/android/build-rules.md:16
+msgid "We will look at `rust_binary` and `rust_library` next."
+msgstr "下面我们来看看 `rust_binary` 和 `rust_library`。"
+
+#: src/android/build-rules/binary.md:1
+msgid "Rust Binaries"
+msgstr "Rust 二进制文件"
+
+#: src/android/build-rules/binary.md:3
+msgid ""
+"Let us start with a simple application. At the root of an AOSP checkout, "
+"create the following files:"
+msgstr "让我们从一个简单的应用程序开始。在 AOSP 签出的根目录下，创建以下文件："
+
+#: src/android/build-rules/binary.md:6
+#: src/android/build-rules/library.md:13
+msgid "_hello_rust/Android.bp_:"
+msgstr "_hello_rust/Android.bp_:"
+
+#: src/android/build-rules/binary.md:8
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust\",\n"
+"    crate_name: \"hello_rust\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust\",\n"
+"    crate_name: \"hello_rust\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/binary.md:16
+#: src/android/build-rules/library.md:34
+msgid "_hello_rust/src/main.rs_:"
+msgstr "_hello_rust/src/main.rs_:"
+
+#: src/android/build-rules/binary.md:18
+msgid ""
+"```rust\n"
+"//! Rust demo.\n"
+"\n"
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"Hello from Rust!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"//! Rust demo.\n"
+"\n"
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"Hello from Rust!\");\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/binary.md:27
+msgid "You can now build, push, and run the binary:"
+msgstr "你现在可以构建、推送和运行二进制文件："
+
+#: src/android/build-rules/binary.md:29
+#, fuzzy
+msgid ""
+"```shell\n"
+"m hello_rust\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust /data/local/tmp\"\n"
+"adb shell /data/local/tmp/hello_rust\n"
+"```"
+msgstr ""
+
+#: src/android/build-rules/library.md:1
+msgid "Rust Libraries"
+msgstr "Rust 库"
+
+#: src/android/build-rules/library.md:3
+msgid "You use `rust_library` to create a new Rust library for Android."
+msgstr "您可以使用 `rust_library` 为 Android 创建一个新的 Rust 库。"
+
+#: src/android/build-rules/library.md:5
+msgid "Here we declare a dependency on two libraries:"
+msgstr "在这里，我们声明了对两个库的依赖："
+
+#: src/android/build-rules/library.md:7
+msgid "`libgreeting`, which we define below,"
+msgstr "`libgreeting`, 我们在下面进行了定义，"
+
+#: src/android/build-rules/library.md:8
+msgid ""
+"`libtextwrap`, which is a crate already vendored in "
+"[`external/rust/crates/`](https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/)."
+msgstr ""
+"`libtextwrap`, 一个已经在 "
+"[`external/rust/crates/`](https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/) "
+"中提供的 crate。"
+
+#: src/android/build-rules/library.md:15
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"\n"
+"rust_library {\n"
+"    name: \"libgreetings\",\n"
+"    crate_name: \"greetings\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"\n"
+"rust_library {\n"
+"    name: \"libgreetings\",\n"
+"    crate_name: \"greetings\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/library.md:36
+msgid ""
+"```rust,ignore\n"
+"//! Rust demo.\n"
+"\n"
+"use greetings::greeting;\n"
+"use textwrap::fill;\n"
+"\n"
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"//! Rust demo.\n"
+"\n"
+"use greetings::greeting;\n"
+"use textwrap::fill;\n"
+"\n"
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/library.md:48
+msgid "_hello_rust/src/lib.rs_:"
+msgstr "_hello_rust/src/lib.rs_:"
+
+#: src/android/build-rules/library.md:50
+msgid ""
+"```rust,ignore\n"
+"//! Greeting library.\n"
+"\n"
+"/// Greet `name`.\n"
+"pub fn greeting(name: &str) -> String {\n"
+"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"//! Greeting library.\n"
+"\n"
+"/// Greet `name`.\n"
+"pub fn greeting(name: &str) -> String {\n"
+"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/library.md:59
+msgid "You build, push, and run the binary like before:"
+msgstr "您可以像之前一样构建、推送和运行二进制文件："
+
+#: src/android/build-rules/library.md:61
+#, fuzzy
+msgid ""
+"```shell\n"
+"m hello_rust_with_dep\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep "
+"/data/local/tmp\"\n"
+"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"```"
+msgstr ""
+
+#: src/android/aidl.md:3
+msgid ""
+"The [Android Interface Definition Language "
+"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
+"Rust:"
+msgstr ""
+"Rust 支持 [Android 接口定义语言 "
+"(AIDL)](https://developer.android.com/guide/components/aidl)："
+
+#: src/android/aidl.md:6
+msgid "Rust code can call existing AIDL servers,"
+msgstr "Rust 代码可以调用现有的 AIDL 服务器，"
+
+#: src/android/aidl.md:7
+msgid "You can create new AIDL servers in Rust."
+msgstr "您可以在 Rust 中创建新的 AIDL 服务器。"
+
+#: src/android/aidl/interface.md:1
+msgid "AIDL Interfaces"
+msgstr "AIDL 接口"
+
+#: src/android/aidl/interface.md:3
+msgid "You declare the API of your service using an AIDL interface:"
+msgstr "您可以使用 AIDL 接口声明您的服务的 API："
+
+#: src/android/aidl/interface.md:5
+msgid ""
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
+msgstr ""
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
+
+#: src/android/aidl/interface.md:17
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_birthday_service/aidl/Android.bp_:"
+
+#: src/android/aidl/interface.md:19
+msgid ""
+"```javascript\n"
+"aidl_interface {\n"
+"    name: \"com.example.birthdayservice\",\n"
+"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
+"    unstable: true,\n"
+"    backend: {\n"
+"        rust: { // Rust is not enabled by default\n"
+"            enabled: true,\n"
+"        },\n"
+"    },\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"aidl_interface {\n"
+"    name: \"com.example.birthdayservice\",\n"
+"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
+"    unstable: true,\n"
+"    backend: {\n"
+"        rust: { // 默认情况下不启用 Rust \n"
+"            enabled: true,\n"
+"        },\n"
+"    },\n"
+"}\n"
+"```"
+
+#: src/android/aidl/interface.md:32
+msgid ""
+"Add `vendor_available: true` if your AIDL file is used by a binary in the "
+"vendor partition."
+msgstr "如果供应商分区中的二进制文件使用了您的 AIDL 文件，请添加 `vendor_available: true`。"
+
+#: src/android/aidl/implementation.md:1
+msgid "Service Implementation"
+msgstr "服务实现"
+
+#: src/android/aidl/implementation.md:3
+msgid "We can now implement the AIDL service:"
+msgstr "我们现在可以实现AIDL服务："
+
+#: src/android/aidl/implementation.md:5
+msgid "_birthday_service/src/lib.rs_:"
+msgstr "_birthday_service/src/lib.rs_:"
+
+#: src/android/aidl/implementation.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Implementation of the `IBirthdayService` AIDL interface.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"/// The `IBirthdayService` implementation.\n"
+"pub struct BirthdayService;\n"
+"\n"
+"impl binder::Interface for BirthdayService {}\n"
+"\n"
+"impl IBirthdayService for BirthdayService {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
+"binder::Result<String> {\n"
+"        Ok(format!(\n"
+"            \"Happy Birthday {name}, congratulations with the {years} "
+"years!\"\n"
+"        ))\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"//! 实现了 `IBirthdayService` AIDL 接口。\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"/// `IBirthdayService` 接口的具体实现。\n"
+"pub struct BirthdayService;\n"
+"\n"
+"impl binder::Interface for BirthdayService {}\n"
+"\n"
+"impl IBirthdayService for BirthdayService {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
+"binder::Result<String> {\n"
+"        Ok(format!(\n"
+"            \"Happy Birthday {name}, congratulations with the {years} "
+"years!\"\n"
+"        ))\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/android/aidl/implementation.md:26
+#: src/android/aidl/server.md:28
+#: src/android/aidl/client.md:37
+msgid "_birthday_service/Android.bp_:"
+msgstr "_birthday_service/Android.bp_:"
+
+#: src/android/aidl/implementation.md:28
+msgid ""
+"```javascript\n"
+"rust_library {\n"
+"    name: \"libbirthdayservice\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    crate_name: \"birthdayservice\",\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_library {\n"
+"    name: \"libbirthdayservice\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    crate_name: \"birthdayservice\",\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"}\n"
+"```"
+
+#: src/android/aidl/server.md:1
+msgid "AIDL Server"
+msgstr "AIDL 服务器"
+
+#: src/android/aidl/server.md:3
+msgid "Finally, we can create a server which exposes the service:"
+msgstr "最后，我们可以创建一个暴露服务的服务器："
+
+#: src/android/aidl/server.md:5
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_birthday_service/src/server.rs_:"
+
+#: src/android/aidl/server.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use birthdayservice::BirthdayService;\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
+"\n"
+"/// Entry point for birthday service.\n"
+"fn main() {\n"
+"    let birthday_service = BirthdayService;\n"
+"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
+"        birthday_service,\n"
+"        binder::BinderFeatures::default(),\n"
+"    );\n"
+"    binder::add_service(SERVICE_IDENTIFIER, "
+"birthday_service_binder.as_binder())\n"
+"        .expect(\"Failed to register service\");\n"
+"    binder::ProcessState::join_thread_pool()\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"//! 生日服务。\n"
+"use birthdayservice::BirthdayService;\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
+"\n"
+"/// 生日服务的入口。\n"
+"fn main() {\n"
+"    let birthday_service = BirthdayService;\n"
+"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
+"        birthday_service,\n"
+"        binder::BinderFeatures::default(),\n"
+"    );\n"
+"    binder::add_service(SERVICE_IDENTIFIER, "
+"birthday_service_binder.as_binder())\n"
+"        .expect(\"Failed to register service\");\n"
+"    binder::ProcessState::join_thread_pool()\n"
+"}\n"
+"```"
+
+#: src/android/aidl/server.md:30
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_server\",\n"
+"    crate_name: \"birthday_server\",\n"
+"    srcs: [\"src/server.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"        \"libbirthdayservice\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_server\",\n"
+"    crate_name: \"birthday_server\",\n"
+"    srcs: [\"src/server.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"        \"libbirthdayservice\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+
+#: src/android/aidl/deploy.md:3
+msgid "We can now build, push, and start the service:"
+msgstr "我们现在可以构建、推送和启动服务："
+
+#: src/android/aidl/deploy.md:5
+#, fuzzy
+msgid ""
+"```shell\n"
+"m birthday_server\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server "
+"/data/local/tmp\"\n"
+"adb shell /data/local/tmp/birthday_server\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/deploy.md:11
+msgid "In another terminal, check that the service runs:"
+msgstr "在另一个终端中，检查该服务是否正在运行："
+
+#: src/android/aidl/deploy.md:21
+msgid "You can also call the service with `service call`:"
+msgstr "您还可以使用 `service call` 命令调用该服务："
+
+#: src/android/aidl/client.md:1
+msgid "AIDL Client"
+msgstr "AIDL 客户端"
+
+#: src/android/aidl/client.md:3
+msgid "Finally, we can create a Rust client for our new service."
+msgstr "最后，我们可以为我们的新服务创建一个 Rust 客户端。"
+
+#: src/android/aidl/client.md:5
+msgid "_birthday_service/src/client.rs_:"
+msgstr "_birthday_service/src/client.rs_:"
+
+#: src/android/aidl/client.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
+"\n"
+"/// Connect to the BirthdayService.\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
+"binder::StatusCode> {\n"
+"    binder::get_interface(SERVICE_IDENTIFIER)\n"
+"}\n"
+"\n"
+"/// Call the birthday service.\n"
+"fn main() -> Result<(), binder::Status> {\n"
+"    let name = std::env::args()\n"
+"        .nth(1)\n"
+"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
+"    let years = std::env::args()\n"
+"        .nth(2)\n"
+"        .and_then(|arg| arg.parse::<i32>().ok())\n"
+"        .unwrap_or(42);\n"
+"\n"
+"    binder::ProcessState::start_thread_pool();\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
+"    let msg = service.wishHappyBirthday(&name, years)?;\n"
+"    println!(\"{msg}\");\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"//! 生日服务。\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
+"\n"
+"/// 连接到 BirthdayService。\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
+"binder::StatusCode> {\n"
+"    binder::get_interface(SERVICE_IDENTIFIER)\n"
+"}\n"
+"\n"
+"/// 调用生日服务。\n"
+"fn main() -> Result<(), binder::Status> {\n"
+"    let name = std::env::args()\n"
+"        .nth(1)\n"
+"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
+"    let years = std::env::args()\n"
+"        .nth(2)\n"
+"        .and_then(|arg| arg.parse::<i32>().ok())\n"
+"        .unwrap_or(42);\n"
+"\n"
+"    binder::ProcessState::start_thread_pool();\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
+"    let msg = service.wishHappyBirthday(&name, years)?;\n"
+"    println!(\"{msg}\");\n"
+"    Ok(())\n"
+"}\n"
+"```"
+
+#: src/android/aidl/client.md:39
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_client\",\n"
+"    crate_name: \"birthday_client\",\n"
+"    srcs: [\"src/client.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_client\",\n"
+"    crate_name: \"birthday_client\",\n"
+"    srcs: [\"src/client.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+
+#: src/android/aidl/client.md:52
+msgid "Notice that the client does not depend on `libbirthdayservice`."
+msgstr "请注意，客户端不依赖于 `libbirthdayservice`。"
+
+#: src/android/aidl/client.md:54
+msgid "Build, push, and run the client on your device:"
+msgstr "在您的设备上构建、推送并运行客户端："
+
+#: src/android/aidl/client.md:56
+#, fuzzy
+msgid ""
+"```shell\n"
+"m birthday_client\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client "
+"/data/local/tmp\"\n"
+"adb shell /data/local/tmp/birthday_client Charlie 60\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/changing.md:3
+msgid ""
+"Let us extend the API with more functionality: we want to let clients "
+"specify a list of lines for the birthday card:"
+msgstr "让我们扩展API以提供更多功能：我们希望允许客户端指定生日贺卡的行列表："
+
+#: src/android/logging.md:3
+msgid ""
+"You should use the `log` crate to automatically log to `logcat` (on-device) "
+"or `stdout` (on-host):"
+msgstr "你应该使用 `log` crate 来自动记录日志到 `logcat` （设备上）或 `stdout`（主机上）："
+
+#: src/android/logging.md:6
+msgid "_hello_rust_logs/Android.bp_:"
+msgstr "_hello_rust_logs/Android.bp_:"
+
+#: src/android/logging.md:8
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_logs\",\n"
+"    crate_name: \"hello_rust_logs\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"liblog_rust\",\n"
+"        \"liblogger\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"    host_supported: true,\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_logs\",\n"
+"    crate_name: \"hello_rust_logs\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"liblog_rust\",\n"
+"        \"liblogger\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"    host_supported: true,\n"
+"}\n"
+"```"
+
+#: src/android/logging.md:22
+msgid "_hello_rust_logs/src/main.rs_:"
+msgstr "_hello_rust_logs/src/main.rs_:"
+
+#: src/android/logging.md:24
+msgid ""
+"```rust,ignore\n"
+"//! Rust logging demo.\n"
+"\n"
+"use log::{debug, error, info};\n"
+"\n"
+"/// Logs a greeting.\n"
+"fn main() {\n"
+"    logger::init(\n"
+"        logger::Config::default()\n"
+"            .with_tag_on_device(\"rust\")\n"
+"            .with_min_level(log::Level::Trace),\n"
+"    );\n"
+"    debug!(\"Starting program.\");\n"
+"    info!(\"Things are going fine.\");\n"
+"    error!(\"Something went wrong!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"//! Rust logging demo.\n"
+"\n"
+"use log::{debug, error, info};\n"
+"\n"
+"/// Logs a greeting.\n"
+"fn main() {\n"
+"    logger::init(\n"
+"        logger::Config::default()\n"
+"            .with_tag_on_device(\"rust\")\n"
+"            .with_min_level(log::Level::Trace),\n"
+"    );\n"
+"    debug!(\"Starting program.\");\n"
+"    info!(\"Things are going fine.\");\n"
+"    error!(\"Something went wrong!\");\n"
+"}\n"
+"```"
+
+#: src/android/logging.md:42
+#: src/android/interoperability/with-c/bindgen.md:98
+#: src/android/interoperability/with-c/rust.md:73
+msgid "Build, push, and run the binary on your device:"
+msgstr "在你的设备上构建，推送，并运行二进制文件 ："
+
+#: src/android/logging.md:44
+#, fuzzy
+msgid ""
+"```shell\n"
+"m hello_rust_logs\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs "
+"/data/local/tmp\"\n"
+"adb shell /data/local/tmp/hello_rust_logs\n"
+"```"
+msgstr ""
+
+#: src/android/logging.md:50
+msgid "The logs show up in `adb logcat`:"
+msgstr "日志将会在 `adb logcat` 中显示："
+
+#: src/android/interoperability.md:3
+msgid ""
+"Rust has excellent support for interoperability with other languages. This "
+"means that you can:"
+msgstr ""
+
+#: src/android/interoperability.md:6
+msgid "Call Rust functions from other languages."
+msgstr ""
+
+#: src/android/interoperability.md:7
+msgid "Call functions written in other languages from Rust."
+msgstr ""
+
+#: src/android/interoperability.md:9
+msgid ""
+"When you call functions in a foreign language we say that you're using a "
+"_foreign function interface_, also known as FFI."
+msgstr ""
+
+#: src/android/interoperability/with-c.md:1
+msgid "Interoperability with C"
+msgstr ""
+
+#: src/android/interoperability/with-c.md:3
+msgid ""
+"Rust has full support for linking object files with a C calling convention. "
+"Similarly, you can export Rust functions and call them from C."
+msgstr ""
+
+#: src/android/interoperability/with-c.md:6
+msgid "You can do it by hand if you want:"
+msgstr ""
+
+#: src/android/interoperability/with-c.md:8
+msgid ""
+"```rust\n"
+"extern \"C\" {\n"
+"    fn abs(x: i32) -> i32;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let x = -42;\n"
+"    let abs_x = unsafe { abs(x) };\n"
+"    println!(\"{x}, {abs_x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c.md:20
+msgid ""
+"We already saw this in the [Safe FFI Wrapper "
+"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+msgstr ""
+
+#: src/android/interoperability/with-c.md:23
+msgid ""
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
+msgstr ""
+
+#: src/android/interoperability/with-c.md:26
+msgid "We will look at better options next."
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:1
+msgid "Using Bindgen"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:3
+msgid ""
+"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
+"tool can auto-generate bindings from a C header file."
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:6
+msgid "First create a small C library:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:8
+msgid "_interoperability/bindgen/libbirthday.h_:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:19
+msgid "_interoperability/bindgen/libbirthday.c_:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:21
+msgid ""
+"```c\n"
+"#include <stdio.h>\n"
+"#include \"libbirthday.h\"\n"
+"\n"
+"void print_card(const card* card) {\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"  printf(\"| Happy Birthday %s!\\n"
+"\", card->name);\n"
+"  printf(\"| Congratulations with the %i years!\\n"
+"\", card->years);\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:33
+msgid "Add this to your `Android.bp` file:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:35
+#: src/android/interoperability/with-c/bindgen.md:55
+#: src/android/interoperability/with-c/bindgen.md:69
+#: src/android/interoperability/with-c/bindgen.md:108
+msgid "_interoperability/bindgen/Android.bp_:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:37
+msgid ""
+"```javascript\n"
+"cc_library {\n"
+"    name: \"libbirthday\",\n"
+"    srcs: [\"libbirthday.c\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:44
+msgid ""
+"Create a wrapper header file for the library (not strictly needed in this "
+"example):"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:47
+msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:49
+msgid ""
+"```c\n"
+"#include \"libbirthday.h\"\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:53
+msgid "You can now auto-generate the bindings:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:57
+msgid ""
+"```javascript\n"
+"rust_bindgen {\n"
+"    name: \"libbirthday_bindgen\",\n"
+"    crate_name: \"birthday_bindgen\",\n"
+"    wrapper_src: \"libbirthday_wrapper.h\",\n"
+"    source_stem: \"bindings\",\n"
+"    static_libs: [\"libbirthday\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:67
+msgid "Finally, we can use the bindings in our Rust program:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:71
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"print_birthday_card\",\n"
+"    srcs: [\"main.rs\"],\n"
+"    rustlibs: [\"libbirthday_bindgen\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:79
+msgid "_interoperability/bindgen/main.rs_:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:81
+msgid ""
+"```rust,compile_fail\n"
+"//! Bindgen demo.\n"
+"\n"
+"use birthday_bindgen::{card, print_card};\n"
+"\n"
+"fn main() {\n"
+"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
+"    let card = card {\n"
+"        name: name.as_ptr(),\n"
+"        years: 42,\n"
+"    };\n"
+"    unsafe {\n"
+"        print_card(&card as *const card);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:100
+#, fuzzy
+msgid ""
+"```shell\n"
+"m print_birthday_card\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card "
+"/data/local/tmp\"\n"
+"adb shell /data/local/tmp/print_birthday_card\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:106
+msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:110
+msgid ""
+"```javascript\n"
+"rust_test {\n"
+"    name: \"libbirthday_bindgen_test\",\n"
+"    srcs: [\":libbirthday_bindgen\"],\n"
+"    crate_name: \"libbirthday_bindgen_test\",\n"
+"    test_suites: [\"general-tests\"],\n"
+"    auto_gen_config: true,\n"
+"    clippy_lints: \"none\", // Generated file, skip linting\n"
+"    lints: \"none\",\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:1
+msgid "Calling Rust"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:3
+msgid "Exporting Rust functions and types to C is easy:"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:5
+msgid "_interoperability/rust/libanalyze/analyze.rs_"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:7
+msgid ""
+"```rust,editable\n"
+"//! Rust FFI demo.\n"
+"#![deny(improper_ctypes_definitions)]\n"
+"\n"
+"use std::os::raw::c_int;\n"
+"\n"
+"/// Analyze the numbers.\n"
+"#[no_mangle]\n"
+"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
+"    if x < y {\n"
+"        println!(\"x ({x}) is smallest!\");\n"
+"    } else {\n"
+"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:24
+msgid "_interoperability/rust/libanalyze/analyze.h_"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:26
+msgid ""
+"```c\n"
+"#ifndef ANALYSE_H\n"
+"#define ANALYSE_H\n"
+"\n"
+"extern \"C\" {\n"
+"void analyze_numbers(int x, int y);\n"
+"}\n"
+"\n"
+"#endif\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:37
+msgid "_interoperability/rust/libanalyze/Android.bp_"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:39
+msgid ""
+"```javascript\n"
+"rust_ffi {\n"
+"    name: \"libanalyze_ffi\",\n"
+"    crate_name: \"analyze_ffi\",\n"
+"    srcs: [\"analyze.rs\"],\n"
+"    include_dirs: [\".\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:48
+msgid "We can now call this from a C binary:"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:50
+msgid "_interoperability/rust/analyze/main.c_"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:52
+msgid ""
+"```c\n"
+"#include \"analyze.h\"\n"
+"\n"
+"int main() {\n"
+"  analyze_numbers(10, 20);\n"
+"  analyze_numbers(123, 123);\n"
+"  return 0;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:62
+msgid "_interoperability/rust/analyze/Android.bp_"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:64
+msgid ""
+"```javascript\n"
+"cc_binary {\n"
+"    name: \"analyze_numbers\",\n"
+"    srcs: [\"main.c\"],\n"
+"    static_libs: [\"libanalyze_ffi\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:75
+#, fuzzy
+msgid ""
+"```shell\n"
+"m analyze_numbers\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers "
+"/data/local/tmp\"\n"
+"adb shell /data/local/tmp/analyze_numbers\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:83
+msgid ""
+"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:3
+msgid ""
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:6
+msgid "The overall approach looks like this:"
+msgstr ""
+
+#: src/android/interoperability/cpp.md:10
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:14
+msgid ""
+"At this point, the instructor should switch to the [CXX "
+"tutorial](https://cxx.rs/tutorial.html)."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:16
+msgid "Walk the students through the tutorial step by step."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:18
+msgid ""
+"Highlight how CXX presents a clean interface without unsafe code in _both "
+"languages_."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:20
+msgid ""
+"Show the correspondence between [Rust and C++ "
+"types](https://cxx.rs/bindings.html):"
+msgstr ""
+
+#: src/android/interoperability/cpp.md:22
+msgid ""
+"Explain how a Rust `String` cannot map to a C++ `std::string` (the latter "
+"does not uphold the UTF-8 invariant). Show that despite being different "
+"types, `rust::String` in C++ can be easily constructed from a C++ "
+"`std::string`, making it very ergonomic to use."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:28
+msgid ""
+"Explain that a Rust function returning `Result<T, E>` becomes a function "
+"which throws a `E` exception in C++ (and vice versa)."
+msgstr ""
+
+#: src/android/interoperability/java.md:1
+msgid "Interoperability with Java"
+msgstr ""
+
+#: src/android/interoperability/java.md:3
+msgid ""
+"Java can load shared objects via [Java Native Interface "
+"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni` "
+"crate](https://docs.rs/jni/) allows you to create a compatible library."
+msgstr ""
+
+#: src/android/interoperability/java.md:7
+msgid "First, we create a Rust function to export to Java:"
+msgstr ""
+
+#: src/android/interoperability/java.md:9
+msgid "_interoperability/java/src/lib.rs_:"
+msgstr ""
+
+#: src/android/interoperability/java.md:11
+msgid ""
+"```rust,compile_fail\n"
+"//! Rust <-> Java FFI demo.\n"
+"\n"
+"use jni::objects::{JClass, JString};\n"
+"use jni::sys::jstring;\n"
+"use jni::JNIEnv;\n"
+"\n"
+"/// HelloWorld::hello method implementation.\n"
+"#[no_mangle]\n"
+"pub extern \"system\" fn Java_HelloWorld_hello(\n"
+"    env: JNIEnv,\n"
+"    _class: JClass,\n"
+"    name: JString,\n"
+") -> jstring {\n"
+"    let input: String = env.get_string(name).unwrap().into();\n"
+"    let greeting = format!(\"Hello, {input}!\");\n"
+"    let output = env.new_string(greeting).unwrap();\n"
+"    output.into_inner()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:32
+#: src/android/interoperability/java.md:62
+msgid "_interoperability/java/Android.bp_:"
+msgstr ""
+
+#: src/android/interoperability/java.md:34
+msgid ""
+"```javascript\n"
+"rust_ffi_shared {\n"
+"    name: \"libhello_jni\",\n"
+"    crate_name: \"hello_jni\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    rustlibs: [\"libjni\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:43
+msgid "Finally, we can call this function from Java:"
+msgstr ""
+
+#: src/android/interoperability/java.md:45
+msgid "_interoperability/java/HelloWorld.java_:"
+msgstr ""
+
+#: src/android/interoperability/java.md:47
+msgid ""
+"```java\n"
+"class HelloWorld {\n"
+"    private static native String hello(String name);\n"
+"\n"
+"    static {\n"
+"        System.loadLibrary(\"hello_jni\");\n"
+"    }\n"
+"\n"
+"    public static void main(String[] args) {\n"
+"        String output = HelloWorld.hello(\"Alice\");\n"
+"        System.out.println(output);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:64
+msgid ""
+"```javascript\n"
+"java_binary {\n"
+"    name: \"helloworld_jni\",\n"
+"    srcs: [\"HelloWorld.java\"],\n"
+"    main_class: \"HelloWorld\",\n"
+"    required: [\"libhello_jni\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:73
+msgid "Finally, you can build, sync, and run the binary:"
+msgstr ""
+
+#: src/exercises/android/morning.md:3
+msgid ""
+"This is a group exercise: We will look at one of the projects you work with "
+"and try to integrate some Rust into it. Some suggestions:"
+msgstr ""
+
+#: src/exercises/android/morning.md:6
+msgid "Call your AIDL service with a client written in Rust."
+msgstr ""
+
+#: src/exercises/android/morning.md:8
+msgid "Move a function from your project to Rust and call it."
+msgstr ""
+
+#: src/exercises/android/morning.md:12
+msgid ""
+"No solution is provided here since this is open-ended: it relies on someone "
+"in the class having a piece of code which you can turn in to Rust on the fly."
+msgstr ""
+
+#: src/bare-metal.md:1
+msgid "Welcome to Bare Metal Rust"
+msgstr ""
+
+#: src/bare-metal.md:3
+msgid ""
+"This is a standalone one-day course about bare-metal Rust, aimed at people "
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with "
+"bare-metal programming in some other language such as C."
+msgstr ""
+
+#: src/bare-metal.md:7
+msgid ""
+"Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
+"underneath us. This will be divided into several parts:"
+msgstr ""
+
+#: src/bare-metal.md:10
+msgid "What is `no_std` Rust?"
+msgstr ""
+
+#: src/bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr ""
+
+#: src/bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr ""
+
+#: src/bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
+msgstr ""
+
+#: src/bare-metal.md:15
+msgid ""
+"For the microcontroller part of the course we will use the [BBC "
+"micro:bit](https://microbit.org/) v2 as an example. It's a [development "
+"board](https://tech.microbit.org/hardware/) based on the Nordic nRF51822 "
+"microcontroller with some LEDs and buttons, an I2C-connected accelerometer "
+"and compass, and an on-board SWD debugger."
+msgstr ""
+
+#: src/bare-metal.md:20
+msgid "To get started, install some tools we'll need later. On gLinux or Debian:"
+msgstr ""
+
+#: src/bare-metal.md:30
+msgid "And give users in the `plugdev` group access to the micro:bit programmer:"
+msgstr ""
+
+#: src/bare-metal.md:32
+msgid ""
+"```bash\n"
+"echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0d28\", MODE=\"0664\", "
+"GROUP=\"plugdev\"' |\\\n"
+"  sudo tee /etc/udev/rules.d/50-microbit.rules\n"
+"sudo udevadm control --reload-rules\n"
+"```"
+msgstr ""
+
+#: src/bare-metal.md:38
+msgid "On MacOS:"
+msgstr ""
+
+#: src/bare-metal/no_std.md:1
+msgid "`no_std`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:7
+msgid "`core`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:12
+#: src/bare-metal/alloc.md:1
+msgid "`alloc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:17
+msgid "`std`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:24
+msgid "Slices, `&str`, `CStr`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr ""
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:38
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:45
+msgid "`Error`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:62
+msgid "`HashMap` depends on RNG."
+msgstr ""
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:1
+msgid "A minimal `no_std` program"
+msgstr ""
+
+#: src/bare-metal/minimal.md:17
+msgid "This will compile to an empty binary."
+msgstr ""
+
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
+msgstr ""
+
+#: src/bare-metal/alloc.md:3
+msgid ""
+"To use `alloc` you must implement a [global (heap) "
+"allocator](https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
+msgstr ""
+
+#: src/bare-metal/alloc.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate alloc;\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use alloc::string::ToString;\n"
+"use alloc::vec::Vec;\n"
+"use buddy_system_allocator::LockedHeap;\n"
+"\n"
+"#[global_allocator]\n"
+"static HEAP_ALLOCATOR: LockedHeap<32> = LockedHeap::<32>::new();\n"
+"\n"
+"static mut HEAP: [u8; 65536] = [0; 65536];\n"
+"\n"
+"pub fn entry() {\n"
+"    // Safe because `HEAP` is only used here and `entry` is only called "
+"once.\n"
+"    unsafe {\n"
+"        // Give the allocator some memory to allocate.\n"
+"        HEAP_ALLOCATOR\n"
+"            .lock()\n"
+"            .init(HEAP.as_mut_ptr() as usize, HEAP.len());\n"
+"    }\n"
+"\n"
+"    // Now we can do things that require heap allocation.\n"
+"    let mut v = Vec::new();\n"
+"    v.push(\"A string\".to_string());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/alloc.md:39
+msgid ""
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
+msgstr ""
+
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
+msgstr ""
+
+#: src/bare-metal/microcontrollers.md:3
+msgid ""
+"The `cortex_m_rt` crate provides (among other things) a reset handler for "
+"Cortex M microcontrollers."
+msgstr ""
+
+#: src/bare-metal/microcontrollers.md:21
+msgid ""
+"Next we'll look at how to access peripherals, with increasing levels of "
+"abstraction."
+msgstr ""
+
+#: src/bare-metal/microcontrollers.md:25
+msgid ""
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -> "
+"!`, because returning to the reset handler doesn't make sense."
+msgstr ""
+
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:3
+msgid ""
+"Most microcontrollers access peripherals via memory-mapped IO. Let's try "
+"turning on an LED on our micro:bit:"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"mod interrupts;\n"
+"\n"
+"use core::mem::size_of;\n"
+"use cortex_m_rt::entry;\n"
+"\n"
+"/// GPIO port 0 peripheral address\n"
+"const GPIO_P0: usize = 0x5000_0000;\n"
+"\n"
+"// GPIO peripheral offsets\n"
+"const PIN_CNF: usize = 0x700;\n"
+"const OUTSET: usize = 0x508;\n"
+"const OUTCLR: usize = 0x50c;\n"
+"\n"
+"// PIN_CNF fields\n"
+"const DIR_OUTPUT: u32 = 0x1;\n"
+"const INPUT_DISCONNECT: u32 = 0x1 << 1;\n"
+"const PULL_DISABLED: u32 = 0x0 << 2;\n"
+"const DRIVE_S0S1: u32 = 0x0 << 8;\n"
+"const SENSE_DISABLED: u32 = 0x0 << 16;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+"    let pin_cnf_21 = (GPIO_P0 + PIN_CNF + 21 * size_of::<u32>()) as *mut "
+"u32;\n"
+"    let pin_cnf_28 = (GPIO_P0 + PIN_CNF + 28 * size_of::<u32>()) as *mut "
+"u32;\n"
+"    // Safe because the pointers are to valid peripheral control registers, "
+"and\n"
+"    // no aliases exist.\n"
+"    unsafe {\n"
+"        pin_cnf_21.write_volatile(\n"
+"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
+"SENSE_DISABLED,\n"
+"        );\n"
+"        pin_cnf_28.write_volatile(\n"
+"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
+"SENSE_DISABLED,\n"
+"        );\n"
+"    }\n"
+"\n"
+"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
+"    let gpio0_outset = (GPIO_P0 + OUTSET) as *mut u32;\n"
+"    let gpio0_outclr = (GPIO_P0 + OUTCLR) as *mut u32;\n"
+"    // Safe because the pointers are to valid peripheral control registers, "
+"and\n"
+"    // no aliases exist.\n"
+"    unsafe {\n"
+"        gpio0_outclr.write_volatile(1 << 28);\n"
+"        gpio0_outset.write_volatile(1 << 21);\n"
+"    }\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:64
+msgid ""
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:66
+#: src/bare-metal/microcontrollers/pacs.md:59
+#: src/bare-metal/microcontrollers/hals.md:43
+#: src/bare-metal/microcontrollers/board-support.md:34
+msgid "Run the example with:"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:1
+msgid "Peripheral Access Crates"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:3
+msgid ""
+"[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
+"wrappers for memory-mapped peripherals from "
+"[CMSIS-SVD](https://www.keil.com/pack/doc/CMSIS/SVD/html/index.html) files."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use cortex_m_rt::entry;\n"
+"use nrf52833_pac::Peripherals;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let p = Peripherals::take().unwrap();\n"
+"    let gpio0 = p.P0;\n"
+"\n"
+"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+"    gpio0.pin_cnf[21].write(|w| {\n"
+"        w.dir().output();\n"
+"        w.input().disconnect();\n"
+"        w.pull().disabled();\n"
+"        w.drive().s0s1();\n"
+"        w.sense().disabled();\n"
+"        w\n"
+"    });\n"
+"    gpio0.pin_cnf[28].write(|w| {\n"
+"        w.dir().output();\n"
+"        w.input().disconnect();\n"
+"        w.pull().disabled();\n"
+"        w.drive().s0s1();\n"
+"        w.sense().disabled();\n"
+"        w\n"
+"    });\n"
+"\n"
+"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
+"    gpio0.outclr.write(|w| w.pin28().clear());\n"
+"    gpio0.outset.write(|w| w.pin21().set());\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:49
+msgid ""
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:1
+msgid "HAL crates"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:3
+msgid ""
+"[HAL "
+"crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-implementation-crates) "
+"for many microcontrollers provide wrappers around various peripherals. These "
+"generally implement traits from "
+"[`embedded-hal`](https://crates.io/crates/embedded-hal)."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use cortex_m_rt::entry;\n"
+"use nrf52833_hal::gpio::{p0, Level};\n"
+"use nrf52833_hal::pac::Peripherals;\n"
+"use nrf52833_hal::prelude::*;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let p = Peripherals::take().unwrap();\n"
+"\n"
+"    // Create HAL wrapper for GPIO port 0.\n"
+"    let gpio0 = p0::Parts::new(p.P0);\n"
+"\n"
+"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+"    let mut col1 = gpio0.p0_28.into_push_pull_output(Level::High);\n"
+"    let mut row1 = gpio0.p0_21.into_push_pull_output(Level::Low);\n"
+"\n"
+"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
+"    col1.set_low().unwrap();\n"
+"    row1.set_high().unwrap();\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:39
+msgid ""
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:1
+msgid "Board support crates"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:3
+msgid ""
+"Board support crates provide a further level of wrapping for a specific "
+"board for convenience."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:28
+msgid ""
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:1
+msgid "The type state pattern"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:3
+msgid ""
+"```rust,editable,compile_fail\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let p = Peripherals::take().unwrap();\n"
+"    let gpio0 = p0::Parts::new(p.P0);\n"
+"\n"
+"    let pin: P0_01<Disconnected> = gpio0.p0_01;\n"
+"\n"
+"    // let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
+"    let pin_input: P0_01<Input<Floating>> = pin.into_floating_input();\n"
+"    if pin_input.is_high().unwrap() {\n"
+"        // ...\n"
+"    }\n"
+"    let mut pin_output: P0_01<Output<OpenDrain>> = pin_input\n"
+"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
+"Level::Low);\n"
+"    pin_output.set_high().unwrap();\n"
+"    // pin_input.is_high(); // Error, moved.\n"
+"\n"
+"    let _pin2: P0_02<Output<OpenDrain>> = gpio0\n"
+"        .p0_02\n"
+"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
+"Level::Low);\n"
+"    let _pin3: P0_03<Output<PushPull>> = "
+"gpio0.p0_03.into_push_pull_output(Level::Low);\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:32
+msgid ""
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:1
+msgid "`embedded-hal`"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:3
+msgid ""
+"The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
+"number of traits covering common microcontroller peripherals."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:6
+msgid "GPIO"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:13
+msgid ""
+"Other crates then implement "
+"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-crates) "
+"in terms of these traits, e.g. an accelerometer driver might need an I2C or "
+"SPI bus implementation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:19
+msgid ""
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
+"isn't stable yet."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:1
+msgid "`probe-rs`, `cargo-embed`"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:3
+msgid ""
+"[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
+"like OpenOCD but better integrated."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid "SWD"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid "and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "server"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:10
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid ""
+"output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:16
+msgid ""
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter "
+"Protocol](https://microsoft.github.io/debug-adapter-protocol/) lets VSCode "
+"and other IDEs debug code running on any supported microcontroller."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/debugging.md:3
+msgid "_Embed.toml_:"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/debugging.md:5
+msgid ""
+"```toml\n"
+"[default.general]\n"
+"chip = \"nrf52833_xxAA\"\n"
+"\n"
+"[debug.gdb]\n"
+"enabled = true\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/debugging.md:13
+msgid "In one terminal under `src/bare-metal/microcontrollers/examples/`:"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/debugging.md:19
+msgid "In another terminal in the same directory:"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/debugging.md:21
+msgid ""
+"```sh\n"
+"gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support "
+"--eval-command=\"target remote :1337\"\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/debugging.md:27
+msgid "In GDB, try running:"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:1
+#: src/bare-metal/aps/other-projects.md:1
+msgid "Other projects"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "[RTIC](https://rtic.rs/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
+msgid "Shared resource management, message passing, task scheduling, timer queue"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. "
+"[esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-library.html)."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
+msgid ""
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid "Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"applications."
+msgstr ""
+
+#: src/exercises/bare-metal/morning.md:3
+msgid ""
+"We will read the direction from an I2C compass, and log the readings to a "
+"serial port."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:3
+msgid ""
+"We will read the direction from an I2C compass, and log the readings to a "
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:6
+msgid "Hints:"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:8
+msgid ""
+"Check the documentation for the "
+"[`lsm303agr`](https://docs.rs/lsm303agr/latest/lsm303agr/) and "
+"[`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
+"well as the [micro:bit hardware](https://tech.microbit.org/hardware/)."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:11
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:12
+msgid "TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:13
+msgid ""
+"The LSM303AGR driver needs something implementing the "
+"`embedded_hal::blocking::i2c::WriteRead` trait. The "
+"[`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/struct.Twim.html) "
+"struct implements this."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:17
+msgid ""
+"You have a "
+"[`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/struct.Board.html) "
+"struct with fields for the various pins and peripherals."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:19
+msgid ""
+"You can also look at the [nRF52833 "
+"datasheet](https://infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.5.pdf) if "
+"you want, but it shouldn't be necessary for this exercise."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:23
+msgid ""
+"Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
+"look in the `compass` directory for the following files."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:26
+#: src/exercises/bare-metal/rtc.md:19
+#, fuzzy
+msgid "_src/main.rs_:"
+msgstr "_hello_rust/src/main.rs_:"
+
+#: src/exercises/bare-metal/compass.md:30
+msgid ""
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use core::fmt::Write;\n"
+"use cortex_m_rt::entry;\n"
+"use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let board = Board::take().unwrap();\n"
+"\n"
+"    // Configure serial port.\n"
+"    let mut serial = Uarte::new(\n"
+"        board.UARTE0,\n"
+"        board.uart.into(),\n"
+"        Parity::EXCLUDED,\n"
+"        Baudrate::BAUD115200,\n"
+"    );\n"
+"\n"
+"    // Set up the I2C controller and Inertial Measurement Unit.\n"
+"    // TODO\n"
+"\n"
+"    writeln!(serial, \"Ready.\").unwrap();\n"
+"\n"
+"    loop {\n"
+"        // Read compass data and log it to the serial port.\n"
+"        // TODO\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:64
+#: src/exercises/bare-metal/rtc.md:385
+msgid "_Cargo.toml_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:68
+msgid ""
+"```toml\n"
+"[workspace]\n"
+"\n"
+"[package]\n"
+"name = \"compass\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"publish = false\n"
+"\n"
+"[dependencies]\n"
+"cortex-m-rt = \"0.7.3\"\n"
+"embedded-hal = \"0.2.6\"\n"
+"lsm303agr = \"0.2.2\"\n"
+"microbit-v2 = \"0.13.0\"\n"
+"panic-halt = \"0.2.0\"\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:85
+msgid "_Embed.toml_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:89
+msgid ""
+"```toml\n"
+"[default.general]\n"
+"chip = \"nrf52833_xxAA\"\n"
+"\n"
+"[debug.gdb]\n"
+"enabled = true\n"
+"\n"
+"[debug.reset]\n"
+"halt_afterwards = true\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:100
+#: src/exercises/bare-metal/rtc.md:985
+msgid "_.cargo/config.toml_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:104
+msgid ""
+"```toml\n"
+"[build]\n"
+"target = \"thumbv7em-none-eabihf\" # Cortex-M4F\n"
+"\n"
+"[target.'cfg(all(target_arch = \"arm\", target_os = \"none\"))']\n"
+"rustflags = [\"-C\", \"link-arg=-Tlink.x\"]\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:112
+msgid "See the serial output on Linux with:"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:118
+msgid "Or on Mac OS something like (the device name may be slightly different):"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:124
+msgid "Use Ctrl+A Ctrl+Q to quit picocom."
+msgstr ""
+
+#: src/bare-metal/aps.md:1
+msgid "Application processors"
+msgstr ""
+
+#: src/bare-metal/aps.md:3
+msgid ""
+"So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 "
+"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+msgstr ""
+
+#: src/bare-metal/aps.md:9
+msgid ""
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
+msgstr ""
+
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:3
+msgid "Before we can start running Rust code, we need to do some initialisation."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:5
+msgid ""
+"```armasm\n"
+".section .init.entry, \"ax\"\n"
+".global entry\n"
+"entry:\n"
+"    /*\n"
+"     * Load and apply the memory management configuration, ready to enable "
+"MMU and\n"
+"     * caches.\n"
+"     */\n"
+"    adrp x30, idmap\n"
+"    msr ttbr0_el1, x30\n"
+"\n"
+"    mov_i x30, .Lmairval\n"
+"    msr mair_el1, x30\n"
+"\n"
+"    mov_i x30, .Ltcrval\n"
+"    /* Copy the supported PA range into TCR_EL1.IPS. */\n"
+"    mrs x29, id_aa64mmfr0_el1\n"
+"    bfi x30, x29, #32, #4\n"
+"\n"
+"    msr tcr_el1, x30\n"
+"\n"
+"    mov_i x30, .Lsctlrval\n"
+"\n"
+"    /*\n"
+"     * Ensure everything before this point has completed, then invalidate "
+"any\n"
+"     * potentially stale local TLB entries before they start being used.\n"
+"     */\n"
+"    isb\n"
+"    tlbi vmalle1\n"
+"    ic iallu\n"
+"    dsb nsh\n"
+"    isb\n"
+"\n"
+"    /*\n"
+"     * Configure sctlr_el1 to enable MMU and cache and don't proceed until "
+"this\n"
+"     * has completed.\n"
+"     */\n"
+"    msr sctlr_el1, x30\n"
+"    isb\n"
+"\n"
+"    /* Disable trapping floating point access in EL1. */\n"
+"    mrs x30, cpacr_el1\n"
+"    orr x30, x30, #(0x3 << 20)\n"
+"    msr cpacr_el1, x30\n"
+"    isb\n"
+"\n"
+"    /* Zero out the bss section. */\n"
+"    adr_l x29, bss_begin\n"
+"    adr_l x30, bss_end\n"
+"0:  cmp x29, x30\n"
+"    b.hs 1f\n"
+"    stp xzr, xzr, [x29], #16\n"
+"    b 0b\n"
+"\n"
+"1:  /* Prepare the stack. */\n"
+"    adr_l x30, boot_stack_end\n"
+"    mov sp, x30\n"
+"\n"
+"    /* Set up exception vector. */\n"
+"    adr x30, vector_table_el1\n"
+"    msr vbar_el1, x30\n"
+"\n"
+"    /* Call into Rust code. */\n"
+"    bl main\n"
+"\n"
+"    /* Loop forever waiting for interrupts. */\n"
+"2:  wfi\n"
+"    b 2b\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:77
+msgid ""
+"This is the same as it would be for C: initialising the processor state, "
+"zeroing the BSS, and setting up the stack pointer."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:79
+msgid ""
+"The BSS (block starting symbol, for historical reasons) is the part of the "
+"object file which containing statically allocated variables which are "
+"initialised to zero. They are omitted from the image, to avoid wasting space "
+"on zeroes. The compiler assumes that the loader will take care of zeroing "
+"them."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:83
+msgid ""
+"The BSS may already be zeroed, depending on how memory is initialised and "
+"the image is loaded, but we zero it to be sure."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:85
+msgid ""
+"We need to enable the MMU and cache before reading or writing any memory. If "
+"we don't:"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:86
+msgid ""
+"Unaligned accesses will fault. We build the Rust code for the "
+"`aarch64-unknown-none` target which sets `+strict-align` to prevent the "
+"compiler generating unaligned accesses, so it should be fine in this case, "
+"but this is not necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:89
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cacheable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost when the cache "
+"is cleaned or the VM enables the cache. (Cache is keyed by physical address, "
+"not VA or IPA.)"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:94
+msgid ""
+"For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
+"identity maps the first 1 GiB of address space for devices, the next 1 GiB "
+"for DRAM, and another 1 GiB higher up for more devices. This matches the "
+"memory layout that QEMU uses."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:97
+msgid ""
+"We also set up the exception vector (`vbar_el1`), which we'll see more about "
+"later."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:98
+msgid ""
+"All examples this afternoon assume we will be running at exception level 1 "
+"(EL1). If you need to run at a different exception level you'll need to "
+"modify `entry.S` accordingly."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:1
+msgid "Inline assembly"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:3
+msgid ""
+"Sometimes we need to use assembly to do things that aren't possible with "
+"Rust code. For example, to make an "
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "to tell the firmware to power off the system:"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"use core::arch::asm;\n"
+"use core::panic::PanicInfo;\n"
+"\n"
+"mod exceptions;\n"
+"\n"
+"const PSCI_SYSTEM_OFF: u32 = 0x84000008;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(_x0: u64, _x1: u64, _x2: u64, _x3: u64) {\n"
+"    // Safe because this only uses the declared registers and doesn't do\n"
+"    // anything with memory.\n"
+"    unsafe {\n"
+"        asm!(\"hvc #0\",\n"
+"            inout(\"w0\") PSCI_SYSTEM_OFF => _,\n"
+"            inout(\"w1\") 0 => _,\n"
+"            inout(\"w2\") 0 => _,\n"
+"            inout(\"w3\") 0 => _,\n"
+"            inout(\"w4\") 0 => _,\n"
+"            inout(\"w5\") 0 => _,\n"
+"            inout(\"w6\") 0 => _,\n"
+"            inout(\"w7\") 0 => _,\n"
+"            options(nomem, nostack)\n"
+"        );\n"
+"    }\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:39
+msgid ""
+"(If you actually want to do this, use the "
+"[`smccc`](https://crates.io/crates/smccc) crate which has wrappers for all "
+"these functions.)"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:43
+msgid ""
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:51
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:56
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under "
+"`src/bare-metal/aps/examples`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:1
+msgid "Volatile memory access for MMIO"
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:5
+msgid ""
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:9
+msgid ""
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:1
+msgid "Let's write a UART driver"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:3
+msgid ""
+"The QEMU 'virt' machine has a "
+"[PL011](https://developer.arm.com/documentation/ddi0183/g) UART, so let's "
+"write a driver for that."
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:5
+msgid ""
+"```rust,editable\n"
+"const FLAG_REGISTER_OFFSET: usize = 0x18;\n"
+"const FR_BUSY: u8 = 1 << 3;\n"
+"const FR_TXFF: u8 = 1 << 5;\n"
+"\n"
+"/// Minimal driver for a PL011 UART.\n"
+"#[derive(Debug)]\n"
+"pub struct Uart {\n"
+"    base_address: *mut u8,\n"
+"}\n"
+"\n"
+"impl Uart {\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
+"    /// given base address.\n"
+"    ///\n"
+"    /// # Safety\n"
+"    ///\n"
+"    /// The given base address must point to the 8 MMIO control registers of "
+"a\n"
+"    /// PL011 device, which must be mapped into the address space of the "
+"process\n"
+"    /// as device memory and not have any other aliases.\n"
+"    pub unsafe fn new(base_address: *mut u8) -> Self {\n"
+"        Self { base_address }\n"
+"    }\n"
+"\n"
+"    /// Writes a single byte to the UART.\n"
+"    pub fn write_byte(&self, byte: u8) {\n"
+"        // Wait until there is room in the TX buffer.\n"
+"        while self.read_flag_register() & FR_TXFF != 0 {}\n"
+"\n"
+"        // Safe because we know that the base address points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe {\n"
+"            // Write to the TX buffer.\n"
+"            self.base_address.write_volatile(byte);\n"
+"        }\n"
+"\n"
+"        // Wait until the UART is no longer busy.\n"
+"        while self.read_flag_register() & FR_BUSY != 0 {}\n"
+"    }\n"
+"\n"
+"    fn read_flag_register(&self) -> u8 {\n"
+"        // Safe because we know that the base address points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET).read_volatile() "
+"}\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:55
+msgid ""
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:60
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:63
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:1
+msgid "More traits"
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:3
+msgid ""
+"We derived the `Debug` trait. It would be useful to implement a few more "
+"traits too."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use core::fmt::{self, Write};\n"
+"\n"
+"impl Write for Uart {\n"
+"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
+"        for c in s.as_bytes() {\n"
+"            self.write_byte(*c);\n"
+"        }\n"
+"        Ok(())\n"
+"    }\n"
+"}\n"
+"\n"
+"// Safe because it just contains a pointer to device memory, which can be\n"
+"// accessed from any context.\n"
+"unsafe impl Send for Uart {}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:24
+msgid ""
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:25
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under "
+"`src/bare-metal/aps/examples`."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:1
+msgid "A better UART driver"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:3
+msgid ""
+"The PL011 actually has [a bunch more "
+"registers](https://developer.arm.com/documentation/ddi0183/g/programmers-model/summary-of-registers), "
+"and adding offsets to construct pointers to access them is error-prone and "
+"hard to read. Plus, some of them are bit fields which would be nice to "
+"access in a structured way."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Offset"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+#: src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+#: src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+#: src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+#: src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20
+#: src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:26
+msgid "There are also some ID registers which have been omitted for brevity."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:3
+msgid ""
+"The [`bitflags`](https://crates.io/crates/bitflags) crate is useful for "
+"working with bitflags."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use bitflags::bitflags;\n"
+"\n"
+"bitflags! {\n"
+"    /// Flags from the UART flag register.\n"
+"    #[repr(transparent)]\n"
+"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"    struct Flags: u16 {\n"
+"        /// Clear to send.\n"
+"        const CTS = 1 << 0;\n"
+"        /// Data set ready.\n"
+"        const DSR = 1 << 1;\n"
+"        /// Data carrier detect.\n"
+"        const DCD = 1 << 2;\n"
+"        /// UART busy transmitting data.\n"
+"        const BUSY = 1 << 3;\n"
+"        /// Receive FIFO is empty.\n"
+"        const RXFE = 1 << 4;\n"
+"        /// Transmit FIFO is full.\n"
+"        const TXFF = 1 << 5;\n"
+"        /// Receive FIFO is full.\n"
+"        const RXFF = 1 << 6;\n"
+"        /// Transmit FIFO is empty.\n"
+"        const TXFE = 1 << 7;\n"
+"        /// Ring indicator.\n"
+"        const RI = 1 << 8;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:37
+msgid ""
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/registers.md:1
+msgid "Multiple registers"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/registers.md:3
+msgid ""
+"We can use a struct to represent the memory layout of the UART's registers."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/registers.md:41
+msgid ""
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-representation) "
+"tells the compiler to lay the struct fields out in order, following the same "
+"rules as C. This is necessary for our struct to have a predictable layout, "
+"as default Rust representation allows the compiler to (among other things) "
+"reorder fields however it sees fit."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:3
+msgid "Now let's use the new `Registers` struct in our driver."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"/// Driver for a PL011 UART.\n"
+"#[derive(Debug)]\n"
+"pub struct Uart {\n"
+"    registers: *mut Registers,\n"
+"}\n"
+"\n"
+"impl Uart {\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
+"    /// given base address.\n"
+"    ///\n"
+"    /// # Safety\n"
+"    ///\n"
+"    /// The given base address must point to the 8 MMIO control registers of "
+"a\n"
+"    /// PL011 device, which must be mapped into the address space of the "
+"process\n"
+"    /// as device memory and not have any other aliases.\n"
+"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
+"        Self {\n"
+"            registers: base_address as *mut Registers,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Writes a single byte to the UART.\n"
+"    pub fn write_byte(&self, byte: u8) {\n"
+"        // Wait until there is room in the TX buffer.\n"
+"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
+"\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe {\n"
+"            // Write to the TX buffer.\n"
+"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
+"        }\n"
+"\n"
+"        // Wait until the UART is no longer busy.\n"
+"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
+"    }\n"
+"\n"
+"    /// Reads and returns a pending byte, or `None` if nothing has been "
+"received.\n"
+"    pub fn read_byte(&self) -> Option<u8> {\n"
+"        if self.read_flag_register().contains(Flags::RXFE) {\n"
+"            None\n"
+"        } else {\n"
+"            let data = unsafe { "
+"addr_of!((*self.registers).dr).read_volatile() };\n"
+"            // TODO: Check for error conditions in bits 8-11.\n"
+"            Some(data as u8)\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn read_flag_register(&self) -> Flags {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:64
+msgid ""
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:1
+#: src/bare-metal/aps/logging/using.md:1
+msgid "Using it"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:3
+msgid ""
+"Let's write a small program using our driver to write to the serial console, "
+"and echo incoming bytes."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod pl011;\n"
+"\n"
+"use crate::pl011::Uart;\n"
+"use core::fmt::Write;\n"
+"use core::panic::PanicInfo;\n"
+"use log::error;\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let mut uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"\n"
+"    writeln!(uart, \"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\").unwrap();\n"
+"\n"
+"    loop {\n"
+"        if let Some(byte) = uart.read_byte() {\n"
+"            uart.write_byte(byte);\n"
+"            match byte {\n"
+"                b'\\r' => {\n"
+"                    uart.write_byte(b'\\n"
+"');\n"
+"                }\n"
+"                b'q' => break,\n"
+"                _ => {}\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"\n"
+"    writeln!(uart, \"Bye!\").unwrap();\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:51
+msgid ""
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:53
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
+msgstr ""
+
+#: src/bare-metal/aps/logging.md:3
+msgid ""
+"It would be nice to be able to use the logging macros from the "
+"[`log`](https://crates.io/crates/log) crate. We can do this by implementing "
+"the `Log` trait."
+msgstr ""
+
+#: src/bare-metal/aps/logging.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use crate::pl011::Uart;\n"
+"use core::fmt::Write;\n"
+"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
+"use spin::mutex::SpinMutex;\n"
+"\n"
+"static LOGGER: Logger = Logger {\n"
+"    uart: SpinMutex::new(None),\n"
+"};\n"
+"\n"
+"struct Logger {\n"
+"    uart: SpinMutex<Option<Uart>>,\n"
+"}\n"
+"\n"
+"impl Log for Logger {\n"
+"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
+"        true\n"
+"    }\n"
+"\n"
+"    fn log(&self, record: &Record) {\n"
+"        writeln!(\n"
+"            self.uart.lock().as_mut().unwrap(),\n"
+"            \"[{}] {}\",\n"
+"            record.level(),\n"
+"            record.args()\n"
+"        )\n"
+"        .unwrap();\n"
+"    }\n"
+"\n"
+"    fn flush(&self) {}\n"
+"}\n"
+"\n"
+"/// Initialises UART logger.\n"
+"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
+"SetLoggerError> {\n"
+"    LOGGER.uart.lock().replace(uart);\n"
+"\n"
+"    log::set_logger(&LOGGER)?;\n"
+"    log::set_max_level(max_level);\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/logging.md:50
+msgid ""
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"`set_logger`."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:3
+msgid "We need to initialise the logger before we use it."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod logger;\n"
+"mod pl011;\n"
+"\n"
+"use crate::pl011::Uart;\n"
+"use core::panic::PanicInfo;\n"
+"use log::{error, info, LevelFilter};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
+"\n"
+"    info!(\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\");\n"
+"\n"
+"    assert_eq!(x1, 42);\n"
+"\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[panic_handler]\n"
+"fn panic(info: &PanicInfo) -> ! {\n"
+"    error!(\"{info}\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:46
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:47
+msgid ""
+"Run the example in QEMU with `make qemu_logger` under "
+"`src/bare-metal/aps/examples`."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:3
+msgid ""
+"AArch64 defines an exception vector table with 16 entries, for 4 types of "
+"exceptions (synchronous, IRQ, FIQ, SError) from 4 states (current EL with "
+"SP0, current EL with SPx, lower EL using AArch64, lower EL using AArch32). "
+"We implement this in assembly to save volatile registers to the stack before "
+"calling into Rust code:"
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:8
+msgid ""
+"```rust,editable,compile_fail\n"
+"use log::error;\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn sync_exception_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"sync_exception_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn irq_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"irq_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn fiq_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"fiq_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn serr_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"serr_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn sync_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"sync_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn irq_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"irq_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn fiq_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"fiq_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn serr_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"serr_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:64
+msgid "EL is exception level; all our examples this afternoon run in EL1."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:65
+msgid ""
+"For simplicity we aren't distinguishing between SP0 and SPx for the current "
+"EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:67
+msgid ""
+"For this example we just log the exception and power down, as we don't "
+"expect any of them to actually happen."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:69
+msgid ""
+"We can think of exception handlers and our main execution context more or "
+"less like different threads. [`Send` and "
+"`Sync`](../../concurrency/send-sync.md) will control what we can share "
+"between them, just like with threads. For example, if we want to share some "
+"value between exception handlers and the rest of the program, and it's "
+"`Send` but not `Sync`, then we'll need to wrap it in something like a "
+"`Mutex` and put it in a static."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:3
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:7
+msgid ""
+"[Rust RaspberryPi OS "
+"tutorial](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid ""
+"Some dodginess around cache maintenance and initialisation in Rust, not "
+"necessarily a good example to copy for production code."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:12
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:13
+msgid "Static analysis to determine maximum stack usage."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:17
+msgid ""
+"The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
+"enabled. This will read and write memory (e.g. the stack). However:"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:19
+msgid ""
+"Without the MMU and cache, unaligned accesses will fault. It builds with "
+"`aarch64-unknown-none` which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses so it should be alright, but this is not "
+"necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:22
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cacheable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost. Again this is "
+"alright in this particular case (running directly on the hardware with no "
+"hypervisor), but isn't a good pattern in general."
+msgstr ""
+
+#: src/bare-metal/useful-crates.md:3
+msgid ""
+"We'll go over a few crates which solve some common problems in bare-metal "
+"programming."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:1
+msgid "`zerocopy`"
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:3
+msgid ""
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:40
+msgid ""
+"This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:45
+msgid ""
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid "`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+msgid ""
+"Run the example with `cargo run` under "
+"`src/bare-metal/useful-crates/zerocopy-example/`. (It won't run in the "
+"Playground because of the crate dependency.)"
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:1
+msgid "`aarch64-paging`"
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:3
+msgid ""
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use aarch64_paging::{\n"
+"    idmap::IdMap,\n"
+"    paging::{Attributes, MemoryRegion},\n"
+"};\n"
+"\n"
+"const ASID: usize = 1;\n"
+"const ROOT_LEVEL: usize = 1;\n"
+"\n"
+"// Create a new page table with identity mapping.\n"
+"let mut idmap = IdMap::new(ASID, ROOT_LEVEL);\n"
+"// Map a 2 MiB region of memory as read-only.\n"
+"idmap.map_range(\n"
+"    &MemoryRegion::new(0x80200000, 0x80400000),\n"
+"    Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,\n"
+").unwrap();\n"
+"// Set `TTBR0_EL1` to activate the page table.\n"
+"idmap.activate();\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:28
+msgid ""
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM "
+"Firmware](https://cs.android.com/android/platform/superproject/+/master:packages/modules/Virtualization/pvmfw/)."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:1
+msgid "`buddy_system_allocator`"
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:3
+msgid ""
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for "
+"[`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/buddy_system_allocator/struct.LockedHeap.html) "
+"implementing "
+"[`GlobalAlloc`](https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) "
+"so you can use the standard `alloc` crate (as we saw [before](../alloc.md)), "
+"or for allocating other address space. For example, we might want to "
+"allocate MMIO space for PCI BARs:"
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:8
+msgid ""
+"```rust,editable,compile_fail\n"
+"use buddy_system_allocator::FrameAllocator;\n"
+"use core::alloc::Layout;\n"
+"\n"
+"fn main() {\n"
+"    let mut allocator = FrameAllocator::<32>::new();\n"
+"    allocator.add_frame(0x200_0000, 0x400_0000);\n"
+"\n"
+"    let layout = Layout::from_size_align(0x100, 0x100).unwrap();\n"
+"    let bar = allocator\n"
+"        .alloc_aligned(layout)\n"
+"        .expect(\"Failed to allocate 0x100 byte MMIO region\");\n"
+"    println!(\"Allocated 0x100 byte MMIO region at {:#x}\", bar);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+msgid "PCI BARs always have alignment equal to their size."
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
+msgid ""
+"Run the example with `cargo run` under "
+"`src/bare-metal/useful-crates/allocator-example/`. (It won't run in the "
+"Playground because of the crate dependency.)"
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:1
+msgid "`tinyvec`"
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:3
+msgid ""
+"Sometimes you want something which can be resized like a `Vec`, but without "
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
+"allocated or on the stack, which keeps track of how many elements are used "
+"and panics if you try to use more than are allocated."
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:8
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tinyvec::{array_vec, ArrayVec};\n"
+"\n"
+"fn main() {\n"
+"    let mut numbers: ArrayVec<[u32; 5]> = array_vec!(42, 66);\n"
+"    println!(\"{numbers:?}\");\n"
+"    numbers.push(7);\n"
+"    println!(\"{numbers:?}\");\n"
+"    numbers.remove(1);\n"
+"    println!(\"{numbers:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:23
+msgid ""
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:1
+msgid "`spin`"
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:3
+msgid ""
+"`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:7
+msgid ""
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:9
+msgid ""
+"```rust,editable,compile_fail\n"
+"use spin::mutex::SpinMutex;\n"
+"\n"
+"static counter: SpinMutex<u32> = SpinMutex::new(0);\n"
+"\n"
+"fn main() {\n"
+"    println!(\"count: {}\", counter.lock());\n"
+"    *counter.lock() += 2;\n"
+"    println!(\"count: {}\", counter.lock());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:23
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
+msgstr ""
+
+#: src/bare-metal/android.md:3
+msgid ""
+"To build a bare-metal Rust binary in AOSP, you need to use a "
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
+msgstr ""
+
+#: src/bare-metal/android.md:7
+msgid ""
+"```soong\n"
+"rust_ffi_static {\n"
+"    name: \"libvmbase_example\",\n"
+"    defaults: [\"vmbase_ffi_defaults\"],\n"
+"    crate_name: \"vmbase_example\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libvmbase\",\n"
+"    ],\n"
+"}\n"
+"\n"
+"cc_binary {\n"
+"    name: \"vmbase_example\",\n"
+"    defaults: [\"vmbase_elf_defaults\"],\n"
+"    srcs: [\n"
+"        \"idmap.S\",\n"
+"    ],\n"
+"    static_libs: [\n"
+"        \"libvmbase_example\",\n"
+"    ],\n"
+"    linker_scripts: [\n"
+"        \"image.ld\",\n"
+"        \":vmbase_sections\",\n"
+"    ],\n"
+"}\n"
+"\n"
+"raw_binary {\n"
+"    name: \"vmbase_example_bin\",\n"
+"    stem: \"vmbase_example.bin\",\n"
+"    src: \":vmbase_example\",\n"
+"    enabled: false,\n"
+"    target: {\n"
+"        android_arm64: {\n"
+"            enabled: true,\n"
+"        },\n"
+"    },\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:3
+msgid ""
+"For VMs running under crosvm on aarch64, the "
+"[vmbase](https://android.googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/master/vmbase/) "
+"library provides a linker script and useful defaults for the build rules, "
+"along with an entry point, UART console logging and more."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:6
+msgid ""
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"use vmbase::{main, println};\n"
+"\n"
+"main!(main);\n"
+"\n"
+"pub fn main(arg0: u64, arg1: u64, arg2: u64, arg3: u64) {\n"
+"    println!(\"Hello world\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:21
+msgid ""
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
+msgstr ""
+
+#: src/exercises/bare-metal/afternoon.md:3
+msgid "We will write a driver for the PL031 real-time clock device."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:1
+#: src/exercises/bare-metal/solutions-afternoon.md:3
+msgid "RTC driver"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:3
+msgid ""
+"The QEMU aarch64 virt machine has a "
+"[PL031](https://developer.arm.com/documentation/ddi0224/c) real-time clock "
+"at 0x9010000. For this exercise, you should write a driver for it."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:6
+msgid ""
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:8
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call "
+"[`core::hint::spin_loop`](https://doc.rust-lang.org/core/hint/fn.spin_loop.html) "
+"inside the loop.)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:10
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the "
+"[`arm-gic`](https://docs.rs/arm-gic/) crate to configure the Arm Generic "
+"Interrupt Controller."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:12
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:13
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via "
+"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
+"interrupt."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:16
+msgid ""
+"Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
+"look in the `rtc` directory for the following files."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:23
+msgid ""
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod logger;\n"
+"mod pl011;\n"
+"\n"
+"use crate::pl011::Uart;\n"
+"use arm_gic::gicv3::GicV3;\n"
+"use core::panic::PanicInfo;\n"
+"use log::{error, info, trace, LevelFilter};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base addresses of the GICv3.\n"
+"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
+"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
+"\n"
+"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
+"\n"
+"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
+"base\n"
+"    // addresses of a GICv3 distributor and redistributor respectively, and\n"
+"    // nothing else accesses those address ranges.\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) "
+"};\n"
+"    gic.setup();\n"
+"\n"
+"    // TODO: Create instance of RTC driver and print current time.\n"
+"\n"
+"    // TODO: Wait for 3 seconds.\n"
+"\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[panic_handler]\n"
+"fn panic(info: &PanicInfo) -> ! {\n"
+"    error!(\"{info}\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:75
+msgid ""
+"_src/exceptions.rs_ (you should only need to change this for the 3rd part of "
+"the exercise):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:79
+msgid ""
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"use arm_gic::gicv3::GicV3;\n"
+"use log::{error, info, trace};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn sync_exception_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"sync_exception_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn irq_current(_elr: u64, _spsr: u64) {\n"
+"    trace!(\"irq_current\");\n"
+"    let intid = GicV3::get_and_acknowledge_interrupt().expect(\"No pending "
+"interrupt\");\n"
+"    info!(\"IRQ {intid:?}\");\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn fiq_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"fiq_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn serr_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"serr_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn sync_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"sync_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn irq_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"irq_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn fiq_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"fiq_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn serr_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"serr_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:149
+msgid "_src/logger.rs_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:153
+msgid ""
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"// ANCHOR: main\n"
+"use crate::pl011::Uart;\n"
+"use core::fmt::Write;\n"
+"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
+"use spin::mutex::SpinMutex;\n"
+"\n"
+"static LOGGER: Logger = Logger {\n"
+"    uart: SpinMutex::new(None),\n"
+"};\n"
+"\n"
+"struct Logger {\n"
+"    uart: SpinMutex<Option<Uart>>,\n"
+"}\n"
+"\n"
+"impl Log for Logger {\n"
+"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
+"        true\n"
+"    }\n"
+"\n"
+"    fn log(&self, record: &Record) {\n"
+"        writeln!(\n"
+"            self.uart.lock().as_mut().unwrap(),\n"
+"            \"[{}] {}\",\n"
+"            record.level(),\n"
+"            record.args()\n"
+"        )\n"
+"        .unwrap();\n"
+"    }\n"
+"\n"
+"    fn flush(&self) {}\n"
+"}\n"
+"\n"
+"/// Initialises UART logger.\n"
+"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
+"SetLoggerError> {\n"
+"    LOGGER.uart.lock().replace(uart);\n"
+"\n"
+"    log::set_logger(&LOGGER)?;\n"
+"    log::set_max_level(max_level);\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:210
+msgid "_src/pl011.rs_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:214
+msgid ""
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"#![allow(unused)]\n"
+"\n"
+"use core::fmt::{self, Write};\n"
+"use core::ptr::{addr_of, addr_of_mut};\n"
+"\n"
+"// ANCHOR: Flags\n"
+"use bitflags::bitflags;\n"
+"\n"
+"bitflags! {\n"
+"    /// Flags from the UART flag register.\n"
+"    #[repr(transparent)]\n"
+"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"    struct Flags: u16 {\n"
+"        /// Clear to send.\n"
+"        const CTS = 1 << 0;\n"
+"        /// Data set ready.\n"
+"        const DSR = 1 << 1;\n"
+"        /// Data carrier detect.\n"
+"        const DCD = 1 << 2;\n"
+"        /// UART busy transmitting data.\n"
+"        const BUSY = 1 << 3;\n"
+"        /// Receive FIFO is empty.\n"
+"        const RXFE = 1 << 4;\n"
+"        /// Transmit FIFO is full.\n"
+"        const TXFF = 1 << 5;\n"
+"        /// Receive FIFO is full.\n"
+"        const RXFF = 1 << 6;\n"
+"        /// Transmit FIFO is empty.\n"
+"        const TXFE = 1 << 7;\n"
+"        /// Ring indicator.\n"
+"        const RI = 1 << 8;\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: Flags\n"
+"\n"
+"bitflags! {\n"
+"    /// Flags from the UART Receive Status Register / Error Clear Register.\n"
+"    #[repr(transparent)]\n"
+"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"    struct ReceiveStatus: u16 {\n"
+"        /// Framing error.\n"
+"        const FE = 1 << 0;\n"
+"        /// Parity error.\n"
+"        const PE = 1 << 1;\n"
+"        /// Break error.\n"
+"        const BE = 1 << 2;\n"
+"        /// Overrun error.\n"
+"        const OE = 1 << 3;\n"
+"    }\n"
+"}\n"
+"\n"
+"// ANCHOR: Registers\n"
+"#[repr(C, align(4))]\n"
+"struct Registers {\n"
+"    dr: u16,\n"
+"    _reserved0: [u8; 2],\n"
+"    rsr: ReceiveStatus,\n"
+"    _reserved1: [u8; 19],\n"
+"    fr: Flags,\n"
+"    _reserved2: [u8; 6],\n"
+"    ilpr: u8,\n"
+"    _reserved3: [u8; 3],\n"
+"    ibrd: u16,\n"
+"    _reserved4: [u8; 2],\n"
+"    fbrd: u8,\n"
+"    _reserved5: [u8; 3],\n"
+"    lcr_h: u8,\n"
+"    _reserved6: [u8; 3],\n"
+"    cr: u16,\n"
+"    _reserved7: [u8; 3],\n"
+"    ifls: u8,\n"
+"    _reserved8: [u8; 3],\n"
+"    imsc: u16,\n"
+"    _reserved9: [u8; 2],\n"
+"    ris: u16,\n"
+"    _reserved10: [u8; 2],\n"
+"    mis: u16,\n"
+"    _reserved11: [u8; 2],\n"
+"    icr: u16,\n"
+"    _reserved12: [u8; 2],\n"
+"    dmacr: u8,\n"
+"    _reserved13: [u8; 3],\n"
+"}\n"
+"// ANCHOR_END: Registers\n"
+"\n"
+"// ANCHOR: Uart\n"
+"/// Driver for a PL011 UART.\n"
+"#[derive(Debug)]\n"
+"pub struct Uart {\n"
+"    registers: *mut Registers,\n"
+"}\n"
+"\n"
+"impl Uart {\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
+"    /// given base address.\n"
+"    ///\n"
+"    /// # Safety\n"
+"    ///\n"
+"    /// The given base address must point to the MMIO control registers of "
+"a\n"
+"    /// PL011 device, which must be mapped into the address space of the "
+"process\n"
+"    /// as device memory and not have any other aliases.\n"
+"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
+"        Self {\n"
+"            registers: base_address as *mut Registers,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Writes a single byte to the UART.\n"
+"    pub fn write_byte(&self, byte: u8) {\n"
+"        // Wait until there is room in the TX buffer.\n"
+"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
+"\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe {\n"
+"            // Write to the TX buffer.\n"
+"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
+"        }\n"
+"\n"
+"        // Wait until the UART is no longer busy.\n"
+"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
+"    }\n"
+"\n"
+"    /// Reads and returns a pending byte, or `None` if nothing has been "
+"received.\n"
+"    pub fn read_byte(&self) -> Option<u8> {\n"
+"        if self.read_flag_register().contains(Flags::RXFE) {\n"
+"            None\n"
+"        } else {\n"
+"            let data = unsafe { "
+"addr_of!((*self.registers).dr).read_volatile() };\n"
+"            // TODO: Check for error conditions in bits 8-11.\n"
+"            Some(data as u8)\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn read_flag_register(&self) -> Flags {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: Uart\n"
+"\n"
+"impl Write for Uart {\n"
+"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
+"        for c in s.as_bytes() {\n"
+"            self.write_byte(*c);\n"
+"        }\n"
+"        Ok(())\n"
+"    }\n"
+"}\n"
+"\n"
+"// Safe because it just contains a pointer to device memory, which can be\n"
+"// accessed from any context.\n"
+"unsafe impl Send for Uart {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:389
+msgid ""
+"```toml\n"
+"[workspace]\n"
+"\n"
+"[package]\n"
+"name = \"rtc\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"publish = false\n"
+"\n"
+"[dependencies]\n"
+"arm-gic = \"0.1.0\"\n"
+"bitflags = \"2.0.0\"\n"
+"chrono = { version = \"0.4.24\", default-features = false }\n"
+"log = \"0.4.17\"\n"
+"smccc = \"0.1.1\"\n"
+"spin = \"0.9.8\"\n"
+"\n"
+"[build-dependencies]\n"
+"cc = \"1.0.73\"\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:410
+msgid "_build.rs_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:414
+msgid ""
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"use cc::Build;\n"
+"use std::env;\n"
+"\n"
+"fn main() {\n"
+"    #[cfg(target_os = \"linux\")]\n"
+"    env::set_var(\"CROSS_COMPILE\", \"aarch64-linux-gnu\");\n"
+"    #[cfg(not(target_os = \"linux\"))]\n"
+"    env::set_var(\"CROSS_COMPILE\", \"aarch64-none-elf\");\n"
+"\n"
+"    Build::new()\n"
+"        .file(\"entry.S\")\n"
+"        .file(\"exceptions.S\")\n"
+"        .file(\"idmap.S\")\n"
+"        .compile(\"empty\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:446
+msgid "_entry.S_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:450
+msgid ""
+"```armasm\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+".macro adr_l, reg:req, sym:req\n"
+"\tadrp \\reg, \\sym\n"
+"\tadd \\reg, \\reg, :lo12:\\sym\n"
+".endm\n"
+"\n"
+".macro mov_i, reg:req, imm:req\n"
+"\tmovz \\reg, :abs_g3:\\imm\n"
+"\tmovk \\reg, :abs_g2_nc:\\imm\n"
+"\tmovk \\reg, :abs_g1_nc:\\imm\n"
+"\tmovk \\reg, :abs_g0_nc:\\imm\n"
+".endm\n"
+"\n"
+".set .L_MAIR_DEV_nGnRE,\t0x04\n"
+".set .L_MAIR_MEM_WBWA,\t0xff\n"
+".set .Lmairval, .L_MAIR_DEV_nGnRE | (.L_MAIR_MEM_WBWA << 8)\n"
+"\n"
+"/* 4 KiB granule size for TTBR0_EL1. */\n"
+".set .L_TCR_TG0_4KB, 0x0 << 14\n"
+"/* 4 KiB granule size for TTBR1_EL1. */\n"
+".set .L_TCR_TG1_4KB, 0x2 << 30\n"
+"/* Disable translation table walk for TTBR1_EL1, generating a translation "
+"fault instead. */\n"
+".set .L_TCR_EPD1, 0x1 << 23\n"
+"/* Translation table walks for TTBR0_EL1 are inner sharable. */\n"
+".set .L_TCR_SH_INNER, 0x3 << 12\n"
+"/*\n"
+" * Translation table walks for TTBR0_EL1 are outer write-back read-allocate "
+"write-allocate\n"
+" * cacheable.\n"
+" */\n"
+".set .L_TCR_RGN_OWB, 0x1 << 10\n"
+"/*\n"
+" * Translation table walks for TTBR0_EL1 are inner write-back read-allocate "
+"write-allocate\n"
+" * cacheable.\n"
+" */\n"
+".set .L_TCR_RGN_IWB, 0x1 << 8\n"
+"/* Size offset for TTBR0_EL1 is 2**39 bytes (512 GiB). */\n"
+".set .L_TCR_T0SZ_512, 64 - 39\n"
+".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | "
+".L_TCR_RGN_OWB\n"
+".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | "
+".L_TCR_T0SZ_512\n"
+"\n"
+"/* Stage 1 instruction access cacheability is unaffected. */\n"
+".set .L_SCTLR_ELx_I, 0x1 << 12\n"
+"/* SP alignment fault if SP is not aligned to a 16 byte boundary. */\n"
+".set .L_SCTLR_ELx_SA, 0x1 << 3\n"
+"/* Stage 1 data access cacheability is unaffected. */\n"
+".set .L_SCTLR_ELx_C, 0x1 << 2\n"
+"/* EL0 and EL1 stage 1 MMU enabled. */\n"
+".set .L_SCTLR_ELx_M, 0x1 << 0\n"
+"/* Privileged Access Never is unchanged on taking an exception to EL1. */\n"
+".set .L_SCTLR_EL1_SPAN, 0x1 << 23\n"
+"/* SETEND instruction disabled at EL0 in aarch32 mode. */\n"
+".set .L_SCTLR_EL1_SED, 0x1 << 8\n"
+"/* Various IT instructions are disabled at EL0 in aarch32 mode. */\n"
+".set .L_SCTLR_EL1_ITD, 0x1 << 7\n"
+".set .L_SCTLR_EL1_RES1, (0x1 << 11) | (0x1 << 20) | (0x1 << 22) | (0x1 << "
+"28) | (0x1 << 29)\n"
+".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | "
+".L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
+".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | "
+".L_SCTLR_EL1_RES1\n"
+"\n"
+"/**\n"
+" * This is a generic entry point for an image. It carries out the operations "
+"required to prepare the\n"
+" * loaded image to be run. Specifically, it zeroes the bss section using "
+"registers x25 and above,\n"
+" * prepares the stack, enables floating point, and sets up the exception "
+"vector. It preserves x0-x3\n"
+" * for the Rust entry point, as these may contain boot parameters.\n"
+" */\n"
+".section .init.entry, \"ax\"\n"
+".global entry\n"
+"entry:\n"
+"\t/* Load and apply the memory management configuration, ready to enable MMU "
+"and caches. */\n"
+"\tadrp x30, idmap\n"
+"\tmsr ttbr0_el1, x30\n"
+"\n"
+"\tmov_i x30, .Lmairval\n"
+"\tmsr mair_el1, x30\n"
+"\n"
+"\tmov_i x30, .Ltcrval\n"
+"\t/* Copy the supported PA range into TCR_EL1.IPS. */\n"
+"\tmrs x29, id_aa64mmfr0_el1\n"
+"\tbfi x30, x29, #32, #4\n"
+"\n"
+"\tmsr tcr_el1, x30\n"
+"\n"
+"\tmov_i x30, .Lsctlrval\n"
+"\n"
+"\t/*\n"
+"\t * Ensure everything before this point has completed, then invalidate any "
+"potentially stale\n"
+"\t * local TLB entries before they start being used.\n"
+"\t */\n"
+"\tisb\n"
+"\ttlbi vmalle1\n"
+"\tic iallu\n"
+"\tdsb nsh\n"
+"\tisb\n"
+"\n"
+"\t/*\n"
+"\t * Configure sctlr_el1 to enable MMU and cache and don't proceed until "
+"this has completed.\n"
+"\t */\n"
+"\tmsr sctlr_el1, x30\n"
+"\tisb\n"
+"\n"
+"\t/* Disable trapping floating point access in EL1. */\n"
+"\tmrs x30, cpacr_el1\n"
+"\torr x30, x30, #(0x3 << 20)\n"
+"\tmsr cpacr_el1, x30\n"
+"\tisb\n"
+"\n"
+"\t/* Zero out the bss section. */\n"
+"\tadr_l x29, bss_begin\n"
+"\tadr_l x30, bss_end\n"
+"0:\tcmp x29, x30\n"
+"\tb.hs 1f\n"
+"\tstp xzr, xzr, [x29], #16\n"
+"\tb 0b\n"
+"\n"
+"1:\t/* Prepare the stack. */\n"
+"\tadr_l x30, boot_stack_end\n"
+"\tmov sp, x30\n"
+"\n"
+"\t/* Set up exception vector. */\n"
+"\tadr x30, vector_table_el1\n"
+"\tmsr vbar_el1, x30\n"
+"\n"
+"\t/* Call into Rust code. */\n"
+"\tbl main\n"
+"\n"
+"\t/* Loop forever waiting for interrupts. */\n"
+"2:\twfi\n"
+"\tb 2b\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:595
+msgid "_exceptions.S_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:599
+msgid ""
+"```armasm\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+"/**\n"
+" * Saves the volatile registers onto the stack. This currently takes 14\n"
+" * instructions, so it can be used in exception handlers with 18 "
+"instructions\n"
+" * left.\n"
+" *\n"
+" * On return, x0 and x1 are initialised to elr_el2 and spsr_el2 "
+"respectively,\n"
+" * which can be used as the first and second arguments of a subsequent "
+"call.\n"
+" */\n"
+".macro save_volatile_to_stack\n"
+"\t/* Reserve stack space and save registers x0-x18, x29 & x30. */\n"
+"\tstp x0, x1, [sp, #-(8 * 24)]!\n"
+"\tstp x2, x3, [sp, #8 * 2]\n"
+"\tstp x4, x5, [sp, #8 * 4]\n"
+"\tstp x6, x7, [sp, #8 * 6]\n"
+"\tstp x8, x9, [sp, #8 * 8]\n"
+"\tstp x10, x11, [sp, #8 * 10]\n"
+"\tstp x12, x13, [sp, #8 * 12]\n"
+"\tstp x14, x15, [sp, #8 * 14]\n"
+"\tstp x16, x17, [sp, #8 * 16]\n"
+"\tstr x18, [sp, #8 * 18]\n"
+"\tstp x29, x30, [sp, #8 * 20]\n"
+"\n"
+"\t/*\n"
+"\t * Save elr_el1 & spsr_el1. This such that we can take nested exception\n"
+"\t * and still be able to unwind.\n"
+"\t */\n"
+"\tmrs x0, elr_el1\n"
+"\tmrs x1, spsr_el1\n"
+"\tstp x0, x1, [sp, #8 * 22]\n"
+".endm\n"
+"\n"
+"/**\n"
+" * Restores the volatile registers from the stack. This currently takes 14\n"
+" * instructions, so it can be used in exception handlers while still leaving "
+"18\n"
+" * instructions left; if paired with save_volatile_to_stack, there are 4\n"
+" * instructions to spare.\n"
+" */\n"
+".macro restore_volatile_from_stack\n"
+"\t/* Restore registers x2-x18, x29 & x30. */\n"
+"\tldp x2, x3, [sp, #8 * 2]\n"
+"\tldp x4, x5, [sp, #8 * 4]\n"
+"\tldp x6, x7, [sp, #8 * 6]\n"
+"\tldp x8, x9, [sp, #8 * 8]\n"
+"\tldp x10, x11, [sp, #8 * 10]\n"
+"\tldp x12, x13, [sp, #8 * 12]\n"
+"\tldp x14, x15, [sp, #8 * 14]\n"
+"\tldp x16, x17, [sp, #8 * 16]\n"
+"\tldr x18, [sp, #8 * 18]\n"
+"\tldp x29, x30, [sp, #8 * 20]\n"
+"\n"
+"\t/* Restore registers elr_el1 & spsr_el1, using x0 & x1 as scratch. */\n"
+"\tldp x0, x1, [sp, #8 * 22]\n"
+"\tmsr elr_el1, x0\n"
+"\tmsr spsr_el1, x1\n"
+"\n"
+"\t/* Restore x0 & x1, and release stack space. */\n"
+"\tldp x0, x1, [sp], #8 * 24\n"
+".endm\n"
+"\n"
+"/**\n"
+" * This is a generic handler for exceptions taken at the current EL while "
+"using\n"
+" * SP0. It behaves similarly to the SPx case by first switching to SPx, "
+"doing\n"
+" * the work, then switching back to SP0 before returning.\n"
+" *\n"
+" * Switching to SPx and calling the Rust handler takes 16 instructions. To\n"
+" * restore and return we need an additional 16 instructions, so we can "
+"implement\n"
+" * the whole handler within the allotted 32 instructions.\n"
+" */\n"
+".macro current_exception_sp0 handler:req\n"
+"\tmsr spsel, #1\n"
+"\tsave_volatile_to_stack\n"
+"\tbl \\handler\n"
+"\trestore_volatile_from_stack\n"
+"\tmsr spsel, #0\n"
+"\teret\n"
+".endm\n"
+"\n"
+"/**\n"
+" * This is a generic handler for exceptions taken at the current EL while "
+"using\n"
+" * SPx. It saves volatile registers, calls the Rust handler, restores "
+"volatile\n"
+" * registers, then returns.\n"
+" *\n"
+" * This also works for exceptions taken from EL0, if we don't care about\n"
+" * non-volatile registers.\n"
+" *\n"
+" * Saving state and jumping to the Rust handler takes 15 instructions, and\n"
+" * restoring and returning also takes 15 instructions, so we can fit the "
+"whole\n"
+" * handler in 30 instructions, under the limit of 32.\n"
+" */\n"
+".macro current_exception_spx handler:req\n"
+"\tsave_volatile_to_stack\n"
+"\tbl \\handler\n"
+"\trestore_volatile_from_stack\n"
+"\teret\n"
+".endm\n"
+"\n"
+".section .text.vector_table_el1, \"ax\"\n"
+".global vector_table_el1\n"
+".balign 0x800\n"
+"vector_table_el1:\n"
+"sync_cur_sp0:\n"
+"\tcurrent_exception_sp0 sync_exception_current\n"
+"\n"
+".balign 0x80\n"
+"irq_cur_sp0:\n"
+"\tcurrent_exception_sp0 irq_current\n"
+"\n"
+".balign 0x80\n"
+"fiq_cur_sp0:\n"
+"\tcurrent_exception_sp0 fiq_current\n"
+"\n"
+".balign 0x80\n"
+"serr_cur_sp0:\n"
+"\tcurrent_exception_sp0 serr_current\n"
+"\n"
+".balign 0x80\n"
+"sync_cur_spx:\n"
+"\tcurrent_exception_spx sync_exception_current\n"
+"\n"
+".balign 0x80\n"
+"irq_cur_spx:\n"
+"\tcurrent_exception_spx irq_current\n"
+"\n"
+".balign 0x80\n"
+"fiq_cur_spx:\n"
+"\tcurrent_exception_spx fiq_current\n"
+"\n"
+".balign 0x80\n"
+"serr_cur_spx:\n"
+"\tcurrent_exception_spx serr_current\n"
+"\n"
+".balign 0x80\n"
+"sync_lower_64:\n"
+"\tcurrent_exception_spx sync_lower\n"
+"\n"
+".balign 0x80\n"
+"irq_lower_64:\n"
+"\tcurrent_exception_spx irq_lower\n"
+"\n"
+".balign 0x80\n"
+"fiq_lower_64:\n"
+"\tcurrent_exception_spx fiq_lower\n"
+"\n"
+".balign 0x80\n"
+"serr_lower_64:\n"
+"\tcurrent_exception_spx serr_lower\n"
+"\n"
+".balign 0x80\n"
+"sync_lower_32:\n"
+"\tcurrent_exception_spx sync_lower\n"
+"\n"
+".balign 0x80\n"
+"irq_lower_32:\n"
+"\tcurrent_exception_spx irq_lower\n"
+"\n"
+".balign 0x80\n"
+"fiq_lower_32:\n"
+"\tcurrent_exception_spx fiq_lower\n"
+"\n"
+".balign 0x80\n"
+"serr_lower_32:\n"
+"\tcurrent_exception_spx serr_lower\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:780
+msgid "_idmap.S_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:784
+msgid ""
+"```armasm\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+".set .L_TT_TYPE_BLOCK, 0x1\n"
+".set .L_TT_TYPE_PAGE,  0x3\n"
+".set .L_TT_TYPE_TABLE, 0x3\n"
+"\n"
+"/* Access flag. */\n"
+".set .L_TT_AF, 0x1 << 10\n"
+"/* Not global. */\n"
+".set .L_TT_NG, 0x1 << 11\n"
+".set .L_TT_XN, 0x3 << 53\n"
+"\n"
+".set .L_TT_MT_DEV, 0x0 << 2\t\t\t// MAIR #0 (DEV_nGnRE)\n"
+".set .L_TT_MT_MEM, (0x1 << 2) | (0x3 << 8)\t// MAIR #1 (MEM_WBWA), inner "
+"shareable\n"
+"\n"
+".set .L_BLOCK_DEV, .L_TT_TYPE_BLOCK | .L_TT_MT_DEV | .L_TT_AF | .L_TT_XN\n"
+".set .L_BLOCK_MEM, .L_TT_TYPE_BLOCK | .L_TT_MT_MEM | .L_TT_AF | .L_TT_NG\n"
+"\n"
+".section \".rodata.idmap\", \"a\", %progbits\n"
+".global idmap\n"
+".align 12\n"
+"idmap:\n"
+"\t/* level 1 */\n"
+"\t.quad\t\t.L_BLOCK_DEV | 0x0\t\t    // 1 GiB of device mappings\n"
+"\t.quad\t\t.L_BLOCK_MEM | 0x40000000\t// 1 GiB of DRAM\n"
+"\t.fill\t\t254, 8, 0x0\t\t\t// 254 GiB of unmapped VA space\n"
+"\t.quad\t\t.L_BLOCK_DEV | 0x4000000000 // 1 GiB of device mappings\n"
+"\t.fill\t\t255, 8, 0x0\t\t\t// 255 GiB of remaining VA space\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:829
+msgid "_image.ld_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:833
+msgid ""
+"```ld\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+"/*\n"
+" * Code will start running at this symbol which is placed at the start of "
+"the\n"
+" * image.\n"
+" */\n"
+"ENTRY(entry)\n"
+"\n"
+"MEMORY\n"
+"{\n"
+"\timage : ORIGIN = 0x40080000, LENGTH = 2M\n"
+"}\n"
+"\n"
+"SECTIONS\n"
+"{\n"
+"\t/*\n"
+"\t * Collect together the code.\n"
+"\t */\n"
+"\t.init : ALIGN(4096) {\n"
+"\t\ttext_begin = .;\n"
+"\t\t*(.init.entry)\n"
+"\t\t*(.init.*)\n"
+"\t} >image\n"
+"\t.text : {\n"
+"\t\t*(.text.*)\n"
+"\t} >image\n"
+"\ttext_end = .;\n"
+"\n"
+"\t/*\n"
+"\t * Collect together read-only data.\n"
+"\t */\n"
+"\t.rodata : ALIGN(4096) {\n"
+"\t\trodata_begin = .;\n"
+"\t\t*(.rodata.*)\n"
+"\t} >image\n"
+"\t.got : {\n"
+"\t\t*(.got)\n"
+"\t} >image\n"
+"\trodata_end = .;\n"
+"\n"
+"\t/*\n"
+"\t * Collect together the read-write data including .bss at the end which\n"
+"\t * will be zero'd by the entry code.\n"
+"\t */\n"
+"\t.data : ALIGN(4096) {\n"
+"\t\tdata_begin = .;\n"
+"\t\t*(.data.*)\n"
+"\t\t/*\n"
+"\t\t * The entry point code assumes that .data is a multiple of 32\n"
+"\t\t * bytes long.\n"
+"\t\t */\n"
+"\t\t. = ALIGN(32);\n"
+"\t\tdata_end = .;\n"
+"\t} >image\n"
+"\n"
+"\t/* Everything beyond this point will not be included in the binary. */\n"
+"\tbin_end = .;\n"
+"\n"
+"\t/* The entry point code assumes that .bss is 16-byte aligned. */\n"
+"\t.bss : ALIGN(16)  {\n"
+"\t\tbss_begin = .;\n"
+"\t\t*(.bss.*)\n"
+"\t\t*(COMMON)\n"
+"\t\t. = ALIGN(16);\n"
+"\t\tbss_end = .;\n"
+"\t} >image\n"
+"\n"
+"\t.stack (NOLOAD) : ALIGN(4096) {\n"
+"\t\tboot_stack_begin = .;\n"
+"\t\t. += 40 * 4096;\n"
+"\t\t. = ALIGN(4096);\n"
+"\t\tboot_stack_end = .;\n"
+"\t} >image\n"
+"\n"
+"\t. = ALIGN(4K);\n"
+"\tPROVIDE(dma_region = .);\n"
+"\n"
+"\t/*\n"
+"\t * Remove unused sections from the image.\n"
+"\t */\n"
+"\t/DISCARD/ : {\n"
+"\t\t/* The image loads itself so doesn't need these sections. */\n"
+"\t\t*(.gnu.hash)\n"
+"\t\t*(.hash)\n"
+"\t\t*(.interp)\n"
+"\t\t*(.eh_frame_hdr)\n"
+"\t\t*(.eh_frame)\n"
+"\t\t*(.note.gnu.build-id)\n"
+"\t}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:940
+msgid "_Makefile_ (you shouldn't need to change this):"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:944
+msgid ""
+"```makefile\n"
+"# Copyright 2023 Google LLC\n"
+"#\n"
+"# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"# you may not use this file except in compliance with the License.\n"
+"# You may obtain a copy of the License at\n"
+"#\n"
+"#      http://www.apache.org/licenses/LICENSE-2.0\n"
+"#\n"
+"# Unless required by applicable law or agreed to in writing, software\n"
+"# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"# See the License for the specific language governing permissions and\n"
+"# limitations under the License.\n"
+"\n"
+"UNAME := $(shell uname -s)\n"
+"ifeq ($(UNAME),Linux)\n"
+"\tTARGET = aarch64-linux-gnu\n"
+"else\n"
+"\tTARGET = aarch64-none-elf\n"
+"endif\n"
+"OBJCOPY = $(TARGET)-objcopy\n"
+"\n"
+".PHONY: build qemu_minimal qemu qemu_logger\n"
+"\n"
+"all: rtc.bin\n"
+"\n"
+"build:\n"
+"\tcargo build\n"
+"\n"
+"rtc.bin: build\n"
+"\t$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@\n"
+"\n"
+"qemu: rtc.bin\n"
+"\tqemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio "
+"-display none -kernel $< -s\n"
+"\n"
+"clean:\n"
+"\tcargo clean\n"
+"\trm -f *.bin\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:989
+msgid ""
+"```toml\n"
+"[build]\n"
+"target = \"aarch64-unknown-none\"\n"
+"rustflags = [\"-C\", \"link-arg=-Timage.ld\"]\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:995
+msgid "Run the code in QEMU with `make qemu`."
+msgstr ""
+
+#: src/concurrency.md:1
+msgid "Welcome to Concurrency in Rust"
+msgstr "欢迎了解 Rust 中的并发"
+
+#: src/concurrency.md:3
+msgid ""
+"Rust has full support for concurrency using OS threads with mutexes and "
+"channels."
+msgstr "Rust 完全支持使用带有互斥锁和通道的操作系统线程进行并发。"
+
+#: src/concurrency.md:6
+msgid ""
+"The Rust type system plays an important role in making many concurrency bugs "
+"compile time bugs. This is often referred to as _fearless concurrency_ since "
+"you can rely on the compiler to ensure correctness at runtime."
+msgstr ""
+"Rust 类型系统能帮助我们把许多并发bug转换为编译期bug 发挥着重要作用。这通常称为“无畏并发”，因为你可以依靠编译器来确保 运行时的正确性。"
+
+#: src/concurrency/threads.md:3
+msgid "Rust threads work similarly to threads in other languages:"
+msgstr "Rust 线程的运作方式与其他语言中的线程类似："
+
+#: src/concurrency/threads.md:5
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    thread::spawn(|| {\n"
+"        for i in 1..10 {\n"
+"            println!(\"Count in thread: {i}!\");\n"
+"            thread::sleep(Duration::from_millis(5));\n"
+"        }\n"
+"    });\n"
+"\n"
+"    for i in 1..5 {\n"
+"        println!(\"Main thread: {i}\");\n"
+"        thread::sleep(Duration::from_millis(5));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    thread::spawn(|| {\n"
+"        for i in 1..10 {\n"
+"            println!(\"Count in thread: {i}!\");\n"
+"            thread::sleep(Duration::from_millis(5));\n"
+"        }\n"
+"    });\n"
+"\n"
+"    for i in 1..5 {\n"
+"        println!(\"Main thread: {i}\");\n"
+"        thread::sleep(Duration::from_millis(5));\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/concurrency/threads.md:24
+msgid "Threads are all daemon threads, the main thread does not wait for them."
+msgstr "线程均为守护程序线程，主线程不会等待这些线程。"
+
+#: src/concurrency/threads.md:25
+msgid "Thread panics are independent of each other."
+msgstr "线程紧急警报 (panic) 是彼此独立的。"
+
+#: src/concurrency/threads.md:26
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr "紧急警报可以携带载荷，并可以使用 `downcast_ref` 对载荷进行解压缩。"
+
+#: src/concurrency/threads.md:32
+msgid ""
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
+msgstr "请注意，线程在达到 10 之前就停止了，而主线程并 没有等待。"
+
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr "使用 `let handle = thread::spawn(...)` 和后面的 `handle.join()` 等待 线程完成。"
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr "在线程中触发紧急警报，并注意这为何不会影响到 `main`。"
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about "
+"[`Any`](https://doc.rust-lang.org/std/any/index.html)."
+msgstr ""
+"使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报 载荷的访问权限。现在有必要介绍一下 "
+"[`Any`](https://doc.rust-lang.org/std/any/index.html) 了。"
+
+#: src/concurrency/scoped-threads.md:3
+msgid "Normal threads cannot borrow from their environment:"
+msgstr "常规线程不能从它们所处的环境中借用："
+
+#: src/concurrency/scoped-threads.md:5
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"\n"
+"fn foo() {\n"
+"    let s = String::from(\"Hello\");\n"
+"    thread::spawn(|| {\n"
+"        println!(\"Length: {}\", s.len());\n"
+"    });\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    foo();\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let s = String::from(\"Hello\");\n"
+"\n"
+"    thread::spawn(|| {\n"
+"        println!(\"Length: {}\", s.len());\n"
+"    });\n"
+"}\n"
+"```"
+
+#: src/concurrency/scoped-threads.md:20
+msgid ""
+"However, you can use a [scoped "
+"thread](https://doc.rust-lang.org/std/thread/fn.scope.html) for this:"
+msgstr ""
+"不过，你可以使用[范围线程](https://doc.rust-lang.org/std/thread/fn.scope.html)来实现此目的："
+
+#: src/concurrency/scoped-threads.md:22
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let s = String::from(\"Hello\");\n"
+"\n"
+"    thread::scope(|scope| {\n"
+"        scope.spawn(|| {\n"
+"            println!(\"Length: {}\", s.len());\n"
+"        });\n"
+"    });\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let s = String::from(\"Hello\");\n"
+"\n"
+"    thread::scope(|scope| {\n"
+"        scope.spawn(|| {\n"
+"            println!(\"Length: {}\", s.len());\n"
+"        });\n"
+"    });\n"
+"}\n"
+"```"
+
+#: src/concurrency/scoped-threads.md:40
+msgid ""
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
+msgstr "其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使得线程能够返回借用的数据。"
+
+#: src/concurrency/scoped-threads.md:41
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr "此时须遵守常规 Rust 借用规则：你可以通过一个线程以可变的方式借用，也可以通过任意数量的线程以不可变的方式借用。"
+
+#: src/concurrency/channels.md:3
+msgid ""
+"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
+"parts are connected via the channel, but you only see the end-points."
+msgstr ""
+"Rust 通道（Channel）包含两个部分：`Sender<T>` 和 `Receiver<T>`。这两个部分 通过通道进行连接，但你只能看到端点。"
+
+#: src/concurrency/channels.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::channel();\n"
+"\n"
+"    tx.send(10).unwrap();\n"
+"    tx.send(20).unwrap();\n"
+"\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"\n"
+"    let tx2 = tx.clone();\n"
+"    tx2.send(30).unwrap();\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::channel();\n"
+"\n"
+"    tx.send(10).unwrap();\n"
+"    tx.send(20).unwrap();\n"
+"\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"\n"
+"    let tx2 = tx.clone();\n"
+"    tx2.send(30).unwrap();\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"}\n"
+"```"
+
+#: src/concurrency/channels.md:26
+msgid ""
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
+msgstr ""
+"`mpsc` 代表多个生产方，单个使用方。`Sender` 和 `SyncSender` 会实现 `Clone`（因此， 你可以设置多个生产方），但 "
+"`Receiver` 不会实现。"
+
+#: src/concurrency/channels.md:28
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()` 和 `recv()` 会返回 `Result`。如果它们返回 `Err`，则表示对应的 `Sender` 或 `Receiver` "
+"已被丢弃，且通道已关闭。"
+
+#: src/concurrency/channels/unbounded.md:3
+msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
+msgstr "你可以使用 `mpsc::channel()` 获得无边界的异步通道："
+
+#: src/concurrency/channels/unbounded.md:5
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::channel();\n"
+"\n"
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));\n"
+"\n"
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {msg}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::channel();\n"
+"\n"
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));\n"
+"\n"
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {msg}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/concurrency/channels/bounded.md:3
+#, fuzzy
+msgid "With bounded (synchronous) channels, `send` can block the current thread:"
+msgstr "有边界的同步通道会使 `send` 阻塞当前线程："
+
+#: src/concurrency/channels/bounded.md:5
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::sync_channel(3);\n"
+"\n"
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));\n"
+"\n"
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {msg}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::sync_channel(3);\n"
+"\n"
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));\n"
+"\n"
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {msg}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/concurrency/channels/bounded.md:31
+msgid ""
+"Calling `send` will block the current thread until there is space in the "
+"channel for the new message. The thread can be blocked indefinitely if there "
+"is nobody who reads from the channel."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:32
+msgid ""
+"A call to `send` will abort with an error (that is why it returns `Result`) "
+"if the channel is closed. A channel is closed when the receiver is dropped."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:33
+msgid ""
+"A bounded channel with a size of zero is called a \"rendezvous channel\". "
+"Every send will block the current thread until another thread calls `read`."
+msgstr ""
+
+#: src/concurrency/send-sync.md:1
+msgid "`Send` and `Sync`"
+msgstr "`Send` 和 `Sync`"
+
+#: src/concurrency/send-sync.md:3
+#, fuzzy
+msgid ""
+"How does Rust know to forbid shared access across threads? The answer is in "
+"two traits:"
+msgstr "Rust 如何知道要禁止跨线程共享访问？答案在于 Rust 的两个特征："
+
+#: src/concurrency/send-sync.md:5
+msgid ""
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
+msgstr ""
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)：如果跨线程边界移动 `T` "
+"是安全的，则类型 `T` 为 `Send`。"
+
+#: src/concurrency/send-sync.md:7
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)：如果跨线程边界移动 "
+"`&T` 是安全的，则类型 `T` 为 `Sync`。"
+
+#: src/concurrency/send-sync.md:10
+msgid ""
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
+msgstr ""
+"`Send` 和 `Sync` 均为[不安全特征](../unsafe/unsafe-traits.md)。只要类型仅包含 `Send` 和 "
+"`Sync` 类型，编译器就会自动为类型派生 这两种特征。你也可以手动实现它们（如果你确定这样 有效的话）。"
+
+#: src/concurrency/send-sync.md:20
+msgid ""
+"One can think of these traits as markers that the type has certain "
+"thread-safety properties."
+msgstr "不妨将这些特征视为类型包含某些线程安全属性的标记。"
+
+#: src/concurrency/send-sync.md:21
+msgid "They can be used in the generic constraints as normal traits."
+msgstr "它们可以在泛型约束中作为常规特征使用。"
+
+#: src/concurrency/send-sync/send.md:1
+msgid "`Send`"
+msgstr "`Send`"
+
+#: src/concurrency/send-sync/send.md:3
+msgid ""
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
+msgstr ""
+"如果将 `T` 值移动到另一个线程是安全的，则类型 `T` 为 "
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)。"
+
+#: src/concurrency/send-sync/send.md:5
+msgid ""
+"The effect of moving ownership to another thread is that _destructors_ will "
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
+msgstr ""
+"将所有权转移到另一个线程的影响是，“析构函数”将在相应线程中 运行。因此，问题在于你何时可以在一个线程中分配某个值，然后在 另一个线程中取消分配该值。"
+
+#: src/concurrency/send-sync/send.md:13
+msgid ""
+"As an example, a connection to the SQLite library must only be accessed from "
+"a single thread."
+msgstr "例如，与 SQLite 库的连接只能通过 单个线程访问。"
+
+#: src/concurrency/send-sync/sync.md:1
+msgid "`Sync`"
+msgstr "`Sync`"
+
+#: src/concurrency/send-sync/sync.md:3
+msgid ""
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
+msgstr ""
+"如果同时从多个线程访问 `T` 值是安全的，则类型 `T` 为 "
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)。"
+
+#: src/concurrency/send-sync/sync.md:6
+msgid "More precisely, the definition is:"
+msgstr "更准确地说，定义是："
+
+#: src/concurrency/send-sync/sync.md:8
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
+msgstr "当且仅当 `&T` 为 `Send` 时，`T` 为 `Sync`"
+
+#: src/concurrency/send-sync/sync.md:14
+msgid ""
+"This statement is essentially a shorthand way of saying that if a type is "
+"thread-safe for shared use, it is also thread-safe to pass references of it "
+"across threads."
+msgstr "该语句实质上是一种简写形式，表示如果某个类型对于共享使用是线程安全的，那么跨线程传递对该类型的引用也是线程安全的。"
+
+#: src/concurrency/send-sync/sync.md:16
+msgid ""
+"This is because if a type is Sync it means that it can be shared across "
+"multiple threads without the risk of data races or other synchronization "
+"issues, so it is safe to move it to another thread. A reference to the type "
+"is also safe to move to another thread, because the data it references can "
+"be accessed from any thread safely."
+msgstr ""
+"这是因为如果某个类型为 "
+"Sync，则意味着它可以在多个线程之间共享，而不存在数据争用或其他同步问题的风险，因此将其移动到另一个线程是安全的。对该类型的引用同样可以安全地移动到另一个线程，因为它引用的数据可以从任何线程安全地访问。"
+
+#: src/concurrency/send-sync/examples.md:3
+msgid "`Send + Sync`"
+msgstr "`Send + Sync`"
+
+#: src/concurrency/send-sync/examples.md:5
+msgid "Most types you come across are `Send + Sync`:"
+msgstr "你遇到的类型大都属于 `Send + Sync`："
+
+#: src/concurrency/send-sync/examples.md:7
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr "`i8`、`f32`、`bool`、`char`、`&str`…"
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr "`(T1, T2)`、`[T; N]`、`&[T]`、`struct { x: T }`…"
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr "`String`、`Option<T>`、`Vec<T>`、`Box<T>`…"
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr "`Arc<T>`：明确通过原子引用计数实现线程安全。"
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr "`Mutex<T>`：明确通过内部锁定实现线程安全。"
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgstr "`AtomicBool`、`AtomicU8`…：使用特殊的原子指令。"
+
+#: src/concurrency/send-sync/examples.md:14
+msgid ""
+"The generic types are typically `Send + Sync` when the type parameters are "
+"`Send + Sync`."
+msgstr "当类型参数为 `Send + Sync` 时，泛型类型通常 为 `Send + Sync`。"
+
+#: src/concurrency/send-sync/examples.md:17
+msgid "`Send + !Sync`"
+msgstr "`Send + !Sync`"
+
+#: src/concurrency/send-sync/examples.md:19
+msgid ""
+"These types can be moved to other threads, but they're not thread-safe. "
+"Typically because of interior mutability:"
+msgstr "这些类型可以移动到其他线程，但它们不是线程安全的。 这通常是由内部可变性造成的："
+
+#: src/concurrency/send-sync/examples.md:22
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Sender<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Receiver<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+msgid "`Cell<T>`"
+msgstr "`Cell<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+msgid "`RefCell<T>`"
+msgstr "`RefCell<T>`"
+
+#: src/concurrency/send-sync/examples.md:27
+msgid "`!Send + Sync`"
+msgstr "`!Send + Sync`"
+
+#: src/concurrency/send-sync/examples.md:29
+msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgstr "这些类型是线程安全的，但它们不能移动到另一个线程："
+
+#: src/concurrency/send-sync/examples.md:31
+msgid ""
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
+msgstr "`MutexGuard<T>`：使用操作系统级别的原语（必须在创建这些原语的线程上 取消分配）。"
+
+#: src/concurrency/send-sync/examples.md:34
+msgid "`!Send + !Sync`"
+msgstr "`!Send + !Sync`"
+
+#: src/concurrency/send-sync/examples.md:36
+msgid "These types are not thread-safe and cannot be moved to other threads:"
+msgstr "这些类型不是线程安全的，不能移动到其他线程："
+
+#: src/concurrency/send-sync/examples.md:38
+msgid ""
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a "
+"non-atomic reference count."
+msgstr "`Rc<T>`：每个 `Rc<T>` 都具有对 `RcBox<T>` 的引用，其中包含 非原子引用计数。"
+
+#: src/concurrency/send-sync/examples.md:40
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr "`*const T`、`*mut T`：Rust 会假定原始指针可能 在并发方面有特殊的注意事项。"
+
+#: src/concurrency/shared_state.md:3
+msgid ""
+"Rust uses the type system to enforce synchronization of shared data. This is "
+"primarily done via two types:"
+msgstr "Rust 使用类型系统来强制同步共享数据。这主要 通过两种类型实现："
+
+#: src/concurrency/shared_state.md:6
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
+msgstr ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)，对 `T` "
+"进行原子计数：用于处理线程之间的共享，并负责 在最后一个引用被丢弃时取消分配 `T`。"
+
+#: src/concurrency/shared_state.md:8
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)：确保对 `T` "
+"值的互斥访问。"
+
+#: src/concurrency/shared_state/arc.md:1
+msgid "`Arc`"
+msgstr "`Arc`"
+
+#: src/concurrency/shared_state/arc.md:3
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
+msgstr ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) 允许通过 "
+"`Arc::clone` 实现共享只读权限："
+
+#: src/concurrency/shared_state/arc.md:5
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::sync::Arc;\n"
+"\n"
+"fn main() {\n"
+"    let v = Arc::new(vec![10, 20, 30]);\n"
+"    let mut handles = Vec::new();\n"
+"    for _ in 1..5 {\n"
+"        let v = Arc::clone(&v);\n"
+"        handles.push(thread::spawn(move || {\n"
+"            let thread_id = thread::current().id();\n"
+"            println!(\"{thread_id:?}: {v:?}\");\n"
+"        }));\n"
+"    }\n"
+"\n"
+"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::sync::Arc;\n"
+"\n"
+"fn main() {\n"
+"    let v = Arc::new(vec![10, 20, 30]);\n"
+"    let mut handles = Vec::new();\n"
+"    for _ in 1..5 {\n"
+"        let v = Arc::clone(&v);\n"
+"        handles.push(thread::spawn(move || {\n"
+"            let thread_id = thread::current().id();\n"
+"            println!(\"{thread_id:?}: {v:?}\");\n"
+"        }));\n"
+"    }\n"
+"\n"
+"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+
+#: src/concurrency/shared_state/arc.md:29
+msgid ""
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
+msgstr "`Arc` 代表“原子引用计数”，它是使用原子操作的 `Rc` 的 线程安全版本。"
+
+#: src/concurrency/shared_state/arc.md:31
+#, fuzzy
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` if and only if `T` implements them both."
+msgstr ""
+"无论 `T` 是否实现 `Clone`，`Arc<T>` 都会实现 `Clone`。如果 `T` 实现了 `Send` 和 "
+"`Sync`，`Arc<T>` 便会 实现二者。"
+
+#: src/concurrency/shared_state/arc.md:33
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr "`Arc::clone()` 在执行原子操作方面有开销，但在此之后，`T` 便可 随意使用，而没有任何开销。"
+
+#: src/concurrency/shared_state/arc.md:35
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr "请警惕引用循环，`Arc` 不会使用垃圾回收器检测引用循环。"
+
+#: src/concurrency/shared_state/arc.md:36
+msgid "`std::sync::Weak` can help."
+msgstr "`std::sync::Weak` 对此有所帮助。"
+
+#: src/concurrency/shared_state/mutex.md:1
+msgid "`Mutex`"
+msgstr "`互斥器 (Mutex)`"
+
+#: src/concurrency/shared_state/mutex.md:3
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) "
+"能够确保互斥，并允许对只读接口 后面的 `T` 进行可变访问："
+
+#: src/concurrency/shared_state/mutex.md:6
+msgid ""
+"```rust,editable\n"
+"use std::sync::Mutex;\n"
+"\n"
+"fn main() {\n"
+"    let v = Mutex::new(vec![10, 20, 30]);\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"\n"
+"    {\n"
+"        let mut guard = v.lock().unwrap();\n"
+"        guard.push(40);\n"
+"    }\n"
+"\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::sync::Mutex;\n"
+"\n"
+"fn main() {\n"
+"    let v = Mutex::new(vec![10, 20, 30]);\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"\n"
+"    {\n"
+"        let mut guard = v.lock().unwrap();\n"
+"        guard.push(40);\n"
+"    }\n"
+"\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"}\n"
+"```"
+
+#: src/concurrency/shared_state/mutex.md:22
+msgid ""
+"Notice how we have a [`impl<T: Send> Sync for "
+"Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) "
+"blanket implementation."
+msgstr ""
+"请注意我们如何设置 [`impl<T: Send> Sync for "
+"Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) "
+"通用 实现。"
+
+#: src/concurrency/shared_state/mutex.md:31
+msgid ""
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
+msgstr "Rust 中的互斥器看起来就像只包含一个元素的集合，其中的元素就是受保护的数据。"
+
+#: src/concurrency/shared_state/mutex.md:32
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr "在访问受保护的数据之前不可能忘记获取互斥量。"
+
+#: src/concurrency/shared_state/mutex.md:33
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+"你可以通过获取锁，从 `&Mutex<T>` 中获取 `&mut T`。`MutexGuard` 能够确保 `&mut T` "
+"存在的时间不会比持有锁的时间更长。"
+
+#: src/concurrency/shared_state/mutex.md:35
+#, fuzzy
+msgid ""
+"`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
+"implements `Send`."
+msgstr "如果 `T` 实现了 `Send`，`Mutex<T>` 便会实现 `Send` 和 `Sync`。"
+
+#: src/concurrency/shared_state/mutex.md:36
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "读写锁版本 - `RwLock`。"
+
+#: src/concurrency/shared_state/mutex.md:37
+msgid "Why does `lock()` return a `Result`? "
+msgstr "为什么 `lock()` 会返回 `Result`？"
+
+#: src/concurrency/shared_state/mutex.md:38
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"如果持有 `Mutex` 的线程发生panic，`Mutex` 便会“中毒”并发出信号， 表明其所保护的数据可能处于不一致状态。对中毒的互斥量调用 "
+"`lock()` 将会失败， 并将显示 "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html)。无论如何，你可以对该错误调用 "
+"`into_inner()` 来 恢复数据。"
+
+#: src/concurrency/shared_state/example.md:3
+msgid "Let us see `Arc` and `Mutex` in action:"
+msgstr "让我们看看 `Arc` 和 `Mutex` 的实际效果："
+
+#: src/concurrency/shared_state/example.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"// use std::sync::{Arc, Mutex};\n"
+"\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let handle = thread::spawn(|| {\n"
+"        v.push(10);\n"
+"    });\n"
+"    v.push(1000);\n"
+"\n"
+"    handle.join().unwrap();\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"// use std::sync::{Arc, Mutex};\n"
+"\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let handle = thread::spawn(|| {\n"
+"        v.push(10);\n"
+"    });\n"
+"    v.push(1000);\n"
+"\n"
+"    handle.join().unwrap();\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+
+#: src/concurrency/shared_state/example.md:23
+msgid "Possible solution:"
+msgstr "可能有用的解决方案："
+
+#: src/concurrency/shared_state/example.md:25
+msgid ""
+"```rust,editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let v = Arc::new(Mutex::new(vec![10, 20, 30]));\n"
+"\n"
+"    let v2 = Arc::clone(&v);\n"
+"    let handle = thread::spawn(move || {\n"
+"        let mut v2 = v2.lock().unwrap();\n"
+"        v2.push(10);\n"
+"    });\n"
+"\n"
+"    {\n"
+"        let mut v = v.lock().unwrap();\n"
+"        v.push(1000);\n"
+"    }\n"
+"\n"
+"    handle.join().unwrap();\n"
+"\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let v = Arc::new(Mutex::new(vec![10, 20, 30]));\n"
+"\n"
+"    let v2 = Arc::clone(&v);\n"
+"    let handle = thread::spawn(move || {\n"
+"        let mut v2 = v2.lock().unwrap();\n"
+"        v2.push(10);\n"
+"    });\n"
+"\n"
+"    {\n"
+"        let mut v = v.lock().unwrap();\n"
+"        v.push(1000);\n"
+"    }\n"
+"\n"
+"    handle.join().unwrap();\n"
+"\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+
+#: src/concurrency/shared_state/example.md:49
+msgid "Notable parts:"
+msgstr "值得注意的部分："
+
+#: src/concurrency/shared_state/example.md:51
+msgid ""
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr "`Arc` 和 `Mutex` 中都封装了 `v`，因为它们的关注点是正交的。"
+
+#: src/concurrency/shared_state/example.md:52
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr "将 `Mutex` 封装在 `Arc` 中是一种在线程之间共享可变状态的常见模式。"
+
+#: src/concurrency/shared_state/example.md:53
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr "`v: Arc<_>` 必须先克隆为 `v2`，然后才能移动到另一个线程中。请注意，lambda 签名中添加了 `move`。"
+
+#: src/concurrency/shared_state/example.md:54
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible."
+msgstr "我们引入了块，以尽可能缩小 `LockGuard` 的作用域。"
+
+#: src/exercises/concurrency/morning.md:3
+msgid "Let us practice our new concurrency skills with"
+msgstr ""
+
+#: src/exercises/concurrency/morning.md:5
+msgid "Dining philosophers: a classic problem in concurrency."
+msgstr ""
+
+#: src/exercises/concurrency/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:3
+msgid "The dining philosophers problem is a classic problem in concurrency:"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:5
+msgid ""
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:13
+msgid ""
+"You will need a local [Cargo installation](../../cargo/running-locally.md) "
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:19
+msgid ""
+"```rust,compile_fail\n"
+"use std::sync::{mpsc, Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // thoughts: ...\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];\n"
+"\n"
+"fn main() {\n"
+"    // Create forks\n"
+"\n"
+"    // Create philosophers\n"
+"\n"
+"    // Make each of them think and eat 100 times\n"
+"\n"
+"    // Output their thoughts\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:61
+msgid "You can use the following `Cargo.toml`:"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:65
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"dining-philosophers\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:3
+msgid ""
+"Let us use our new knowledge to create a multi-threaded link checker. It "
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:8
+msgid ""
+"For this, you will need an HTTP client such as "
+"[`reqwest`](https://docs.rs/reqwest/). Create a new Cargo project and "
+"`reqwest` it as a dependency with:"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:17
+msgid ""
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:20
+msgid ""
+"You will also need a way to find links. We can use "
+"[`scraper`](https://docs.rs/scraper/) for that:"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:26
+msgid ""
+"Finally, we'll need some way of handling errors. We use "
+"[`thiserror`](https://docs.rs/thiserror/) for that:"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:33
+msgid ""
+"The `cargo add` calls will update the `Cargo.toml` file to look like this:"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:37
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"link-checker\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"publish = false\n"
+"\n"
+"[dependencies]\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] "
+"}\n"
+"scraper = \"0.13.0\"\n"
+"thiserror = \"1.0.37\"\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:50
+msgid ""
+"You can now download the start page. Try with a small site such as "
+"`https://www.google.org/`."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:53
+msgid "Your `src/main.rs` file should look something like this:"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:57
+msgid ""
+"```rust,compile_fail\n"
+"use reqwest::{blocking::Client, Url};\n"
+"use scraper::{Html, Selector};\n"
+"use thiserror::Error;\n"
+"\n"
+"#[derive(Error, Debug)]\n"
+"enum Error {\n"
+"    #[error(\"request error: {0}\")]\n"
+"    ReqwestError(#[from] reqwest::Error),\n"
+"    #[error(\"bad http response: {0}\")]\n"
+"    BadResponse(String),\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct CrawlCommand {\n"
+"    url: Url,\n"
+"    extract_links: bool,\n"
+"}\n"
+"\n"
+"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
+"Error> {\n"
+"    println!(\"Checking {:#}\", command.url);\n"
+"    let response = client.get(command.url.clone()).send()?;\n"
+"    if !response.status().is_success() {\n"
+"        return Err(Error::BadResponse(response.status().to_string()));\n"
+"    }\n"
+"\n"
+"    let mut link_urls = Vec::new();\n"
+"    if !command.extract_links {\n"
+"        return Ok(link_urls);\n"
+"    }\n"
+"\n"
+"    let base_url = response.url().to_owned();\n"
+"    let body_text = response.text()?;\n"
+"    let document = Html::parse_document(&body_text);\n"
+"\n"
+"    let selector = Selector::parse(\"a\").unwrap();\n"
+"    let href_values = document\n"
+"        .select(&selector)\n"
+"        .filter_map(|element| element.value().attr(\"href\"));\n"
+"    for href in href_values {\n"
+"        match base_url.join(href) {\n"
+"            Ok(link_url) => {\n"
+"                link_urls.push(link_url);\n"
+"            }\n"
+"            Err(err) => {\n"
+"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
+"{err}\");\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"    Ok(link_urls)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let client = Client::new();\n"
+"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let crawl_command = CrawlCommand{ url: start_url, extract_links: true "
+"};\n"
+"    match visit_page(&client, &crawl_command) {\n"
+"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
+"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:120
+msgid "Run the code in `src/main.rs` with"
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:128
+msgid ""
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:130
+msgid ""
+"Extend this to recursively extract links from all pages on the "
+"`www.google.org` domain. Put an upper limit of 100 pages or so so that you "
+"don't end up being blocked by the site."
+msgstr ""
+
+#: src/async.md:1
+msgid "Async Rust"
+msgstr ""
+
+#: src/async.md:3
+msgid ""
+"\"Async\" is a concurrency model where multiple tasks are executed "
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
+msgstr ""
+
+#: src/async.md:10
+msgid ""
+"Rust's asynchronous operation is based on \"futures\", which represent work "
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
+msgstr ""
+
+#: src/async.md:14
+msgid ""
+"Futures are polled by an async runtime, and several different runtimes are "
+"available."
+msgstr ""
+
+#: src/async.md:17
+msgid "Comparisons"
+msgstr ""
+
+#: src/async.md:19
+msgid ""
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
+msgstr ""
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
+msgstr ""
+
+#: src/async/async-await.md:1
+msgid "`async`/`await`"
+msgstr ""
+
+#: src/async/async-await.md:3
+msgid ""
+"At a high level, async Rust code looks very much like \"normal\" sequential "
+"code:"
+msgstr "从高层次上看，异步 Rust 代码与“正常”的顺序代码非常类似："
+
+#: src/async/async-await.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use futures::executor::block_on;\n"
+"\n"
+"async fn count_to(count: i32) {\n"
+"    for i in 1..=count {\n"
+"        println!(\"Count is: {i}!\");\n"
+"    }\n"
+"}\n"
+"\n"
+"async fn async_main(count: i32) {\n"
+"    count_to(count).await;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    block_on(async_main(10));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/async-await.md:27
+msgid ""
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
+msgstr "请注意，这只是一个简单的示例，用于展示语法。其中没有长时间运行的操作或任何真正的并发！"
+
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr "异步调用的返回类型是什么？"
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr "在 `main` 中使用 `let future: () = async_main(10);` 来查看类型。"
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr "\"async\" 关键字是语法糖。编译器会将返回类型替换为 future。"
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr "你不能将 `main` 声明为异步函数，除非在编译器中加入额外的指令来告诉它如何使用返回的 future。"
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr "你需要一个执行器来运行异步代码。`block_on`会阻塞当前线程，直到提供的future完成为止。 "
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr "`.await` 会异步地等待另一个操作的完成。与 `block_on` 不同，`.await` 不会阻塞当前线程。"
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr "`.await` 只能在 `async` 函数（或块，这些稍后会介绍）中使用。 "
+
+#: src/async/futures.md:3
+msgid ""
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a "
+"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+msgstr ""
+
+#: src/async/futures.md:23
+msgid ""
+"An async function returns an `impl Future`. It's also possible (but "
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
+msgstr ""
+
+#: src/async/futures.md:27
+msgid ""
+"The `.await` keyword, applied to a Future, causes the current async function "
+"to pause until that Future is ready, and then evaluates to its output."
+msgstr ""
+
+#: src/async/futures.md:32
+msgid ""
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
+msgstr ""
+
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
+msgstr ""
+
+#: src/async/runtimes.md:3
+msgid ""
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
+msgstr ""
+
+#: src/async/runtimes.md:7
+msgid ""
+"[Tokio](https://tokio.rs/): performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or "
+"[Tonic](https://github.com/hyperium/tonic) for gRPC."
+msgstr ""
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/): aims to be a \"std for async\", and includes "
+"a basic runtime in `async::task`."
+msgstr ""
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/): simple and lightweight"
+msgstr ""
+
+#: src/async/runtimes.md:14
+msgid ""
+"Several larger applications have their own runtimes. For example, "
+"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-async/src/lib.rs) "
+"already has one."
+msgstr ""
+
+#: src/async/runtimes.md:20
+msgid ""
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
+msgstr ""
+
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:4
+msgid "Tokio provides: "
+msgstr ""
+
+#: src/async/runtimes/tokio.md:6
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:10
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::time;\n"
+"\n"
+"async fn count_to(count: i32) {\n"
+"    for i in 1..=count {\n"
+"        println!(\"Count in task: {i}!\");\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    tokio::spawn(count_to(10));\n"
+"\n"
+"    for i in 1..5 {\n"
+"        println!(\"Main task: {i}\");\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/runtimes/tokio.md:33
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:39
+msgid "**Further exploration:**"
+msgstr ""
+
+#: src/async/runtimes/tokio.md:41
+msgid ""
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
+msgstr ""
+
+#: src/async/tasks.md:3
+msgid "Rust has a task system, which is a form of lightweight threading."
+msgstr ""
+
+#: src/async/tasks.md:5
+msgid ""
+"A task has a single top-level future which the executor polls to make "
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
+msgstr ""
+
+#: src/async/tasks.md:10
+msgid ""
+"```rust,compile_fail\n"
+"use tokio::io::{self, AsyncReadExt, AsyncWriteExt};\n"
+"use tokio::net::TcpListener;\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> io::Result<()> {\n"
+"    let listener = TcpListener::bind(\"127.0.0.1:6142\").await?;\n"
+"\tprintln!(\"listening on port 6142\");\n"
+"\n"
+"    loop {\n"
+"        let (mut socket, addr) = listener.accept().await?;\n"
+"\n"
+"        println!(\"connection from {addr:?}\");\n"
+"\n"
+"        tokio::spawn(async move {\n"
+"            if let Err(e) = socket.write_all(b\"Who are you?\\n"
+"\").await {\n"
+"                println!(\"socket error: {e:?}\");\n"
+"                return;\n"
+"            }\n"
+"\n"
+"            let mut buf = vec![0; 1024];\n"
+"            let reply = match socket.read(&mut buf).await {\n"
+"                Ok(n) => {\n"
+"                    let name = "
+"std::str::from_utf8(&buf[..n]).unwrap().trim();\n"
+"                    format!(\"Thanks for dialing in, {name}!\\n"
+"\")\n"
+"                }\n"
+"                Err(e) => {\n"
+"                    println!(\"socket error: {e:?}\");\n"
+"                    return;\n"
+"                }\n"
+"            };\n"
+"\n"
+"            if let Err(e) = socket.write_all(reply.as_bytes()).await {\n"
+"                println!(\"socket error: {e:?}\");\n"
+"            }\n"
+"        });\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/tasks.md:52
+#: src/async/control-flow/join.md:36
+msgid "Copy this example into your prepared `src/main.rs` and run it from there."
+msgstr ""
+
+#: src/async/tasks.md:54
+msgid ""
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
+msgstr ""
+
+#: src/async/tasks.md:57
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+
+#: src/async/tasks.md:61
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
+"using `?`."
+msgstr ""
+
+#: src/async/channels.md:3
+msgid ""
+"Several crates have support for asynchronous channels. For instance `tokio`:"
+msgstr ""
+
+#: src/async/channels.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::sync::mpsc::{self, Receiver};\n"
+"\n"
+"async fn ping_handler(mut input: Receiver<()>) {\n"
+"    let mut count: usize = 0;\n"
+"\n"
+"    while let Some(_) = input.recv().await {\n"
+"        count += 1;\n"
+"        println!(\"Received {count} pings so far.\");\n"
+"    }\n"
+"\n"
+"    println!(\"ping_handler complete\");\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let (sender, receiver) = mpsc::channel(32);\n"
+"    let ping_handler_task = tokio::spawn(ping_handler(receiver));\n"
+"    for i in 0..10 {\n"
+"        sender.send(()).await.expect(\"Failed to send ping.\");\n"
+"        println!(\"Sent {} pings so far.\", i + 1);\n"
+"    }\n"
+"\n"
+"    drop(sender);\n"
+"    ping_handler_task.await.expect(\"Something went wrong in ping handler "
+"task.\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/channels.md:35
+msgid "Change the channel size to `3` and see how it affects the execution."
+msgstr ""
+
+#: src/async/channels.md:37
+msgid ""
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
+msgstr ""
+
+#: src/async/control-flow.md:1
+msgid "Futures Control Flow"
+msgstr ""
+
+#: src/async/control-flow.md:3
+msgid ""
+"Futures can be combined together to produce concurrent compute flow graphs. "
+"We have already seen tasks, that function as independent threads of "
+"execution."
+msgstr ""
+
+#: src/async/control-flow.md:6
+msgid "[Join](control-flow/join.md)"
+msgstr ""
+
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
+msgstr ""
+
+#: src/async/control-flow/join.md:3
+msgid ""
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
+"JavaScript or `asyncio.gather` in Python."
+msgstr ""
+
+#: src/async/control-flow/join.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use anyhow::Result;\n"
+"use futures::future;\n"
+"use reqwest;\n"
+"use std::collections::HashMap;\n"
+"\n"
+"async fn size_of_page(url: &str) -> Result<usize> {\n"
+"    let resp = reqwest::get(url).await?;\n"
+"    Ok(resp.text().await?.len())\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let urls: [&str; 4] = [\n"
+"        \"https://google.com\",\n"
+"        \"https://httpbin.org/ip\",\n"
+"        \"https://play.rust-lang.org/\",\n"
+"        \"BAD_URL\",\n"
+"    ];\n"
+"    let futures_iter = urls.into_iter().map(size_of_page);\n"
+"    let results = future::join_all(futures_iter).await;\n"
+"    let page_sizes_dict: HashMap<&str, Result<usize>> =\n"
+"        urls.into_iter().zip(results.into_iter()).collect();\n"
+"    println!(\"{:?}\", page_sizes_dict);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/control-flow/join.md:38
+msgid ""
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
+msgstr ""
+
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
+"demonstrates `join!`."
+msgstr ""
+
+#: src/async/control-flow/select.md:3
+msgid ""
+"A select operation waits until any of a set of futures is ready, and "
+"responds to that future's result. In JavaScript, this is similar to "
+"`Promise.race`. In Python, it compares to `asyncio.wait(task_set, "
+"return_when=asyncio.FIRST_COMPLETED)`."
+msgstr ""
+
+#: src/async/control-flow/select.md:8
+msgid ""
+"Similar to a match statement, the body of `select!` has a number of arms, "
+"each of the form `pattern = future => statement`. When the `future` is "
+"ready, the `statement` is executed with the variables in `pattern` bound to "
+"the `future`'s result."
+msgstr ""
+
+#: src/async/control-flow/select.md:13
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::sync::mpsc::{self, Receiver};\n"
+"use tokio::time::{sleep, Duration};\n"
+"\n"
+"#[derive(Debug, PartialEq)]\n"
+"enum Animal {\n"
+"    Cat { name: String },\n"
+"    Dog { name: String },\n"
+"}\n"
+"\n"
+"async fn first_animal_to_finish_race(\n"
+"    mut cat_rcv: Receiver<String>,\n"
+"    mut dog_rcv: Receiver<String>,\n"
+") -> Option<Animal> {\n"
+"    tokio::select! {\n"
+"        cat_name = cat_rcv.recv() => Some(Animal::Cat { name: cat_name? }),\n"
+"        dog_name = dog_rcv.recv() => Some(Animal::Dog { name: dog_name? })\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let (cat_sender, cat_receiver) = mpsc::channel(32);\n"
+"    let (dog_sender, dog_receiver) = mpsc::channel(32);\n"
+"    tokio::spawn(async move {\n"
+"        sleep(Duration::from_millis(500)).await;\n"
+"        cat_sender\n"
+"            .send(String::from(\"Felix\"))\n"
+"            .await\n"
+"            .expect(\"Failed to send cat.\");\n"
+"    });\n"
+"    tokio::spawn(async move {\n"
+"        sleep(Duration::from_millis(50)).await;\n"
+"        dog_sender\n"
+"            .send(String::from(\"Rex\"))\n"
+"            .await\n"
+"            .expect(\"Failed to send dog.\");\n"
+"    });\n"
+"\n"
+"    let winner = first_animal_to_finish_race(cat_receiver, dog_receiver)\n"
+"        .await\n"
+"        .expect(\"Failed to receive winner\");\n"
+"\n"
+"    println!(\"Winner is {winner:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/control-flow/select.md:62
+msgid ""
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms."
+msgstr ""
+
+#: src/async/control-flow/select.md:67
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+
+#: src/async/control-flow/select.md:70
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:73
+msgid ""
+"Note that `select!` drops unmatched branches, which cancels their futures. "
+"It is easiest to use when every execution of `select!` creates new futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:76
+msgid ""
+"An alternative is to pass `&mut future` instead of the future itself, but "
+"this can lead to issues, further discussed in the pinning slide."
+msgstr ""
+
+#: src/async/pitfalls.md:1
+msgid "Pitfalls of async/await"
+msgstr ""
+
+#: src/async/pitfalls.md:3
+msgid ""
+"Async / await provides convenient and efficient abstraction for concurrent "
+"asynchronous programming. However, the async/await model in Rust also comes "
+"with its share of pitfalls and footguns. We illustrate some of them in this "
+"chapter:"
+msgstr ""
+
+#: src/async/pitfalls.md:5
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfalls/async-traits.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:8
+msgid "[Cancellation](pitfalls/cancellation.md)"
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:1
+msgid "Blocking the executor"
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:3
+msgid ""
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use futures::future::join_all;\n"
+"use std::time::Instant;\n"
+"\n"
+"async fn sleep_ms(start: &Instant, id: u64, duration_ms: u64) {\n"
+"    std::thread::sleep(std::time::Duration::from_millis(duration_ms));\n"
+"    println!(\n"
+"        \"future {id} slept for {duration_ms}ms, finished after {}ms\",\n"
+"        start.elapsed().as_millis()\n"
+"    );\n"
+"}\n"
+"\n"
+"#[tokio::main(flavor = \"current_thread\")]\n"
+"async fn main() {\n"
+"    let start = Instant::now();\n"
+"    let sleep_futures = (1..=10).map(|t| sleep_ms(&start, t, t * 10));\n"
+"    join_all(sleep_futures).await;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:29
+msgid ""
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the "
+"multi-threaded flavor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:3
+msgid ""
+"When you await a future, all local variables (that would ordinarily be "
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:8
+msgid ""
+"Therefore, you must guarantee that the addresses your future points to don't "
+"change. That is why we need to `pin` futures. Using the same future "
+"repeatedly in a `select!` often leads to issues with pinned values."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:12
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::sync::{mpsc, oneshot};\n"
+"use tokio::task::spawn;\n"
+"use tokio::time::{sleep, Duration};\n"
+"\n"
+"// A work item. In this case, just sleep for the given time and respond\n"
+"// with a message on the `respond_on` channel.\n"
+"#[derive(Debug)]\n"
+"struct Work {\n"
+"    input: u32,\n"
+"    respond_on: oneshot::Sender<u32>,\n"
+"}\n"
+"\n"
+"// A worker which listens for work on a queue and performs it.\n"
+"async fn worker(mut work_queue: mpsc::Receiver<Work>) {\n"
+"    let mut iterations = 0;\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            Some(work) = work_queue.recv() => {\n"
+"                sleep(Duration::from_millis(10)).await; // Pretend to work.\n"
+"                work.respond_on\n"
+"                    .send(work.input * 1000)\n"
+"                    .expect(\"failed to send response\");\n"
+"                iterations += 1;\n"
+"            }\n"
+"            // TODO: report number of iterations every 100ms\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// A requester which requests work and waits for it to complete.\n"
+"async fn do_work(work_queue: &mpsc::Sender<Work>, input: u32) -> u32 {\n"
+"    let (tx, rx) = oneshot::channel();\n"
+"    work_queue\n"
+"        .send(Work {\n"
+"            input,\n"
+"            respond_on: tx,\n"
+"        })\n"
+"        .await\n"
+"        .expect(\"failed to send on work queue\");\n"
+"    rx.await.expect(\"failed waiting for response\")\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let (tx, rx) = mpsc::channel(10);\n"
+"    spawn(worker(rx));\n"
+"    for i in 0..100 {\n"
+"        let resp = do_work(&tx, i).await;\n"
+"        println!(\"work result for iteration {i}: {resp}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:68
+msgid ""
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using "
+"`Box::pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:3
+msgid ""
+"Async methods in traits are not yet supported in the stable channel ([An "
+"experimental feature exists in nightly and should be stabilized in the mid "
+"term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html))"
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:5
+msgid ""
+"The crate [async_trait](https://docs.rs/async-trait/latest/async_trait/) "
+"provides a workaround through a macro:"
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use async_trait::async_trait;\n"
+"use std::time::Instant;\n"
+"use tokio::time::{sleep, Duration};\n"
+"\n"
+"#[async_trait]\n"
+"trait Sleeper {\n"
+"    async fn sleep(&self);\n"
+"}\n"
+"\n"
+"struct FixedSleeper {\n"
+"    sleep_ms: u64,\n"
+"}\n"
+"\n"
+"#[async_trait]\n"
+"impl Sleeper for FixedSleeper {\n"
+"    async fn sleep(&self) {\n"
+"        sleep(Duration::from_millis(self.sleep_ms)).await;\n"
+"    }\n"
+"}\n"
+"\n"
+"async fn run_all_sleepers_multiple_times(sleepers: Vec<Box<dyn Sleeper>>, "
+"n_times: usize) {\n"
+"    for _ in 0..n_times {\n"
+"        println!(\"running all sleepers..\");\n"
+"        for sleeper in &sleepers {\n"
+"            let start = Instant::now();\n"
+"            sleeper.sleep().await;\n"
+"            println!(\"slept for {}ms\", start.elapsed().as_millis());\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let sleepers: Vec<Box<dyn Sleeper>> = vec![\n"
+"        Box::new(FixedSleeper { sleep_ms: 50 }),\n"
+"        Box::new(FixedSleeper { sleep_ms: 100 }),\n"
+"    ];\n"
+"    run_all_sleepers_multiple_times(sleepers, 5).await;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:51
+msgid ""
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this "
+"post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/) "
+"if you are interested in digging deeper."
+msgstr ""
+"对于 `async trait` 的语言支持中的挑战是深入  Rust的，并且可能不值得深入描述。如果您对深入了解感兴趣，Niko Matsakis "
+"在[这篇文章](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)中对它们做了很好的解释。"
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
+msgstr "尝试创建一个新的 sleeper 结构，使其随机休眠一段时间，并将其添加到 Vec 中。"
+
+#: src/async/pitfalls/cancellation.md:3
+msgid ""
+"Dropping a future implies it can never be polled again. This is called "
+"_cancellation_ and it can occur at any `await` point. Care is needed to "
+"ensure the system works correctly even when futures are cancelled. For "
+"example, it shouldn't deadlock or lose data."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:8
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::io::{self, ErrorKind};\n"
+"use std::time::Duration;\n"
+"use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};\n"
+"\n"
+"struct LinesReader {\n"
+"    stream: DuplexStream,\n"
+"}\n"
+"\n"
+"impl LinesReader {\n"
+"    fn new(stream: DuplexStream) -> Self {\n"
+"        Self { stream }\n"
+"    }\n"
+"\n"
+"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
+"        let mut bytes = Vec::new();\n"
+"        let mut buf = [0];\n"
+"        while self.stream.read(&mut buf[..]).await? != 0 {\n"
+"            bytes.push(buf[0]);\n"
+"            if buf[0] == b'\\n"
+"' {\n"
+"                break;\n"
+"            }\n"
+"        }\n"
+"        if bytes.is_empty() {\n"
+"            return Ok(None)\n"
+"        }\n"
+"        let s = String::from_utf8(bytes)\n"
+"            .map_err(|_| io::Error::new(ErrorKind::InvalidData, \"not "
+"UTF-8\"))?;\n"
+"        Ok(Some(s))\n"
+"    }\n"
+"}\n"
+"\n"
+"async fn slow_copy(source: String, mut dest: DuplexStream) -> "
+"std::io::Result<()> {\n"
+"    for b in source.bytes() {\n"
+"        dest.write_u8(b).await?;\n"
+"        tokio::time::sleep(Duration::from_millis(10)).await\n"
+"    }\n"
+"    Ok(())\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> std::io::Result<()> {\n"
+"    let (client, server) = tokio::io::duplex(5);\n"
+"    let handle = tokio::spawn(slow_copy(\"hi\\n"
+"there\\n"
+"\".to_owned(), client));\n"
+"\n"
+"    let mut lines = LinesReader::new(server);\n"
+"    let mut interval = tokio::time::interval(Duration::from_millis(60));\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            _ = interval.tick() => println!(\"tick!\"),\n"
+"            line = lines.next() => if let Some(l) = line? {\n"
+"                print!(\"{}\", l)\n"
+"            } else {\n"
+"                break\n"
+"            },\n"
+"        }\n"
+"    }\n"
+"    handle.await.unwrap()?;\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:72
+msgid ""
+"The compiler doesn't help with cancellation-safety. You need to read API "
+"documentation and consider what state your `async fn` holds."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:75
+msgid ""
+"Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
+"error-handling)."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:78
+msgid "The example loses parts of the string."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:80
+msgid ""
+"Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
+"dropped."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:82
+msgid ""
+"`LinesReader` can be made cancellation-safe by making `buf` part of the "
+"struct:"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:83
+msgid ""
+"```rust,compile_fail\n"
+"struct LinesReader {\n"
+"    stream: DuplexStream,\n"
+"    bytes: Vec<u8>,\n"
+"    buf: [u8; 1],\n"
+"}\n"
+"\n"
+"impl LinesReader {\n"
+"    fn new(stream: DuplexStream) -> Self {\n"
+"        Self { stream, bytes: Vec::new(), buf: [0] }\n"
+"    }\n"
+"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
+"        // prefix buf and bytes with self.\n"
+"        // ...\n"
+"        let raw = std::mem::take(&mut self.bytes);\n"
+"        let s = String::from_utf8(raw)\n"
+"        // ...\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:104
+#, fuzzy
+msgid ""
+"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick) "
+"is cancellation-safe because it keeps track of whether a tick has been "
+"'delivered'."
+msgstr ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+
+#: src/async/pitfalls/cancellation.md:107
+#, fuzzy
+msgid ""
+"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read) "
+"is cancellation-safe because it either returns or doesn't read data."
+msgstr ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+
+#: src/async/pitfalls/cancellation.md:110
+#, fuzzy
+msgid ""
+"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line) "
+"is similar to the example and _isn't_ cancellation-safe. See its "
+"documentation for details and alternatives."
+msgstr ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+
+#: src/exercises/concurrency/afternoon.md:3
+msgid "To practice your Async Rust skills, we have again two exercises for you:"
+msgstr "为了练习您的异步 Rust 技能，我们再次为您提供了两个练习："
+
+#: src/exercises/concurrency/afternoon.md:5
+msgid ""
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr "哲学家进餐：我们已经在上午看到了这个问题。这次你将使用异步 Rust 来实现它。"
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
+msgstr "广播聊天应用：这是一个更大的项目，允许您尝试更高级的异步Rust功能。"
+
+#: src/exercises/concurrency/dining-philosophers-async.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:3
+msgid "Dining Philosophers - Async"
+msgstr "哲学家进餐 - 异步"
+
+#: src/exercises/concurrency/dining-philosophers-async.md:3
+msgid ""
+"See [dining philosophers](dining-philosophers.md) for a description of the "
+"problem."
+msgstr "查看[哲学家进餐](dining-philosophers.md)以获取问题的描述。"
+
+#: src/exercises/concurrency/dining-philosophers-async.md:6
+msgid ""
+"As before, you will need a local [Cargo "
+"installation](../../cargo/running-locally.md) for this exercise. Copy the "
+"code below to a file called `src/main.rs`, fill out the blanks, and test "
+"that `cargo run` does not deadlock:"
+msgstr ""
+"与之前一样，您需要一个本地的 [Cargo "
+"安装](../../cargo/running-locally.md)来进行这个练习。将下面的代码复制到一个名为 `src/main.rs` "
+"的文件中，填写空白部分，并测试确保 `cargo run` 不会死锁："
+
+#: src/exercises/concurrency/dining-philosophers-async.md:13
+msgid ""
+"```rust,compile_fail\n"
+"use std::sync::Arc;\n"
+"use tokio::time;\n"
+"use tokio::sync::mpsc::{self, Sender};\n"
+"use tokio::sync::Mutex;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // thoughts: ...\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    async fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", "
+"&self.name)).await\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    async fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    // Create forks\n"
+"\n"
+"    // Create philosophers\n"
+"\n"
+"    // Make them think and eat\n"
+"\n"
+"    // Output their thoughts\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers-async.md:57
+msgid ""
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
+"You can use the following `Cargo.toml`:"
+msgstr "因为这次您正在使用异步Rust，您将需要一个 `tokio` 依赖。您可以使用以下的 `Cargo.toml`："
+
+#: src/exercises/concurrency/dining-philosophers-async.md:62
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"dining-philosophers-async-dine\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"\n"
+"[dependencies]\n"
+"tokio = {version = \"1.26.0\", features = [\"sync\", \"time\", \"macros\", "
+"\"rt-multi-thread\"]}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers-async.md:72
+msgid ""
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
+"from the `tokio` crate."
+msgstr "另外，请注意，这次您必须使用来自 `tokio` 包的 `Mutex` 和 `mpsc` 模块。"
+
+#: src/exercises/concurrency/dining-philosophers-async.md:77
+msgid "Can you make your implementation single-threaded? "
+msgstr "您可以使您的实现为单线程吗？"
+
+#: src/exercises/concurrency/chat-app.md:3
+msgid ""
+"In this exercise, we want to use our new knowledge to implement a broadcast "
+"chat application. We have a chat server that the clients connect to and "
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
+msgstr ""
+"在本练习中，我们想要使用我们的新知识来实现一个广播聊天应用。我们有一个聊天服务器，客户端连接到该服务器并发布他们的消息。客户端从标准输入读取用户消息，并将其发送到服务器。聊天服务器将收到的每条消息广播给所有客户端。"
+
+#: src/exercises/concurrency/chat-app.md:9
+#, fuzzy
+msgid ""
+"For this, we use [a broadcast "
+"channel](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html) "
+"on the server, and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/) "
+"for the communication between the client and the server."
+msgstr ""
+"为此，我们在服务器上使用一个[广播 "
+"channel](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html)，并使用[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) "
+"来进行客户端与服务器之间的通信。"
+
+#: src/exercises/concurrency/chat-app.md:13
+msgid "Create a new Cargo project and add the following dependencies:"
+msgstr "创建一个新的 Cargo 项目并添加以下依赖："
+
+#: src/exercises/concurrency/chat-app.md:15
+#, fuzzy
+msgid "_Cargo.toml_:"
+msgstr "`Cargo.toml`："
+
+#: src/exercises/concurrency/chat-app.md:19
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"chat-async\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"\n"
+"[dependencies]\n"
+"futures-util = { version = \"0.3.28\", features = [\"sink\"] }\n"
+"http = \"0.2.9\"\n"
+"tokio = { version = \"1.28.1\", features = [\"full\"] }\n"
+"tokio-websockets = { version = \"0.4.0\", features = [\"client\", "
+"\"fastrand\", \"server\", \"sha1_smol\"] }\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:32
+msgid "The required APIs"
+msgstr "所需的API"
+
+#: src/exercises/concurrency/chat-app.md:33
+#, fuzzy
+msgid ""
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/). "
+"Spend a few minutes to familiarize yourself with the API. "
+msgstr ""
+"您将需要来自 `tokio` 和 "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) "
+"的以下函数。请花几分钟时间熟悉这些 API。"
+
+#: src/exercises/concurrency/chat-app.md:37
+#, fuzzy
+msgid ""
+"[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/trait.StreamExt.html#method.next) "
+"implemented by `WebsocketStream`: for asynchronously reading messages from a "
+"Websocket Stream."
+msgstr ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
+"由`WebsocketStream`实现：用于在Websocket流上异步发送消息。"
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
+"implemented by `WebsocketStream`: for asynchronously sending messages on a "
+"Websocket Stream."
+msgstr ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
+"由`WebsocketStream`实现：用于在Websocket流上异步发送消息。"
+
+#: src/exercises/concurrency/chat-app.md:41
+#, fuzzy
+msgid ""
+"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line): "
+"for asynchronously reading user messages from the standard input."
+msgstr ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.subscribe): "
+"for subscribing to a broadcast channel."
+msgstr ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.subscribe)：用于订阅广播频道。"
+
+#: src/exercises/concurrency/chat-app.md:46
+msgid "Two binaries"
+msgstr "两个可执行文件"
+
+#: src/exercises/concurrency/chat-app.md:48
+msgid ""
+"Normally in a Cargo project, you can have only one binary, and one "
+"`src/main.rs` file. In this project, we need two binaries. One for the "
+"client, and one for the server. You could potentially make them two separate "
+"Cargo projects, but we are going to put them in a single Cargo project with "
+"two binaries. For this to work, the client and the server code should go "
+"under `src/bin` (see the "
+"[documentation](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries)). "
+msgstr ""
+"通常在一个Cargo项目中，你只能有一个二进制文件，和一个`src/main.rs`文件。在这个项目中，我们需要两个二进制文件。一个用于客户端，另一个用于服务器。你可能会考虑将它们制作成两个单独的Cargo项目，但我们将它们放在一个包含两个二进制文件的Cargo项目中。为了使这个工作，客户端和服务器的代码应该放在`src/bin`下（参见[文档](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries)）。"
+
+#: src/exercises/concurrency/chat-app.md:55
+msgid ""
+"Copy the following server and client code into `src/bin/server.rs` and "
+"`src/bin/client.rs`, respectively. Your task is to complete these files as "
+"described below. "
+msgstr ""
+"将以下服务器和客户端代码分别复制到 `src/bin/server.rs` 和 `src/bin/client.rs` "
+"中。您的任务是按照下面的描述完成这些文件。"
+
+#: src/exercises/concurrency/chat-app.md:59
+#: src/exercises/concurrency/solutions-afternoon.md:99
+#, fuzzy
+msgid "_src/bin/server.rs_:"
+msgstr "`src/bin/server.rs`:"
+
+#: src/exercises/concurrency/chat-app.md:63
+msgid ""
+"```rust,compile_fail\n"
+"use futures_util::sink::SinkExt;\n"
+"use futures_util::stream::StreamExt;\n"
+"use std::error::Error;\n"
+"use std::net::SocketAddr;\n"
+"use tokio::net::{TcpListener, TcpStream};\n"
+"use tokio::sync::broadcast::{channel, Sender};\n"
+"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
+"\n"
+"async fn handle_connection(\n"
+"    addr: SocketAddr,\n"
+"    mut ws_stream: WebsocketStream<TcpStream>,\n"
+"    bcast_tx: Sender<String>,\n"
+") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"\n"
+"    // TODO: For a hint, see the description of the task below.\n"
+"\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"    let (bcast_tx, _) = channel(16);\n"
+"\n"
+"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
+"    println!(\"listening on port 2000\");\n"
+"\n"
+"    loop {\n"
+"        let (socket, addr) = listener.accept().await?;\n"
+"        println!(\"New connection from {addr:?}\");\n"
+"        let bcast_tx = bcast_tx.clone();\n"
+"        tokio::spawn(async move {\n"
+"            // Wrap the raw TCP stream into a websocket.\n"
+"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
+"\n"
+"            handle_connection(addr, ws_stream, bcast_tx).await\n"
+"        });\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:103
+#: src/exercises/concurrency/solutions-afternoon.md:166
+#, fuzzy
+msgid "_src/bin/client.rs_:"
+msgstr "`src/bin/client.rs`:"
+
+#: src/exercises/concurrency/chat-app.md:107
+msgid ""
+"```rust,compile_fail\n"
+"use futures_util::stream::StreamExt;\n"
+"use futures_util::SinkExt;\n"
+"use http::Uri;\n"
+"use tokio::io::{AsyncBufReadExt, BufReader};\n"
+"use tokio_websockets::{ClientBuilder, Message};\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), tokio_websockets::Error> {\n"
+"    let (mut ws_stream, _) =\n"
+"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
+"            .connect()\n"
+"            .await?;\n"
+"\n"
+"    let stdin = tokio::io::stdin();\n"
+"    let mut stdin = BufReader::new(stdin).lines();\n"
+"\n"
+"\n"
+"    // TODO: For a hint, see the description of the task below.\n"
+"\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:130
+msgid "Running the binaries"
+msgstr "运行可执行文件"
+
+#: src/exercises/concurrency/chat-app.md:131
+msgid "Run the server with:"
+msgstr "使用以下命令运行服务器："
+
+#: src/exercises/concurrency/chat-app.md:137
+msgid "and the client with:"
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:145
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
+msgstr "在 `src/bin/server.rs` 中实现 `handle_connection` 函数。"
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+"提示：使用 `tokio::select!` "
+"在一个连续的循环中并发执行两个任务。一个任务从客户端接收消息并广播它们。另一个任务将服务器接收到的消息发送给客户端。"
+
+#: src/exercises/concurrency/chat-app.md:149
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr "完成 `src/bin/client.rs` 中的 `main` 函数。"
+
+#: src/exercises/concurrency/chat-app.md:150
+#, fuzzy
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+"提示：与之前一样，使用 `tokio::select!` 在一个连续的循环中并发执行两个任务：(1) 从标准输入读取用户消息并发送给服务器，以及 (2) "
+"从服务器接收消息并显示给用户。"
+
+#: src/exercises/concurrency/chat-app.md:154
+#, fuzzy
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
+msgstr "可选：完成后，将代码更改为将消息广播给除消息发送者以外的所有客户端。"
+
+#: src/thanks.md:3
+#, fuzzy
+msgid ""
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
+"it was useful."
+msgstr "_感谢您参与学习 Comprehensive Rust 🦀！_ 希望您喜欢并且觉得它有用。"
+
+#: src/thanks.md:6
+msgid ""
+"We've had a lot of fun putting the course together. The course is not "
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on "
+"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
+"love to hear from you."
+msgstr ""
+
+#: src/glossary.md:3
+msgid ""
+"The following is a glossary which aims to give a short definition of many "
+"Rust terms. For translations, this also serves to connect the term back to "
+"the English original."
+msgstr ""
+
+#: src/glossary.md:10
+msgid "Term"
+msgstr ""
+
+#: src/glossary.md:10
+msgid "Notes"
+msgstr ""
+
+#: src/glossary.md:12
+#, fuzzy
+msgid "allocate"
+msgstr "alloc"
+
+#: src/glossary.md:12
+msgid ""
+"Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md)."
+msgstr ""
+
+#: src/glossary.md:13
+msgid "argument"
+msgstr ""
+
+#: src/glossary.md:14
+#, fuzzy
+msgid "Bare-metal Rust"
+msgstr "裸机"
+
+#: src/glossary.md:14
+msgid "See [Bare-metal Rust](bare-metal.md)."
+msgstr ""
+
+#: src/glossary.md:15
+#, fuzzy
+msgid "block"
+msgstr "块"
+
+#: src/glossary.md:15
+msgid "See [Blocks](control-flow/blocks.md) and _scope_."
+msgstr ""
+
+#: src/glossary.md:16
+#, fuzzy
+msgid "borrow"
+msgstr "借用"
+
+#: src/glossary.md:16
+msgid "See [Borrowing](ownership/borrowing.md)."
+msgstr ""
+
+#: src/glossary.md:17
+msgid "borrow checker"
+msgstr ""
+
+#: src/glossary.md:17
+msgid "The part of the Rust compiler which checks that all borrows are valid."
+msgstr ""
+
+#: src/glossary.md:18
+msgid "brace"
+msgstr ""
+
+#: src/glossary.md:18
+msgid "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
+msgstr ""
+
+#: src/glossary.md:19
+msgid "build"
+msgstr ""
+
+#: src/glossary.md:20
+msgid "call"
+msgstr ""
+
+#: src/glossary.md:21
+#, fuzzy
+msgid "channel"
+msgstr "通道"
+
+#: src/glossary.md:21
+msgid "Used to safely pass messages [between threads](concurrency/channels.md)."
+msgstr ""
+
+#: src/glossary.md:22
+#, fuzzy
+msgid "Comprehensive Rust 🦀"
+msgstr "欢迎来到 Comprehensive Rust 🦀"
+
+#: src/glossary.md:22
+#, fuzzy
+msgid "The courses here are jointly called Comprehensive Rust 🦀."
+msgstr "欢迎来到 Comprehensive Rust 🦀"
+
+#: src/glossary.md:23
+#, fuzzy
+msgid "concurrency"
+msgstr "并发"
+
+#: src/glossary.md:24
+#, fuzzy
+msgid "See [Concurrency in Rust](concurrency.md)."
+msgstr "欢迎了解 Rust 中的并发"
+
+#: src/glossary.md:25
+#, fuzzy
+msgid "constant"
+msgstr "`const`"
+
+#: src/glossary.md:26
+#, fuzzy
+msgid "control flow"
+msgstr "控制流"
+
+#: src/glossary.md:27
+msgid "crash"
+msgstr ""
+
+#: src/glossary.md:28
+#, fuzzy
+msgid "enumeration"
+msgstr "实现"
+
+#: src/glossary.md:29
+msgid "error"
+msgstr ""
+
+#: src/glossary.md:30
+#, fuzzy
+msgid "error handling"
+msgstr "错误处理"
+
+#: src/glossary.md:31
+#, fuzzy
+msgid "exercise"
+msgstr "习题"
+
+#: src/glossary.md:32
+#, fuzzy
+msgid "function"
+msgstr "函数"
+
+#: src/glossary.md:33
+#, fuzzy
+msgid "garbage collector"
+msgstr "垃圾回收"
+
+#: src/glossary.md:34
+#, fuzzy
+msgid "generics"
+msgstr "泛型"
+
+#: src/glossary.md:35
+msgid "immutable"
+msgstr ""
+
+#: src/glossary.md:36
+#, fuzzy
+msgid "integration test"
+msgstr "集成测试"
+
+#: src/glossary.md:37
+msgid "keyword"
+msgstr ""
+
+#: src/glossary.md:38
+#, fuzzy
+msgid "library"
+msgstr "库"
+
+#: src/glossary.md:39
+msgid "macro"
+msgstr ""
+
+#: src/glossary.md:40
+#, fuzzy
+msgid "main function"
+msgstr "调用 Unsafe 函数"
+
+#: src/glossary.md:41
+msgid "match"
+msgstr ""
+
+#: src/glossary.md:42
+#, fuzzy
+msgid "memory leak"
+msgstr "内存泄漏。"
+
+#: src/glossary.md:43
+#, fuzzy
+msgid "method"
+msgstr "方法"
+
+#: src/glossary.md:44
+#, fuzzy
+msgid "module"
+msgstr "模块"
+
+#: src/glossary.md:45
+msgid "move"
+msgstr ""
+
+#: src/glossary.md:46
+msgid "mutable"
+msgstr ""
+
+#: src/glossary.md:47
+#, fuzzy
+msgid "ownership"
+msgstr "所有权"
+
+#: src/glossary.md:48
+#, fuzzy
+msgid "panic"
+msgstr "Panics"
+
+#: src/glossary.md:49
+msgid "parameter"
+msgstr ""
+
+#: src/glossary.md:50
+msgid "pattern"
+msgstr ""
+
+#: src/glossary.md:51
+msgid "payload"
+msgstr ""
+
+#: src/glossary.md:52
+msgid "program"
+msgstr ""
+
+#: src/glossary.md:53
+msgid "programming language"
+msgstr ""
+
+#: src/glossary.md:54
+#, fuzzy
+msgid "receiver"
+msgstr "驱动程序"
+
+#: src/glossary.md:55
+#, fuzzy
+msgid "reference counting"
+msgstr "解引用原始指针。"
+
+#: src/glossary.md:56
+msgid "return"
+msgstr ""
+
+#: src/glossary.md:57
+#, fuzzy
+msgid "Rust"
+msgstr "Rustdoc"
+
+#: src/glossary.md:58
+msgid "Days 1 to 3 of this course."
+msgstr ""
+
+#: src/glossary.md:59
+#, fuzzy
+msgid "See [Rust in Android](android.md)."
+msgstr "欢迎来到Android 中的Rust"
+
+#: src/glossary.md:60
+msgid "safe"
+msgstr ""
+
+#: src/glossary.md:61
+msgid "scope"
+msgstr ""
+
+#: src/glossary.md:62
+#, fuzzy
+msgid "standard library"
+msgstr "标准库"
+
+#: src/glossary.md:63
+#, fuzzy
+msgid "static"
+msgstr "`static`"
+
+#: src/glossary.md:64
+#, fuzzy
+msgid "string"
+msgstr "String"
+
+#: src/glossary.md:65
+#, fuzzy
+msgid "struct"
+msgstr "结构体"
+
+#: src/glossary.md:66
+msgid "test"
+msgstr ""
+
+#: src/glossary.md:67
+#, fuzzy
+msgid "thread"
+msgstr "线程"
+
+#: src/glossary.md:68
+#, fuzzy
+msgid "thread safety"
+msgstr "线程"
+
+#: src/glossary.md:69
+#, fuzzy
+msgid "trait"
+msgstr "特征"
+
+#: src/glossary.md:70
+msgid "type"
+msgstr ""
+
+#: src/glossary.md:71
+#, fuzzy
+msgid "type inference"
+msgstr "类型推导"
+
+#: src/glossary.md:72
+#, fuzzy
+msgid "undefined behavior"
+msgstr "Rust 没有运行时未定义行为："
+
+#: src/glossary.md:73
+#, fuzzy
+msgid "union"
+msgstr "联合体"
+
+#: src/glossary.md:74
+#, fuzzy
+msgid "unit test"
+msgstr "单元测试"
+
+#: src/glossary.md:75
+msgid "unsafe"
+msgstr ""
+
+#: src/glossary.md:76
+#, fuzzy
+msgid "variable"
+msgstr "变量"
+
+#: src/other-resources.md:1
+msgid "Other Rust Resources"
+msgstr "其他 Rust 资源"
+
+#: src/other-resources.md:3
+msgid ""
+"The Rust community has created a wealth of high-quality and free resources "
+"online."
+msgstr "Rust 社区已经创造了丰富的高质量免费资源在线提供。"
+
+#: src/other-resources.md:6
+msgid "Official Documentation"
+msgstr "官方文档"
+
+#: src/other-resources.md:8
+msgid "The Rust project hosts many resources. These cover Rust in general:"
+msgstr "Rust 项目提供了许多资源。这些资源涵盖了 Rust 的一般内容："
+
+#: src/other-resources.md:10
+msgid ""
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
+msgstr ""
+
+#: src/other-resources.md:13
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+
+#: src/other-resources.md:17
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+
+#: src/other-resources.md:19
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
+msgstr ""
+
+#: src/other-resources.md:22
+msgid "More specialized guides hosted on the official Rust site:"
+msgstr ""
+
+#: src/other-resources.md:24
+msgid ""
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
+msgstr ""
+
+#: src/other-resources.md:27
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+
+#: src/other-resources.md:30
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
+msgstr ""
+
+#: src/other-resources.md:33
+msgid "Unofficial Learning Material"
+msgstr "非官方学习资料"
+
+#: src/other-resources.md:35
+msgid "A small selection of other guides and tutorial for Rust:"
+msgstr "其他 Rust 指南和教程的小选集："
+
+#: src/other-resources.md:37
+msgid ""
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
+msgstr ""
+
+#: src/other-resources.md:39
+msgid ""
+"[Rust for Embedded C "
+"Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
+"from the perspective of developers who write firmware in C."
+msgstr ""
+
+#: src/other-resources.md:42
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+
+#: src/other-resources.md:45
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+
+#: src/other-resources.md:47
+msgid ""
+"[Ferrous Teaching "
+"Material](https://ferrous-systems.github.io/teaching-material/index.html): a "
+"series of small presentations covering both basic and advanced part of the "
+"Rust language. Other topics such as WebAssembly, and async/await are also "
+"covered."
+msgstr ""
+
+#: src/other-resources.md:52
+msgid ""
+"[Beginner's Series to "
+"Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) and "
+"[Take your first steps with "
+"Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): two "
+"Rust guides aimed at new developers. The first is a set of 35 videos and the "
+"second is a set of 11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked "
+"Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth "
+"exploration of Rust's memory management rules, through implementing a few "
+"different types of list structures."
+msgstr ""
+
+#: src/other-resources.md:63
+msgid ""
+"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
+"for even more Rust books."
+msgstr ""
+
+#: src/credits.md:3
+msgid ""
+"The material here builds on top of the many great sources of Rust "
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
+msgstr ""
+"本课中的资料以众多优秀的 Rust 文档资源为基础。 如需查看实用资源的完整列表， 请参阅关于[其他资源](other-resources.md)的页面。"
+
+#: src/credits.md:7
+#, fuzzy
+msgid ""
+"The material of Comprehensive Rust is licensed under the terms of the Apache "
+"2.0 license, please see "
+"[`LICENSE`](https://github.com/google/comprehensive-rust/blob/main/LICENSE) "
+"for details."
+msgstr ""
+"我们根据 Apache 2.0 许可条款 授权你使用“全面了解 Rust”（Comprehensive "
+"Rust）的资料。如需了解详情，请参阅[`许可`](../LICENSE)。"
+
+#: src/credits.md:12
+msgid "Rust by Example"
+msgstr "Rust 示例"
+
+#: src/credits.md:14
+msgid ""
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
+"terms."
+msgstr ""
+"部分示例和练习复制并 改编自[Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/)。如需了解详情（包括许可 条款），请参阅 "
+"`third_party/rust-by-example/` 目录。"
+
+#: src/credits.md:19
+msgid "Rust on Exercism"
+msgstr "Rust on Exercism"
+
+#: src/credits.md:21
+msgid ""
+"Some exercises have been copied and adapted from [Rust on "
+"Exercism](https://exercism.org/tracks/rust). Please see the "
+"`third_party/rust-on-exercism/` directory for details, including the license "
+"terms."
+msgstr ""
+"部分练习复制并 改编自 [Rust on Exercism](https://exercism.org/tracks/rust)。如需了解详情（包括许可 "
+"条款），请参阅 `third_party/rust-on-exercism/` 目录。"
+
+#: src/credits.md:26
+msgid "CXX"
+msgstr "CXX"
+
+#: src/credits.md:28
+msgid ""
+"The [Interoperability with C++](android/interoperability/cpp.md) section "
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
+msgstr ""
+"“[与 C++ 的互操作性](android/interoperability/cpp.md)”部分引用了一张 来自 "
+"[CXX](https://cxx.rs/) 的图片。如需了解详情（包括许可条款）， 请参阅 `third_party/cxx/` 目录。"
+
+#: src/credits.md:34
+msgid ""
+"The [Why Rust? - An Example in C](why-rust/an-example-in-c.md) section has "
+"been taken from the presentation slides of [Colin Finck's Master "
+"Thesis](https://colinfinck.de/Master_Thesis_Colin_Finck.pdf). It has been "
+"relicensed under the terms of the Apache 2.0 license for this course by the "
+"author."
+msgstr ""
+
+#: src/exercises/solutions.md:3
+msgid "You will find solutions to the exercises on the following pages."
+msgstr "您将在下面的页面找到练习的解答。"
+
+#: src/exercises/solutions.md:5
+msgid ""
+"Feel free to ask questions about the solutions [on "
+"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
+"know if you have a different or better solution than what is presented here."
+msgstr ""
+"欢迎您在 [GitHub](https://github.com/google/comprehensive-rust/discussions) "
+"上提问关于解决方案的问题。如果您有与此处呈现的不同或更好的解决方案，请告诉我们。"
+
+#: src/exercises/day-1/solutions-morning.md:1
+msgid "Day 1 Morning Exercises"
+msgstr "第一天上午的练习"
+
+#: src/exercises/day-1/solutions-morning.md:5
+msgid "([back to exercise](for-loops.md))"
+msgstr "([返回练习](for-loops.md))"
+
+#: src/exercises/day-1/solutions-morning.md:7
+msgid ""
+"```rust\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    let mut result = [[0; 3]; 3];\n"
+"    for i in 0..3 {\n"
+"        for j in 0..3 {\n"
+"            result[j][i] = matrix[i][j];\n"
+"        }\n"
+"    }\n"
+"    return result;\n"
+"}\n"
+"\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    for row in matrix {\n"
+"        println!(\"{row:?}\");\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_transpose() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], //\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"    let transposed = transpose(matrix);\n"
+"    assert_eq!(\n"
+"        transposed,\n"
+"        [\n"
+"            [101, 201, 301], //\n"
+"            [102, 202, 302],\n"
+"            [103, 203, 303],\n"
+"        ]\n"
+"    );\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"\n"
+"    println!(\"matrix:\");\n"
+"    pretty_print(&matrix);\n"
+"\n"
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:57
+msgid "Bonus question"
+msgstr "附加问题"
+
+#: src/exercises/day-1/solutions-morning.md:59
+msgid ""
+"It requires more advanced concepts. It might seem that we could use a "
+"slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make "
+"our function handle any size of matrix. However, this quickly breaks down: "
+"the return type cannot be `&[&[i32]]` since it needs to own the data you "
+"return."
+msgstr ""
+"这需要更高级的概念。看起来，我们可以使用切片的切片（`&[&[i32]]`）作为输入类型来进行转置，从而使我们的函数能够处理任意大小的矩阵。然而，这很快就会崩溃：返回类型不能是 "
+"`&[&[i32]]`，因为它需要拥有您返回的数据。"
+
+#: src/exercises/day-1/solutions-morning.md:61
+msgid ""
+"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work "
+"out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to "
+"`&[&[i32]]` so now you cannot easily use `pretty_print` either."
+msgstr ""
+"您可以尝试使用类似 `Vec<Vec<i32>>` 的方式，但这也无法直接工作：从 `Vec<Vec<i32>>` 转换为 `&[&[i32]]` "
+"很困难，因此您现在也不能轻松使用 `pretty_print`。"
+
+#: src/exercises/day-1/solutions-morning.md:63
+msgid ""
+"Once we get to traits and generics, we'll be able to use the "
+"[`std::convert::AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) "
+"trait to abstract over anything that can be referenced as a slice."
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:65
+msgid ""
+"```rust\n"
+"use std::convert::AsRef;\n"
+"use std::fmt::Debug;\n"
+"\n"
+"fn pretty_print<T, Line, Matrix>(matrix: Matrix)\n"
+"where\n"
+"    T: Debug,\n"
+"    // A line references a slice of items\n"
+"    Line: AsRef<[T]>,\n"
+"    // A matrix references a slice of lines\n"
+"    Matrix: AsRef<[Line]>\n"
+"{\n"
+"    for row in matrix.as_ref() {\n"
+"        println!(\"{:?}\", row.as_ref());\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    // &[&[i32]]\n"
+"    pretty_print(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);\n"
+"    // [[&str; 2]; 2]\n"
+"    pretty_print([[\"a\", \"b\"], [\"c\", \"d\"]]);\n"
+"    // Vec<Vec<i32>>\n"
+"    pretty_print(vec![vec![1, 2], vec![3, 4]]);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:92
+msgid ""
+"In addition, the type itself would not enforce that the child slices are of "
+"the same length, so such variable could contain an invalid matrix."
+msgstr "此外，类型本身不会强制要求子切片具有相同的长度，因此这样的变量可能包含一个无效的矩阵。"
+
+#: src/exercises/day-1/solutions-afternoon.md:1
+msgid "Day 1 Afternoon Exercises"
+msgstr "第一天下午的练习"
+
+#: src/exercises/day-1/solutions-afternoon.md:5
+msgid "([back to exercise](luhn.md))"
+msgstr "([返回练习](luhn.md))"
+
+#: src/exercises/day-1/solutions-afternoon.md:7
+msgid ""
+"```rust\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    let mut digits_seen = 0;\n"
+"    let mut sum = 0;\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' "
+"').enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Some(d) => {\n"
+"                sum += if i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd / 10 + dd % 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                digits_seen += 1;\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    if digits_seen < 2 {\n"
+"        return false;\n"
+"    }\n"
+"\n"
+"    sum % 10 == 0\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let cc_number = \"1234 5678 1234 5670\";\n"
+"    println!(\n"
+"        \"Is {cc_number} a valid credit card number? {}\",\n"
+"        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"    assert!(!luhn(\"foo 0 0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:80
+#, fuzzy
+msgid "Pattern matching"
+msgstr "模式匹配"
+
+#: src/exercises/day-1/solutions-afternoon.md:82
+msgid ""
+"```rust\n"
+"/// An operation to perform on two subexpressions.\n"
+"#[derive(Debug)]\n"
+"enum Operation {\n"
+"    Add,\n"
+"    Sub,\n"
+"    Mul,\n"
+"    Div,\n"
+"}\n"
+"\n"
+"/// An expression, in tree form.\n"
+"#[derive(Debug)]\n"
+"enum Expression {\n"
+"    /// An operation on two subexpressions.\n"
+"    Op {\n"
+"        op: Operation,\n"
+"        left: Box<Expression>,\n"
+"        right: Box<Expression>,\n"
+"    },\n"
+"\n"
+"    /// A literal value\n"
+"    Value(i64),\n"
+"}\n"
+"\n"
+"/// The result of evaluating an expression.\n"
+"#[derive(Debug, PartialEq, Eq)]\n"
+"enum Res {\n"
+"    /// Evaluation was successful, with the given result.\n"
+"    Ok(i64),\n"
+"    /// Evaluation failed, with the given error message.\n"
+"    Err(String),\n"
+"}\n"
+"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
+"use Res::{Err, Ok};\n"
+"\n"
+"fn eval(e: Expression) -> Res {\n"
+"    match e {\n"
+"        Expression::Op { op, left, right } => {\n"
+"            let left = match eval(*left) {\n"
+"                Ok(v) => v,\n"
+"                Err(msg) => return Err(msg),\n"
+"            };\n"
+"            let right = match eval(*right) {\n"
+"                Ok(v) => v,\n"
+"                Err(msg) => return Err(msg),\n"
+"            };\n"
+"            Ok(match op {\n"
+"                Operation::Add => left + right,\n"
+"                Operation::Sub => left - right,\n"
+"                Operation::Mul => left * right,\n"
+"                Operation::Div => {\n"
+"                    if right == 0 {\n"
+"                        return Err(String::from(\"division by zero\"));\n"
+"                    } else {\n"
+"                        left / right\n"
+"                    }\n"
+"                }\n"
+"            })\n"
+"        }\n"
+"        Expression::Value(v) => Ok(v),\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_value() {\n"
+"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_sum() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(Expression::Value(10)),\n"
+"            right: Box::new(Expression::Value(20)),\n"
+"        }),\n"
+"        Ok(30)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_recursion() {\n"
+"    let term1 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Value(10)),\n"
+"        right: Box::new(Expression::Value(9)),\n"
+"    };\n"
+"    let term2 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Op {\n"
+"            op: Operation::Sub,\n"
+"            left: Box::new(Expression::Value(3)),\n"
+"            right: Box::new(Expression::Value(4)),\n"
+"        }),\n"
+"        right: Box::new(Expression::Value(5)),\n"
+"    };\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(term1),\n"
+"            right: Box::new(term2),\n"
+"        }),\n"
+"        Ok(85)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_error() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Div,\n"
+"            left: Box::new(Expression::Value(99)),\n"
+"            right: Box::new(Expression::Value(0)),\n"
+"        }),\n"
+"        Err(String::from(\"division by zero\"))\n"
+"    );\n"
+"}\n"
+"fn main() {\n"
+"    let expr = Expression::Op {\n"
+"        op: Operation::Sub,\n"
+"        left: Box::new(Expression::Value(20)),\n"
+"        right: Box::new(Expression::Value(10)),\n"
+"    };\n"
+"    println!(\"expr: {:?}\", expr);\n"
+"    println!(\"result: {:?}\", eval(expr));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:1
+msgid "Day 2 Morning Exercises"
+msgstr "第二天上午的练习"
+
+#: src/exercises/day-2/solutions-morning.md:3
+msgid "Designing a Library"
+msgstr "设计一个库"
+
+#: src/exercises/day-2/solutions-morning.md:5
+msgid "([back to exercise](book-library.md))"
+msgstr "([返回练习](book-library.md))"
+
+#: src/exercises/day-2/solutions-morning.md:7
+msgid ""
+"```rust\n"
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}\n"
+"\n"
+"struct Book {\n"
+"    title: String,\n"
+"    year: u16,\n"
+"}\n"
+"\n"
+"impl Book {\n"
+"    // This is a constructor, used below.\n"
+"    fn new(title: &str, year: u16) -> Book {\n"
+"        Book {\n"
+"            title: String::from(title),\n"
+"            year,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// Implement the methods below. Notice how the `self` parameter\n"
+"// changes type to indicate the method's required level of ownership\n"
+"// over the object:\n"
+"//\n"
+"// - `&self` for shared read-only access,\n"
+"// - `&mut self` for unique and mutable access,\n"
+"// - `self` for unique access by value.\n"
+"impl Library {\n"
+"\n"
+"    fn new() -> Library {\n"
+"        Library { books: Vec::new() }\n"
+"    }\n"
+"\n"
+"    fn len(&self) -> usize {\n"
+"        self.books.len()\n"
+"    }\n"
+"\n"
+"    fn is_empty(&self) -> bool {\n"
+"        self.books.is_empty()\n"
+"    }\n"
+"\n"
+"    fn add_book(&mut self, book: Book) {\n"
+"        self.books.push(book)\n"
+"    }\n"
+"\n"
+"    fn print_books(&self) {\n"
+"        for book in &self.books {\n"
+"            println!(\"{}, published in {}\", book.title, book.year);\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn oldest_book(&self) -> Option<&Book> {\n"
+"        // Using a closure and a built-in method:\n"
+"        // self.books.iter().min_by_key(|book| book.year)\n"
+"\n"
+"        // Longer hand-written solution:\n"
+"        let mut oldest: Option<&Book> = None;\n"
+"        for book in self.books.iter() {\n"
+"            if oldest.is_none() || book.year < oldest.unwrap().year {\n"
+"                oldest = Some(book);\n"
+"            }\n"
+"        }\n"
+"\n"
+"        oldest\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut library = Library::new();\n"
+"\n"
+"    println!(\n"
+"        \"The library is empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"\n"
+"    println!(\n"
+"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.print_books();\n"
+"\n"
+"    match library.oldest_book() {\n"
+"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
+"        None => println!(\"The library is empty!\"),\n"
+"    }\n"
+"\n"
+"    println!(\"The library has {} books\", library.len());\n"
+"    library.print_books();\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_len() {\n"
+"    let mut library = Library::new();\n"
+"    assert_eq!(library.len(), 0);\n"
+"    assert!(library.is_empty());\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(library.len(), 2);\n"
+"    assert!(!library.is_empty());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_is_empty() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.is_empty());\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert!(!library.is_empty());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_print_books() {\n"
+"    let mut library = Library::new();\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    // We could try and capture stdout, but let us just call the\n"
+"    // method to start with.\n"
+"    library.print_books();\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_oldest_book() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.oldest_book().is_none());\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Lord of the Rings\")\n"
+"    );\n"
+"\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Alice's Adventures in Wonderland\")\n"
+"    );\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:153
+#, fuzzy
+msgid "([back to exercise](health-statistics.md))"
+msgstr "([返回练习](rtc.md))"
+
+#: src/exercises/day-2/solutions-morning.md:155
+msgid ""
+"```rust\n"
+"pub struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    height: f32,\n"
+"    visit_count: usize,\n"
+"    last_blood_pressure: Option<(u32, u32)>,\n"
+"}\n"
+"\n"
+"pub struct Measurements {\n"
+"    height: f32,\n"
+"    blood_pressure: (u32, u32),\n"
+"}\n"
+"\n"
+"pub struct HealthReport<'a> {\n"
+"    patient_name: &'a str,\n"
+"    visit_count: u32,\n"
+"    height_change: f32,\n"
+"    blood_pressure_change: Option<(i32, i32)>,\n"
+"}\n"
+"\n"
+"impl User {\n"
+"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
+"        Self {\n"
+"            name,\n"
+"            age,\n"
+"            height,\n"
+"            visit_count: 0,\n"
+"            last_blood_pressure: None,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    pub fn name(&self) -> &str {\n"
+"        &self.name\n"
+"    }\n"
+"\n"
+"    pub fn age(&self) -> u32 {\n"
+"        self.age\n"
+"    }\n"
+"\n"
+"    pub fn height(&self) -> f32 {\n"
+"        self.height\n"
+"    }\n"
+"\n"
+"    pub fn doctor_visits(&self) -> u32 {\n"
+"        self.visit_count as u32\n"
+"    }\n"
+"\n"
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        self.age = new_age\n"
+"    }\n"
+"\n"
+"    pub fn set_height(&mut self, new_height: f32) {\n"
+"        self.height = new_height\n"
+"    }\n"
+"\n"
+"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
+"HealthReport {\n"
+"        self.visit_count += 1;\n"
+"        let bp = measurements.blood_pressure;\n"
+"        let report = HealthReport {\n"
+"            patient_name: &self.name,\n"
+"            visit_count: self.visit_count as u32,\n"
+"            height_change: measurements.height - self.height,\n"
+"            blood_pressure_change: match self.last_blood_pressure {\n"
+"                Some(lbp) => Some((\n"
+"                    bp.0 as i32 - lbp.0 as i32,\n"
+"                    bp.1 as i32 - lbp.1 as i32\n"
+"                )),\n"
+"                None => None,\n"
+"            }\n"
+"        };\n"
+"        self.height = measurements.height;\n"
+"        self.last_blood_pressure = Some(bp);\n"
+"        report\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_height() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.height(), 155.2);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_set_age() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.age(), 32);\n"
+"    bob.set_age(33);\n"
+"    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_visit() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.doctor_visits(), 0);\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (120, 80),\n"
+"    });\n"
+"    assert_eq!(report.patient_name, \"Bob\");\n"
+"    assert_eq!(report.visit_count, 1);\n"
+"    assert_eq!(report.blood_pressure_change, None);\n"
+"\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (115, 76),\n"
+"    });\n"
+"\n"
+"    assert_eq!(report.visit_count, 2);\n"
+"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:1
+msgid "Day 2 Afternoon Exercises"
+msgstr "第二天下午的练习"
+
+#: src/exercises/day-2/solutions-afternoon.md:5
+msgid "([back to exercise](strings-iterators.md))"
+msgstr "([返回练习](strings-iterators.md))"
+
+#: src/exercises/day-2/solutions-afternoon.md:7
+msgid ""
+"```rust\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"\n"
+"    let mut request_segments = request_path.split('/');\n"
+"\n"
+"    for prefix_segment in prefix.split('/') {\n"
+"        let Some(request_segment) = request_segments.next() else {\n"
+"            return false;\n"
+"        };\n"
+"        if request_segment != prefix_segment && prefix_segment != \"*\" {\n"
+"            return false;\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"\n"
+"    // Alternatively, Iterator::zip() lets us iterate simultaneously over "
+"prefix\n"
+"    // and request segments. The zip() iterator is finished as soon as one "
+"of\n"
+"    // the source iterators is finished, but we need to iterate over all "
+"request\n"
+"    // segments. A neat trick that makes zip() work is to use map() and "
+"chain()\n"
+"    // to produce an iterator that returns Some(str) for each pattern "
+"segments,\n"
+"    // and then returns None indefinitely.\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", "
+"\"/v1/parent/publishers\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"\n"
+"fn main() {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:1
+msgid "Day 3 Morning Exercise"
+msgstr "第三天上午的练习"
+
+#: src/exercises/day-3/solutions-morning.md:5
+msgid "([back to exercise](simple-gui.md))"
+msgstr "([返回练习](simple-gui.md))"
+
+#: src/exercises/day-3/solutions-morning.md:7
+msgid ""
+"```rust\n"
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;\n"
+"\n"
+"    /// Draw the widget into a buffer.\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
+"\n"
+"    /// Draw the widget on standard output.\n"
+"    fn draw(&self) {\n"
+"        let mut buffer = String::new();\n"
+"        self.draw_into(&mut buffer);\n"
+"        println!(\"{buffer}\");\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Label {\n"
+"    label: String,\n"
+"}\n"
+"\n"
+"impl Label {\n"
+"    fn new(label: &str) -> Label {\n"
+"        Label {\n"
+"            label: label.to_owned(),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Button {\n"
+"    label: Label,\n"
+"}\n"
+"\n"
+"impl Button {\n"
+"    fn new(label: &str) -> Button {\n"
+"        Button {\n"
+"            label: Label::new(label),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Window {\n"
+"    title: String,\n"
+"    widgets: Vec<Box<dyn Widget>>,\n"
+"}\n"
+"\n"
+"impl Window {\n"
+"    fn new(title: &str) -> Window {\n"
+"        Window {\n"
+"            title: title.to_owned(),\n"
+"            widgets: Vec::new(),\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"        self.widgets.push(widget);\n"
+"    }\n"
+"\n"
+"    fn inner_width(&self) -> usize {\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }\n"
+"}\n"
+"\n"
+"\n"
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        // Add 4 paddings for borders\n"
+"        self.inner_width() + 4\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        let mut inner = String::new();\n"
+"        for widget in &self.widgets {\n"
+"            widget.draw_into(&mut inner);\n"
+"        }\n"
+"\n"
+"        let inner_width = self.inner_width();\n"
+"\n"
+"        // TODO: after learning about error handling, you can change\n"
+"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
+"        // the ?-operator here instead of .unwrap().\n"
+"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
+"        writeln!(buffer, \"| {:^inner_width$} |\", &self.title).unwrap();\n"
+"        writeln!(buffer, \"+={:=<inner_width$}=+\", \"\").unwrap();\n"
+"        for line in inner.lines() {\n"
+"            writeln!(buffer, \"| {:inner_width$} |\", line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        self.label.width() + 8 // add a bit of padding\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        let width = self.width();\n"
+"        let mut label = String::new();\n"
+"        self.label.draw_into(&mut label);\n"
+"\n"
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"        for line in label.lines() {\n"
+"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        self.label\n"
+"            .lines()\n"
+"            .map(|line| line.chars().count())\n"
+"            .max()\n"
+"            .unwrap_or(0)\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\"\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:144
+msgid "([back to exercise](points-polygons.md))"
+msgstr "([返回练习](points-polygons.md))"
+
+#: src/exercises/day-3/solutions-morning.md:146
+msgid ""
+"```rust\n"
+"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
+"pub struct Point {\n"
+"    x: i32,\n"
+"    y: i32,\n"
+"}\n"
+"\n"
+"impl Point {\n"
+"    pub fn new(x: i32, y: i32) -> Point {\n"
+"        Point { x, y }\n"
+"    }\n"
+"\n"
+"    pub fn magnitude(self) -> f64 {\n"
+"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"    }\n"
+"\n"
+"    pub fn dist(self, other: Point) -> f64 {\n"
+"        (self - other).magnitude()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl std::ops::Add for Point {\n"
+"    type Output = Self;\n"
+"\n"
+"    fn add(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x + other.x,\n"
+"            y: self.y + other.y,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"impl std::ops::Sub for Point {\n"
+"    type Output = Self;\n"
+"\n"
+"    fn sub(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x - other.x,\n"
+"            y: self.y - other.y,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Polygon {\n"
+"    points: Vec<Point>,\n"
+"}\n"
+"\n"
+"impl Polygon {\n"
+"    pub fn new() -> Polygon {\n"
+"        Polygon { points: Vec::new() }\n"
+"    }\n"
+"\n"
+"    pub fn add_point(&mut self, point: Point) {\n"
+"        self.points.push(point);\n"
+"    }\n"
+"\n"
+"    pub fn left_most_point(&self) -> Option<Point> {\n"
+"        self.points.iter().min_by_key(|p| p.x).copied()\n"
+"    }\n"
+"\n"
+"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"        self.points.iter()\n"
+"    }\n"
+"\n"
+"    pub fn length(&self) -> f64 {\n"
+"        if self.points.is_empty() {\n"
+"            return 0.0;\n"
+"        }\n"
+"\n"
+"        let mut result = 0.0;\n"
+"        let mut last_point = self.points[0];\n"
+"        for point in &self.points[1..] {\n"
+"            result += last_point.dist(*point);\n"
+"            last_point = *point;\n"
+"        }\n"
+"        result += last_point.dist(self.points[0]);\n"
+"        result\n"
+"        // Alternatively, Iterator::zip() lets us iterate over the points as "
+"pairs\n"
+"        // but we need to pair each point with the next one, and the last "
+"point\n"
+"        // with the first point. The zip() iterator is finished as soon as "
+"one of \n"
+"        // the source iterators is finished, a neat trick is to combine "
+"Iterator::cycle\n"
+"        // with Iterator::skip to create the second iterator for the zip and "
+"using map \n"
+"        // and sum to calculate the total length.\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Circle {\n"
+"    center: Point,\n"
+"    radius: i32,\n"
+"}\n"
+"\n"
+"impl Circle {\n"
+"    pub fn new(center: Point, radius: i32) -> Circle {\n"
+"        Circle { center, radius }\n"
+"    }\n"
+"\n"
+"    pub fn circumference(&self) -> f64 {\n"
+"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"    }\n"
+"\n"
+"    pub fn dist(&self, other: &Self) -> f64 {\n"
+"        self.center.dist(other.center)\n"
+"    }\n"
+"}\n"
+"\n"
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}\n"
+"\n"
+"impl From<Polygon> for Shape {\n"
+"    fn from(poly: Polygon) -> Self {\n"
+"        Shape::Polygon(poly)\n"
+"    }\n"
+"}\n"
+"\n"
+"impl From<Circle> for Shape {\n"
+"    fn from(circle: Circle) -> Self {\n"
+"        Shape::Circle(circle)\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Shape {\n"
+"    pub fn perimeter(&self) -> f64 {\n"
+"        match self {\n"
+"            Shape::Polygon(poly) => poly.length(),\n"
+"            Shape::Circle(circle) => circle.circumference(),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"\n"
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100.0).round() / 100.0\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_magnitude() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_dist() {\n"
+"        let p1 = Point::new(10, 10);\n"
+"        let p2 = Point::new(14, 13);\n"
+"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_add() {\n"
+"        let p1 = Point::new(16, 16);\n"
+"        let p2 = p1 + Point::new(-4, 3);\n"
+"        assert_eq!(p2, Point::new(12, 19));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_left_most_point() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"        assert_eq!(poly.left_most_point(), Some(p1));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_iter() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"\n"
+"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:1
+msgid "Day 3 Afternoon Exercises"
+msgstr "第三天下午的练习"
+
+#: src/exercises/day-3/solutions-afternoon.md:5
+msgid "([back to exercise](safe-ffi-wrapper.md))"
+msgstr "([返回练习](safe-ffi-wrapper.md))"
+
+#: src/exercises/day-3/solutions-afternoon.md:7
+msgid ""
+"```rust\n"
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int};\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
+"\n"
+"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"    #[repr(C)]\n"
+"    pub struct DIR {\n"
+"        _data: [u8; 0],\n"
+"        _marker: core::marker::PhantomData<(*mut u8, "
+"core::marker::PhantomPinned)>,\n"
+"    }\n"
+"\n"
+"    // Layout according to the Linux man page for readdir(3), where ino_t "
+"and\n"
+"    // off_t are resolved according to the definitions in\n"
+"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_ino: c_ulong,\n"
+"        pub d_off: c_long,\n"
+"        pub d_reclen: c_ushort,\n"
+"        pub d_type: c_uchar,\n"
+"        pub d_name: [c_char; 256],\n"
+"    }\n"
+"\n"
+"    // Layout according to the macOS man page for dir(5).\n"
+"    #[cfg(all(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_fileno: u64,\n"
+"        pub d_seekoff: u64,\n"
+"        pub d_reclen: u16,\n"
+"        pub d_namlen: u16,\n"
+"        pub d_type: u8,\n"
+"        pub d_name: [c_char; 1024],\n"
+"    }\n"
+"\n"
+"    extern \"C\" {\n"
+"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"\n"
+"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        // See https://github.com/rust-lang/libc/issues/414 and the section "
+"on\n"
+"        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
+"        //\n"
+"        // \"Platforms that existed before these updates were available\" "
+"refers\n"
+"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
+"PowerPC.\n"
+"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
+"        #[link_name = \"readdir$INODE64\"]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        pub fn closedir(s: *mut DIR) -> c_int;\n"
+"    }\n"
+"}\n"
+"\n"
+"use std::ffi::{CStr, CString, OsStr, OsString};\n"
+"use std::os::unix::ffi::OsStrExt;\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"\n"
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
+"        // otherwise return Err with a message.\n"
+"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
+"{err}\"))?;\n"
+"        // SAFETY: path.as_ptr() cannot be NULL.\n"
+"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
+"        if dir.is_null() {\n"
+"            Err(format!(\"Could not open {:?}\", path))\n"
+"        } else {\n"
+"            Ok(DirectoryIterator { path, dir })\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
+"        // SAFETY: self.dir is never NULL.\n"
+"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
+"        if dirent.is_null() {\n"
+"            // We have reached the end of the directory.\n"
+"            return None;\n"
+"        }\n"
+"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
+"        // terminated.\n"
+"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
+"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
+"        Some(os_str.to_owned())\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        if !self.dir.is_null() {\n"
+"            // SAFETY: self.dir is not NULL.\n"
+"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
+"                panic!(\"Could not close {:?}\", self.path);\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"    use std::error::Error;\n"
+"\n"
+"    #[test]\n"
+"    fn test_nonexisting_directory() {\n"
+"        let iter = DirectoryIterator::new(\"no-such-directory\");\n"
+"        assert!(iter.is_err());\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_empty_directory() -> Result<(), Box<dyn Error>> {\n"
+"        let tmp = tempfile::TempDir::new()?;\n"
+"        let iter = DirectoryIterator::new(\n"
+"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
+"        )?;\n"
+"        let mut entries = iter.collect::<Vec<_>>();\n"
+"        entries.sort();\n"
+"        assert_eq!(entries, &[\".\", \"..\"]);\n"
+"        Ok(())\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
+"        let tmp = tempfile::TempDir::new()?;\n"
+"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo Diaries\\n"
+"\")?;\n"
+"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n"
+"\")?;\n"
+"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n"
+"\")?;\n"
+"        let iter = DirectoryIterator::new(\n"
+"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
+"        )?;\n"
+"        let mut entries = iter.collect::<Vec<_>>();\n"
+"        entries.sort();\n"
+"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", "
+"\"foo.txt\"]);\n"
+"        Ok(())\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:1
+msgid "Bare Metal Rust Morning Exercise"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:5
+msgid "([back to exercise](compass.md))"
+msgstr "([返回练习](compass.md))"
+
+#: src/exercises/bare-metal/solutions-morning.md:7
+msgid ""
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use core::fmt::Write;\n"
+"use cortex_m_rt::entry;\n"
+"use core::cmp::{max, min};\n"
+"use lsm303agr::{AccelOutputDataRate, Lsm303agr, MagOutputDataRate};\n"
+"use microbit::display::blocking::Display;\n"
+"use microbit::hal::prelude::*;\n"
+"use microbit::hal::twim::Twim;\n"
+"use microbit::hal::uarte::{Baudrate, Parity, Uarte};\n"
+"use microbit::hal::Timer;\n"
+"use microbit::pac::twim0::frequency::FREQUENCY_A;\n"
+"use microbit::Board;\n"
+"\n"
+"const COMPASS_SCALE: i32 = 30000;\n"
+"const ACCELEROMETER_SCALE: i32 = 700;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let board = Board::take().unwrap();\n"
+"\n"
+"    // Configure serial port.\n"
+"    let mut serial = Uarte::new(\n"
+"        board.UARTE0,\n"
+"        board.uart.into(),\n"
+"        Parity::EXCLUDED,\n"
+"        Baudrate::BAUD115200,\n"
+"    );\n"
+"\n"
+"    // Set up the I2C controller and Inertial Measurement Unit.\n"
+"    writeln!(serial, \"Setting up IMU...\").unwrap();\n"
+"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), "
+"FREQUENCY_A::K100);\n"
+"    let mut imu = Lsm303agr::new_with_i2c(i2c);\n"
+"    imu.init().unwrap();\n"
+"    imu.set_mag_odr(MagOutputDataRate::Hz50).unwrap();\n"
+"    imu.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();\n"
+"    let mut imu = imu.into_mag_continuous().ok().unwrap();\n"
+"\n"
+"    // Set up display and timer.\n"
+"    let mut timer = Timer::new(board.TIMER0);\n"
+"    let mut display = Display::new(board.display_pins);\n"
+"\n"
+"    let mut mode = Mode::Compass;\n"
+"    let mut button_pressed = false;\n"
+"\n"
+"    writeln!(serial, \"Ready.\").unwrap();\n"
+"\n"
+"    loop {\n"
+"        // Read compass data and log it to the serial port.\n"
+"        while !(imu.mag_status().unwrap().xyz_new_data\n"
+"            && imu.accel_status().unwrap().xyz_new_data)\n"
+"        {}\n"
+"        let compass_reading = imu.mag_data().unwrap();\n"
+"        let accelerometer_reading = imu.accel_data().unwrap();\n"
+"        writeln!(\n"
+"            serial,\n"
+"            \"{},{},{}\\t{},{},{}\",\n"
+"            compass_reading.x,\n"
+"            compass_reading.y,\n"
+"            compass_reading.z,\n"
+"            accelerometer_reading.x,\n"
+"            accelerometer_reading.y,\n"
+"            accelerometer_reading.z,\n"
+"        )\n"
+"        .unwrap();\n"
+"\n"
+"        let mut image = [[0; 5]; 5];\n"
+"        let (x, y) = match mode {\n"
+"            Mode::Compass => (\n"
+"                scale(-compass_reading.x, -COMPASS_SCALE, COMPASS_SCALE, 0, "
+"4) as usize,\n"
+"                scale(compass_reading.y, -COMPASS_SCALE, COMPASS_SCALE, 0, "
+"4) as usize,\n"
+"            ),\n"
+"            Mode::Accelerometer => (\n"
+"                scale(\n"
+"                    accelerometer_reading.x,\n"
+"                    -ACCELEROMETER_SCALE,\n"
+"                    ACCELEROMETER_SCALE,\n"
+"                    0,\n"
+"                    4,\n"
+"                ) as usize,\n"
+"                scale(\n"
+"                    -accelerometer_reading.y,\n"
+"                    -ACCELEROMETER_SCALE,\n"
+"                    ACCELEROMETER_SCALE,\n"
+"                    0,\n"
+"                    4,\n"
+"                ) as usize,\n"
+"            ),\n"
+"        };\n"
+"        image[y][x] = 255;\n"
+"        display.show(&mut timer, image, 100);\n"
+"\n"
+"        // If button A is pressed, switch to the next mode and briefly blink "
+"all LEDs on.\n"
+"        if board.buttons.button_a.is_low().unwrap() {\n"
+"            if !button_pressed {\n"
+"                mode = mode.next();\n"
+"                display.show(&mut timer, [[255; 5]; 5], 200);\n"
+"            }\n"
+"            button_pressed = true;\n"
+"        } else {\n"
+"            button_pressed = false;\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"enum Mode {\n"
+"    Compass,\n"
+"    Accelerometer,\n"
+"}\n"
+"\n"
+"impl Mode {\n"
+"    fn next(self) -> Self {\n"
+"        match self {\n"
+"            Self::Compass => Self::Accelerometer,\n"
+"            Self::Accelerometer => Self::Compass,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) "
+"-> i32 {\n"
+"    let range_in = max_in - min_in;\n"
+"    let range_out = max_out - min_out;\n"
+"    cap(\n"
+"        min_out + range_out * (value - min_in) / range_in,\n"
+"        min_out,\n"
+"        max_out,\n"
+"    )\n"
+"}\n"
+"\n"
+"fn cap(value: i32, min_value: i32, max_value: i32) -> i32 {\n"
+"    max(min_value, min(value, max_value))\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:5
+msgid "([back to exercise](rtc.md))"
+msgstr "([返回练习](rtc.md))"
+
+#: src/exercises/bare-metal/solutions-afternoon.md:7
+#, fuzzy
+msgid "_main.rs_:"
+msgstr "`main.rs`:"
+
+#: src/exercises/bare-metal/solutions-afternoon.md:9
+msgid ""
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod logger;\n"
+"mod pl011;\n"
+"mod pl031;\n"
+"\n"
+"use crate::pl031::Rtc;\n"
+"use arm_gic::gicv3::{IntId, Trigger};\n"
+"use arm_gic::{irq_enable, wfi};\n"
+"use chrono::{TimeZone, Utc};\n"
+"use core::hint::spin_loop;\n"
+"use crate::pl011::Uart;\n"
+"use arm_gic::gicv3::GicV3;\n"
+"use core::panic::PanicInfo;\n"
+"use log::{error, info, trace, LevelFilter};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base addresses of the GICv3.\n"
+"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
+"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"/// Base address of the PL031 RTC.\n"
+"const PL031_BASE_ADDRESS: *mut u32 = 0x901_0000 as _;\n"
+"/// The IRQ used by the PL031 RTC.\n"
+"const PL031_IRQ: IntId = IntId::spi(2);\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
+"\n"
+"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
+"\n"
+"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
+"base\n"
+"    // addresses of a GICv3 distributor and redistributor respectively, and\n"
+"    // nothing else accesses those address ranges.\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) "
+"};\n"
+"    gic.setup();\n"
+"\n"
+"    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let mut rtc = unsafe { Rtc::new(PL031_BASE_ADDRESS) };\n"
+"    let timestamp = rtc.read();\n"
+"    let time = Utc.timestamp_opt(timestamp.into(), 0).unwrap();\n"
+"    info!(\"RTC: {time}\");\n"
+"\n"
+"    GicV3::set_priority_mask(0xff);\n"
+"    gic.set_interrupt_priority(PL031_IRQ, 0x80);\n"
+"    gic.set_trigger(PL031_IRQ, Trigger::Level);\n"
+"    irq_enable();\n"
+"    gic.enable_interrupt(PL031_IRQ, true);\n"
+"\n"
+"    // Wait for 3 seconds, without interrupts.\n"
+"    let target = timestamp + 3;\n"
+"    rtc.set_match(target);\n"
+"    info!(\n"
+"        \"Waiting for {}\",\n"
+"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
+"    );\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    while !rtc.matched() {\n"
+"        spin_loop();\n"
+"    }\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    info!(\"Finished waiting\");\n"
+"\n"
+"    // Wait another 3 seconds for an interrupt.\n"
+"    let target = timestamp + 6;\n"
+"    info!(\n"
+"        \"Waiting for {}\",\n"
+"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
+"    );\n"
+"    rtc.set_match(target);\n"
+"    rtc.clear_interrupt();\n"
+"    rtc.enable_interrupt(true);\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    while !rtc.interrupt_pending() {\n"
+"        wfi();\n"
+"    }\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    info!(\"Finished waiting\");\n"
+"\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[panic_handler]\n"
+"fn panic(info: &PanicInfo) -> ! {\n"
+"    error!(\"{info}\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:127
+msgid "_pl031.rs_:"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:129
+msgid ""
+"```rust\n"
+"use core::ptr::{addr_of, addr_of_mut};\n"
+"\n"
+"#[repr(C, align(4))]\n"
+"struct Registers {\n"
+"    /// Data register\n"
+"    dr: u32,\n"
+"    /// Match register\n"
+"    mr: u32,\n"
+"    /// Load register\n"
+"    lr: u32,\n"
+"    /// Control register\n"
+"    cr: u8,\n"
+"    _reserved0: [u8; 3],\n"
+"    /// Interrupt Mask Set or Clear register\n"
+"    imsc: u8,\n"
+"    _reserved1: [u8; 3],\n"
+"    /// Raw Interrupt Status\n"
+"    ris: u8,\n"
+"    _reserved2: [u8; 3],\n"
+"    /// Masked Interrupt Status\n"
+"    mis: u8,\n"
+"    _reserved3: [u8; 3],\n"
+"    /// Interrupt Clear Register\n"
+"    icr: u8,\n"
+"    _reserved4: [u8; 3],\n"
+"}\n"
+"\n"
+"/// Driver for a PL031 real-time clock.\n"
+"#[derive(Debug)]\n"
+"pub struct Rtc {\n"
+"    registers: *mut Registers,\n"
+"}\n"
+"\n"
+"impl Rtc {\n"
+"    /// Constructs a new instance of the RTC driver for a PL031 device at "
+"the\n"
+"    /// given base address.\n"
+"    ///\n"
+"    /// # Safety\n"
+"    ///\n"
+"    /// The given base address must point to the MMIO control registers of "
+"a\n"
+"    /// PL031 device, which must be mapped into the address space of the "
+"process\n"
+"    /// as device memory and not have any other aliases.\n"
+"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
+"        Self {\n"
+"            registers: base_address as *mut Registers,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Reads the current RTC value.\n"
+"    pub fn read(&self) -> u32 {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        unsafe { addr_of!((*self.registers).dr).read_volatile() }\n"
+"    }\n"
+"\n"
+"    /// Writes a match value. When the RTC value matches this then an "
+"interrupt\n"
+"    /// will be generated (if it is enabled).\n"
+"    pub fn set_match(&mut self, value: u32) {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        unsafe { addr_of_mut!((*self.registers).mr).write_volatile(value) }\n"
+"    }\n"
+"\n"
+"    /// Returns whether the match register matches the RTC value, whether or "
+"not\n"
+"    /// the interrupt is enabled.\n"
+"    pub fn matched(&self) -> bool {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        let ris = unsafe { addr_of!((*self.registers).ris).read_volatile() "
+"};\n"
+"        (ris & 0x01) != 0\n"
+"    }\n"
+"\n"
+"    /// Returns whether there is currently an interrupt pending.\n"
+"    ///\n"
+"    /// This should be true if and only if `matched` returns true and the\n"
+"    /// interrupt is masked.\n"
+"    pub fn interrupt_pending(&self) -> bool {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        let ris = unsafe { addr_of!((*self.registers).mis).read_volatile() "
+"};\n"
+"        (ris & 0x01) != 0\n"
+"    }\n"
+"\n"
+"    /// Sets or clears the interrupt mask.\n"
+"    ///\n"
+"    /// When the mask is true the interrupt is enabled; when it is false "
+"the\n"
+"    /// interrupt is disabled.\n"
+"    pub fn enable_interrupt(&mut self, mask: bool) {\n"
+"        let imsc = if mask { 0x01 } else { 0x00 };\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        unsafe { addr_of_mut!((*self.registers).imsc).write_volatile(imsc) "
+"}\n"
+"    }\n"
+"\n"
+"    /// Clears a pending interrupt, if any.\n"
+"    pub fn clear_interrupt(&mut self) {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        unsafe { addr_of_mut!((*self.registers).icr).write_volatile(0x01) }\n"
+"    }\n"
+"}\n"
+"\n"
+"// Safe because it just contains a pointer to device memory, which can be\n"
+"// accessed from any context.\n"
+"unsafe impl Send for Rtc {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:1
+msgid "Concurrency Morning Exercise"
+msgstr "并发编程：上午练习"
+
+#: src/exercises/concurrency/solutions-morning.md:5
+msgid "([back to exercise](dining-philosophers.md))"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:7
+msgid ""
+"```rust\n"
+"use std::sync::{mpsc, Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    thoughts: mpsc::SyncSender<String>,\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    fn eat(&self) {\n"
+"        println!(\"{} is trying to eat\", &self.name);\n"
+"        let left = self.left_fork.lock().unwrap();\n"
+"        let right = self.right_fork.lock().unwrap();\n"
+"\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::sync_channel(10);\n"
+"\n"
+"    let forks = (0..PHILOSOPHERS.len())\n"
+"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
+"        .collect::<Vec<_>>();\n"
+"\n"
+"    for i in 0..forks.len() {\n"
+"        let tx = tx.clone();\n"
+"        let mut left_fork = Arc::clone(&forks[i]);\n"
+"        let mut right_fork = Arc::clone(&forks[(i + 1) % forks.len()]);\n"
+"\n"
+"        // To avoid a deadlock, we have to break the symmetry\n"
+"        // somewhere. This will swap the forks without deinitializing\n"
+"        // either of them.\n"
+"        if i == forks.len() - 1 {\n"
+"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"        }\n"
+"\n"
+"        let philosopher = Philosopher {\n"
+"            name: PHILOSOPHERS[i].to_string(),\n"
+"            thoughts: tx,\n"
+"            left_fork,\n"
+"            right_fork,\n"
+"        };\n"
+"\n"
+"        thread::spawn(move || {\n"
+"            for _ in 0..100 {\n"
+"                philosopher.eat();\n"
+"                philosopher.think();\n"
+"            }\n"
+"        });\n"
+"    }\n"
+"\n"
+"    drop(tx);\n"
+"    for thought in rx {\n"
+"        println!(\"{thought}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:82
+#, fuzzy
+msgid "Link Checker"
+msgstr "多线程链接检查器"
+
+#: src/exercises/concurrency/solutions-morning.md:84
+#, fuzzy
+msgid "([back to exercise](link-checker.md))"
+msgstr "([返回练习](luhn.md))"
+
+#: src/exercises/concurrency/solutions-morning.md:86
+msgid ""
+"```rust,compile_fail\n"
+"use std::{sync::Arc, sync::Mutex, sync::mpsc, thread};\n"
+"\n"
+"use reqwest::{blocking::Client, Url};\n"
+"use scraper::{Html, Selector};\n"
+"use thiserror::Error;\n"
+"\n"
+"#[derive(Error, Debug)]\n"
+"enum Error {\n"
+"    #[error(\"request error: {0}\")]\n"
+"    ReqwestError(#[from] reqwest::Error),\n"
+"    #[error(\"bad http response: {0}\")]\n"
+"    BadResponse(String),\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct CrawlCommand {\n"
+"    url: Url,\n"
+"    extract_links: bool,\n"
+"}\n"
+"\n"
+"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
+"Error> {\n"
+"    println!(\"Checking {:#}\", command.url);\n"
+"    let response = client.get(command.url.clone()).send()?;\n"
+"    if !response.status().is_success() {\n"
+"        return Err(Error::BadResponse(response.status().to_string()));\n"
+"    }\n"
+"\n"
+"    let mut link_urls = Vec::new();\n"
+"    if !command.extract_links {\n"
+"        return Ok(link_urls);\n"
+"    }\n"
+"\n"
+"    let base_url = response.url().to_owned();\n"
+"    let body_text = response.text()?;\n"
+"    let document = Html::parse_document(&body_text);\n"
+"\n"
+"    let selector = Selector::parse(\"a\").unwrap();\n"
+"    let href_values = document\n"
+"        .select(&selector)\n"
+"        .filter_map(|element| element.value().attr(\"href\"));\n"
+"    for href in href_values {\n"
+"        match base_url.join(href) {\n"
+"            Ok(link_url) => {\n"
+"                link_urls.push(link_url);\n"
+"            }\n"
+"            Err(err) => {\n"
+"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
+"{err}\");\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"    Ok(link_urls)\n"
+"}\n"
+"\n"
+"struct CrawlState {\n"
+"    domain: String,\n"
+"    visited_pages: std::collections::HashSet<String>,\n"
+"}\n"
+"\n"
+"impl CrawlState {\n"
+"    fn new(start_url: &Url) -> CrawlState {\n"
+"        let mut visited_pages = std::collections::HashSet::new();\n"
+"        visited_pages.insert(start_url.as_str().to_string());\n"
+"        CrawlState {\n"
+"            domain: start_url.domain().unwrap().to_string(),\n"
+"            visited_pages,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Determine whether links within the given page should be extracted.\n"
+"    fn should_extract_links(&self, url: &Url) -> bool {\n"
+"        let Some(url_domain) = url.domain() else {\n"
+"            return false;\n"
+"        };\n"
+"        url_domain == self.domain\n"
+"    }\n"
+"\n"
+"    /// Mark the given page as visited, returning true if it had already\n"
+"    /// been visited.\n"
+"    fn mark_visited(&mut self, url: &Url) -> bool {\n"
+"        self.visited_pages.insert(url.as_str().to_string())\n"
+"    }\n"
+"}\n"
+"\n"
+"type CrawlResult = Result<Vec<Url>, (Url, Error)>;\n"
+"fn spawn_crawler_threads(\n"
+"    command_receiver: mpsc::Receiver<CrawlCommand>,\n"
+"    result_sender: mpsc::Sender<CrawlResult>,\n"
+"    thread_count: u32,\n"
+") {\n"
+"    let command_receiver = Arc::new(Mutex::new(command_receiver));\n"
+"\n"
+"    for _ in 0..thread_count {\n"
+"        let result_sender = result_sender.clone();\n"
+"        let command_receiver = command_receiver.clone();\n"
+"        thread::spawn(move || {\n"
+"            let client = Client::new();\n"
+"            loop {\n"
+"                let command_result = {\n"
+"                    let receiver_guard = command_receiver.lock().unwrap();\n"
+"                    receiver_guard.recv()\n"
+"                };\n"
+"                let Ok(crawl_command) = command_result else {\n"
+"                    // The sender got dropped. No more commands coming in.\n"
+"                    break;\n"
+"                };\n"
+"                let crawl_result = match visit_page(&client, &crawl_command) "
+"{\n"
+"                    Ok(link_urls) => Ok(link_urls),\n"
+"                    Err(error) => Err((crawl_command.url, error)),\n"
+"                };\n"
+"                result_sender.send(crawl_result).unwrap();\n"
+"            }\n"
+"        });\n"
+"    }\n"
+"}\n"
+"\n"
+"fn control_crawl(\n"
+"    start_url: Url,\n"
+"    command_sender: mpsc::Sender<CrawlCommand>,\n"
+"    result_receiver: mpsc::Receiver<CrawlResult>,\n"
+") -> Vec<Url> {\n"
+"    let mut crawl_state = CrawlState::new(&start_url);\n"
+"    let start_command = CrawlCommand { url: start_url, extract_links: true "
+"};\n"
+"    command_sender.send(start_command).unwrap();\n"
+"    let mut pending_urls = 1;\n"
+"\n"
+"    let mut bad_urls = Vec::new();\n"
+"    while pending_urls > 0 {\n"
+"        let crawl_result = result_receiver.recv().unwrap();\n"
+"        pending_urls -= 1;\n"
+"\n"
+"        match crawl_result {\n"
+"            Ok(link_urls) => {\n"
+"                for url in link_urls {\n"
+"                    if crawl_state.mark_visited(&url) {\n"
+"                        let extract_links = "
+"crawl_state.should_extract_links(&url);\n"
+"                        let crawl_command = CrawlCommand { url, "
+"extract_links };\n"
+"                        command_sender.send(crawl_command).unwrap();\n"
+"                        pending_urls += 1;\n"
+"                    }\n"
+"                }\n"
+"            }\n"
+"            Err((url, error)) => {\n"
+"                bad_urls.push(url);\n"
+"                println!(\"Got crawling error: {:#}\", error);\n"
+"                continue;\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"    bad_urls\n"
+"}\n"
+"\n"
+"fn check_links(start_url: Url) -> Vec<Url> {\n"
+"    let (result_sender, result_receiver) = mpsc::channel::<CrawlResult>();\n"
+"    let (command_sender, command_receiver) = "
+"mpsc::channel::<CrawlCommand>();\n"
+"    spawn_crawler_threads(command_receiver, result_sender, 16);\n"
+"    control_crawl(start_url, command_sender, result_receiver)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let start_url = "
+"reqwest::Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let bad_urls = check_links(start_url);\n"
+"    println!(\"Bad URLs: {:#?}\", bad_urls);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:1
+msgid "Concurrency Afternoon Exercise"
+msgstr "并发编程：下午练习"
+
+#: src/exercises/concurrency/solutions-afternoon.md:5
+msgid "([back to exercise](dining-philosophers-async.md))"
+msgstr "([返回练习](dining-philosophers-async.md))"
+
+#: src/exercises/concurrency/solutions-afternoon.md:7
+msgid ""
+"```rust,compile_fail\n"
+"use std::sync::Arc;\n"
+"use tokio::time;\n"
+"use tokio::sync::mpsc::{self, Sender};\n"
+"use tokio::sync::Mutex;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    thoughts: Sender<String>,\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    async fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", "
+"&self.name)).await\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    async fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        let _first_lock = self.left_fork.lock().await;\n"
+"        // Add a delay before picking the second fork to allow the "
+"execution\n"
+"        // to transfer to another task\n"
+"        time::sleep(time::Duration::from_millis(1)).await;\n"
+"        let _second_lock = self.right_fork.lock().await;\n"
+"\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"\n"
+"        // The locks are dropped here\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    // Create forks\n"
+"    let mut forks = vec![];\n"
+"    (0..PHILOSOPHERS.len()).for_each(|_| "
+"forks.push(Arc::new(Mutex::new(Fork))));\n"
+"\n"
+"    // Create philosophers\n"
+"    let (philosophers, mut rx) = {\n"
+"        let mut philosophers = vec![];\n"
+"        let (tx, rx) = mpsc::channel(10);\n"
+"        for (i, name) in PHILOSOPHERS.iter().enumerate() {\n"
+"            let left_fork = Arc::clone(&forks[i]);\n"
+"            let right_fork = Arc::clone(&forks[(i + 1) % "
+"PHILOSOPHERS.len()]);\n"
+"            // To avoid a deadlock, we have to break the symmetry\n"
+"            // somewhere. This will swap the forks without deinitializing\n"
+"            // either of them.\n"
+"            if i  == 0 {\n"
+"                std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"            }\n"
+"            philosophers.push(Philosopher {\n"
+"                name: name.to_string(),\n"
+"                left_fork,\n"
+"                right_fork,\n"
+"                thoughts: tx.clone(),\n"
+"            });\n"
+"        }\n"
+"        (philosophers, rx)\n"
+"        // tx is dropped here, so we don't need to explicitly drop it later\n"
+"    };\n"
+"\n"
+"    // Make them think and eat\n"
+"    for phil in philosophers {\n"
+"        tokio::spawn(async move {\n"
+"            for _ in 0..100 {\n"
+"                phil.think().await;\n"
+"                phil.eat().await;\n"
+"            }\n"
+"        });\n"
+"\n"
+"    }\n"
+"\n"
+"    // Output their thoughts\n"
+"    while let Some(thought) = rx.recv().await {\n"
+"        println!(\"Here is a thought: {thought}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:97
+msgid "([back to exercise](chat-app.md))"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:101
+msgid ""
+"```rust,compile_fail\n"
+"use futures_util::sink::SinkExt;\n"
+"use futures_util::stream::StreamExt;\n"
+"use std::error::Error;\n"
+"use std::net::SocketAddr;\n"
+"use tokio::net::{TcpListener, TcpStream};\n"
+"use tokio::sync::broadcast::{channel, Sender};\n"
+"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
+"\n"
+"async fn handle_connection(\n"
+"    addr: SocketAddr,\n"
+"    mut ws_stream: WebsocketStream<TcpStream>,\n"
+"    bcast_tx: Sender<String>,\n"
+") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"\n"
+"    ws_stream\n"
+"        .send(Message::text(\"Welcome to chat! Type a message\".into()))\n"
+"        .await?;\n"
+"    let mut bcast_rx = bcast_tx.subscribe();\n"
+"\n"
+"    // A continuous loop for concurrently performing two tasks: (1) "
+"receiving\n"
+"    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
+"    // messages on `bcast_rx` and sending them to the client.\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            incoming = ws_stream.next() => {\n"
+"                match incoming {\n"
+"                    Some(Ok(msg)) => {\n"
+"                        if let Some(text) = msg.as_text() {\n"
+"                            println!(\"From client {addr:?} {text:?}\");\n"
+"                            bcast_tx.send(text.into())?;\n"
+"                        }\n"
+"                    }\n"
+"                    Some(Err(err)) => return Err(err.into()),\n"
+"                    None => return Ok(()),\n"
+"                }\n"
+"            }\n"
+"            msg = bcast_rx.recv() => {\n"
+"                ws_stream.send(Message::text(msg?)).await?;\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"    let (bcast_tx, _) = channel(16);\n"
+"\n"
+"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
+"    println!(\"listening on port 2000\");\n"
+"\n"
+"    loop {\n"
+"        let (socket, addr) = listener.accept().await?;\n"
+"        println!(\"New connection from {addr:?}\");\n"
+"        let bcast_tx = bcast_tx.clone();\n"
+"        tokio::spawn(async move {\n"
+"            // Wrap the raw TCP stream into a websocket.\n"
+"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
+"\n"
+"            handle_connection(addr, ws_stream, bcast_tx).await\n"
+"        });\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:168
+msgid ""
+"```rust,compile_fail\n"
+"use futures_util::stream::StreamExt;\n"
+"use futures_util::SinkExt;\n"
+"use http::Uri;\n"
+"use tokio::io::{AsyncBufReadExt, BufReader};\n"
+"use tokio_websockets::{ClientBuilder, Message};\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), tokio_websockets::Error> {\n"
+"    let (mut ws_stream, _) =\n"
+"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
+"            .connect()\n"
+"            .await?;\n"
+"\n"
+"    let stdin = tokio::io::stdin();\n"
+"    let mut stdin = BufReader::new(stdin).lines();\n"
+"\n"
+"    // Continuous loop for concurrently sending and receiving messages.\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            incoming = ws_stream.next() => {\n"
+"                match incoming {\n"
+"                    Some(Ok(msg)) => {\n"
+"                        if let Some(text) = msg.as_text() {\n"
+"                            println!(\"From server: {}\", text);\n"
+"                        }\n"
+"                    },\n"
+"                    Some(Err(err)) => return Err(err.into()),\n"
+"                    None => return Ok(()),\n"
+"                }\n"
+"            }\n"
+"            res = stdin.next_line() => {\n"
+"                match res {\n"
+"                    Ok(None) => return Ok(()),\n"
+"                    Ok(Some(line)) => "
+"ws_stream.send(Message::text(line.to_string())).await?,\n"
+"                    Err(err) => return Err(err.into()),\n"
+"                }\n"
+"            }\n"
+"\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+


### PR DESCRIPTION
Addresses issue #1311

zh-CN.po stats:
```
msgfmt -o /dev/null --statistics po/zh-CN.po
1258 translated messages, 178 fuzzy translations, 1038 untranslated messages.
```