### PR TITLE
[54.1 join] add cargo dependencies in speaker notes

### DIFF
--- a/src/async/control-flow/join.md
+++ b/src/async/control-flow/join.md
@@ -33,6 +33,14 @@ async fn main() {
 
 <details>
 
+> Before running this example you should install the following dependencies:
+> * [anyhow](https://crates.io/crates/anyhow)
+> * [futures](https://crates.io/crates/futures)
+> * [reqwest](https://crates.io/crates/reqwest)
+> * [tokio](https://crates.io/crates/tokio)
+>
+> You can install them by running the following command in your terminal: `cargo add <package_name>`
+
 Copy this example into your prepared `src/main.rs` and run it from there.
 
 * For multiple futures of disjoint types, you can use `std::future::join!` but


### PR DESCRIPTION
The example in 54.1 Join requires additional dependencies which need to be installed prior to running. This PR adds the required dependencies in the speaker notes of the page.

Closes #1330.

Preview:
![join](https://github.com/google/comprehensive-rust/assets/71343264/340bdd87-5a15-4ddc-b8e8-bb0c22abee77)
