### PR TITLE
Update debugging.md gdb command

### DIFF
--- a/src/bare-metal/microcontrollers/debugging.md
+++ b/src/bare-metal/microcontrollers/debugging.md
@@ -18,10 +18,15 @@ cargo embed --bin board_support debug
 
 In another terminal in the same directory:
 
+On gLinux or Debian:
 ```sh
 gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support --eval-command="target remote :1337"
 ```
 
+On MacOS:
+```sh
+arm-none-eabi-gdb target/thumbv7em-none-eabihf/debug/board_support --eval-command="target remote :1337"
+```
 <details>
 
 In GDB, try running:


### PR DESCRIPTION
The provided example did not work for me. I got:

`zsh: command not found: gdb-multiarch`

The other version worked instead. This might be a MacOS thing, or an Apple Silicon thing. The other command is the same as used in https://docs.rust-embedded.org/book/intro/install/macos.html so maybe the MacOS installation guidance also needs updating?