### PR TITLE
zh-CN: Restores PO file structure format

### DIFF
--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -1,44 +1,38 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
 "POT-Creation-Date: 2023-10-06T12:36:03-07:00\n"
-"PO-Revision-Date: 2023-09-11 10:30-0700\n"
+"PO-Revision-Date: 2023-10-10 11:33-0700\n"
 "Last-Translator: \n"
 "Language-Team: Language zh-Hans\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.4\n"
 
-#: src/SUMMARY.md:4
-#: src/index.md:1
+#: src/SUMMARY.md:4 src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "欢迎来到 Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:5
-#: src/running-the-course.md:1
+#: src/SUMMARY.md:5 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "授课"
 
-#: src/SUMMARY.md:6
-#: src/running-the-course/course-structure.md:1
+#: src/SUMMARY.md:6 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "课程结构"
 
-#: src/SUMMARY.md:7
-#: src/running-the-course/keyboard-shortcuts.md:1
+#: src/SUMMARY.md:7 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "键盘快捷键"
 
-#: src/SUMMARY.md:8
-#: src/running-the-course/translations.md:1
+#: src/SUMMARY.md:8 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "翻译"
 
-#: src/SUMMARY.md:9
-#: src/cargo.md:1
+#: src/SUMMARY.md:9 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "使用 Cargo"
 
@@ -58,84 +52,64 @@ msgstr "在本地运行 Cargo"
 msgid "Day 1: Morning"
 msgstr "第一天：早上"
 
-#: src/SUMMARY.md:19
-#: src/SUMMARY.md:80
-#: src/SUMMARY.md:135
-#: src/SUMMARY.md:193
-#: src/SUMMARY.md:219
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md:19 src/SUMMARY.md:80 src/SUMMARY.md:135 src/SUMMARY.md:193
+#: src/SUMMARY.md:219 src/SUMMARY.md:269
 msgid "Welcome"
 msgstr "欢迎"
 
-#: src/SUMMARY.md:20
-#: src/welcome-day-1/what-is-rust.md:1
+#: src/SUMMARY.md:20 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "什么是 Rust？"
 
-#: src/SUMMARY.md:21
-#: src/hello-world.md:1
+#: src/SUMMARY.md:21 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Hello World!"
 
-#: src/SUMMARY.md:22
-#: src/hello-world/small-example.md:1
+#: src/SUMMARY.md:22 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "简短示例"
 
-#: src/SUMMARY.md:23
-#: src/why-rust.md:1
+#: src/SUMMARY.md:23 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "为什么选择 Rust？"
 
-#: src/SUMMARY.md:24
-#: src/why-rust/an-example-in-c.md:1
-#: src/credits.md:32
-#, fuzzy
+#: src/SUMMARY.md:24 src/why-rust/an-example-in-c.md:1 src/credits.md:32
 msgid "An Example in C"
 msgstr "C++ 示例"
 
-#: src/SUMMARY.md:25
-#: src/why-rust/compile-time.md:1
+#: src/SUMMARY.md:25 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "编译期保障"
 
-#: src/SUMMARY.md:26
-#: src/why-rust/runtime.md:1
+#: src/SUMMARY.md:26 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "运行时保障"
 
-#: src/SUMMARY.md:27
-#: src/why-rust/modern.md:1
+#: src/SUMMARY.md:27 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "现代特性"
 
-#: src/SUMMARY.md:28
-#: src/basic-syntax.md:1
+#: src/SUMMARY.md:28 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "基本语法"
 
-#: src/SUMMARY.md:29
-#: src/basic-syntax/scalar-types.md:1
+#: src/SUMMARY.md:29 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "标量类型"
 
-#: src/SUMMARY.md:30
-#: src/basic-syntax/compound-types.md:1
+#: src/SUMMARY.md:30 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "复合类型"
 
-#: src/SUMMARY.md:31
-#: src/basic-syntax/references.md:1
+#: src/SUMMARY.md:31 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "引用"
 
-#: src/SUMMARY.md:32
-#: src/basic-syntax/references-dangling.md:1
+#: src/SUMMARY.md:32 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "悬垂引用"
 
-#: src/SUMMARY.md:33
-#: src/basic-syntax/slices.md:1
+#: src/SUMMARY.md:33 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "切片"
 
@@ -143,19 +117,15 @@ msgstr "切片"
 msgid "String vs str"
 msgstr "String 和 str"
 
-#: src/SUMMARY.md:35
-#: src/basic-syntax/functions.md:1
+#: src/SUMMARY.md:35 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "函数"
 
-#: src/SUMMARY.md:36
-#: src/basic-syntax/rustdoc.md:1
+#: src/SUMMARY.md:36 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr "Rustdoc"
 
-#: src/SUMMARY.md:37
-#: src/SUMMARY.md:103
-#: src/basic-syntax/methods.md:1
+#: src/SUMMARY.md:37 src/SUMMARY.md:103 src/basic-syntax/methods.md:1
 #: src/methods.md:1
 msgid "Methods"
 msgstr "方法"
@@ -164,27 +134,17 @@ msgstr "方法"
 msgid "Overloading"
 msgstr "重载"
 
-#: src/SUMMARY.md:39
-#: src/SUMMARY.md:72
-#: src/SUMMARY.md:106
-#: src/SUMMARY.md:126
-#: src/SUMMARY.md:155
-#: src/SUMMARY.md:185
-#: src/SUMMARY.md:212
-#: src/SUMMARY.md:233
-#: src/SUMMARY.md:261
-#: src/SUMMARY.md:283
-#: src/SUMMARY.md:304
-#: src/exercises/android/morning.md:1
-#: src/exercises/bare-metal/morning.md:1
+#: src/SUMMARY.md:39 src/SUMMARY.md:72 src/SUMMARY.md:106 src/SUMMARY.md:126
+#: src/SUMMARY.md:155 src/SUMMARY.md:185 src/SUMMARY.md:212 src/SUMMARY.md:233
+#: src/SUMMARY.md:261 src/SUMMARY.md:283 src/SUMMARY.md:304
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
 #: src/exercises/bare-metal/afternoon.md:1
 #: src/exercises/concurrency/morning.md:1
 #: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "习题"
 
-#: src/SUMMARY.md:40
-#: src/exercises/day-1/implicit-conversions.md:1
+#: src/SUMMARY.md:40 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "隐式类型转换"
 
@@ -196,14 +156,11 @@ msgstr "数组与 for 循环"
 msgid "Day 1: Afternoon"
 msgstr "第 1 天：下午"
 
-#: src/SUMMARY.md:45
-#: src/SUMMARY.md:296
-#: src/control-flow.md:1
+#: src/SUMMARY.md:45 src/SUMMARY.md:296 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "控制流"
 
-#: src/SUMMARY.md:46
-#: src/control-flow/blocks.md:1
+#: src/SUMMARY.md:46 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "块"
 
@@ -227,13 +184,11 @@ msgstr "break & continue"
 msgid "loop expressions"
 msgstr "loop 表达式"
 
-#: src/SUMMARY.md:53
-#: src/basic-syntax/variables.md:1
+#: src/SUMMARY.md:53 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "变量"
 
-#: src/SUMMARY.md:54
-#: src/basic-syntax/type-inference.md:1
+#: src/SUMMARY.md:54 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "类型推导"
 
@@ -241,28 +196,23 @@ msgstr "类型推导"
 msgid "static & const"
 msgstr "静态与常量"
 
-#: src/SUMMARY.md:56
-#: src/basic-syntax/scopes-shadowing.md:1
+#: src/SUMMARY.md:56 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "作用域和隐藏 (Shadowing)"
 
-#: src/SUMMARY.md:57
-#: src/enums.md:1
+#: src/SUMMARY.md:57 src/enums.md:1
 msgid "Enums"
 msgstr "枚举"
 
-#: src/SUMMARY.md:58
-#: src/enums/variant-payloads.md:1
+#: src/SUMMARY.md:58 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "变体载荷"
 
-#: src/SUMMARY.md:59
-#: src/enums/sizes.md:1
+#: src/SUMMARY.md:59 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "枚举大小"
 
-#: src/SUMMARY.md:61
-#: src/control-flow/novel.md:1
+#: src/SUMMARY.md:61 src/control-flow/novel.md:1
 #, fuzzy
 msgid "Novel Control Flow"
 msgstr "控制流"
@@ -279,34 +229,27 @@ msgstr "while let 表达式"
 msgid "match expressions"
 msgstr "match 表达式"
 
-#: src/SUMMARY.md:66
-#: src/SUMMARY.md:74
-#: src/pattern-matching.md:1
+#: src/SUMMARY.md:66 src/SUMMARY.md:74 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "模式匹配"
 
-#: src/SUMMARY.md:67
-#: src/pattern-matching/destructuring-enums.md:1
+#: src/SUMMARY.md:67 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "解构枚举"
 
-#: src/SUMMARY.md:68
-#: src/pattern-matching/destructuring-structs.md:1
+#: src/SUMMARY.md:68 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "解构结构体"
 
-#: src/SUMMARY.md:69
-#: src/pattern-matching/destructuring-arrays.md:1
+#: src/SUMMARY.md:69 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "解构数组"
 
-#: src/SUMMARY.md:70
-#: src/pattern-matching/match-guards.md:1
+#: src/SUMMARY.md:70 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "匹配守卫"
 
-#: src/SUMMARY.md:73
-#: src/exercises/day-1/luhn.md:1
+#: src/SUMMARY.md:73 src/exercises/day-1/luhn.md:1
 #: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Luhn 算法"
@@ -315,8 +258,7 @@ msgstr "Luhn 算法"
 msgid "Day 2: Morning"
 msgstr "第二天：上午"
 
-#: src/SUMMARY.md:82
-#: src/memory-management.md:1
+#: src/SUMMARY.md:82 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "内存管理"
 
@@ -328,13 +270,11 @@ msgstr "栈 vs 堆"
 msgid "Stack Memory"
 msgstr "栈内存"
 
-#: src/SUMMARY.md:85
-#: src/memory-management/manual.md:1
+#: src/SUMMARY.md:85 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "手动内存管理"
 
-#: src/SUMMARY.md:86
-#: src/memory-management/scope-based.md:1
+#: src/SUMMARY.md:86 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "基于作用域的内存管理"
 
@@ -346,18 +286,15 @@ msgstr "垃圾回收"
 msgid "Rust Memory Management"
 msgstr "Rust 内存管理"
 
-#: src/SUMMARY.md:89
-#: src/ownership.md:1
+#: src/SUMMARY.md:89 src/ownership.md:1
 msgid "Ownership"
 msgstr "所有权"
 
-#: src/SUMMARY.md:90
-#: src/ownership/move-semantics.md:1
+#: src/SUMMARY.md:90 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "移动语义"
 
-#: src/SUMMARY.md:91
-#: src/ownership/moved-strings-rust.md:1
+#: src/SUMMARY.md:91 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Rust 中移动的字符串"
 
@@ -365,77 +302,61 @@ msgstr "Rust 中移动的字符串"
 msgid "Double Frees in Modern C++"
 msgstr "现代 C++ 中的双重释放"
 
-#: src/SUMMARY.md:93
-#: src/ownership/moves-function-calls.md:1
+#: src/SUMMARY.md:93 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "函数调用中的移动"
 
-#: src/SUMMARY.md:94
-#: src/ownership/copy-clone.md:1
+#: src/SUMMARY.md:94 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "复制和克隆"
 
-#: src/SUMMARY.md:95
-#: src/ownership/borrowing.md:1
+#: src/SUMMARY.md:95 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "借用"
 
-#: src/SUMMARY.md:96
-#: src/ownership/shared-unique-borrows.md:1
+#: src/SUMMARY.md:96 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "共享和唯一的借用"
 
-#: src/SUMMARY.md:97
-#: src/ownership/lifetimes.md:1
+#: src/SUMMARY.md:97 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "生命周期"
 
-#: src/SUMMARY.md:98
-#: src/ownership/lifetimes-function-calls.md:1
+#: src/SUMMARY.md:98 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "函数调用中的生命周期"
 
-#: src/SUMMARY.md:99
-#: src/ownership/lifetimes-data-structures.md:1
+#: src/SUMMARY.md:99 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "数据结构中的生命周期"
 
-#: src/SUMMARY.md:100
-#: src/structs.md:1
+#: src/SUMMARY.md:100 src/structs.md:1
 msgid "Structs"
 msgstr "结构体"
 
-#: src/SUMMARY.md:101
-#: src/structs/tuple-structs.md:1
+#: src/SUMMARY.md:101 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "元组结构体"
 
-#: src/SUMMARY.md:102
-#: src/structs/field-shorthand.md:1
+#: src/SUMMARY.md:102 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "字段简写语法"
 
-#: src/SUMMARY.md:104
-#: src/methods/receiver.md:1
+#: src/SUMMARY.md:104 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "方法接收者"
 
-#: src/SUMMARY.md:105
-#: src/SUMMARY.md:167
-#: src/SUMMARY.md:282
-#: src/methods/example.md:1
-#: src/concurrency/shared_state/example.md:1
+#: src/SUMMARY.md:105 src/SUMMARY.md:167 src/SUMMARY.md:282
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "示例"
 
-#: src/SUMMARY.md:107
-#: src/exercises/day-2/book-library.md:1
+#: src/SUMMARY.md:107 src/exercises/day-2/book-library.md:1
 #, fuzzy
 msgid "Storing Books"
 msgstr "字符串"
 
-#: src/SUMMARY.md:108
-#: src/exercises/day-2/health-statistics.md:1
+#: src/SUMMARY.md:108 src/exercises/day-2/health-statistics.md:1
 #: src/exercises/day-2/solutions-morning.md:151
 msgid "Health Statistics"
 msgstr "健康统计"
@@ -444,8 +365,7 @@ msgstr "健康统计"
 msgid "Day 2: Afternoon"
 msgstr "第二天：下午"
 
-#: src/SUMMARY.md:112
-#: src/std.md:1
+#: src/SUMMARY.md:112 src/std.md:1
 msgid "Standard Library"
 msgstr "标准库"
 
@@ -453,8 +373,7 @@ msgstr "标准库"
 msgid "Option and Result"
 msgstr "Option 和 Result"
 
-#: src/SUMMARY.md:114
-#: src/std/string.md:1
+#: src/SUMMARY.md:114 src/std/string.md:1
 msgid "String"
 msgstr "String"
 
@@ -474,8 +393,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "递归数据类型"
 
-#: src/SUMMARY.md:119
-#: src/std/box-niche.md:1
+#: src/SUMMARY.md:119 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "小众优化"
 
@@ -487,33 +405,27 @@ msgstr "Rc"
 msgid "Cell/RefCell"
 msgstr "Cell/RefCell"
 
-#: src/SUMMARY.md:122
-#: src/modules.md:1
+#: src/SUMMARY.md:122 src/modules.md:1
 msgid "Modules"
 msgstr "模块"
 
-#: src/SUMMARY.md:123
-#: src/modules/visibility.md:1
+#: src/SUMMARY.md:123 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "可见性"
 
-#: src/SUMMARY.md:124
-#: src/modules/paths.md:1
+#: src/SUMMARY.md:124 src/modules/paths.md:1
 msgid "Paths"
 msgstr "路径"
 
-#: src/SUMMARY.md:125
-#: src/modules/filesystem.md:1
+#: src/SUMMARY.md:125 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "文件系统层级结构"
 
-#: src/SUMMARY.md:127
-#: src/exercises/day-2/iterators-and-ownership.md:1
+#: src/SUMMARY.md:127 src/exercises/day-2/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "迭代器和所有权"
 
-#: src/SUMMARY.md:128
-#: src/exercises/day-2/strings-iterators.md:1
+#: src/SUMMARY.md:128 src/exercises/day-2/strings-iterators.md:1
 #: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Strings and Iterators"
 msgstr "字符串和迭代器"
@@ -522,48 +434,39 @@ msgstr "字符串和迭代器"
 msgid "Day 3: Morning"
 msgstr "第三天：上午"
 
-#: src/SUMMARY.md:136
-#: src/generics.md:1
+#: src/SUMMARY.md:136 src/generics.md:1
 msgid "Generics"
 msgstr "泛型"
 
-#: src/SUMMARY.md:137
-#: src/generics/data-types.md:1
+#: src/SUMMARY.md:137 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "通用数据类型"
 
-#: src/SUMMARY.md:138
-#: src/generics/methods.md:1
+#: src/SUMMARY.md:138 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "泛型方法"
 
-#: src/SUMMARY.md:139
-#: src/generics/monomorphization.md:1
+#: src/SUMMARY.md:139 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "单态化"
 
-#: src/SUMMARY.md:140
-#: src/traits.md:1
+#: src/SUMMARY.md:140 src/traits.md:1
 msgid "Traits"
 msgstr "特征"
 
-#: src/SUMMARY.md:141
-#: src/traits/trait-objects.md:1
+#: src/SUMMARY.md:141 src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "特征（Trait）对象"
 
-#: src/SUMMARY.md:142
-#: src/traits/deriving-traits.md:1
+#: src/SUMMARY.md:142 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "派生特征"
 
-#: src/SUMMARY.md:143
-#: src/traits/default-methods.md:1
+#: src/SUMMARY.md:143 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "默认方法"
 
-#: src/SUMMARY.md:144
-#: src/traits/trait-bounds.md:1
+#: src/SUMMARY.md:144 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "特征边界"
 
@@ -571,8 +474,7 @@ msgstr "特征边界"
 msgid "impl Trait"
 msgstr "impl Trait"
 
-#: src/SUMMARY.md:146
-#: src/traits/important-traits.md:1
+#: src/SUMMARY.md:146 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "重要特征"
 
@@ -580,8 +482,7 @@ msgstr "重要特征"
 msgid "Iterator"
 msgstr "迭代器"
 
-#: src/SUMMARY.md:148
-#: src/traits/from-iterator.md:1
+#: src/SUMMARY.md:148 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -613,8 +514,7 @@ msgstr "闭包：Fn、FnMut、FnOnce"
 msgid "A Simple GUI Library"
 msgstr "一个简单的 GUI 库"
 
-#: src/SUMMARY.md:157
-#: src/exercises/day-3/solutions-morning.md:142
+#: src/SUMMARY.md:157 src/exercises/day-3/solutions-morning.md:142
 msgid "Points and Polygons"
 msgstr "点和多边形"
 
@@ -622,13 +522,11 @@ msgstr "点和多边形"
 msgid "Day 3: Afternoon"
 msgstr "第三天：下午"
 
-#: src/SUMMARY.md:161
-#: src/error-handling.md:1
+#: src/SUMMARY.md:161 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "错误处理"
 
-#: src/SUMMARY.md:162
-#: src/error-handling/panics.md:1
+#: src/SUMMARY.md:162 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Panics"
 
@@ -644,84 +542,68 @@ msgstr "结构化错误处理"
 msgid "Propagating Errors with ?"
 msgstr "使用 ? 传播错误"
 
-#: src/SUMMARY.md:166
-#: src/error-handling/converting-error-types.md:1
+#: src/SUMMARY.md:166 src/error-handling/converting-error-types.md:1
 #: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "转换错误类型"
 
-#: src/SUMMARY.md:168
-#: src/error-handling/deriving-error-enums.md:1
+#: src/SUMMARY.md:168 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "派生错误枚举"
 
-#: src/SUMMARY.md:169
-#: src/error-handling/dynamic-errors.md:1
+#: src/SUMMARY.md:169 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "动态错误类型"
 
-#: src/SUMMARY.md:170
-#: src/error-handling/error-contexts.md:1
+#: src/SUMMARY.md:170 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "为错误添加背景信息"
 
-#: src/SUMMARY.md:171
-#: src/testing.md:1
+#: src/SUMMARY.md:171 src/testing.md:1
 msgid "Testing"
 msgstr "测试"
 
-#: src/SUMMARY.md:172
-#: src/testing/unit-tests.md:1
+#: src/SUMMARY.md:172 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "单元测试"
 
-#: src/SUMMARY.md:173
-#: src/testing/test-modules.md:1
+#: src/SUMMARY.md:173 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "测试模块"
 
-#: src/SUMMARY.md:174
-#: src/testing/doc-tests.md:1
+#: src/SUMMARY.md:174 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "文档测试"
 
-#: src/SUMMARY.md:175
-#: src/testing/integration-tests.md:1
+#: src/SUMMARY.md:175 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "集成测试"
 
-#: src/SUMMARY.md:176
-#: src/bare-metal/useful-crates.md:1
+#: src/SUMMARY.md:176 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr "实用 crate"
 
-#: src/SUMMARY.md:177
-#: src/unsafe.md:1
+#: src/SUMMARY.md:177 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "不安全 Rust"
 
-#: src/SUMMARY.md:178
-#: src/unsafe/raw-pointers.md:1
+#: src/SUMMARY.md:178 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "解引用裸指针"
 
-#: src/SUMMARY.md:179
-#: src/unsafe/mutable-static-variables.md:1
+#: src/SUMMARY.md:179 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "可变的静态变量"
 
-#: src/SUMMARY.md:180
-#: src/unsafe/unions.md:1
+#: src/SUMMARY.md:180 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "联合体"
 
-#: src/SUMMARY.md:181
-#: src/unsafe/calling-unsafe-functions.md:1
+#: src/SUMMARY.md:181 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "调用 Unsafe 函数"
 
-#: src/SUMMARY.md:182
-#: src/unsafe/writing-unsafe-functions.md:1
+#: src/SUMMARY.md:182 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "编写 Unsafe 函数"
 
@@ -729,30 +611,24 @@ msgstr "编写 Unsafe 函数"
 msgid "Extern Functions"
 msgstr "外部函数"
 
-#: src/SUMMARY.md:184
-#: src/unsafe/unsafe-traits.md:1
+#: src/SUMMARY.md:184 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "实现 Unsafe Trait"
 
-#: src/SUMMARY.md:186
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/SUMMARY.md:186 src/exercises/day-3/safe-ffi-wrapper.md:1
 #: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "安全 FFI 封装容器"
 
-#: src/SUMMARY.md:189
-#: src/SUMMARY.md:259
-#: src/bare-metal/android.md:1
+#: src/SUMMARY.md:189 src/SUMMARY.md:259 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:194
-#: src/android/setup.md:1
+#: src/SUMMARY.md:194 src/android/setup.md:1
 msgid "Setup"
 msgstr "设置"
 
-#: src/SUMMARY.md:195
-#: src/android/build-rules.md:1
+#: src/SUMMARY.md:195 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "构建规则"
 
@@ -764,8 +640,7 @@ msgstr "可执行文件"
 msgid "Library"
 msgstr "库"
 
-#: src/SUMMARY.md:198
-#: src/android/aidl.md:1
+#: src/SUMMARY.md:198 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -781,8 +656,7 @@ msgstr "实现"
 msgid "Server"
 msgstr "服务器"
 
-#: src/SUMMARY.md:202
-#: src/android/aidl/deploy.md:1
+#: src/SUMMARY.md:202 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "部署"
 
@@ -790,20 +664,16 @@ msgstr "部署"
 msgid "Client"
 msgstr "客户端"
 
-#: src/SUMMARY.md:204
-#: src/android/aidl/changing.md:1
+#: src/SUMMARY.md:204 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "更改 API"
 
-#: src/SUMMARY.md:205
-#: src/SUMMARY.md:249
-#: src/android/logging.md:1
+#: src/SUMMARY.md:205 src/SUMMARY.md:249 src/android/logging.md:1
 #: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "日志记录"
 
-#: src/SUMMARY.md:206
-#: src/android/interoperability.md:1
+#: src/SUMMARY.md:206 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "互操作性"
 
@@ -819,8 +689,7 @@ msgstr "使用Bindgen调用C语言"
 msgid "Calling Rust from C"
 msgstr "从C语言调用Rust语言"
 
-#: src/SUMMARY.md:210
-#: src/android/interoperability/cpp.md:1
+#: src/SUMMARY.md:210 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "与 C++ 交互"
 
@@ -844,13 +713,11 @@ msgstr "最小示例"
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:223
-#: src/bare-metal/microcontrollers.md:1
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "微控制器"
 
-#: src/SUMMARY.md:224
-#: src/bare-metal/microcontrollers/mmio.md:1
+#: src/SUMMARY.md:224 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "原始 MMIO"
 
@@ -878,18 +745,15 @@ msgstr "embedded-hal"
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs、cargo-embed"
 
-#: src/SUMMARY.md:231
-#: src/bare-metal/microcontrollers/debugging.md:1
+#: src/SUMMARY.md:231 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/SUMMARY.md:232
-#: src/SUMMARY.md:252
+#: src/SUMMARY.md:232 src/SUMMARY.md:252
 msgid "Other Projects"
 msgstr "其他项目"
 
-#: src/SUMMARY.md:234
-#: src/exercises/bare-metal/compass.md:1
+#: src/SUMMARY.md:234 src/exercises/bare-metal/compass.md:1
 #: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "罗盘"
@@ -902,8 +766,7 @@ msgstr "裸机:下午"
 msgid "Application Processors"
 msgstr "应用处理器"
 
-#: src/SUMMARY.md:239
-#: src/bare-metal/aps/entry-point.md:1
+#: src/SUMMARY.md:239 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr "准备使用 Rust"
 
@@ -927,8 +790,7 @@ msgstr "更多 trait"
 msgid "A Better UART Driver"
 msgstr "一个更好的 UART 驱动程序"
 
-#: src/SUMMARY.md:245
-#: src/bare-metal/aps/better-uart/bitflags.md:1
+#: src/SUMMARY.md:245 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "Bitflags"
 
@@ -936,18 +798,15 @@ msgstr "Bitflags"
 msgid "Multiple Registers"
 msgstr "多个寄存器"
 
-#: src/SUMMARY.md:247
-#: src/bare-metal/aps/better-uart/driver.md:1
+#: src/SUMMARY.md:247 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "驱动程序"
 
-#: src/SUMMARY.md:248
-#: src/SUMMARY.md:250
+#: src/SUMMARY.md:248 src/SUMMARY.md:250
 msgid "Using It"
 msgstr "开始使用"
 
-#: src/SUMMARY.md:251
-#: src/bare-metal/aps/exceptions.md:1
+#: src/SUMMARY.md:251 src/bare-metal/aps/exceptions.md:1
 #, fuzzy
 msgid "Exceptions"
 msgstr "函数"
@@ -976,8 +835,7 @@ msgstr "tinyvec"
 msgid "spin"
 msgstr "转动"
 
-#: src/SUMMARY.md:260
-#: src/bare-metal/android/vmbase.md:1
+#: src/SUMMARY.md:260 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
@@ -989,28 +847,23 @@ msgstr "RTC驱动"
 msgid "Concurrency: Morning"
 msgstr "并发编程：入门篇"
 
-#: src/SUMMARY.md:270
-#: src/concurrency/threads.md:1
+#: src/SUMMARY.md:270 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "线程"
 
-#: src/SUMMARY.md:271
-#: src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:271 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "范围线程"
 
-#: src/SUMMARY.md:272
-#: src/concurrency/channels.md:1
+#: src/SUMMARY.md:272 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "通道"
 
-#: src/SUMMARY.md:273
-#: src/concurrency/channels/unbounded.md:1
+#: src/SUMMARY.md:273 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "无界通道"
 
-#: src/SUMMARY.md:274
-#: src/concurrency/channels/bounded.md:1
+#: src/SUMMARY.md:274 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "有界通道"
 
@@ -1026,13 +879,11 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:278
-#: src/concurrency/send-sync/examples.md:1
+#: src/SUMMARY.md:278 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "示例"
 
-#: src/SUMMARY.md:279
-#: src/concurrency/shared_state.md:1
+#: src/SUMMARY.md:279 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "共享状态"
 
@@ -1044,15 +895,13 @@ msgstr "Arc"
 msgid "Mutex"
 msgstr "Mutex"
 
-#: src/SUMMARY.md:284
-#: src/SUMMARY.md:305
+#: src/SUMMARY.md:284 src/SUMMARY.md:305
 #: src/exercises/concurrency/dining-philosophers.md:1
 #: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "哲学家就餐问题 (Dining philosophers problem)"
 
-#: src/SUMMARY.md:285
-#: src/exercises/concurrency/link-checker.md:1
+#: src/SUMMARY.md:285 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "多线程链接检查器"
 
@@ -1068,40 +917,32 @@ msgstr "异步基础"
 msgid "async/await"
 msgstr "async/await"
 
-#: src/SUMMARY.md:291
-#: src/async/futures.md:1
+#: src/SUMMARY.md:291 src/async/futures.md:1
 msgid "Futures"
 msgstr "Futures"
 
-#: src/SUMMARY.md:292
-#: src/async/runtimes.md:1
+#: src/SUMMARY.md:292 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "Runtimes"
 
-#: src/SUMMARY.md:293
-#: src/async/runtimes/tokio.md:1
+#: src/SUMMARY.md:293 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:294
-#: src/exercises/concurrency/link-checker.md:126
-#: src/async/tasks.md:1
-#: src/exercises/concurrency/chat-app.md:143
+#: src/SUMMARY.md:294 src/exercises/concurrency/link-checker.md:126
+#: src/async/tasks.md:1 src/exercises/concurrency/chat-app.md:143
 msgid "Tasks"
 msgstr "任务"
 
-#: src/SUMMARY.md:295
-#: src/async/channels.md:1
+#: src/SUMMARY.md:295 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "异步通道"
 
-#: src/SUMMARY.md:297
-#: src/async/control-flow/join.md:1
+#: src/SUMMARY.md:297 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr "加入"
 
-#: src/SUMMARY.md:298
-#: src/async/control-flow/select.md:1
+#: src/SUMMARY.md:298 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr "选择"
 
@@ -1113,24 +954,20 @@ msgstr "误区"
 msgid "Blocking the Executor"
 msgstr "屏蔽执行器"
 
-#: src/SUMMARY.md:301
-#: src/async/pitfalls/pin.md:1
+#: src/SUMMARY.md:301 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr "固定"
 
-#: src/SUMMARY.md:302
-#: src/async/pitfalls/async-traits.md:1
+#: src/SUMMARY.md:302 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "异步特质"
 
-#: src/SUMMARY.md:303
-#: src/async/pitfalls/cancellation.md:1
+#: src/SUMMARY.md:303 src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
 msgstr "安装"
 
-#: src/SUMMARY.md:306
-#: src/exercises/concurrency/chat-app.md:1
+#: src/SUMMARY.md:306 src/exercises/concurrency/chat-app.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:95
 msgid "Broadcast Chat Application"
 msgstr "广播聊天应用程序"
@@ -1139,13 +976,11 @@ msgstr "广播聊天应用程序"
 msgid "Final Words"
 msgstr "结束语"
 
-#: src/SUMMARY.md:313
-#: src/thanks.md:1
+#: src/SUMMARY.md:313 src/thanks.md:1
 msgid "Thanks!"
 msgstr "谢谢！"
 
-#: src/SUMMARY.md:314
-#: src/glossary.md:1
+#: src/SUMMARY.md:314 src/glossary.md:1
 msgid "Glossary"
 msgstr ""
 
@@ -1153,13 +988,11 @@ msgstr ""
 msgid "Other Resources"
 msgstr "其他资源"
 
-#: src/SUMMARY.md:316
-#: src/credits.md:1
+#: src/SUMMARY.md:316 src/credits.md:1
 msgid "Credits"
 msgstr "鸣谢"
 
-#: src/SUMMARY.md:319
-#: src/exercises/solutions.md:1
+#: src/SUMMARY.md:319 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "解答"
 
@@ -1191,8 +1024,7 @@ msgstr "第三天下午"
 msgid "Bare Metal Rust Morning"
 msgstr "嵌入式 Rust：入门篇"
 
-#: src/SUMMARY.md:331
-#: src/exercises/bare-metal/solutions-afternoon.md:1
+#: src/SUMMARY.md:331 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "嵌入式 Rust：进阶篇"
 
@@ -1207,32 +1039,39 @@ msgstr "并发编程：进阶篇"
 #: src/index.md:3
 #, fuzzy
 msgid ""
-"[![Build "
-"workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) "
-"[![GitHub "
-"contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors) "
-"[![GitHub "
-"stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
-"[![构建工作流](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) "
-"[![GitHub "
-"贡献者](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
+"[![构建工作流](https://img.shields.io/github/actions/workflow/status/google/"
+"comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub 贡献者](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors)"
 
 #: src/index.md:7
 msgid ""
 "This is a free Rust course developed by the Android team at Google. The "
 "course covers the full spectrum of Rust, from basic syntax to advanced "
 "topics like generics and error handling."
-msgstr "这是由 Android 团队开发的免费 Rust 课程。该课程涵盖了 Rust 的全部范围,从基本语法到高级主题如泛型和错误处理。"
+msgstr ""
+"这是由 Android 团队开发的免费 Rust 课程。该课程涵盖了 Rust 的全部范围,从基本"
+"语法到高级主题如泛型和错误处理。"
 
 #: src/index.md:11
 msgid ""
-"The latest version of the course can be found at "
-"<https://google.github.io/comprehensive-rust/>. If you are reading somewhere "
-"else, please check there for updates."
+"The latest version of the course can be found at <https://google.github.io/"
+"comprehensive-rust/>. If you are reading somewhere else, please check there "
+"for updates."
 msgstr ""
-"如需查看课程的最新版本,请访问 "
-"<https://google.github.io/comprehensive-rust/>。如果您是在其他地方阅读,请查看这个网址了解是否有更新。"
+"如需查看课程的最新版本,请访问 <https://google.github.io/comprehensive-rust/"
+">。如果您是在其他地方阅读,请查看这个网址了解是否有更新。"
 
 #: src/index.md:15
 msgid ""
@@ -1266,8 +1105,8 @@ msgid ""
 "[Android](android.md): a half-day course on using Rust for Android platform "
 "development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"[Android](android.md)：一个半天的课程，介绍如何在 Android 平台开发中使用 Rust（AOSP）。课程内容包括与 C、C++ "
-"和 Java 的互操作性。"
+"[Android](android.md)：一个半天的课程，介绍如何在 Android 平台开发中使用 Rust"
+"（AOSP）。课程内容包括与 C、C++ 和 Java 的互操作性。"
 
 #: src/index.md:28
 msgid ""
@@ -1275,7 +1114,8 @@ msgid ""
 "(embedded) development. Both microcontrollers and application processors are "
 "covered."
 msgstr ""
-"[Bare-metal](bare-metal.md):为期一天的课程,介绍如何使用 Rust 进行裸机(嵌入式)开发。课程内容涵盖微控制器和应用处理器。"
+"[Bare-metal](bare-metal.md):为期一天的课程,介绍如何使用 Rust 进行裸机(嵌入式)"
+"开发。课程内容涵盖微控制器和应用处理器。"
 
 #: src/index.md:31
 #, fuzzy
@@ -1285,8 +1125,9 @@ msgid ""
 "mutexes) and async/await concurrency (cooperative multitasking using "
 "futures)."
 msgstr ""
-"[并发](concurrency.md):一天的课程,介绍 Rust 中的并发性。我们将涵盖传统并发(使用线程和互斥锁进行抢占式调度)和 "
-"async/await 并发(使用 futures 进行协作式多任务处理)。"
+"[并发](concurrency.md):一天的课程,介绍 Rust 中的并发性。我们将涵盖传统并发(使"
+"用线程和互斥锁进行抢占式调度)和 async/await 并发(使用 futures 进行协作式多任"
+"务处理)。"
 
 #: src/index.md:37
 msgid "Non-Goals"
@@ -1296,18 +1137,19 @@ msgstr "非目标"
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
 "days. Some non-goals of this course are:"
-msgstr "Rust 是一门庞大的语言，我们无法在几天内涵盖所有内容。本课程的一些非目标包括："
+msgstr ""
+"Rust 是一门庞大的语言，我们无法在几天内涵盖所有内容。本课程的一些非目标包括："
 
 #: src/index.md:42
 #, fuzzy
 msgid ""
-"Learning how to develop macros: please see [Chapter 19.5 in the Rust "
-"Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by "
-"Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
-"了解如何开发宏,请参阅[本书中的第 19.5 "
-"章](https://doc.rust-lang.org/book/ch19-06-macros.html)和 [Rust by "
-"Examples](https://doc.rust-lang.org/rust-by-example/macros.html)。"
+"了解如何开发宏,请参阅[本书中的第 19.5 章](https://doc.rust-lang.org/book/"
+"ch19-06-macros.html)和 [Rust by Examples](https://doc.rust-lang.org/rust-by-"
+"example/macros.html)。"
 
 #: src/index.md:46
 msgid "Assumptions"
@@ -1319,14 +1161,18 @@ msgid ""
 "The course assumes that you already know how to program. Rust is a "
 "statically-typed language and we will sometimes make comparisons with C and "
 "C++ to better explain or contrast the Rust approach."
-msgstr "本课程假设你已经具备编程知识。Rust 是一种静态类型语言,我们有时会与 C 和 C++ 进行比较,以更好地解释或对比 Rust 的方法。"
+msgstr ""
+"本课程假设你已经具备编程知识。Rust 是一种静态类型语言,我们有时会与 C 和 C++ "
+"进行比较,以更好地解释或对比 Rust 的方法。"
 
 #: src/index.md:52
 #, fuzzy
 msgid ""
 "If you know how to program in a dynamically-typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
-msgstr "如果你已经了解如 Python 或 JavaScript 等动态类型语言的编程,那么你也能够很好地跟上本课程。"
+msgstr ""
+"如果你已经了解如 Python 或 JavaScript 等动态类型语言的编程,那么你也能够很好地"
+"跟上本课程。"
 
 #: src/index.md:57
 #, fuzzy
@@ -1334,10 +1180,11 @@ msgid ""
 "This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
 "should cover as well as answers to typical questions which come up in class."
-msgstr "这是演讲者备注的示例。我们将使用这些备注来为幻灯片添加额外的信息。这可能包括讲师应该涵盖的关键点,以及课堂上常见问题的答案。"
+msgstr ""
+"这是演讲者备注的示例。我们将使用这些备注来为幻灯片添加额外的信息。这可能包括"
+"讲师应该涵盖的关键点,以及课堂上常见问题的答案。"
 
-#: src/running-the-course.md:3
-#: src/running-the-course/course-structure.md:3
+#: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
 msgid "This page is for the course instructor."
 msgstr "本页面适用于课程教师。"
 
@@ -1356,9 +1203,10 @@ msgid ""
 "The downside of longer session is that people can become very tired after 6 "
 "full hours of class in the afternoon."
 msgstr ""
-"上课时间通常是从上午 10:00 到下午 4:00,中间有 1 小时的午餐休息时间。这样,上午和下午各留了 2.5 "
-"小时的上课时间。请注意,这仅是建议:您也可以上午上课 3 小时,让学员有更多的时间进行练习。上课时间较长的缺点是,学员上了整整 6 "
-"小时的课,到了下午可能会非常疲倦。"
+"上课时间通常是从上午 10:00 到下午 4:00,中间有 1 小时的午餐休息时间。这样,上午"
+"和下午各留了 2.5 小时的上课时间。请注意,这仅是建议:您也可以上午上课 3 小时,让"
+"学员有更多的时间进行练习。上课时间较长的缺点是,学员上了整整 6 小时的课,到了下"
+"午可能会非常疲倦。"
 
 #: src/running-the-course.md:16
 msgid "Before you run the course, you will want to:"
@@ -1372,7 +1220,10 @@ msgid ""
 "notes in a popup (click the link with a little arrow next to \"Speaker "
 "Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"熟悉课程资料。我们添加了演讲者备注，借此强调要点（请帮个忙，多多贡献演讲者备注！）。演示幻灯片时，你应确保在弹出式窗口中打开演讲者备注（点击对应的链接，在“演讲者备注”旁边有一个小箭头）。这样，你就可以确保屏幕整洁有序，更好地向全班学员展示课程内容。"
+"熟悉课程资料。我们添加了演讲者备注，借此强调要点（请帮个忙，多多贡献演讲者备"
+"注！）。演示幻灯片时，你应确保在弹出式窗口中打开演讲者备注（点击对应的链接，"
+"在“演讲者备注”旁边有一个小箭头）。这样，你就可以确保屏幕整洁有序，更好地向全"
+"班学员展示课程内容。"
 
 #: src/running-the-course.md:24
 msgid ""
@@ -1381,7 +1232,9 @@ msgid ""
 "have said that they find it helpful to have a gap in the course since it "
 "helps them process all the information we give them."
 msgstr ""
-"确定培训日期。由于本课程至少需要三天的时间，因此我们建议你安排两周以上的时间。课程学员曾表示，在每堂课之间留一段间隔会很有帮助，因为这有利于他们吸收我们所提供的所有信息。"
+"确定培训日期。由于本课程至少需要三天的时间，因此我们建议你安排两周以上的时"
+"间。课程学员曾表示，在每堂课之间留一段间隔会很有帮助，因为这有利于他们吸收我"
+"们所提供的所有信息。"
 
 #: src/running-the-course.md:29
 msgid ""
@@ -1393,21 +1246,24 @@ msgid ""
 "laptops. In particular, you will be doing a lot of live-coding as an "
 "instructor, so a lectern won't be very helpful for you."
 msgstr ""
-"找一间足以容纳全体线下学员的大教室。我们建议你将课程人数控制在 15-25 "
-"人之间。这样，人数足够少，不仅便于学员提问问题，配备的一位教师也有时间答疑解惑。确保教室备有供你和学生使用的“课桌”：你们都需要能够坐下来并操作各自的笔记本电脑。特别是身为教师，你现场要进行大量编码，所以讲台对你来说用处不大。"
+"找一间足以容纳全体线下学员的大教室。我们建议你将课程人数控制在 15-25 人之间。"
+"这样，人数足够少，不仅便于学员提问问题，配备的一位教师也有时间答疑解惑。确保"
+"教室备有供你和学生使用的“课桌”：你们都需要能够坐下来并操作各自的笔记本电脑。"
+"特别是身为教师，你现场要进行大量编码，所以讲台对你来说用处不大。"
 
 #: src/running-the-course.md:37
 msgid ""
 "On the day of your course, show up to the room a little early to set things "
 "up. We recommend presenting directly using `mdbook serve` running on your "
-"laptop (see the [installation "
-"instructions](https://github.com/google/comprehensive-rust#building)). This "
-"ensures optimal performance with no lag as you change pages. Using your "
-"laptop will also allow you to fix typos as you or the course participants "
-"spot them."
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
 msgstr ""
-"在开课当天，请提前一点到教室，设置好教学设备。我们建议你直接在笔记本电脑上运行 `mdbook serve` "
-"来演示课程内容（请参阅[安装说明](https://github.com/google/comprehensive-rust#building)）。这样可以确保你在切换页面时没有延迟，演示效果更好。当你或课程学员发现拼写错误时，你也可以使用笔记本电脑及时更正。"
+"在开课当天，请提前一点到教室，设置好教学设备。我们建议你直接在笔记本电脑上运"
+"行 `mdbook serve` 来演示课程内容（请参阅[安装说明](https://github.com/google/"
+"comprehensive-rust#building)）。这样可以确保你在切换页面时没有延迟，演示效果"
+"更好。当你或课程学员发现拼写错误时，你也可以使用笔记本电脑及时更正。"
 
 #: src/running-the-course.md:43
 msgid ""
@@ -1419,8 +1275,10 @@ msgid ""
 "offer a solution, e.g., by showing people where to find the relevant "
 "information in the standard library."
 msgstr ""
-"让学员采取小组形式或独立解题。通常，我们会在上午和下午各安排 30-45 "
-"分钟的练习时间（包括查看解决方案的时间）。请务必询问学员是否遇到困难，或是否需要任何帮助。如果你看到多位学员遇到同样的问题，请在班级集体进行讲解，并提供相应的解决方案，例如告诉大家在标准库的什么位置可以找到相关信息。"
+"让学员采取小组形式或独立解题。通常，我们会在上午和下午各安排 30-45 分钟的练习"
+"时间（包括查看解决方案的时间）。请务必询问学员是否遇到困难，或是否需要任何帮"
+"助。如果你看到多位学员遇到同样的问题，请在班级集体进行讲解，并提供相应的解决"
+"方案，例如告诉大家在标准库的什么位置可以找到相关信息。"
 
 #: src/running-the-course.md:51
 msgid ""
@@ -1430,14 +1288,16 @@ msgstr "今天的分享就是这些，祝你授课顺利！希望你和我们一
 
 #: src/running-the-course.md:54
 msgid ""
-"Please [provide "
-"feedback](https://github.com/google/comprehensive-rust/discussions/86) "
-"afterwards so that we can keep improving the course. We would love to hear "
-"what worked well for you and what can be made better. Your students are also "
-"very welcome to [send us "
-"feedback](https://github.com/google/comprehensive-rust/discussions/100)!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"欢迎你课后[提供反馈](https://github.com/google/comprehensive-rust/discussions/86)，帮助我们不断改进课程。我们非常期待了解哪些方面做得不错，哪些方面还需要改进。同时非常欢迎学生们[向我们发送反馈](https://github.com/google/comprehensive-rust/discussions/100)！"
+"欢迎你课后[提供反馈](https://github.com/google/comprehensive-rust/"
+"discussions/86)，帮助我们不断改进课程。我们非常期待了解哪些方面做得不错，哪些"
+"方面还需要改进。同时非常欢迎学生们[向我们发送反馈](https://github.com/google/"
+"comprehensive-rust/discussions/100)！"
 
 #: src/running-the-course/course-structure.md:5
 msgid "Rust Fundamentals"
@@ -1447,7 +1307,9 @@ msgstr "Rust 二进制文件"
 msgid ""
 "The first three days make up [Rust Fundaments](../welcome-day-1.md). The "
 "days are fast paced and we cover a lot of ground:"
-msgstr "我们会在头三天介绍 [Rust 基础知识](../welcome-day-1.md)。这几天的步调会稍快,因为我们要探讨许多层面:"
+msgstr ""
+"我们会在头三天介绍 [Rust 基础知识](../welcome-day-1.md)。这几天的步调会稍快,"
+"因为我们要探讨许多层面:"
 
 #: src/running-the-course/course-structure.md:10
 msgid "Day 1: Basic Rust, syntax, control flow, creating and consuming values."
@@ -1487,23 +1349,21 @@ msgid ""
 "Rust for Android platform development. This includes interoperability with "
 "C, C++, and Java."
 msgstr ""
-"`[深入探究 Android](../android.md)`课程为期半天,旨在介绍如何使用 Rust 进行 Android 平台开发。其中包括与 "
-"C、C++ 和 Java 的互操作性。"
+"`[深入探究 Android](../android.md)`课程为期半天,旨在介绍如何使用 Rust 进行 "
+"Android 平台开发。其中包括与 C、C++ 和 Java 的互操作性。"
 
 #: src/running-the-course/course-structure.md:25
 msgid ""
-"You will need an [AOSP "
-"checkout](https://source.android.com/docs/setup/download/downloading). Make "
-"a checkout of the [course "
-"repository](https://github.com/google/comprehensive-rust) on the same "
-"machine and move the `src/android/` directory into the root of your AOSP "
-"checkout. This will ensure that the Android build system sees the "
-"`Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"你将需要[签出 "
-"AOSP](https://source.android.com/docs/setup/download/downloading)。在同一机器上签出[课程库](https://github.com/google/comprehensive-rust)， "
-"然后将 `src/android/` 目录移至所签出的 AOSP 的根目录。这将确保 Android 构建系统能检测到 `src/android/` "
-"中的 `Android.bp` 文件。"
+"你将需要[签出 AOSP](https://source.android.com/docs/setup/download/"
+"downloading)。在同一机器上签出[课程库](https://github.com/google/"
+"comprehensive-rust)， 然后将 `src/android/` 目录移至所签出的 AOSP 的根目录。"
+"这将确保 Android 构建系统能检测到 `src/android/` 中的 `Android.bp` 文件。"
 
 #: src/running-the-course/course-structure.md:30
 msgid ""
@@ -1511,8 +1371,9 @@ msgid ""
 "all Android examples using `src/android/build_all.sh`. Read the script to "
 "see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"确保 `adb sync` 适用于你的模拟器或实际设备， 并使用 `src/android/build_all.sh` 预构建所有 Android "
-"示例。请阅读脚本， 查看它所运行的命令，并确保这些命令能在你手动运行时正确执行。"
+"确保 `adb sync` 适用于你的模拟器或实际设备， 并使用 `src/android/build_all."
+"sh` 预构建所有 Android 示例。请阅读脚本， 查看它所运行的命令，并确保这些命令"
+"能在你手动运行时正确执行。"
 
 #: src/running-the-course/course-structure.md:37
 #, fuzzy
@@ -1526,18 +1387,19 @@ msgid ""
 "using Rust for bare-metal (embedded) development. Both microcontrollers and "
 "application processors are covered."
 msgstr ""
-"`[深入探究裸机](../bare-metal.md)`课程为期一天,旨在介绍如何使用 Rust 进行裸机(嵌入式)开发。其中涵盖了微控制器和应用 "
-"处理器。"
+"`[深入探究裸机](../bare-metal.md)`课程为期一天,旨在介绍如何使用 Rust 进行裸机"
+"(嵌入式)开发。其中涵盖了微控制器和应用 处理器。"
 
 #: src/running-the-course/course-structure.md:43
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC "
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody will need to install a number of packages as described on the "
-"[welcome page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
 "对于微控制器部分，你需要提前购买 [BBC micro:bit](https://microbit.org/) 第 2 "
-"版开发板。每个人都需要安装多个软件包， 具体如[欢迎页面](../bare-metal.md)中所述。"
+"版开发板。每个人都需要安装多个软件包， 具体如[欢迎页面](../bare-metal.md)中所"
+"述。"
 
 #: src/running-the-course/course-structure.md:48
 msgid "Concurrency in Rust"
@@ -1547,7 +1409,9 @@ msgstr "欢迎了解 Rust 中的并发"
 msgid ""
 "The [Concurrency in Rust](../concurrency.md) deep dive is a full day class "
 "on classical as well as `async`/`await` concurrency."
-msgstr "`[深入探究并发](../concurrency.md)`课程为期一天,旨在介绍传统并发和 `async`/`await` 并发。"
+msgstr ""
+"`[深入探究并发](../concurrency.md)`课程为期一天,旨在介绍传统并发和 `async`/"
+"`await` 并发。"
 
 #: src/running-the-course/course-structure.md:53
 msgid ""
@@ -1555,7 +1419,8 @@ msgid ""
 "to go. You can then copy/paste the examples into `src/main.rs` to experiment "
 "with them:"
 msgstr ""
-"你需要设置一个新 crate，下载所需的依赖项， 做好课前准备。然后，你可以将示例复制/粘贴到 `src/main.rs` 中， 以便对以下代码进行实验："
+"你需要设置一个新 crate，下载所需的依赖项， 做好课前准备。然后，你可以将示例复"
+"制/粘贴到 `src/main.rs` 中， 以便对以下代码进行实验："
 
 #: src/running-the-course/course-structure.md:64
 msgid "Format"
@@ -1587,8 +1452,7 @@ msgstr "向右箭头"
 msgid ": Navigate to the next page."
 msgstr "：转到下一页。"
 
-#: src/running-the-course/keyboard-shortcuts.md:7
-#: src/cargo/code-samples.md:19
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
 msgid "Ctrl + Enter"
 msgstr "Ctrl + Enter"
 
@@ -1613,28 +1477,29 @@ msgstr "一批优秀的志愿者已将本课程翻译成其他语言："
 #: src/running-the-course/translations.md:6
 msgid ""
 "[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
-"by [@rastringer](https://github.com/rastringer), "
-"[@hugojacob](https://github.com/hugojacob), "
-"[@joaovicmendes](https://github.com/joaovicmendes), and "
+"by [@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
+"com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), and "
 "[@henrif75](https://github.com/henrif75)."
 msgstr ""
-"[巴西葡萄牙语版本](https://google.github.io/comprehensive-rust/pt-BR/)译者:[@rastringer](https://github.com/rastringer)、[@hugojacob](https://github.com/hugojacob)、[@joaovicmendes](https://github.com/joaovicmendes) "
-"和 [@henrif75](https://github.com/henrif75)。"
+"[巴西葡萄牙语版本](https://google.github.io/comprehensive-rust/pt-BR/)译者:"
+"[@rastringer](https://github.com/rastringer)、[@hugojacob](https://github."
+"com/hugojacob)、[@joaovicmendes](https://github.com/joaovicmendes) 和 "
+"[@henrif75](https://github.com/henrif75)。"
 
 #: src/running-the-course/translations.md:7
 msgid ""
-"[Korean](https://google.github.io/comprehensive-rust/ko/) by "
-"[@keispace](https://github.com/keispace), "
-"[@jiyongp](https://github.com/jiyongp), and "
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
-"[韩语版本](https://google.github.io/comprehensive-rust/ko/)译者:[@keispace](https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp) "
-"和 [@jooyunghan](https://github.com/jooyunghan)。"
+"[韩语版本](https://google.github.io/comprehensive-rust/ko/)译者:[@keispace]"
+"(https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp) 和 "
+"[@jooyunghan](https://github.com/jooyunghan)。"
 
 #: src/running-the-course/translations.md:8
 msgid ""
-"[Spanish](https://google.github.io/comprehensive-rust/es/) by "
-"[@deavid](https://github.com/deavid)."
+"[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
+"(https://github.com/deavid)."
 msgstr ""
 
 #: src/running-the-course/translations.md:10
@@ -1654,76 +1519,78 @@ msgstr "多数语言版本仍在翻译中。我们会提供最近更新的翻译
 
 #: src/running-the-course/translations.md:17
 msgid ""
-"[Bengali](https://google.github.io/comprehensive-rust/bn/) by "
-"[@raselmandol](https://github.com/raselmandol)."
+"[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
+"(https://github.com/raselmandol)."
 msgstr ""
-"[孟加拉语版本](https://google.github.io/comprehensive-rust/bn/)译者:[@raselmandol](https://github.com/raselmandol)。"
+"[孟加拉语版本](https://google.github.io/comprehensive-rust/bn/)译者:"
+"[@raselmandol](https://github.com/raselmandol)。"
 
 #: src/running-the-course/translations.md:18
 msgid ""
 "[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
-"by [@hueich](https://github.com/hueich), "
-"[@victorhsieh](https://github.com/victorhsieh), "
-"[@mingyc](https://github.com/mingyc), and "
-"[@johnathan79717](https://github.com/johnathan79717)."
+"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
+"victorhsieh), [@mingyc](https://github.com/mingyc), and [@johnathan79717]"
+"(https://github.com/johnathan79717)."
 msgstr ""
 
 #: src/running-the-course/translations.md:19
 msgid ""
 "[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
-"by [@suetfei](https://github.com/suetfei), "
-"[@wnghl](https://github.com/wnghl), [@anlunx](https://github.com/anlunx), "
-"[@kongy](https://github.com/kongy), "
-"[@noahdragon](https://github.com/noahdragon), and "
-"[@superwhd](https://github.com/superwhd)."
+"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
+"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
+"kongy), [@noahdragon](https://github.com/noahdragon), and [@superwhd]"
+"(https://github.com/superwhd)."
 msgstr ""
 
 #: src/running-the-course/translations.md:20
 msgid ""
-"[French](https://google.github.io/comprehensive-rust/fr/) by "
-"[@KookaS](https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
-"[法语版本](https://google.github.io/comprehensive-rust/fr/)译者:[@KookaS](https://github.com/KookaS) "
-"和 [@vcaen](https://github.com/vcaen)。"
+"[法语版本](https://google.github.io/comprehensive-rust/fr/)译者:[@KookaS]"
+"(https://github.com/KookaS) 和 [@vcaen](https://github.com/vcaen)。"
 
 #: src/running-the-course/translations.md:21
 msgid ""
-"[German](https://google.github.io/comprehensive-rust/de/) by "
-"[@Throvn](https://github.com/Throvn) and "
-"[@ronaldfw](https://github.com/ronaldfw)."
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
 msgstr ""
-"[德语版本](https://google.github.io/comprehensive-rust/de/)译者:[@Throvn](https://github.com/Throvn) "
-"和 [@ronaldfw](https://github.com/ronaldfw)。"
+"[德语版本](https://google.github.io/comprehensive-rust/de/)译者:[@Throvn]"
+"(https://github.com/Throvn) 和 [@ronaldfw](https://github.com/ronaldfw)。"
 
 #: src/running-the-course/translations.md:22
 msgid ""
-"[Japanese](https://google.github.io/comprehensive-rust/ja/) by "
-"[@CoinEZ-JPN](https://github.com/CoinEZ) and "
-"[@momotaro1105](https://github.com/momotaro1105)."
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
 msgstr ""
-"[日语版本](https://google.github.io/comprehensive-rust/ja/)译者:[@CoinEZ-JPN](https://github.com/CoinEZ) "
-"和 [@momotaro1105](https://github.com/momotaro1105)。"
+"[日语版本](https://google.github.io/comprehensive-rust/ja/)译者:[@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) 和 [@momotaro1105](https://github.com/"
+"momotaro1105)。"
 
 #: src/running-the-course/translations.md:24
 msgid ""
-"If you want to help with this effort, please see [our "
-"instructions](https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) "
-"for how to get going. Translations are coordinated on the [issue "
-"tracker](https://github.com/google/comprehensive-rust/issues/282)."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"如果你想帮助我们,请参阅[我们的说明](htts://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md),了解如何开始翻译。翻译工作将通过[问题跟踪器](https://github.com/google/comprehensive-rust/issues/282)."
+"如果你想帮助我们,请参阅[我们的说明](htts://github.com/google/comprehensive-"
+"rust/blob/main/TRANSLATIONS.md),了解如何开始翻译。翻译工作将通过[问题跟踪器]"
+"(https://github.com/google/comprehensive-rust/issues/282)."
 
 #: src/cargo.md:3
 msgid ""
-"When you start reading about Rust, you will soon meet "
-"[Cargo](https://doc.rust-lang.org/cargo/), the standard tool used in the "
-"Rust ecosystem to build and run Rust applications. Here we want to give a "
-"brief overview of what Cargo is and how it fits into the wider ecosystem and "
-"how it fits into this training."
+"When you start reading about Rust, you will soon meet [Cargo](https://doc."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
-"开始了解 Rust 后，你很快就会遇到 [Cargo](https://doc.rust-lang.org/cargo/)，这是 Rust 生态系统中 "
-"用于构建和运行 Rust 应用的标准工具。在这里，我们希望 简要介绍一下什么是 Cargo，它如何融入更广泛的生态系统， 以及我们如何在本培训中合理利用 "
-"Cargo。"
+"开始了解 Rust 后，你很快就会遇到 [Cargo](https://doc.rust-lang.org/cargo/)，"
+"这是 Rust 生态系统中 用于构建和运行 Rust 应用的标准工具。在这里，我们希望 简"
+"要介绍一下什么是 Cargo，它如何融入更广泛的生态系统， 以及我们如何在本培训中合"
+"理利用 Cargo。"
 
 #: src/cargo.md:8
 msgid "Installation"
@@ -1745,14 +1612,12 @@ msgstr ""
 #: src/cargo.md:14
 msgid ""
 "After installing Rust, you should configure your editor or IDE to work with "
-"Rust. Most editors do this by talking to "
-"[rust-analyzer](https://rust-analyzer.github.io/), which provides "
-"auto-completion and jump-to-definition functionality for [VS "
-"Code](https://code.visualstudio.com/), "
-"[Emacs](https://rust-analyzer.github.io/manual.html#emacs), "
-"[Vim/Neovim](https://rust-analyzer.github.io/manual.html#vimneovim), and "
-"many others. There is also a different IDE available called "
-"[RustRover](https://www.jetbrains.com/rust/)."
+"Rust. Most editors do this by talking to [rust-analyzer](https://rust-"
+"analyzer.github.io/), which provides auto-completion and jump-to-definition "
+"functionality for [VS Code](https://code.visualstudio.com/), [Emacs](https://"
+"rust-analyzer.github.io/manual.html#emacs), [Vim/Neovim](https://rust-"
+"analyzer.github.io/manual.html#vimneovim), and many others. There is also a "
+"different IDE available called [RustRover](https://www.jetbrains.com/rust/)."
 msgstr ""
 
 #: src/cargo.md:18
@@ -1762,9 +1627,9 @@ msgid ""
 "gets you an outdated rust version and may lead to unexpected behavior. The "
 "command would be:"
 msgstr ""
-"在 Debian/Ubuntu 上,你也可以通过 `apt` 安装 Cargo、Rust 源代码和 [Rust "
-"格式设置工具](https://github.com/rust-lang/rustfmt)。但是,这样会得到一个过时的 Rust "
-"版本,可能会导致意外的行为。命令如下:"
+"在 Debian/Ubuntu 上,你也可以通过 `apt` 安装 Cargo、Rust 源代码和 [Rust 格式设"
+"置工具](https://github.com/rust-lang/rustfmt)。但是,这样会得到一个过时的 "
+"Rust 版本,可能会导致意外的行为。命令如下:"
 
 #: src/cargo/rust-ecosystem.md:1
 msgid "The Rust Ecosystem"
@@ -1788,8 +1653,9 @@ msgid ""
 "pass them to `rustc` when building your project. Cargo also comes with a "
 "built-in test runner which is used to execute unit tests."
 msgstr ""
-"`cargo`:Rust 依赖项管理器和构建工具。Cargo 知道如何 下载托管在 <https://crates.io> "
-"上的依赖项,并在构建项目时将它们 传递给 `rustc`。Cargo 还附带一个内置的 测试运行程序,用于执行单元测试。"
+"`cargo`:Rust 依赖项管理器和构建工具。Cargo 知道如何 下载托管在 <https://"
+"crates.io> 上的依赖项,并在构建项目时将它们 传递给 `rustc`。Cargo 还附带一个内"
+"置的 测试运行程序,用于执行单元测试。"
 
 #: src/cargo/rust-ecosystem.md:13
 msgid ""
@@ -1799,22 +1665,19 @@ msgid ""
 "standard library. You can have multiple versions of Rust installed at once "
 "and `rustup` will let you switch between them as needed."
 msgstr ""
-"`rustup`：Rust 工具链安装程序和更新程序。发布新版本 Rust 时，此工具用于 安装并更新 `rustc` 和 `cargo`。 "
-"此外，`rustup` 还可以下载标准 库的文档。你可以同时安装多个版本的 Rust，并且 `rustup` 可让你根据需要在这些版本之间切换。"
+"`rustup`：Rust 工具链安装程序和更新程序。发布新版本 Rust 时，此工具用于 安装"
+"并更新 `rustc` 和 `cargo`。 此外，`rustup` 还可以下载标准 库的文档。你可以同"
+"时安装多个版本的 Rust，并且 `rustup` 可让你根据需要在这些版本之间切换。"
 
-#: src/cargo/rust-ecosystem.md:21
-#: src/hello-world.md:25
-#: src/hello-world/small-example.md:27
-#: src/why-rust/runtime.md:10
-#: src/why-rust/modern.md:21
-#: src/basic-syntax/compound-types.md:32
+#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
+#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
+#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:32
 #: src/basic-syntax/references.md:24
 #: src/pattern-matching/destructuring-enums.md:35
 #: src/ownership/double-free-modern-cpp.md:55
 #: src/error-handling/try-operator.md:48
 #: src/error-handling/converting-error-types-example.md:50
-#: src/concurrency/threads.md:30
-#: src/async/async-await.md:25
+#: src/concurrency/threads.md:30 src/async/async-await.md:25
 msgid "Key points:"
 msgstr "关键点："
 
@@ -1823,10 +1686,13 @@ msgid ""
 "Rust has a rapid release schedule with a new release coming out every six "
 "weeks. New releases maintain backwards compatibility with old releases --- "
 "plus they enable new functionality."
-msgstr "Rust 有一个快速发布时间表，每六周就会发布一次 新版本。新版本保持与 旧版本的向后兼容性，还添加了新功能。"
+msgstr ""
+"Rust 有一个快速发布时间表，每六周就会发布一次 新版本。新版本保持与 旧版本的向"
+"后兼容性，还添加了新功能。"
 
 #: src/cargo/rust-ecosystem.md:27
-msgid "There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
 msgstr "共有三个发布阶段：“稳定版”“Beta 版”和“夜间版”。"
 
 #: src/cargo/rust-ecosystem.md:29
@@ -1837,17 +1703,19 @@ msgstr "我们会在“夜间版”上测试新功能，每六周将“Beta 版�
 
 #: src/cargo/rust-ecosystem.md:32
 msgid ""
-"Dependencies can also be resolved from alternative "
-"[registries](https://doc.rust-lang.org/cargo/reference/registries.html), "
-"git, folders, and more."
+"Dependencies can also be resolved from alternative [registries](https://doc."
+"rust-lang.org/cargo/reference/registries.html), git, folders, and more."
 msgstr ""
-"您也可以通过备用的[注册数据库](https://doc.rust-lang.org/cargo/reference/registries.html)、git、文件夹等资源来解析依赖项。"
+"您也可以通过备用的[注册数据库](https://doc.rust-lang.org/cargo/reference/"
+"registries.html)、git、文件夹等资源来解析依赖项。"
 
 #: src/cargo/rust-ecosystem.md:34
 msgid ""
 "Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
 "current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
-msgstr "Rust 也有三个\\[版本\\]：当前版本是 Rust 2021。之前的 版本是 Rust 2015 和 Rust 2018。"
+msgstr ""
+"Rust 也有三个\\[版本\\]：当前版本是 Rust 2021。之前的 版本是 Rust 2015 和 "
+"Rust 2018。"
 
 #: src/cargo/rust-ecosystem.md:37
 msgid ""
@@ -1859,7 +1727,9 @@ msgstr "这些版本支持对语言进行向后不兼容的 更改。"
 msgid ""
 "To prevent breaking code, editions are opt-in: you select the edition for "
 "your crate via the `Cargo.toml` file."
-msgstr "为防止破坏代码，你可以自行选择版本： 通过 `Cargo.toml` 文件为 crate 选择合适的版本。"
+msgstr ""
+"为防止破坏代码，你可以自行选择版本： 通过 `Cargo.toml` 文件为 crate 选择合适"
+"的版本。"
 
 #: src/cargo/rust-ecosystem.md:43
 msgid ""
@@ -1871,14 +1741,17 @@ msgstr "为免分割生态系统，Rust 编译器可以混合使用 为不同版
 msgid ""
 "Mention that it is quite rare to ever use the compiler directly not through "
 "`cargo` (most users never do)."
-msgstr "提及不通过 `cargo` 而直接使用编译器的情况相当少见（大多数用户从不这样做）。"
+msgstr ""
+"提及不通过 `cargo` 而直接使用编译器的情况相当少见（大多数用户从不这样做）。"
 
 #: src/cargo/rust-ecosystem.md:48
 msgid ""
 "It might be worth alluding that Cargo itself is an extremely powerful and "
 "comprehensive tool.  It is capable of many advanced features including but "
 "not limited to: "
-msgstr "值得注意的是，Cargo 本身就是一个功能强大且全面的工具。它能够实现许多高级功能，包括但不限于："
+msgstr ""
+"值得注意的是，Cargo 本身就是一个功能强大且全面的工具。它能够实现许多高级功"
+"能，包括但不限于："
 
 #: src/cargo/rust-ecosystem.md:49
 msgid "Project/package structure"
@@ -1894,14 +1767,14 @@ msgstr "开发依赖项和运行时依赖项管理/缓存"
 
 #: src/cargo/rust-ecosystem.md:52
 msgid ""
-"[build "
-"scripting](https://doc.rust-lang.org/cargo/reference/build-scripts.html)"
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
 msgstr "\\[构建脚本\\]"
 
 #: src/cargo/rust-ecosystem.md:53
 msgid ""
-"[global "
-"installation](https://doc.rust-lang.org/cargo/commands/cargo-install.html)"
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
 msgstr "\\[全局安装\\] \\]"
 
 #: src/cargo/rust-ecosystem.md:54
@@ -1909,7 +1782,8 @@ msgid ""
 "It is also extensible with sub command plugins as well (such as [cargo "
 "clippy](https://github.com/rust-lang/rust-clippy))."
 msgstr ""
-"它还可以使用子命令插件（例如 [cargo clippy](https://github.com/rust-lang/rust-clippy)）进行扩展。"
+"它还可以使用子命令插件（例如 [cargo clippy](https://github.com/rust-lang/"
+"rust-clippy)）进行扩展。"
 
 #: src/cargo/rust-ecosystem.md:55
 msgid ""
@@ -1925,7 +1799,9 @@ msgid ""
 "For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
 "and ensures a consistent experience for everyone."
-msgstr "在本培训中，我们将主要通过示例 探索 Rust 语言，这些示例可通过浏览器执行。这能大大简化设置过程， 并确保所有人都能获得一致的体验。"
+msgstr ""
+"在本培训中，我们将主要通过示例 探索 Rust 语言，这些示例可通过浏览器执行。这能"
+"大大简化设置过程， 并确保所有人都能获得一致的体验。"
 
 #: src/cargo/code-samples.md:7
 msgid ""
@@ -1933,7 +1809,8 @@ msgid ""
 "the exercises. On the last day, we will do a larger exercise which shows you "
 "how to work with dependencies and for that you need Cargo."
 msgstr ""
-"我们仍然建议你安装 Cargo：它有助于你更轻松地完成 练习。在最后一天，我们要做一个更大的练习， 向你展示如何使用依赖项，因此你需要安装 Cargo。"
+"我们仍然建议你安装 Cargo：它有助于你更轻松地完成 练习。在最后一天，我们要做一"
+"个更大的练习， 向你展示如何使用依赖项，因此你需要安装 Cargo。"
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -1966,20 +1843,26 @@ msgstr "来执行代码。"
 msgid ""
 "Most code samples are editable like shown above. A few code samples are not "
 "editable for various reasons:"
-msgstr "大多数代码示例都可修改（如上图所示）。少数代码示例 可能会因各种原因而不可修改："
+msgstr ""
+"大多数代码示例都可修改（如上图所示）。少数代码示例 可能会因各种原因而不可修"
+"改："
 
 #: src/cargo/code-samples.md:27
 msgid ""
 "The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
 "open it in the real Playground to demonstrate unit tests."
-msgstr "嵌入式 Playground 无法执行单元测试。将代码复制并粘贴 到实际 Playground 中，以演示单元测试。"
+msgstr ""
+"嵌入式 Playground 无法执行单元测试。将代码复制并粘贴 到实际 Playground 中，以"
+"演示单元测试。"
 
 #: src/cargo/code-samples.md:30
 msgid ""
 "The embedded playgrounds lose their state the moment you navigate away from "
 "the page! This is the reason that the students should solve the exercises "
 "using a local Rust installation or via the Playground."
-msgstr "嵌入式 Playground 会在你离开页面后立即 丢失其状态！正因如此，学员应使用本地安装的 Rust 或通过 Playground 解题。"
+msgstr ""
+"嵌入式 Playground 会在你离开页面后立即 丢失其状态！正因如此，学员应使用本地安"
+"装的 Rust 或通过 Playground 解题。"
 
 #: src/cargo/running-locally.md:1
 msgid "Running Code Locally with Cargo"
@@ -1993,9 +1876,10 @@ msgid ""
 "should give you a working `rustc` and `cargo`. At the time of writing, the "
 "latest stable Rust release has these version numbers:"
 msgstr ""
-"如果你想在自己的系统上对代码进行实验， 则需要先安装 Rust。为此，请按照 [Rust 图书中的 "
-"说明](https://doc.rust-lang.org/book/ch01-01-installation.html)操作。这应会为你提供一个有效的 "
-"`rustc` 和 `cargo`。在撰写 本文时，最新的 Rust 稳定版具有以下版本号："
+"如果你想在自己的系统上对代码进行实验， 则需要先安装 Rust。为此，请按照 [Rust "
+"图书中的 说明](https://doc.rust-lang.org/book/ch01-01-installation.html)操"
+"作。这应会为你提供一个有效的 `rustc` 和 `cargo`。在撰写 本文时，最新的 Rust "
+"稳定版具有以下版本号："
 
 #: src/cargo/running-locally.md:15
 msgid ""
@@ -2007,7 +1891,8 @@ msgstr "您也可以使用任何更高版本,因为 Rust 保持向后兼容性�
 msgid ""
 "With this in place, follow these steps to build a Rust binary from one of "
 "the examples in this training:"
-msgstr "了解这些信息后，请按照以下步骤从本培训中的 一个示例中构建 Rust 二进制文件："
+msgstr ""
+"了解这些信息后，请按照以下步骤从本培训中的 一个示例中构建 Rust 二进制文件："
 
 #: src/cargo/running-locally.md:20
 msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
@@ -2027,7 +1912,9 @@ msgstr "导航至 `exercise/` 并使用 `cargo run` 构建并运行你的二进�
 msgid ""
 "Replace the boiler-plate code in `src/main.rs` with your own code. For "
 "example, using the example on the previous page, make `src/main.rs` look like"
-msgstr "将 `src/main.rs` 中的样板代码替换为你自己的代码。例如， 使用上一页中的示例，将 `src/main.rs` 改为："
+msgstr ""
+"将 `src/main.rs` 中的样板代码替换为你自己的代码。例如， 使用上一页中的示例，"
+"将 `src/main.rs` 改为："
 
 #: src/cargo/running-locally.md:43
 msgid ""
@@ -2050,27 +1937,31 @@ msgstr "使用 `cargo run` 构建并运行你更新后的二进制文件："
 #: src/cargo/running-locally.md:59
 msgid ""
 "Use `cargo check` to quickly check your project for errors, use `cargo "
-"build` to compile it without running it. You will find the output in "
-"`target/debug/` for a normal debug build. Use `cargo build --release` to "
-"produce an optimized release build in `target/release/`."
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
 msgstr ""
-"使用 `cargo check` 快速检查项目是否存在错误；使用 `cargo build` 只进行编译，而不运行。你可以在 "
-"`target/debug/` 中找到常规调试 build 的输出。使用 `cargo build --release` 在 "
-"`target/release/` 中生成经过优化的 发布 build。"
+"使用 `cargo check` 快速检查项目是否存在错误；使用 `cargo build` 只进行编译，"
+"而不运行。你可以在 `target/debug/` 中找到常规调试 build 的输出。使用 `cargo "
+"build --release` 在 `target/release/` 中生成经过优化的 发布 build。"
 
 #: src/cargo/running-locally.md:64
 msgid ""
 "You can add dependencies for your project by editing `Cargo.toml`. When you "
 "run `cargo` commands, it will automatically download and compile missing "
 "dependencies for you."
-msgstr "你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你 运行 `cargo` 命令时，系统会自动为你下载和编译缺失 的依赖项。"
+msgstr ""
+"你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你 运行 `cargo` 命令时，系统"
+"会自动为你下载和编译缺失 的依赖项。"
 
 #: src/cargo/running-locally.md:72
 msgid ""
 "Try to encourage the class participants to install Cargo and use a local "
 "editor. It will make their life easier since they will have a normal "
 "development environment."
-msgstr "尽量鼓励全班学员安装 Cargo 并使用 本地编辑器。这能为他们营造常规 开发环境，让工作变得更加轻松。"
+msgstr ""
+"尽量鼓励全班学员安装 Cargo 并使用 本地编辑器。这能为他们营造常规 开发环境，让"
+"工作变得更加轻松。"
 
 #: src/welcome-day-1.md:1
 msgid "Welcome to Day 1"
@@ -2087,13 +1978,16 @@ msgstr "现在是学习 Comprehensive Rust 的第一天。今天我们会涉及�
 msgid ""
 "Basic Rust syntax: variables, scalar and compound types, enums, structs, "
 "references, functions, and methods."
-msgstr "Rust 基本语法：变量，标量（scalar）和复合（compound）类型，枚举（enum），结构体（struct），引用，函数和方法。"
+msgstr ""
+"Rust 基本语法：变量，标量（scalar）和复合（compound）类型，枚举（enum），结构"
+"体（struct），引用，函数和方法。"
 
 #: src/welcome-day-1.md:9
 msgid ""
 "Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
 "`continue`."
-msgstr "控制流的构造: `if`, `if let`, `while`, `while let`, `break`, 和 `continue`。"
+msgstr ""
+"控制流的构造: `if`, `if let`, `while`, `while let`, `break`, 和 `continue`。"
 
 #: src/welcome-day-1.md:12
 msgid "Pattern matching: destructuring enums, structs, and arrays."
@@ -2104,7 +1998,8 @@ msgid "Please remind the students that:"
 msgstr "请提醒学生："
 
 #: src/welcome-day-1.md:18
-msgid "They should ask questions when they get them, don't save them to the end."
+msgid ""
+"They should ask questions when they get them, don't save them to the end."
 msgstr "他们可以随时提问，不需要留到最后。"
 
 #: src/welcome-day-1.md:19
@@ -2117,12 +2012,14 @@ msgstr "这个课程本应该是互动的，我们鼓励大家积极讨论。"
 #, fuzzy
 msgid ""
 "As an instructor, you should try to keep the discussions relevant, i.e., "
-"keep the discussions related to how Rust does things vs some other language. "
-" It can be hard to find the right balance, but err on the side of allowing  "
-"discussions since they engage people much more than one-way communication."
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
 msgstr ""
-"作为讲师，你应该尽量保证讨论话题的相关性，例如，讨论围绕Rust是如何做某些事情，而不是其他的语言如何如何。 这个平衡点不容易找到，但是尽量倾向于允许  "
-"讨论，因为讨论比起单方面的灌输更有利于让大家投入。"
+"作为讲师，你应该尽量保证讨论话题的相关性，例如，讨论围绕Rust是如何做某些事"
+"情，而不是其他的语言如何如何。 这个平衡点不容易找到，但是尽量倾向于允许  讨"
+"论，因为讨论比起单方面的灌输更有利于让大家投入。"
 
 #: src/welcome-day-1.md:24
 msgid ""
@@ -2134,7 +2031,9 @@ msgid ""
 "This is perfectly okay! Repetition is an important part of learning. "
 "Remember that the slides are just a support and you are free to skip them as "
 "you like."
-msgstr "这完全没有问题! 重复是学习的一个重要方法。请记得 这些幻灯片只是一个辅助，你可以选择性地跳过。"
+msgstr ""
+"这完全没有问题! 重复是学习的一个重要方法。请记得 这些幻灯片只是一个辅助，你可"
+"以选择性地跳过。"
 
 #: src/welcome-day-1.md:29
 msgid ""
@@ -2142,13 +2041,16 @@ msgid ""
 "speak about the famous borrow checker. The way Rust handles memory is a "
 "major feature and we should show students this right away."
 msgstr ""
-"第一天的主要目标是要谈到著名的 borrow checker，其他方面点到为止。Rust 处理内存的方式是其主要特点，这点我们应该尽早展示给学生。"
+"第一天的主要目标是要谈到著名的 borrow checker，其他方面点到为止。Rust 处理内"
+"存的方式是其主要特点，这点我们应该尽早展示给学生。"
 
 #: src/welcome-day-1.md:33
 msgid ""
 "If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
-msgstr "如果你是在教室里教授此课程，不妨在这里介绍一下时间安排。 这边建议是把每天分成两部分（跟着幻灯片来）："
+msgstr ""
+"如果你是在教室里教授此课程，不妨在这里介绍一下时间安排。 这边建议是把每天分成"
+"两部分（跟着幻灯片来）："
 
 #: src/welcome-day-1.md:36
 msgid "Morning: 9:00 to 12:00,"
@@ -2162,15 +2064,17 @@ msgstr "下午：13:00 到 16:00。"
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
 "breaks, we recommend a break every hour!"
-msgstr "当然你也可以看情况调整时间。但是请务必记得提供休息时间。我们建议每个小时休息一次！"
+msgstr ""
+"当然你也可以看情况调整时间。但是请务必记得提供休息时间。我们建议每个小时休息"
+"一次！"
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in "
-"2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
-"Rust 是一种新的编程语言，它的[1.0 版本于 2015 "
-"年发布](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html)："
+"Rust 是一种新的编程语言，它的[1.0 版本于 2015 年发布](https://blog.rust-lang."
+"org/2015/05/15/Rust-1.0.html)："
 
 #: src/welcome-day-1/what-is-rust.md:5
 msgid "Rust is a statically compiled language in a similar role as C++"
@@ -2182,11 +2086,11 @@ msgstr "`rustc` 使用 LLVM 作为它的后端。"
 
 #: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"Rust supports many [platforms and "
-"architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):"
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"Rust "
-"支持多种[平台和架构](https://doc.rust-lang.org/nightly/rustc/platform-support.html):"
+"Rust 支持多种[平台和架构](https://doc.rust-lang.org/nightly/rustc/platform-"
+"support.html):"
 
 #: src/welcome-day-1/what-is-rust.md:9
 msgid "x86, ARM, WebAssembly, ..."
@@ -2234,7 +2138,8 @@ msgstr "高度的控制能力。"
 
 #: src/welcome-day-1/what-is-rust.md:25
 #, fuzzy
-msgid "Can be scaled down to very constrained devices such as microcontrollers."
+msgid ""
+"Can be scaled down to very constrained devices such as microcontrollers."
 msgstr "能够在资源极度有限的设备（如手机）上运行。"
 
 #: src/welcome-day-1/what-is-rust.md:26
@@ -2295,14 +2200,18 @@ msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
 "see a ton of it over the next three days so we start small with something "
 "familiar."
-msgstr "这张幻灯片试图让学生们熟悉 Rust 代码。在接下来的四天里，他们会看到很多 Rust 代码, 所以我们从一些熟悉的东西开始。"
+msgstr ""
+"这张幻灯片试图让学生们熟悉 Rust 代码。在接下来的四天里，他们会看到很多 Rust "
+"代码, 所以我们从一些熟悉的东西开始。"
 
 #: src/hello-world.md:27
 #, fuzzy
 msgid ""
 "Rust is very much like other languages in the C/C++/Java tradition. It is "
 "imperative and it doesn't try to reinvent things unless absolutely necessary."
-msgstr "Rust 非常像 C/C++/Java 等其他传统语言。它是指令式语言（而非函数式），而且除非绝对必要，它不会尝试重新发明新的概念。"
+msgstr ""
+"Rust 非常像 C/C++/Java 等其他传统语言。它是指令式语言（而非函数式），而且除非"
+"绝对必要，它不会尝试重新发明新的概念。"
 
 #: src/hello-world.md:31
 msgid "Rust is modern with full support for things like Unicode."
@@ -2313,16 +2222,19 @@ msgid ""
 "Rust uses macros for situations where you want to have a variable number of "
 "arguments (no function [overloading](basic-syntax/functions-interlude.md))."
 msgstr ""
-"在需要处理可变数量的参数的情况下，Rust 使用宏（没有函数[重载](basic-syntax/functions-interlude.md)）。"
+"在需要处理可变数量的参数的情况下，Rust 使用宏（没有函数[重载](basic-syntax/"
+"functions-interlude.md)）。"
 
 #: src/hello-world.md:36
 msgid ""
 "Macros being 'hygienic' means they don't accidentally capture identifiers "
 "from the scope they are used in. Rust macros are actually only [partially "
-"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
 msgstr ""
-"宏是“卫生的”意味着它们不会意外地捕获它们所在作用域中的标识符。Rust "
-"的宏实际上只是[部分卫生](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)。"
+"宏是“卫生的”意味着它们不会意外地捕获它们所在作用域中的标识符。Rust 的宏实际上"
+"只是[部分卫生](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)。"
 
 #: src/hello-world.md:40
 msgid ""
@@ -2331,8 +2243,9 @@ msgid ""
 "while it is not a functional language, it includes a range of [functional "
 "concepts](https://doc.rust-lang.org/book/ch13-00-functional-features.html)."
 msgstr ""
-"Rust "
-"是多范式编程语言。例如，它具有强大的[面向对象的编程功能](https://doc.rust-lang.org/book/ch17-00-oop.html)，虽然它不是函数式语言，但包括一系列的[函数概念](https://doc.rust-lang.org/book/ch13-00-functional-features.html)。"
+"Rust 是多范式编程语言。例如，它具有强大的[面向对象的编程功能](https://doc."
+"rust-lang.org/book/ch17-00-oop.html)，虽然它不是函数式语言，但包括一系列的[函"
+"数概念](https://doc.rust-lang.org/book/ch13-00-functional-features.html)。"
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2377,14 +2290,18 @@ msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
 "will always end, but this is not yet proved. Edit the code and play with "
 "different inputs."
-msgstr "这段代码实现了 Collatz 猜想：猜想认为该循环总是会结束，但该猜想还没有被证明。可以编辑代码来尝试不同的输入。"
+msgstr ""
+"这段代码实现了 Collatz 猜想：猜想认为该循环总是会结束，但该猜想还没有被证明。"
+"可以编辑代码来尝试不同的输入。"
 
 #: src/hello-world/small-example.md:29
 msgid ""
 "Explain that all variables are statically typed. Try removing `i32` to "
 "trigger type inference. Try with `i8` instead and trigger a runtime integer "
 "overflow."
-msgstr "说明所有变量的类型都是静态的。尝试删除 `i32` 来触发类型推断。尝试使用 `i8` 来触发运行时整数溢出。"
+msgstr ""
+"说明所有变量的类型都是静态的。尝试删除 `i32` 来触发类型推断。尝试使用 `i8` 来"
+"触发运行时整数溢出。"
 
 #: src/hello-world/small-example.md:32
 msgid "Change `let mut x` to `let x`, discuss the compiler error."
@@ -2404,17 +2321,19 @@ msgstr "展示如何使用 `{}` 作为占位符，来输出比单个变量更复
 
 #: src/hello-world/small-example.md:40
 msgid ""
-"Show the students the standard library, show them how to search for "
-"`std::fmt` which has the rules of the formatting mini-language. It's "
-"important that the students become familiar with searching in the standard "
-"library."
-msgstr "向学生展示标准库，展示如何搜索 `std::fmt`，其中包含用于格式化字符串的微型语言规则。要点是让学生熟悉在标准库中搜索的过程。"
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"向学生展示标准库，展示如何搜索 `std::fmt`，其中包含用于格式化字符串的微型语言"
+"规则。要点是让学生熟悉在标准库中搜索的过程。"
 
 #: src/hello-world/small-example.md:44
 msgid ""
 "In a shell `rustup doc std::fmt` will open a browser on the local std::fmt "
 "documentation"
-msgstr "在 shell 中，运行“rustup doc std::fmt”会在浏览器中打开本地 std::fmt 文档"
+msgstr ""
+"在 shell 中，运行“rustup doc std::fmt”会在浏览器中打开本地 std::fmt 文档"
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
@@ -2445,8 +2364,9 @@ msgid ""
 "have the memory unsafety issues. In addition, you get a modern language with "
 "constructs like pattern matching and built-in dependency management."
 msgstr ""
-"使用过 C 或 C++：Rust 利用\"借用检查\"消除了一类 _运行时错误_ 。你可以达到堪比 C 和 C++ "
-"的性能，而没有内存不安全的问题。并且你还可以得到些现代的语言构造，比如模式匹配和内置依赖管理。"
+"使用过 C 或 C++：Rust 利用\"借用检查\"消除了一类 _运行时错误_ 。你可以达到堪"
+"比 C 和 C++ 的性能，而没有内存不安全的问题。并且你还可以得到些现代的语言构"
+"造，比如模式匹配和内置依赖管理。"
 
 #: src/why-rust.md:19
 msgid ""
@@ -2455,9 +2375,9 @@ msgid ""
 "addition you get fast and predictable performance like C and C++ (no garbage "
 "collector) as well as access to low-level hardware (should you need it)"
 msgstr ""
-"使用过 Java, Go, Python, "
-"JavaScript...：你可以得到和这些语言相同的内存安全特性，并拥有类似的使用高级语言的感受。同时你可以得到类似 C 和 C++ "
-"的高速且可预测的执行性能（无垃圾回收机制），以及在需要时对底层硬件的访问。"
+"使用过 Java, Go, Python, JavaScript...：你可以得到和这些语言相同的内存安全特"
+"性，并拥有类似的使用高级语言的感受。同时你可以得到类似 C 和 C++ 的高速且可预"
+"测的执行性能（无垃圾回收机制），以及在需要时对底层硬件的访问。"
 
 #: src/why-rust/an-example-in-c.md:4
 msgid "Let's consider the following \"minimum wrong example\" program in C:"
@@ -2478,8 +2398,7 @@ msgid ""
 "\n"
 "\tswitch (argc) {\n"
 "\t\tcase 1:\n"
-"\t\t\tprintf(\"Too few arguments!\\n"
-"\");\n"
+"\t\t\tprintf(\"Too few arguments!\\n\");\n"
 "\t\t\treturn 1;\n"
 "\n"
 "\t\tcase 2:\n"
@@ -2489,8 +2408,7 @@ msgid ""
 "\t\t\t\n"
 "\t\t\tbuf = (char*)malloc(len);\n"
 "\t\t\tif (!buf)\n"
-"\t\t\t\tprintf(\"malloc failed!\\n"
-"\", len);\n"
+"\t\t\t\tprintf(\"malloc failed!\\n\", len);\n"
 "\t\t\t\treturn 1;\n"
 "\n"
 "\t\t\tfp = fopen(filename, \"rb\");\n"
@@ -2498,12 +2416,10 @@ msgid ""
 "\t\t\tif (bytes = st.st_size)\n"
 "\t\t\t\tprintf(\"%s\", buf);\n"
 "\t\t\telse\n"
-"\t\t\t\tprintf(\"fread failed!\\n"
-"\");\n"
+"\t\t\t\tprintf(\"fread failed!\\n\");\n"
 "\n"
 "\t\tcase 3:\n"
-"\t\t\tprintf(\"Too many arguments!\\n"
-"\");\n"
+"\t\t\tprintf(\"Too many arguments!\\n\");\n"
 "\t\t\treturn 1;\n"
 "\t}\n"
 "\n"
@@ -2581,20 +2497,21 @@ msgstr ""
 #: src/why-rust/an-example-in-c.md:71
 msgid ""
 "Assignment `=` instead of equality comparison `==`: [The Linux Backdoor "
-"Attempt of "
-"2003](https://freedom-to-tinker.com/2013/10/09/the-linux-backdoor-attempt-of-2003)"
+"Attempt of 2003](https://freedom-to-tinker.com/2013/10/09/the-linux-backdoor-"
+"attempt-of-2003)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:72
 msgid ""
-"Forgotten braces in multi-line `if`: [The Apple goto fail "
-"vulnerability](https://dwheeler.com/essays/apple-goto-fail.html)"
+"Forgotten braces in multi-line `if`: [The Apple goto fail vulnerability]"
+"(https://dwheeler.com/essays/apple-goto-fail.html)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:73
 msgid ""
-"Forgotten `break` in a `switch` statement: [The break that broke "
-"sudo](https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-break-that-broke-sudo)"
+"Forgotten `break` in a `switch` statement: [The break that broke sudo]"
+"(https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-"
+"break-that-broke-sudo)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:75
@@ -2689,39 +2606,37 @@ msgid "No iterator invalidation."
 msgstr "不存在迭代器失效。"
 
 #: src/why-rust/compile-time.md:16
-msgid "It is possible to produce memory leaks in (safe) Rust. Some examples are:"
+msgid ""
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr "在（安全的）Rust 中也有可能产生内存泄漏。例如："
 
 #: src/why-rust/compile-time.md:19
 #, fuzzy
 msgid ""
-"You can use "
-"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) "
-"to leak a pointer. A use of this could be to get runtime-initialized and "
-"runtime-sized static variables"
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"可以使用 "
-"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) "
-"来泄漏一个指针。该方法可以用于得到在运行时决定大小和初始化的静态变量"
+"可以使用 [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) 来泄漏一个指针。该方法可以用于得到在运行时决定大小和初始化"
+"的静态变量"
 
 #: src/why-rust/compile-time.md:21
 msgid ""
-"You can use "
-"[`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html) to "
-"make the compiler \"forget\" about a value (meaning the destructor is never "
-"run)."
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
 msgstr ""
-"可以使用 [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html) "
-"来让编译器“忘记”一个值（即其析构函数不会被执行）。"
+"可以使用 [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) 来让编译器“忘记”一个值（即其析构函数不会被执行）。"
 
 #: src/why-rust/compile-time.md:23
 msgid ""
-"You can also accidentally create a [reference "
-"cycle](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html) with "
-"`Rc` or `Arc`."
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
 msgstr ""
-"可以使用 `Rc` 或 `Arc` 意外创建一个循环引用（[reference "
-"cycle](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html)）。"
+"可以使用 `Rc` 或 `Arc` 意外创建一个循环引用（[reference cycle](https://doc."
+"rust-lang.org/book/ch15-06-reference-cycles.html)）。"
 
 #: src/why-rust/compile-time.md:25
 msgid ""
@@ -2751,16 +2666,16 @@ msgstr "整数溢出的行为有明确定义。"
 #: src/why-rust/runtime.md:12
 #, fuzzy
 msgid ""
-"Integer overflow is defined via the "
-"[`overflow-checks`](https://doc.rust-lang.org/rustc/codegen-options/index.html#overflow-checks) "
-"compile-time flag. If enabled, the program will panic (a controlled crash of "
-"the program), otherwise you get wrap-around semantics. By default, you get "
+"Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
+"lang.org/rustc/codegen-options/index.html#overflow-checks) compile-time "
+"flag. If enabled, the program will panic (a controlled crash of the "
+"program), otherwise you get wrap-around semantics. By default, you get "
 "panics in debug mode (`cargo build`) and wrap-around in release mode (`cargo "
 "build --release`)."
 msgstr ""
-"整数溢出的行为由编译时的标志指定。可以选择 "
-"panic（一种受控的程序崩溃）或使用“绕回（wrap-around）”语义。默认情况下，使用调试模式编译（`cargo build`）的行为为 "
-"panic，使用发布模式编译（`cargo build --release`）的行为为“绕回”。"
+"整数溢出的行为由编译时的标志指定。可以选择 panic（一种受控的程序崩溃）或使"
+"用“绕回（wrap-around）”语义。默认情况下，使用调试模式编译（`cargo build`）的"
+"行为为 panic，使用发布模式编译（`cargo build --release`）的行为为“绕回”。"
 
 #: src/why-rust/runtime.md:18
 msgid ""
@@ -2769,8 +2684,8 @@ msgid ""
 "call functions such as `slice::get_unchecked` which does not do bounds "
 "checking."
 msgstr ""
-"边界检查不能使用编译标志禁用，也不能直接通过 `unsafe` 关键字禁用。然而， `unsafe` 允许你调用 "
-"`slice::get_unchecked` 等不做边界检查的函数。"
+"边界检查不能使用编译标志禁用，也不能直接通过 `unsafe` 关键字禁用。然而， "
+"`unsafe` 允许你调用 `slice::get_unchecked` 等不做边界检查的函数。"
 
 #: src/why-rust/modern.md:3
 #, fuzzy
@@ -2824,8 +2739,9 @@ msgid ""
 "writing a loop using `for` should result in roughly the same low level "
 "instructions as using the `.iter().fold()` construct."
 msgstr ""
-"与 C++ 类似的零成本抽象，意味着你不需要为高级程序语言的结构“付出”更多的内存和 CPU。例如使用 `for` 循环与使用 "
-"`.iter().fold()` 结构应该会生成大致相同的底层指令。"
+"与 C++ 类似的零成本抽象，意味着你不需要为高级程序语言的结构“付出”更多的内存"
+"和 CPU。例如使用 `for` 循环与使用 `.iter().fold()` 结构应该会生成大致相同的底"
+"层指令。"
 
 #: src/why-rust/modern.md:28
 msgid ""
@@ -2833,8 +2749,8 @@ msgid ""
 "known as 'sum types', which allow the type system to express things like "
 "`Option<T>` and `Result<T, E>`."
 msgstr ""
-"值得一提的是，Rust 的枚举是“代数数据类型”（也叫“和类型”）。它使得类型系统可以表示 `Option<T>` 和 `Result<T, E>` "
-"等结构。"
+"值得一提的是，Rust 的枚举是“代数数据类型”（也叫“和类型”）。它使得类型系统可以"
+"表示 `Option<T>` 和 `Result<T, E>` 等结构。"
 
 #: src/why-rust/modern.md:32
 msgid ""
@@ -2843,15 +2759,18 @@ msgid ""
 "talkative than other compilers. It will often provide you with _actionable_ "
 "feedback, ready to copy-paste into your code."
 msgstr ""
-"提醒学生去阅读编译错误 --- 许多开发者已经习惯去忽略冗长的编译器输出。Rust 编译器会比其它编译器更健谈。它通常会提供 _可操作的_ "
-"反馈，可以直接复制粘贴到代码中。"
+"提醒学生去阅读编译错误 --- 许多开发者已经习惯去忽略冗长的编译器输出。Rust 编"
+"译器会比其它编译器更健谈。它通常会提供 _可操作的_ 反馈，可以直接复制粘贴到代"
+"码中。"
 
 #: src/why-rust/modern.md:37
 msgid ""
 "The Rust standard library is small compared to languages like Java, Python, "
 "and Go. Rust does not come with several things you might consider standard "
 "and essential:"
-msgstr "相比 Java, Python 和 Go 等语言，Rust 标准库较为精简。Rust 并没有内置一些你可能认为标准和必要的功能："
+msgstr ""
+"相比 Java, Python 和 Go 等语言，Rust 标准库较为精简。Rust 并没有内置一些你可"
+"能认为标准和必要的功能："
 
 #: src/why-rust/modern.md:41
 msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
@@ -2872,32 +2791,35 @@ msgid ""
 "Rust community is still working on finding the best solution --- and perhaps "
 "there isn't a single \"best solution\" for some of these things."
 msgstr ""
-"Rust 这么做的原因是标准库中的功能是无法去除的，因此该功能必须非常稳定。对于以上例子，Rust 社区仍在寻找最佳解决方案 --- "
-"甚至对一些情况可能没有单一的“最佳解决方案”。"
+"Rust 这么做的原因是标准库中的功能是无法去除的，因此该功能必须非常稳定。对于以"
+"上例子，Rust 社区仍在寻找最佳解决方案 --- 甚至对一些情况可能没有单一的“最佳解"
+"决方案”。"
 
 #: src/why-rust/modern.md:50
 msgid ""
 "Rust comes with a built-in package manager in the form of Cargo and this "
 "makes it trivial to download and compile third-party crates. A consequence "
 "of this is that the standard library can be smaller."
-msgstr "Rust 内置了一个包管理器 Cargo，使得下载和编译第三方 crate 变得简单。这也导致标准库可以更加精简。"
+msgstr ""
+"Rust 内置了一个包管理器 Cargo，使得下载和编译第三方 crate 变得简单。这也导致"
+"标准库可以更加精简。"
 
 #: src/why-rust/modern.md:54
 msgid ""
-"Discovering good third-party crates can be a problem. Sites like "
-"<https://lib.rs/> help with this by letting you compare health metrics for "
-"crates to find a good and trusted one."
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
 msgstr ""
-"发现高质量的第三方 crate 也许是一个问题。 <https://lib.rs/> 等网站对此问题有所帮助。它能帮你比较 crate "
-"的健康指标，以找到一个高质量并受信任的 crate。"
+"发现高质量的第三方 crate 也许是一个问题。 <https://lib.rs/> 等网站对此问题有"
+"所帮助。它能帮你比较 crate 的健康指标，以找到一个高质量并受信任的 crate。"
 
 #: src/why-rust/modern.md:58
 msgid ""
 "[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
 "implementation used in major IDEs and text editors."
 msgstr ""
-"[rust-analyzer](https://rust-analyzer.github.io/) 是一个受到广泛支持的 LSP 实现，被主流的 IDE "
-"和文本编辑器所使用。"
+"[rust-analyzer](https://rust-analyzer.github.io/) 是一个受到广泛支持的 LSP 实"
+"现，被主流的 IDE 和文本编辑器所使用。"
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
@@ -2921,14 +2843,12 @@ msgstr "`if` 和 `while` 等关键词作用与以上语言一致。"
 msgid "Variable assignment is done with `=`, comparison is done with `==`."
 msgstr "变量赋值使用 `=`，值之间比较使用 `==`。"
 
-#: src/basic-syntax/scalar-types.md:3
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
 msgid "Types"
 msgstr "类型"
 
-#: src/basic-syntax/scalar-types.md:3
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
 msgid "Literals"
 msgstr "字面量"
 
@@ -3035,14 +2955,12 @@ msgstr "上表中还有一些未提及的语法："
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"Raw strings allow you to create a `&str` value with escapes disabled: `r\"\\n"
-"\" == \"\\\\n"
-"\"`. You can embed double-quotes by using an equal amount of `#` on either "
-"side of the quotes:"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
-"原始字符串可在创建 `&str` 时禁用转义：`r\"\\n"
-"\" == \"\\\\n"
-"\"`。可以在外层引号两侧添加相同数量的 `#`，以在字符串中嵌入双引号："
+"原始字符串可在创建 `&str` 时禁用转义：`r\"\\n\" == \"\\\\n\"`。可以在外层引号"
+"两侧添加相同数量的 `#`，以在字符串中嵌入双引号："
 
 #: src/basic-syntax/scalar-types.md:35
 msgid "Byte strings allow you to create a `&[u8]` value directly:"
@@ -3054,7 +2972,8 @@ msgid ""
 "`1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written "
 "as `123i64`."
 msgstr ""
-"数字中的所有下划线均可忽略，它们只是为了方便辨识。因此，“1_000”可以写为“1000”（或“10_00”），而“123_i64”可以写为“123i64”。"
+"数字中的所有下划线均可忽略，它们只是为了方便辨识。因此，“1_000”可以写"
+"为“1000”（或“10_00”），而“123_i64”可以写为“123i64”。"
 
 #: src/basic-syntax/compound-types.md:5
 msgid "Arrays"
@@ -3100,8 +3019,9 @@ msgid ""
 "its type_, which means that `[u8; 3]` and `[u8; 4]` are considered two "
 "different types."
 msgstr ""
-"数组中的元素具有相同的类型 `T`，数组的长度为 `N`，`N` 是一个编译期常量。 需要注意的是数组的长度是它_类型的一部分\\_, 这意味着 "
-"`[u8; 3]` 和 `[u8; 4]` 在 Rust 中被认为是不同的类型。"
+"数组中的元素具有相同的类型 `T`，数组的长度为 `N`，`N` 是一个编译期常量。 需要"
+"注意的是数组的长度是它_类型的一部分\\_, 这意味着 `[u8; 3]` 和 `[u8; 4]` 在 "
+"Rust 中被认为是不同的类型。"
 
 #: src/basic-syntax/compound-types.md:40
 msgid "We can use literals to assign values to arrays."
@@ -3114,14 +3034,17 @@ msgid ""
 "the debug output. We could also have used `{a}` and `{a:?}` without "
 "specifying the value after the format string."
 msgstr ""
-"在主函数中，打印（print）语句使用 `?` 格式请求调试实现。 使用参数 `{}` 打印默认输出，`{:?}` 表示以调试格式输出。 "
-"我们也可以不在格式化字符串后面指定变量值，直接使用 `{a}` 和 `{a:?}` 进行输出。"
+"在主函数中，打印（print）语句使用 `?` 格式请求调试实现。 使用参数 `{}` 打印默"
+"认输出，`{:?}` 表示以调试格式输出。 我们也可以不在格式化字符串后面指定变量"
+"值，直接使用 `{a}` 和 `{a:?}` 进行输出。"
 
 #: src/basic-syntax/compound-types.md:47
 msgid ""
 "Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
 "easier to read."
-msgstr "添加 `#`, 比如 `{a:#?}`, 会输出“美观打印（pretty printing）” 格式, 这种格式可能会更加易读。"
+msgstr ""
+"添加 `#`, 比如 `{a:#?}`, 会输出“美观打印（pretty printing）” 格式, 这种格式可"
+"能会更加易读。"
 
 #: src/basic-syntax/compound-types.md:49
 msgid "Tuples:"
@@ -3148,8 +3071,9 @@ msgid ""
 "value are expressed as `()`. It is used to indicate, for example, that a "
 "function or expression has no return value, as we'll see in a future slide. "
 msgstr ""
-"空元组 `()` 也被称作 “单元（unit）类型”. 它既是一个类型， 也是这种类型的唯一值——也就是说它的类型和它的  值都被表示为 "
-"`()`。它通常用于表示，比如，一个  函数或表达式没有返回值，我们会在后续的幻灯片种见到这种用法。"
+"空元组 `()` 也被称作 “单元（unit）类型”. 它既是一个类型， 也是这种类型的唯一"
+"值——也就是说它的类型和它的  值都被表示为 `()`。它通常用于表示，比如，一个  函"
+"数或表达式没有返回值，我们会在后续的幻灯片种见到这种用法。"
 
 #: src/basic-syntax/compound-types.md:61
 msgid ""
@@ -3169,19 +3093,24 @@ msgstr "一些注意事项："
 msgid ""
 "We must dereference `ref_x` when assigning to it, similar to C and C++ "
 "pointers."
-msgstr "就像 C 与 C++ 中的指针一样，对引用 `ref_x` 进行赋值时，我们必须对其解引用。"
+msgstr ""
+"就像 C 与 C++ 中的指针一样，对引用 `ref_x` 进行赋值时，我们必须对其解引用。"
 
 #: src/basic-syntax/references.md:18
 msgid ""
 "Rust will auto-dereference in some cases, in particular when invoking "
 "methods (try `ref_x.count_ones()`)."
-msgstr "Rust 有时会进行自动解引用。比如调用方法 `ref_x.count_ones()` 时，ref_x 会被解引用。"
+msgstr ""
+"Rust 有时会进行自动解引用。比如调用方法 `ref_x.count_ones()` 时，ref_x 会被解"
+"引用。"
 
 #: src/basic-syntax/references.md:20
 msgid ""
 "References that are declared as `mut` can be bound to different values over "
 "their lifetime."
-msgstr "如果引用值被声明为 `mut`（可变引用），那么这个引用值可以在它的生命周期内被绑定为不同的值。"
+msgstr ""
+"如果引用值被声明为 `mut`（可变引用），那么这个引用值可以在它的生命周期内被绑"
+"定为不同的值。"
 
 #: src/basic-syntax/references.md:26
 msgid ""
@@ -3190,8 +3119,9 @@ msgid ""
 "to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"注意 `let mut ref_x: &i32` 与 `let ref_x: &mut i32` "
-"之间的区别。第一条语句声明了一个可变引用，所以我们可以修改这个引用所绑定的值；第二条语句声明了一个指向可变变量的引用。"
+"注意 `let mut ref_x: &i32` 与 `let ref_x: &mut i32` 之间的区别。第一条语句声"
+"明了一个可变引用，所以我们可以修改这个引用所绑定的值；第二条语句声明了一个指"
+"向可变变量的引用。"
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -3238,14 +3168,16 @@ msgid ""
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
 "identical."
 msgstr ""
-"如果切片的起始下标为 0， Rust 语法允许我们省略起始下标。比如说 `&a[0..a.len()]` 与 `&a[..a.len()]` 是等价的。"
+"如果切片的起始下标为 0， Rust 语法允许我们省略起始下标。比如说 `&a[0..a."
+"len()]` 与 `&a[..a.len()]` 是等价的。"
 
 #: src/basic-syntax/slices.md:26
 #, fuzzy
 msgid ""
 "The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
 "identical."
-msgstr "结尾下标也可以用相同方式省略。比如说 `&a[2..a.len()]` 和 `&a[2..]` 是等价的。"
+msgstr ""
+"结尾下标也可以用相同方式省略。比如说 `&a[2..a.len()]` 和 `&a[2..]` 是等价的。"
 
 #: src/basic-syntax/slices.md:28
 #, fuzzy
@@ -3259,7 +3191,9 @@ msgid ""
 "`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
 "computation on slices of different sizes."
-msgstr "切片会从另外一个对象中借用数据。在这个例子中， `a` 必须在其切片存活时保持存活（处于作用域中）。"
+msgstr ""
+"切片会从另外一个对象中借用数据。在这个例子中， `a` 必须在其切片存活时保持存活"
+"（处于作用域中）。"
 
 #: src/basic-syntax/slices.md:32
 #, fuzzy
@@ -3267,8 +3201,9 @@ msgid ""
 "Slices always borrow from another object. In this example, `a` has to remain "
 "'alive' (in scope) for at least as long as our slice. "
 msgstr ""
-"关于修改 `a[3]` 的问题可能会引发精彩的讨论。正确答案是：为了保证内存安全，在创建切片后，我们不能通过 `a` 来修改数据。不过我们可以通过 "
-"`a` 或者 `s` 来读取数据。我们将会在“借用”章节着重介绍这个内容。"
+"关于修改 `a[3]` 的问题可能会引发精彩的讨论。正确答案是：为了保证内存安全，在"
+"创建切片后，我们不能通过 `a` 来修改数据。不过我们可以通过 `a` 或者 `s` 来读取"
+"数据。我们将会在“借用”章节着重介绍这个内容。"
 
 #: src/basic-syntax/slices.md:34
 msgid ""
@@ -3279,8 +3214,10 @@ msgid ""
 "`println`, when the slice is no longer used. More details will be explained "
 "in the borrow checker section."
 msgstr ""
-"关于修改“a\\[3\\]”的问题可能会引发一些有趣的讨论，但正解是，出于内存安全方面的原因，您无法在执行作业的这个时间点通过“a”来进行此修改，但可以从“a”和“s”安全地读取数据。它会在您创建 "
-"Slice 之前运作，在“println”之后（不再使用 Slice 时）再次运作。更多详情会在“借用检查器”部分中加以说明。"
+"关于修改“a\\[3\\]”的问题可能会引发一些有趣的讨论，但正解是，出于内存安全方面"
+"的原因，您无法在执行作业的这个时间点通过“a”来进行此修改，但可以从“a”和“s”安全"
+"地读取数据。它会在您创建 Slice 之前运作，在“println”之后（不再使用 Slice 时）"
+"再次运作。更多详情会在“借用检查器”部分中加以说明。"
 
 #: src/basic-syntax/string-slices.md:1
 msgid "`String` vs `str`"
@@ -3326,14 +3263,16 @@ msgid ""
 "encoded string data  stored in a block of memory. String literals "
 "(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"`&str` 引入了一个字符串切片，它是一个指向保存在内存块中的 UTF-8 编码字符串数据的不可变引用。   "
-"字符串字面量（`”Hello”`）会保存在程序的二进制文件中。"
+"`&str` 引入了一个字符串切片，它是一个指向保存在内存块中的 UTF-8 编码字符串数"
+"据的不可变引用。   字符串字面量（`”Hello”`）会保存在程序的二进制文件中。"
 
 #: src/basic-syntax/string-slices.md:30
 msgid ""
 "Rust’s `String` type is a wrapper around a vector of bytes. As with a "
 "`Vec<T>`, it is owned."
-msgstr "Rust 的 `String` 类型是一个字节 vector 的封装。和 `Vec<T>` 一样，它是拥有所有权的。"
+msgstr ""
+"Rust 的 `String` 类型是一个字节 vector 的封装。和 `Vec<T>` 一样，它是拥有所有"
+"权的。"
 
 #: src/basic-syntax/string-slices.md:32
 msgid ""
@@ -3341,14 +3280,17 @@ msgid ""
 "literal; `String::new()`  creates a new empty string, to which string data "
 "can be added using the `push()` and `push_str()` methods."
 msgstr ""
-"和其他类型一样，`String::from()` 会从字符串字面量创建一个字符串；`String::new()` 会创建一个新的空字符串，   "
-"之后可以使用 `push()` 和 `push_str()` 方法向其中添加字符串数据。"
+"和其他类型一样，`String::from()` 会从字符串字面量创建一个字符串；`String::"
+"new()` 会创建一个新的空字符串，   之后可以使用 `push()` 和 `push_str()` 方法"
+"向其中添加字符串数据。"
 
 #: src/basic-syntax/string-slices.md:35
 msgid ""
 "The `format!()` macro is a convenient way to generate an owned string from "
 "dynamic values. It  accepts the same format specification as `println!()`."
-msgstr "`format!()` 宏可以方便地动态生成拥有所有权的字符串。它接受和 `println!()` 相同的格式规范。"
+msgstr ""
+"`format!()` 宏可以方便地动态生成拥有所有权的字符串。它接受和 `println!()` 相"
+"同的格式规范。"
 
 #: src/basic-syntax/string-slices.md:38
 msgid ""
@@ -3363,21 +3305,25 @@ msgid ""
 "equivalent of `std::string` from C++  (main difference: it can only contain "
 "UTF-8 encoded bytes and will never use a small-string optimization)."
 msgstr ""
-"对于 C++ 程序员：可以把 `&str` 当作 C++ 中的 `const char*`，但是它总是指向内存中的一个有效字符串。   Rust 的 "
-"`String` 大致相当于 C++ 中 `std::string` （主要区别：它只能包含 UTF-8 编码的字节，   "
-"并且永远不会使用小字符串优化（small-string optimization））。"
+"对于 C++ 程序员：可以把 `&str` 当作 C++ 中的 `const char*`，但是它总是指向内"
+"存中的一个有效字符串。   Rust 的 `String` 大致相当于 C++ 中 `std::string` "
+"（主要区别：它只能包含 UTF-8 编码的字节，   并且永远不会使用小字符串优化"
+"（small-string optimization））。"
 
 #: src/basic-syntax/functions.md:3
 msgid ""
-"A Rust version of the famous "
-"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
-msgstr "一个 Rust 版本的著名 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 面试题："
+"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
+"Fizz_buzz) interview question:"
+msgstr ""
+"一个 Rust 版本的著名 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 面试"
+"题："
 
 #: src/basic-syntax/functions.md:36
 msgid ""
 "We refer in `main` to a function written below. Neither forward declarations "
 "nor headers are necessary. "
-msgstr "我们在 `main` 中引用了下面编写的一个函数。不需要提前声明或添加头文件。 "
+msgstr ""
+"我们在 `main` 中引用了下面编写的一个函数。不需要提前声明或添加头文件。 "
 
 #: src/basic-syntax/functions.md:37
 msgid ""
@@ -3389,22 +3335,29 @@ msgstr "类型跟随在声明的参数后（与某些编程语言相反），然
 msgid ""
 "The last expression in a function body (or any block) becomes the return "
 "value. Simply omit the `;` at the end of the expression."
-msgstr "函数体（或任何块）中的最后一个表达式将成为返回值。只需省略表达式末尾的 `;` 即可。"
+msgstr ""
+"函数体（或任何块）中的最后一个表达式将成为返回值。只需省略表达式末尾的 `;` 即"
+"可。"
 
 #: src/basic-syntax/functions.md:39
 msgid ""
 "Some functions have no return value, and return the 'unit type', `()`. The "
 "compiler will infer this if the `-> ()` return type is omitted."
-msgstr "有些函数没有返回值，会返回“单元类型（unit type）”`()`。如果省略了`-> ()`的返回类型，编译器将会自动推断。"
+msgstr ""
+"有些函数没有返回值，会返回“单元类型（unit type）”`()`。如果省略了`-> ()`的返"
+"回类型，编译器将会自动推断。"
 
 #: src/basic-syntax/functions.md:40
 msgid ""
 "The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
 "`=n`, which causes it to include the upper bound."
-msgstr "`print_fizzbuzz_to()`函数中`for`循环的范围表达式（range expression）包含`=n`，这会导致它包括上限。"
+msgstr ""
+"`print_fizzbuzz_to()`函数中`for`循环的范围表达式（range expression）包含"
+"`=n`，这会导致它包括上限。"
 
 #: src/basic-syntax/rustdoc.md:3
-msgid "All language items in Rust can be documented using special `///` syntax."
+msgid ""
+"All language items in Rust can be documented using special `///` syntax."
 msgstr "Rust 中的所有语言元素都可以通过特殊的 `///` 语法进行文档化。"
 
 #: src/basic-syntax/rustdoc.md:5
@@ -3445,26 +3398,31 @@ msgstr ""
 #, fuzzy
 msgid ""
 "The contents are treated as Markdown. All published Rust library crates are "
-"automatically documented at [`docs.rs`](https://docs.rs) using the "
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is idiomatic to document all public items in an API using this pattern. Code "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
+"idiomatic to document all public items in an API using this pattern. Code "
 "snippets can document usage and will be used as unit tests."
 msgstr ""
-"文档的内容会被当做 Markdown 处理。所有已发布 Rust 库 crate "
-"都会自动被[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 工具在 "
-"[`docs.rs`](https://docs.rs)存档。 按照这种方式来为 API 中的所有公开项编写文档是 Rust 中惯用的做法。"
+"文档的内容会被当做 Markdown 处理。所有已发布 Rust 库 crate 都会自动被"
+"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 工具在 "
+"[`docs.rs`](https://docs.rs)存档。 按照这种方式来为 API 中的所有公开项编写文"
+"档是 Rust 中惯用的做法。"
 
 #: src/basic-syntax/rustdoc.md:30
 msgid ""
-"Show students the generated docs for the `rand` crate at "
-"[`docs.rs/rand`](https://docs.rs/rand)."
-msgstr "向学生展示在 [`docs.rs/rand`](https://docs.rs/rand) 中为 `rand` crate 生成的文档。"
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
+msgstr ""
+"向学生展示在 [`docs.rs/rand`](https://docs.rs/rand) 中为 `rand` crate 生成的"
+"文档。"
 
 #: src/basic-syntax/rustdoc.md:33
 msgid ""
 "This course does not include rustdoc on slides, just to save space, but in "
 "real code they should be present."
-msgstr "本课程的幻灯片中不包含 rustdoc，这是为了节省空间，但是在实际的代码中，应当编写相关的程序文档。"
+msgstr ""
+"本课程的幻灯片中不包含 rustdoc，这是为了节省空间，但是在实际的代码中，应当编"
+"写相关的程序文档。"
 
 #: src/basic-syntax/rustdoc.md:36
 msgid ""
@@ -3475,17 +3433,18 @@ msgstr "内部文档注释将在稍后（在讲解模块的页面）讨论，这
 #: src/basic-syntax/rustdoc.md:39
 msgid ""
 "Rustdoc comments can contain code snippets that we can run and test using "
-"`cargo test`. We will discuss these tests in the [Testing "
-"section](../testing/doc-tests.html)."
+"`cargo test`. We will discuss these tests in the [Testing section](../"
+"testing/doc-tests.html)."
 msgstr ""
-"Rustdoc 注释可以包含我们可使用“cargo "
-"test”运行和测试的代码段。我们将在[“测试”部分](../testing/doc-tests.html)中讨论这些测试。"
+"Rustdoc 注释可以包含我们可使用“cargo test”运行和测试的代码段。我们将在[“测"
+"试”部分](../testing/doc-tests.html)中讨论这些测试。"
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
 "method is an instance of the type it is associated with:"
-msgstr "方法是与某种类型关联的函数。方法的 `self` 参数是与其关联类型的一个实例："
+msgstr ""
+"方法是与某种类型关联的函数。方法的 `self` 参数是与其关联类型的一个实例："
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3532,16 +3491,19 @@ msgid ""
 "constructor, `Rectangle { width, height }`, could be called directly. See "
 "the [Rustnomicon](https://doc.rust-lang.org/nomicon/constructors.html)."
 msgstr ""
-"虽然从技术层面来讲，Rust 没有自定义构造函数，但静态方法通常用于初始化结构体（但并非必须这样做）。您可以直接调用实际构造函数“Rectangle { "
-"width, height }”。请参阅 [Rust "
-"秘典](https://doc.rust-lang.org/nomicon/constructors.html)。"
+"虽然从技术层面来讲，Rust 没有自定义构造函数，但静态方法通常用于初始化结构体"
+"（但并非必须这样做）。您可以直接调用实际构造函数“Rectangle { width, "
+"height }”。请参阅 [Rust 秘典](https://doc.rust-lang.org/nomicon/constructors."
+"html)。"
 
 #: src/basic-syntax/methods.md:45
 #, fuzzy
 msgid ""
 "Add a `Rectangle::square(width: u32)` constructor to illustrate that such "
 "static methods can take arbitrary parameters."
-msgstr "新增一个 `Rectangle::new_square(width: u32)` 构造函数来说明构造函数可以接受任意参数。"
+msgstr ""
+"新增一个 `Rectangle::new_square(width: u32)` 构造函数来说明构造函数可以接受任"
+"意参数。"
 
 #: src/basic-syntax/functions-interlude.md:1
 msgid "Function Overloading"
@@ -3608,7 +3570,9 @@ msgid ""
 "When using generics, the standard library's `Into<T>` can provide a kind of "
 "limited polymorphism on argument types. We will see more details in a later "
 "section."
-msgstr "标准库中的 `Into<T>` 通过泛型参数提供了一种具有有限多态性的参数类型。详见之后的章节。"
+msgstr ""
+"标准库中的 `Into<T>` 通过泛型参数提供了一种具有有限多态性的参数类型。详见之后"
+"的章节。"
 
 #: src/exercises/day-1/morning.md:1
 msgid "Day 1: Morning Exercises"
@@ -3632,10 +3596,12 @@ msgstr "在解题时要考虑几件事："
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"Use a local Rust installation, if possible. This way you can get "
-"auto-completion in your editor. See the page about [Using "
-"Cargo](../../cargo.md) for details on installing Rust."
-msgstr "最好使用本地安装的 Rust，以实现在编辑器中自动补全。关于安装 Rust 的细节，请参见 \\[使用 Cargo\\] 页面。"
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
+msgstr ""
+"最好使用本地安装的 Rust，以实现在编辑器中自动补全。关于安装 Rust 的细节，请参"
+"见 \\[使用 Cargo\\] 页面。"
 
 #: src/exercises/day-1/morning.md:17
 msgid "Alternatively, use the Rust Playground."
@@ -3645,63 +3611,63 @@ msgstr "也可以使用 Rust Playground 作为替代。"
 msgid ""
 "The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
-msgstr "页面内嵌的代码片段是不可编辑的：因为离开页面后内嵌代码片段中的修改会丢失。"
+msgstr ""
+"页面内嵌的代码片段是不可编辑的：因为离开页面后内嵌代码片段中的修改会丢失。"
 
-#: src/exercises/day-1/morning.md:22
-#: src/exercises/day-2/morning.md:11
-#: src/exercises/day-3/morning.md:9
-#: src/exercises/bare-metal/morning.md:7
+#: src/exercises/day-1/morning.md:22 src/exercises/day-2/morning.md:11
+#: src/exercises/day-3/morning.md:9 src/exercises/bare-metal/morning.md:7
 #: src/exercises/concurrency/morning.md:12
 #, fuzzy
 msgid ""
-"After looking at the exercises, you can look at the "
-"[solutions](solutions-morning.md) provided."
+"After looking at the exercises, you can look at the [solutions](solutions-"
+"morning.md) provided."
 msgstr "读完习题后，可以阅读本书提供的 \\[题解\\]。"
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike "
-"C++](https://en.cppreference.com/w/cpp/language/implicit_conversion)). You "
-"can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
-"[与 C++ "
-"不同](https://en.cppreference.com/w/cpp/language/implicit_conversion)，Rust "
-"不会自动进行 _隐式类型转换_。例如，下面的程序中不存在隐式类型转换："
+"[与 C++ 不同](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)，Rust 不会自动进行 _隐式类型转换_。例如，下面的程序中不"
+"存在隐式类型转换："
 
 #: src/exercises/day-1/implicit-conversions.md:20
 msgid ""
-"The Rust integer types all implement the "
-"[`From<T>`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
-"[`Into<T>`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits to "
-"let us convert between them. The `From<T>` trait has a single `from()` "
-"method and similarly, the `Into<T>` trait has a single `into()` method. "
-"Implementing these traits is how a type expresses that it can be converted "
-"into another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Rust 的整数类型都实现了 "
-"[`From<T>`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
-"[`Into<T>`](https://doc.rust-lang.org/std/convert/trait.Into.html) "
-"trait，使得我们可以在它们之间进行转换。`From<T>` trait 包含 `from()` 方法，`Into<T>` trait 包含 "
-"`into()` 方法。类型通过实现这些 trait 来表达它将被如何转换为另一个类型。"
+"Rust 的整数类型都实现了 [`From<T>`](https://doc.rust-lang.org/std/convert/"
+"trait.From.html) 和 [`Into<T>`](https://doc.rust-lang.org/std/convert/trait."
+"Into.html) trait，使得我们可以在它们之间进行转换。`From<T>` trait 包含 "
+"`from()` 方法，`Into<T>` trait 包含 `into()` 方法。类型通过实现这些 trait 来"
+"表达它将被如何转换为另一个类型。"
 
 #: src/exercises/day-1/implicit-conversions.md:26
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means that we can convert a variable `x` of type `i8` to an `i16` by calling "
-" `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16` "
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
-"标准库中包含 `From<i8> for i16` 的实现，即我们可以通过调用 `i16::from(x)` 来将 `i8` 类型的变量 `x` 转换为 "
-"`i16`。或者也可以简单地使用 `x.into()`，因为 `From<i8> for i16` 的实现会自动创建 `Into<i16> for "
-"i8` 的实现。"
+"标准库中包含 `From<i8> for i16` 的实现，即我们可以通过调用 `i16::from(x)` 来"
+"将 `i8` 类型的变量 `x` 转换为 `i16`。或者也可以简单地使用 `x.into()`，因为 "
+"`From<i8> for i16` 的实现会自动创建 `Into<i16> for i8` 的实现。"
 
 #: src/exercises/day-1/implicit-conversions.md:31
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
 "it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
-msgstr "这同样也适用于自定义类型的 `From` 实现，只需实现 `From` 就可以自动得到对应的 `Into` 实现。"
+msgstr ""
+"这同样也适用于自定义类型的 `From` 实现，只需实现 `From` 就可以自动得到对应的 "
+"`Into` 实现。"
 
 #: src/exercises/day-1/implicit-conversions.md:34
 msgid "Execute the above program and look at the compiler error."
@@ -3716,14 +3682,13 @@ msgid ""
 "Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
 "`i128`) to see which types you can convert to which other types. Try "
 "converting small types to big types and the other way around. Check the "
-"[standard library "
-"documentation](https://doc.rust-lang.org/std/convert/trait.From.html) to see "
-"if `From<T>` is implemented for the pairs you check."
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
-"修改 `x` 和 `y` 的类型（例如 `f32`, `bool`, `i128` "
-"等）来了解哪些类型之间可以相互转换。尝试将较小的类型转换为较大的类型和将较大的类型转换为较小的类型。阅读 "
-"[标准库文档](https://doc.rust-lang.org/std/convert/trait.From.html) "
-"来了解对于你所尝试的两个类型 `From<T>` 是否已被实现。"
+"修改 `x` 和 `y` 的类型（例如 `f32`, `bool`, `i128` 等）来了解哪些类型之间可以"
+"相互转换。尝试将较小的类型转换为较大的类型和将较大的类型转换为较小的类型。阅"
+"读 [标准库文档](https://doc.rust-lang.org/std/convert/trait.From.html) 来了解"
+"对于你所尝试的两个类型 `From<T>` 是否已被实现。"
 
 #: src/exercises/day-1/for-loops.md:1
 #: src/exercises/day-1/solutions-morning.md:3
@@ -3736,8 +3701,8 @@ msgstr "我们可以这样声明一个数组："
 
 #: src/exercises/day-1/for-loops.md:9
 msgid ""
-"You can print such an array by asking for its debug representation with "
-"`{:?}`:"
+"You can print such an array by asking for its debug representation with `{:?}"
+"`:"
 msgstr "你可以使用 `{:?}` 来打印这种数组的调试格式："
 
 #: src/exercises/day-1/for-loops.md:19
@@ -3789,7 +3754,8 @@ msgid ""
 "and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
-"使用以上知识，写一个用易读的格式输出矩阵的 `pretty_print` 函数，以及一个对矩阵进行转置（将行和列互换）的 `transpose` 函数："
+"使用以上知识，写一个用易读的格式输出矩阵的 `pretty_print` 函数，以及一个对矩"
+"阵进行转置（将行和列互换）的 `transpose` 函数："
 
 #: src/exercises/day-1/for-loops.md:49
 msgid "Hard-code both functions to operate on 3 × 3 matrices."
@@ -3869,26 +3835,32 @@ msgid ""
 "argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"是否可以使用 `&[i32]` 切片而不是硬编码的 3 × 3 矩阵作为函数的参数和返回类型？例如使用 `&[&[i32]]` "
-"表示一个二维的切片的切片。为什么这样做是可行或不可行的？"
+"是否可以使用 `&[i32]` 切片而不是硬编码的 3 × 3 矩阵作为函数的参数和返回类型？"
+"例如使用 `&[&[i32]]` 表示一个二维的切片的切片。为什么这样做是可行或不可行的？"
 
 #: src/exercises/day-1/for-loops.md:89
 msgid ""
 "See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
-msgstr "参考 [`ndarray` crate](https://docs.rs/ndarray/) 以了解该功能满足生产环境质量的实现。"
+msgstr ""
+"参考 [`ndarray` crate](https://docs.rs/ndarray/) 以了解该功能满足生产环境质量"
+"的实现。"
 
 #: src/exercises/day-1/for-loops.md:94
 msgid ""
 "The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
-msgstr "题目解答和附加题的答案在 [题解](solutions-morning.md#arrays-and-for-loops) 章节中。"
+msgstr ""
+"题目解答和附加题的答案在 [题解](solutions-morning.md#arrays-and-for-loops) 章"
+"节中。"
 
 #: src/exercises/day-1/for-loops.md:97
 msgid ""
 "The use of the reference `&array` within `for n in &array` is a subtle "
 "preview of issues of ownership that will come later in the afternoon."
-msgstr "在“for n in &array”中使用引用“&array”这一做法巧妙地预先展示了下午将谈到的所有权问题。"
+msgstr ""
+"在“for n in &array”中使用引用“&array”这一做法巧妙地预先展示了下午将谈到的所有"
+"权问题。"
 
 #: src/exercises/day-1/for-loops.md:100
 msgid "Without the `&`..."
@@ -3897,17 +3869,18 @@ msgstr "如果不使用“&”…"
 #: src/exercises/day-1/for-loops.md:101
 msgid ""
 "The loop would have been one that consumes the array.  This is a change "
-"[introduced in the 2021 "
-"Edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)."
+"[introduced in the 2021 Edition](https://doc.rust-lang.org/edition-guide/"
+"rust-2021/IntoIterator-for-arrays.html)."
 msgstr ""
-"循环将会是一个使用数组的循环。这是一项[在 2021 "
-"年版中引入](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)的变更。"
+"循环将会是一个使用数组的循环。这是一项[在 2021 年版中引入](https://doc.rust-"
+"lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)的变更。"
 
 #: src/exercises/day-1/for-loops.md:104
 msgid ""
 "An implicit array copy would have occurred.  Since `i32` is a copy type, "
 "then `[i32; 3]` is also a copy type."
-msgstr "会发生隐式数组复制。由于“i32”是复制类型，因此“\\[i32; 3\\]”也是复制类型。"
+msgstr ""
+"会发生隐式数组复制。由于“i32”是复制类型，因此“\\[i32; 3\\]”也是复制类型。"
 
 #: src/control-flow.md:3
 msgid ""
@@ -3916,8 +3889,9 @@ msgid ""
 "becomes the value of the `if` expression. Other control flow expressions "
 "work similarly in Rust."
 msgstr ""
-"正如我们所知，`if` 是 Rust 中的一个表达式。它用于有条件地 评估两个块中的一个，但这些块可以有一个值， 然后成为 `if` "
-"表达式的值。其他控制流表达式在 Rust 中也有类似 的运作方式。"
+"正如我们所知，`if` 是 Rust 中的一个表达式。它用于有条件地 评估两个块中的一"
+"个，但这些块可以有一个值， 然后成为 `if` 表达式的值。其他控制流表达式在 Rust "
+"中也有类似 的运作方式。"
 
 #: src/control-flow/blocks.md:3
 #, fuzzy
@@ -3939,14 +3913,9 @@ msgid ""
 "return value:"
 msgstr "同样的规则也适用于函数：函数主体的值 是返回值："
 
-#: src/control-flow/blocks.md:45
-#: src/enums.md:34
-#: src/enums/sizes.md:28
-#: src/pattern-matching.md:25
-#: src/pattern-matching/match-guards.md:22
-#: src/structs.md:31
-#: src/methods.md:30
-#: src/methods/example.md:46
+#: src/control-flow/blocks.md:45 src/enums.md:34 src/enums/sizes.md:28
+#: src/pattern-matching.md:25 src/pattern-matching/match-guards.md:22
+#: src/structs.md:31 src/methods.md:30 src/methods/example.md:46
 msgid "Key Points:"
 msgstr "关键点："
 
@@ -3960,7 +3929,9 @@ msgstr "这张幻灯片的重点是说明在 Rust 中，块有类型和值。"
 msgid ""
 "You can show how the value of the block changes by changing the last line in "
 "the block. For instance, adding/removing a semicolon or using a `return`."
-msgstr "你可以通过更改块的最后一行，来展示块值的变化情况。例如，添加/移除分号或使用 `return`。"
+msgstr ""
+"你可以通过更改块的最后一行，来展示块值的变化情况。例如，添加/移除分号或使用 "
+"`return`。"
 
 #: src/control-flow/if-expressions.md:1
 msgid "`if` expressions"
@@ -3968,19 +3939,19 @@ msgstr "`if` 表达式"
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if` "
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions) "
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
-"[`if` "
-"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions) "
-"的用法与其他语言中的 `if` 语句完全一样。"
+"[`if` 表达式](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-expressions) 的用法与其他语言中的 `if` 语句完全一样。"
 
 #: src/control-flow/if-expressions.md:18
 msgid ""
 "In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
-msgstr "此外，你还可以将 `if` 用作一个表达式。每个块的最后一个表达式 将成为 `if` 表达式的值："
+msgstr ""
+"此外，你还可以将 `if` 用作一个表达式。每个块的最后一个表达式 将成为 `if` 表达"
+"式的值："
 
 #: src/control-flow/if-expressions.md:35
 msgid ""
@@ -3988,8 +3959,8 @@ msgid ""
 "branch blocks must have the same type. Consider showing what happens if you "
 "add `;` after `x / 2` in the second example."
 msgstr ""
-"由于 `if` 是一个表达式且必须有一个特定的类型，因此它的两个分支块必须有相同的类型。考虑在第二个示例中将 `;` 添加到 `x / 2` "
-"的后面，看看会出现什么情况。"
+"由于 `if` 是一个表达式且必须有一个特定的类型，因此它的两个分支块必须有相同的"
+"类型。考虑在第二个示例中将 `;` 添加到 `x / 2` 的后面，看看会出现什么情况。"
 
 #: src/control-flow/for-expressions.md:1
 msgid "`for` loops"
@@ -4003,7 +3974,8 @@ msgid ""
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
 "[`for` 循环](https://doc.rust-lang.org/std/keyword.for.html) 与 [`when let` "
-"循环](when-let-expression.md)密切相关。它会 自动对表达式调用 `into_iter()`，然后对其进行迭代："
+"循环](when-let-expression.md)密切相关。它会 自动对表达式调用 `into_iter()`，"
+"然后对其进行迭代："
 
 #: src/control-flow/for-expressions.md:22
 msgid "You can use `break` and `continue` here as usual."
@@ -4027,7 +3999,9 @@ msgstr "`step_by` 是返回另一个 `Iterator` 的方法，用于逐一跳过�
 msgid ""
 "Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
-msgstr "修改矢量中的元素并说明编译器错误。将矢量 `v` 改为可变，并将 for 循环改为 `for x in v.iter_mut()`。"
+msgstr ""
+"修改矢量中的元素并说明编译器错误。将矢量 `v` 改为可变，并将 for 循环改为 "
+"`for x in v.iter_mut()`。"
 
 #: src/control-flow/while-expressions.md:1
 msgid "`while` loops"
@@ -4035,13 +4009,11 @@ msgstr "`while` 循环"
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
-"The [`while` "
-"keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops) "
-"works very similar to other languages:"
+"The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
-"[`while` "
-"关键字](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops) "
-"的工作方式与其他语言非常相似："
+"[`while` 关键字](https://doc.rust-lang.org/reference/expressions/loop-expr."
+"html#predicate-loops) 的工作方式与其他语言非常相似："
 
 #: src/control-flow/break-continue.md:1
 msgid "`break` and `continue`"
@@ -4049,19 +4021,19 @@ msgstr "`break` 和 `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"If you want to exit a loop early, use "
-"[`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions),"
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
 msgstr ""
-"如果你想提前退出循环，请使用 "
-"[`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions)，"
+"如果你想提前退出循环，请使用 [`break`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#break-expressions)，"
 
 #: src/control-flow/break-continue.md:4
 msgid ""
-"If you want to immediately start the next iteration use "
-"[`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
 msgstr ""
-"如果需要立即启动 下一次迭代，请使用 "
-"[`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)。"
+"如果需要立即启动 下一次迭代，请使用 [`continue`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#continue-expressions)。"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
@@ -4080,13 +4052,11 @@ msgstr "`loop` 表达式"
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
-"Finally, there is a [`loop` "
-"keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops) "
-"which creates an endless loop."
+"Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
-"最后是用于创建无限循环的 [`loop` "
-"关键字](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops) "
-"。"
+"最后是用于创建无限循环的 [`loop` 关键字](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#infinite-loops) 。"
 
 #: src/control-flow/loop-expressions.md:6
 msgid "Here you must either `break` or `return` to stop the loop:"
@@ -4101,7 +4071,9 @@ msgid ""
 "Note that `loop` is the only looping construct which returns a non-trivial "
 "value. This is because it's guaranteed to be entered at least once (unlike "
 "`while` and `for` loops)."
-msgstr "请注意，`loop` 是唯一返回有意义的值的循环结构。 这是因为它保证至少被输入一次（与 `while` 和 `for` 循环不同）。"
+msgstr ""
+"请注意，`loop` 是唯一返回有意义的值的循环结构。 这是因为它保证至少被输入一次"
+"（与 `while` 和 `for` 循环不同）。"
 
 #: src/basic-syntax/variables.md:3
 msgid ""
@@ -4113,7 +4085,8 @@ msgstr "Rust 通过静态类型实现了类型安全。变量绑定默认是不�
 msgid ""
 "Due to type inference the `i32` is optional. We will gradually show the "
 "types less and less as the course progresses."
-msgstr "由于类型推导，`i32` 可以省略。随着课程推进，我们会越来越少地看到类型声明。"
+msgstr ""
+"由于类型推导，`i32` 可以省略。随着课程推进，我们会越来越少地看到类型声明。"
 
 #: src/basic-syntax/type-inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
@@ -4133,7 +4106,9 @@ msgid ""
 "of a type. The compiler does the job for us and helps us write more concise "
 "code."
 msgstr ""
-"需要重点强调的是这样声明的变量并非像那种动态类型语言中可以持有任何数据的“任何类型”。这种声明所生成的机器码与明确类型声明完全相同。编译器进行类型推导能够让我们编写更简略的代码。"
+"需要重点强调的是这样声明的变量并非像那种动态类型语言中可以持有任何数据的“任何"
+"类型”。这种声明所生成的机器码与明确类型声明完全相同。编译器进行类型推导能够让"
+"我们编写更简略的代码。"
 
 #: src/basic-syntax/type-inference.md:33
 #, fuzzy
@@ -4141,21 +4116,22 @@ msgid ""
 "The following code tells the compiler to copy into a certain generic "
 "container without the code ever explicitly specifying the contained type, "
 "using `_` as a placeholder:"
-msgstr "下面的代码通过使用 `_` 占位符来告诉编译器无需明确指定其类型就可以将对应数据拷贝到该容器： "
+msgstr ""
+"下面的代码通过使用 `_` 占位符来告诉编译器无需明确指定其类型就可以将对应数据拷"
+"贝到该容器： "
 
 #: src/basic-syntax/type-inference.md:48
 #, fuzzy
 msgid ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
-"relies on "
-"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html), "
-"which "
-"[`HashSet`](https://doc.rust-lang.org/std/collections/struct.HashSet.html#impl-FromIterator%3CT%3E-for-HashSet%3CT,+S%3E) "
-"implements."
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) relies on [`FromIterator`](https://doc.rust-lang.org/"
+"std/iter/trait.FromIterator.html), which [`HashSet`](https://doc.rust-lang."
+"org/std/collections/struct.HashSet.html#impl-FromIterator%3CT%3E-for-"
+"HashSet%3CT,+S%3E) implements."
 msgstr ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
-"依赖 [`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"实现的 `FromIterator`。"
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) 依赖 [`HashSet`](https://doc.rust-lang.org/std/iter/"
+"trait.FromIterator.html) 实现的 `FromIterator`。"
 
 #: src/basic-syntax/static-and-const.md:1
 msgid "Static and Constant Variables"
@@ -4163,10 +4139,12 @@ msgstr "静态 (Static) 变量和常数 (Constant) 变量"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid ""
-"Static and constant variables are two different ways to create "
-"globally-scoped values that cannot be moved or reallocated during the "
-"execution of the program. "
-msgstr "静态变量和常量变量是创建全局范围值的两种不同方法，这类值在程序执行期间无法移动或重新分配。"
+"Static and constant variables are two different ways to create globally-"
+"scoped values that cannot be moved or reallocated during the execution of "
+"the program. "
+msgstr ""
+"静态变量和常量变量是创建全局范围值的两种不同方法，这类值在程序执行期间无法移"
+"动或重新分配。"
 
 #: src/basic-syntax/static-and-const.md:6
 msgid "`const`"
@@ -4180,19 +4158,19 @@ msgstr "系统会在编译时对常量变量进行求值；无论在何处使用
 
 #: src/basic-syntax/static-and-const.md:30
 msgid ""
-"According to the [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) these are "
-"inlined upon use."
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
 msgstr ""
-"根据 [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
-"这些变量在使用时是内联 (inlined) 的。"
+"根据 [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html) 这些变量在使用时是内联 (inlined) 的。"
 
 #: src/basic-syntax/static-and-const.md:32
 msgid ""
 "Only functions marked `const` can be called at compile time to generate "
 "`const` values. `const` functions can however be called at runtime."
-msgstr "在编译时只能调用标记为“const”的函数以生成“const”值。不过，可在运行时调用“const”函数。"
+msgstr ""
+"在编译时只能调用标记为“const”的函数以生成“const”值。不过，可在运行时调"
+"用“const”函数。"
 
 #: src/basic-syntax/static-and-const.md:34
 msgid "`static`"
@@ -4225,29 +4203,31 @@ msgstr ""
 #: src/basic-syntax/static-and-const.md:46
 #, fuzzy
 msgid ""
-"As noted in the [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html), these are "
-"not inlined upon use and have an actual associated memory location.  This is "
-"useful for unsafe and  embedded code, and the variable lives through the "
-"entirety of the program execution. When a globally-scoped value does not "
-"have a reason to need object identity, `const` is generally preferred."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and  embedded code, "
+"and the variable lives through the entirety of the program execution. When a "
+"globally-scoped value does not have a reason to need object identity, "
+"`const` is generally preferred."
 msgstr ""
-"正如 [Rust RFC "
-"Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
-"中所述，这些变量在使用时并不是内联的，而且还具有实际相关联的内存位置。这对于不安全的嵌入式代码是有用的，并且这些变量存在于整个程序的执行过程之中。"
+"正如 [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html) 中所述，这些变量在使用时并不是内联的，而且还具有实际相关联的内存位置。"
+"这对于不安全的嵌入式代码是有用的，并且这些变量存在于整个程序的执行过程之中。"
 
 #: src/basic-syntax/static-and-const.md:50
 msgid ""
 "Because `static` variables are accessible from any thread, they must be "
-"`Sync`. Interior mutability is possible through a "
-"[`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html), atomic or "
-"similar. It is also possible to have mutable statics, but they require "
-"manual synchronisation so any access to them requires `unsafe` code. We will "
-"look at [mutable statics](../unsafe/mutable-static-variables.md) in the "
-"chapter on Unsafe Rust."
+"`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html), atomic or similar. It is also possible "
+"to have mutable statics, but they require manual synchronisation so any "
+"access to them requires `unsafe` code. We will look at [mutable statics](../"
+"unsafe/mutable-static-variables.md) in the chapter on Unsafe Rust."
 msgstr ""
-"由于“static”变量可从任何线程访问，因此它们必须是“Sync”。内部可变性可通过[“互斥量”](https://doc.rust-lang.org/std/sync/struct.Mutex.html)、原子性或类似对象实现。也可能具有可变静态项，但它们需要手动同步，因此对它们的任何访问都需要“unsafe”代码。我们将在“不安全 "
-"Rust”章节中探讨[可变静态项](../unsafe/mutable-static-variables.md)。"
+"由于“static”变量可从任何线程访问，因此它们必须是“Sync”。内部可变性可通过[“互"
+"斥量”](https://doc.rust-lang.org/std/sync/struct.Mutex.html)、原子性或类似对"
+"象实现。也可能具有可变静态项，但它们需要手动同步，因此对它们的任何访问都需"
+"要“unsafe”代码。我们将在“不安全 Rust”章节中探讨[可变静态项](../unsafe/"
+"mutable-static-variables.md)。"
 
 #: src/basic-syntax/static-and-const.md:58
 msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
@@ -4273,7 +4253,9 @@ msgstr ""
 msgid ""
 "It isn't super common that one would need a runtime evaluated constant, but "
 "it is helpful and safer than using a static."
-msgstr "虽然需要使用在运行中求值的常量的情况并不是很常见，但是它是有帮助的，而且比使用静态变量更安全。"
+msgstr ""
+"虽然需要使用在运行中求值的常量的情况并不是很常见，但是它是有帮助的，而且比使"
+"用静态变量更安全。"
 
 #: src/basic-syntax/static-and-const.md:62
 msgid "`thread_local` data can be created with the macro `std::thread_local`."
@@ -4391,8 +4373,9 @@ msgid ""
 "both variable's memory locations exist at the same time. Both are available "
 "under the same name, depending where you use it in the code. "
 msgstr ""
-"定义: 隐藏和变更 (mutation) "
-"不同，因为在隐藏之后，两个变量都会同时存在于内存的不同位置中。在同一个名字下的两个变量都是可以被使用的，但是你在代码的哪里使用会最终决定你使用哪一个变量。"
+"定义: 隐藏和变更 (mutation) 不同，因为在隐藏之后，两个变量都会同时存在于内存"
+"的不同位置中。在同一个名字下的两个变量都是可以被使用的，但是你在代码的哪里使"
+"用会最终决定你使用哪一个变量。"
 
 #: src/basic-syntax/scopes-shadowing.md:26
 msgid "A shadowing variable can have a different type. "
@@ -4409,7 +4392,9 @@ msgid ""
 "The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
-msgstr "以下代码说明了为什么在作用域内隐藏一个不可变的变量时，即使是在变量类型没有改变的情况下，编译器也不能简单地重复利用之前的内存位置。"
+msgstr ""
+"以下代码说明了为什么在作用域内隐藏一个不可变的变量时，即使是在变量类型没有改"
+"变的情况下，编译器也不能简单地重复利用之前的内存位置。"
 
 #: src/enums.md:3
 msgid ""
@@ -4455,7 +4440,9 @@ msgstr "枚举允许你从一种类型下收集一组值"
 msgid ""
 "This page offers an enum type `CoinFlip` with two variants `Heads` and "
 "`Tails`. You might note the namespace when using variants."
-msgstr "本页提供了一个枚举类型 `CoinFlip`，其中包含 `Heads` 和`Tail`两个变体。在使用变体时，你可能会注意到命名空间。"
+msgstr ""
+"本页提供了一个枚举类型 `CoinFlip`，其中包含 `Heads` 和`Tail`两个变体。在使用"
+"变体时，你可能会注意到命名空间。"
 
 #: src/enums.md:38
 msgid "This might be a good time to compare Structs and Enums:"
@@ -4465,7 +4452,9 @@ msgstr "这可能是比较结构体和枚举的好时机："
 msgid ""
 "In both, you can have a simple version without fields (unit struct) or one "
 "with different types of fields (variant payloads). "
-msgstr "在这两者中，你可以获得一个不含字段的简单版本（单位结构体），或一个包含不同类型字段的版本（变体载荷）。"
+msgstr ""
+"在这两者中，你可以获得一个不含字段的简单版本（单位结构体），或一个包含不同类"
+"型字段的版本（变体载荷）。"
 
 #: src/enums.md:40
 msgid "In both, associated functions are defined within an `impl` block."
@@ -4476,13 +4465,17 @@ msgid ""
 "You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
-msgstr "你甚至可以使用单独的结构体实现枚举的不同变体，但这样一来，如果它们都已在枚举中定义，类型与之前也不一样。"
+msgstr ""
+"你甚至可以使用单独的结构体实现枚举的不同变体，但这样一来，如果它们都已在枚举"
+"中定义，类型与之前也不一样。"
 
 #: src/enums/variant-payloads.md:3
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
 "the `match` statement to extract the data from each variant:"
-msgstr "你可以定义更丰富的枚举，其中变体会携带数据。然后，你可以使用 `match` 语句从每个变体中提取数据："
+msgstr ""
+"你可以定义更丰富的枚举，其中变体会携带数据。然后，你可以使用 `match` 语句从每"
+"个变体中提取数据："
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -4545,7 +4538,9 @@ msgid ""
 "The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
 "after the `=>`."
-msgstr "枚举变体中的值只有在被模式匹配后，才可访问。模式将引用绑定到 `=>` 之后的“match 分支”中的字段。"
+msgstr ""
+"枚举变体中的值只有在被模式匹配后，才可访问。模式将引用绑定到 `=>` 之后"
+"的“match 分支”中的字段。"
 
 #: src/enums/variant-payloads.md:36
 msgid ""
@@ -4563,13 +4558,17 @@ msgstr "匹配表达式拥有一个值。值是 match 分支中被执行的最�
 msgid ""
 "Starting from the top we look for what pattern matches the value then run "
 "the code following the arrow. Once we find a match, we stop. "
-msgstr "从顶部开始，查找与该值匹配的模式，然后沿箭头运行代码。一旦找到匹配，我们便会停止。"
+msgstr ""
+"从顶部开始，查找与该值匹配的模式，然后沿箭头运行代码。一旦找到匹配，我们便会"
+"停止。"
 
 #: src/enums/variant-payloads.md:39
 msgid ""
 "Demonstrate what happens when the search is inexhaustive. Note the advantage "
 "the Rust compiler provides by confirming when all cases are handled. "
-msgstr "展示搜索不详尽时会发生的情况。请注意 Rust 编译器的优势，即确认所有情况何时都得到了处理。"
+msgstr ""
+"展示搜索不详尽时会发生的情况。请注意 Rust 编译器的优势，即确认所有情况何时都"
+"得到了处理。"
 
 #: src/enums/variant-payloads.md:40
 msgid "`match` inspects a hidden discriminant field in the `enum`."
@@ -4577,8 +4576,8 @@ msgstr "`match` 会检查 `enum` 中的隐藏的判别字段。"
 
 #: src/enums/variant-payloads.md:41
 msgid ""
-"It is possible to retrieve the discriminant by calling "
-"`std::mem::discriminant()`"
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
 msgstr "可以通过调用 `std::mem::discriminant()` 来检索判别"
 
 #: src/enums/variant-payloads.md:42
@@ -4589,12 +4588,12 @@ msgstr "这很有用，例如如果为结构体实现 `PartialEq`，比较字段
 
 #: src/enums/variant-payloads.md:43
 msgid ""
-"`WebEvent::Click { ... }` is not exactly the same as "
-"`WebEvent::Click(Click)` with a top level `struct Click { ... }`. The "
-"inlined version cannot implement traits, for example."
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
 msgstr ""
-"`WebEvent::Click { ... }` 与含顶层 `struct Click { ... }` 的 "
-"`WebEvent::Click(Click)` 不完全相同。例如，内嵌版本无法实现 trait。"
+"`WebEvent::Click { ... }` 与含顶层 `struct Click { ... }` 的 `WebEvent::"
+"Click(Click)` 不完全相同。例如，内嵌版本无法实现 trait。"
 
 #: src/enums/sizes.md:3
 msgid ""
@@ -4646,9 +4645,10 @@ msgstr ""
 
 #: src/enums/sizes.md:24
 msgid ""
-"See the [Rust "
-"Reference](https://doc.rust-lang.org/reference/type-layout.html)."
-msgstr "请参阅 [Rust 引用](https://doc.rust-lang.org/reference/type-layout.html)。"
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"html)."
+msgstr ""
+"请参阅 [Rust 引用](https://doc.rust-lang.org/reference/type-layout.html)。"
 
 #: src/enums/sizes.md:30
 #, fuzzy
@@ -4668,7 +4668,9 @@ msgstr "你可以根据需要控制判别（例如，与 C 的兼容性）："
 msgid ""
 "Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
 "bytes."
-msgstr "如果不使用 `repr`，判别类型会占用 2 个字节，因为 10001 是一个 2 个字节的数值。"
+msgstr ""
+"如果不使用 `repr`，判别类型会占用 2 个字节，因为 10001 是一个 2 个字节的数"
+"值。"
 
 #: src/enums/sizes.md:54
 #, fuzzy
@@ -4685,19 +4687,24 @@ msgstr "`dbg_size!(bool)`：大小占用 1 个字节，对齐占用 1 个字节�
 msgid ""
 "`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
 "see below),"
-msgstr "`dbg_size!(Option<bool>)`：大小占用 1 个字节，对齐占用 1 个字节（小众优化，请参阅下文）；"
+msgstr ""
+"`dbg_size!(Option<bool>)`：大小占用 1 个字节，对齐占用 1 个字节（小众优化，请"
+"参阅下文）；"
 
 #: src/enums/sizes.md:58
 #, fuzzy
 msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
-msgstr "`dbg_size!(&i32)`：大小占用 8 个字节，对齐占用 8 个字节（在 64 位设备上）；"
+msgstr ""
+"`dbg_size!(&i32)`：大小占用 8 个字节，对齐占用 8 个字节（在 64 位设备上）；"
 
 #: src/enums/sizes.md:59
 #, fuzzy
 msgid ""
 "`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
 "optimization, see below)."
-msgstr "`dbg_size!(Option<&i32>)`：大小占用 8 个字节，对齐占用 8 个字节（Null 指针优化，请参阅下文）。"
+msgstr ""
+"`dbg_size!(Option<&i32>)`：大小占用 8 个字节，对齐占用 8 个字节（Null 指针优"
+"化，请参阅下文）。"
 
 #: src/enums/sizes.md:61
 #, fuzzy
@@ -4709,13 +4716,13 @@ msgstr "小众优化：Rust 将对枚举判别合并使用 未使用的位模式
 #: src/enums/sizes.md:64
 #, fuzzy
 msgid ""
-"Null pointer optimization: For [some "
-"types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`."
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
 msgstr ""
-"Null 指针优化：对于[某些 "
-"类型](https://doc.rust-lang.org/std/option/#representation)，Rust 保证 "
-"`size_of::<T>()` 等效于 `size_of::<Option<T>>()`。"
+"Null 指针优化：对于[某些 类型](https://doc.rust-lang.org/std/option/"
+"#representation)，Rust 保证 `size_of::<T>()` 等效于 `size_of::"
+"<Option<T>>()`。"
 
 #: src/enums/sizes.md:68
 #, fuzzy
@@ -4723,13 +4730,17 @@ msgid ""
 "Example code if you want to show how the bitwise representation _may_ look "
 "like in practice. It's important to note that the compiler provides no "
 "guarantees regarding this representation, therefore this is totally unsafe."
-msgstr "如果你想展示位表示方式在实践中“可能”会是什么样子，请参考示例代码。 请务必注意，编译器对此表示法不提供任何保证，因此这是完全不安全的。"
+msgstr ""
+"如果你想展示位表示方式在实践中“可能”会是什么样子，请参考示例代码。 请务必注"
+"意，编译器对此表示法不提供任何保证，因此这是完全不安全的。"
 
 #: src/enums/sizes.md:105
 msgid ""
 "More complex example if you want to discuss what happens when we chain more "
 "than 256 `Option`s together."
-msgstr "如果您想讨论将 256 多个“Option”链在一起时会发生什么情况，可以使用下方这个更复杂的示例。"
+msgstr ""
+"如果您想讨论将 256 多个“Option”链在一起时会发生什么情况，可以使用下方这个更复"
+"杂的示例。"
 
 #: src/control-flow/novel.md:3
 msgid ""
@@ -4737,8 +4748,7 @@ msgid ""
 "They are used for pattern matching:"
 msgstr "Rust 有几个与其他语言不同的控制流结构。它们用于模式匹配："
 
-#: src/control-flow/novel.md:6
-#: src/control-flow/if-let-expressions.md:1
+#: src/control-flow/novel.md:6 src/control-flow/if-let-expressions.md:1
 msgid "`if let` expressions"
 msgstr "`if let` 表达式"
 
@@ -4747,21 +4757,18 @@ msgstr "`if let` 表达式"
 msgid "`while let` expressions"
 msgstr "while let 表达式"
 
-#: src/control-flow/novel.md:8
-#: src/control-flow/match-expressions.md:1
+#: src/control-flow/novel.md:8 src/control-flow/match-expressions.md:1
 msgid "`match` expressions"
 msgstr "`match` 表达式"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let` "
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions) "
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
-"[`if let` "
-"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions) "
-"能让你根据某个值是否与模式相匹配来执行不同的代码："
+"[`if let` 表达式](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-let-expressions) 能让你根据某个值是否与模式相匹配来执行不同的代码："
 
 #: src/control-flow/if-let-expressions.md:7
 msgid ""
@@ -4793,7 +4800,8 @@ msgstr ""
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
 "in Rust."
-msgstr "如需详细了解 Rust 中 的模式，请参阅[模式匹配](../pattern-matching.md)。"
+msgstr ""
+"如需详细了解 Rust 中 的模式，请参阅[模式匹配](../pattern-matching.md)。"
 
 #: src/control-flow/if-let-expressions.md:23
 #, fuzzy
@@ -4814,15 +4822,14 @@ msgstr "与 `match` 不同的是，`if let` 不支持模式匹配的 guard 子�
 #: src/control-flow/if-let-expressions.md:26
 #, fuzzy
 msgid ""
-"Since 1.65, a similar "
-"[let-else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) "
-"construct allows to do a destructuring assignment, or if it fails, execute a "
-"block which is required to abort normal control flow (with "
-"`panic`/`return`/`break`/`continue`):"
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"flow_control/let_else.html) construct allows to do a destructuring "
+"assignment, or if it fails, execute a block which is required to abort "
+"normal control flow (with `panic`/`return`/`break`/`continue`):"
 msgstr ""
-"自 1.65 版以来，类似的 "
-"[let-else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) "
-"结构允许执行解构赋值，或者如果不满足条件，则有一个非返回块分支 (panic/return/break/continue)："
+"自 1.65 版以来，类似的 [let-else](https://doc.rust-lang.org/rust-by-example/"
+"flow_control/let_else.html) 结构允许执行解构赋值，或者如果不满足条件，则有一"
+"个非返回块分支 (panic/return/break/continue)："
 
 #: src/control-flow/while-let-expressions.md:1
 msgid "`while let` loops"
@@ -4830,13 +4837,13 @@ msgstr "`while let` 循环"
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
-"Like with `if let`, there is a [`while "
-"let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops) "
-"variant which repeatedly tests a value against a pattern:"
+"Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
-"与 `if let` 一样，[`with "
-"let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops) "
-"变体会针对一个模式重复测试一个值："
+"与 `if let` 一样，[`with let`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#predicate-pattern-loops) 变体会针对一个模式重复测"
+"试一个值："
 
 #: src/control-flow/while-let-expressions.md:18
 #, fuzzy
@@ -4846,8 +4853,9 @@ msgid ""
 "it will return `None`. The `while let` lets us keep iterating through all "
 "items."
 msgstr ""
-"在这里，每次 调用 `next()` 时，`v.iter()` 返回的迭代器都会返回一个 `Option<i32>`。它将一直返回 "
-"`Some(x)`，直到完成。 之后它将返回 `None`。`while let`能让我们持续迭代所有项。"
+"在这里，每次 调用 `next()` 时，`v.iter()` 返回的迭代器都会返回一个 "
+"`Option<i32>`。它将一直返回 `Some(x)`，直到完成。 之后它将返回 `None`。"
+"`while let`能让我们持续迭代所有项。"
 
 #: src/control-flow/while-let-expressions.md:27
 msgid ""
@@ -4861,19 +4869,18 @@ msgid ""
 "statement that breaks when there is no value to unwrap for `iter.next()`. "
 "The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
-"你可以使用 if 语句将 `while let` 循环重写为无限循环，当 `iter.next()` 没有值可以解封时中断。`while let` "
-"为上述情况提供了语法糖。"
+"你可以使用 if 语句将 `while let` 循环重写为无限循环，当 `iter.next()` 没有值"
+"可以解封时中断。`while let` 为上述情况提供了语法糖。"
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
-"The [`match` "
-"keyword](https://doc.rust-lang.org/reference/expressions/match-expr.html) is "
-"used to match a value against one or more patterns. In that sense, it works "
-"like a series of `if let` expressions:"
+"The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
-"[`match` "
-"关键字](https://doc.rust-lang.org/reference/expressions/match-expr.html) "
-"用于将一个值与一个或多个模式进行匹配。从这个意义上讲，它的工作方式 类似于一系列的 `if let` 表达式："
+"[`match` 关键字](https://doc.rust-lang.org/reference/expressions/match-expr."
+"html) 用于将一个值与一个或多个模式进行匹配。从这个意义上讲，它的工作方式 类似"
+"于一系列的 `if let` 表达式："
 
 #: src/control-flow/match-expressions.md:7
 msgid ""
@@ -4907,7 +4914,9 @@ msgstr ""
 msgid ""
 "Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
-msgstr "与 `if let` 类似，每个匹配分支必须有相同的类型。该类型是块的最后一个 表达式（如有）。在上例中，类型是 `()`。"
+msgstr ""
+"与 `if let` 类似，每个匹配分支必须有相同的类型。该类型是块的最后一个 表达式"
+"（如有）。在上例中，类型是 `()`。"
 
 #: src/control-flow/match-expressions.md:28
 msgid "Save the match expression to a variable and print it out."
@@ -4921,15 +4930,17 @@ msgstr "移除 `.as_deref()` 并说明错误。"
 msgid ""
 "`std::env::args().next()` returns an `Option<String>`, but we cannot match "
 "against `String`."
-msgstr "`std::env::args().next()` 会返回  `Option<String>`，但无法与 `String` 进行匹配。"
+msgstr ""
+"`std::env::args().next()` 会返回  `Option<String>`，但无法与 `String` 进行匹"
+"配。"
 
 #: src/control-flow/match-expressions.md:31
 msgid ""
 "`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
 "this turns `Option<String>` into `Option<&str>`."
 msgstr ""
-"`as_deref()` 会将 `Option<T>` 转换为 `Option<&T::Target>`。在我们的示例中，这会将 "
-"`Option<String>` 转换为 `Option<&str>`。"
+"`as_deref()` 会将 `Option<T>` 转换为 `Option<&T::Target>`。在我们的示例中，这"
+"会将 `Option<String>` 转换为 `Option<&str>`。"
 
 #: src/control-flow/match-expressions.md:32
 msgid ""
@@ -4940,7 +4951,9 @@ msgstr "现在，我们可以使用模式匹配来匹配 `Option` 中的 `&str`�
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
-msgstr "使用关键词 `match` 对一个值进行模式匹配。进行匹配时，会从上至下依次进行比较，并选定第一个匹配成功的结果。"
+msgstr ""
+"使用关键词 `match` 对一个值进行模式匹配。进行匹配时，会从上至下依次进行比较，"
+"并选定第一个匹配成功的结果。"
 
 #: src/pattern-matching.md:6
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
@@ -4972,13 +4985,15 @@ msgid ""
 "You might point out how some specific characters are being used when in a "
 "pattern"
 msgstr ""
-"你可以解释一些用于表达模式的特殊字符的用法 \\*`|` 表示或 (or) \\*`..` 可以展开为任意一个或多个值 \\*`1..=5` "
-"代表了一个闭区间范围"
+"你可以解释一些用于表达模式的特殊字符的用法 \\*`|` 表示或 (or) \\*`..` 可以展"
+"开为任意一个或多个值 \\*`1..=5` 代表了一个闭区间范围"
 
 #: src/pattern-matching.md:27
 #, fuzzy
 msgid "`|` as an `or`"
-msgstr "解释模式匹配中的绑定的原理可能会很有帮助。比如可以用一个变量替代外卡，或者去除 `q` 外面的引号。"
+msgstr ""
+"解释模式匹配中的绑定的原理可能会很有帮助。比如可以用一个变量替代外卡，或者去"
+"除 `q` 外面的引号。"
 
 #: src/pattern-matching.md:28
 #, fuzzy
@@ -4988,7 +5003,9 @@ msgstr "你可以展示如何匹配一个引用。"
 #: src/pattern-matching.md:29
 #, fuzzy
 msgid "`1..=5` represents an inclusive range"
-msgstr "现在是一个讲解不可反驳 (irrefutable) 模式的好时机。因为这个术语可能会出现在错误信息中。"
+msgstr ""
+"现在是一个讲解不可反驳 (irrefutable) 模式的好时机。因为这个术语可能会出现在错"
+"误信息中。"
 
 #: src/pattern-matching.md:30
 msgid "`_` is a wild card"
@@ -4998,7 +5015,9 @@ msgstr "“\\_”是通配符"
 msgid ""
 "It can be useful to show how binding works, by for instance replacing a "
 "wildcard character with a variable, or removing the quotes around `q`."
-msgstr "展示绑定的运作方式可能会很有帮助，例如通过用变量替换通配符或移除“q”周围的引号来展示。"
+msgstr ""
+"展示绑定的运作方式可能会很有帮助，例如通过用变量替换通配符或移除“q”周围的引号"
+"来展示。"
 
 #: src/pattern-matching.md:32
 msgid "You can demonstrate matching on a reference."
@@ -5008,14 +5027,18 @@ msgstr "您可以在参照项上演示如何匹配。"
 msgid ""
 "This might be a good time to bring up the concept of irrefutable patterns, "
 "as the term can show up in error messages."
-msgstr "这时可能很适合提到“不可反驳的模式”这个概念，因为这个术语可能会出现在错误消息中。"
+msgstr ""
+"这时可能很适合提到“不可反驳的模式”这个概念，因为这个术语可能会出现在错误消息"
+"中。"
 
 #: src/pattern-matching/destructuring-enums.md:3
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
 "how you inspect the structure of your types. Let us start with a simple "
 "`enum` type:"
-msgstr "模式还可用于将变量绑定到值的某些部分。这是您检查类型结构的方式。我们先从简单的“enum”类型开始："
+msgstr ""
+"模式还可用于将变量绑定到值的某些部分。这是您检查类型结构的方式。我们先从简单"
+"的“enum”类型开始："
 
 #: src/pattern-matching/destructuring-enums.md:6
 msgid ""
@@ -5049,7 +5072,8 @@ msgid ""
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
 "arm, `msg` is bound to the error message."
 msgstr ""
-"在这里，我们使用了分支来解构“Result”值。在第一个分支中，“half”被绑定到“Ok”变体中的值。在第二个分支中，“msg”被绑定到错误消息。"
+"在这里，我们使用了分支来解构“Result”值。在第一个分支中，“half”被绑定到“Ok”变"
+"体中的值。在第二个分支中，“msg”被绑定到错误消息。"
 
 #: src/pattern-matching/destructuring-enums.md:36
 msgid ""
@@ -5062,7 +5086,9 @@ msgid ""
 "You can try adding a third variant to the enum definition and displaying the "
 "errors when running the code. Point out the places where your code is now "
 "inexhaustive and how the compiler tries to give you hints."
-msgstr "您可以尝试在枚举定义中添加第三个变体，并在运行代码时显示错误。指出代码现在有哪些地方还不详尽，并说明编译器会如何尝试给予提示。"
+msgstr ""
+"您可以尝试在枚举定义中添加第三个变体，并在运行代码时显示错误。指出代码现在有"
+"哪些地方还不详尽，并说明编译器会如何尝试给予提示。"
 
 #: src/pattern-matching/destructuring-structs.md:3
 msgid "You can also destructure `structs`:"
@@ -5103,7 +5129,8 @@ msgid ""
 "spot. Try changing the `2` in the second arm to a variable, and see that it "
 "subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
-"捕获和常量表达式之间的区别可能很难发现。尝试将第二个分支中的“2”更改为一个变量，可以看到它几乎无法运作了。将它更改为“const”，可以看到它又正常运作了。"
+"捕获和常量表达式之间的区别可能很难发现。尝试将第二个分支中的“2”更改为一个变"
+"量，可以看到它几乎无法运作了。将它更改为“const”，可以看到它又正常运作了。"
 
 #: src/pattern-matching/destructuring-arrays.md:3
 msgid ""
@@ -5190,7 +5217,9 @@ msgstr "展示使用模式 `[.., b]` 和 `[a@..,b]` 来匹配切片的尾部。"
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
 "Boolean expression which will be executed if the pattern matches:"
-msgstr "匹配时，您可以向模式中添加“守卫”。这是一个任意布尔表达式，如果模式匹配，就会执行该表达式："
+msgstr ""
+"匹配时，您可以向模式中添加“守卫”。这是一个任意布尔表达式，如果模式匹配，就会"
+"执行该表达式："
 
 #: src/pattern-matching/match-guards.md:6
 msgid ""
@@ -5214,7 +5243,9 @@ msgid ""
 "Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
 "allow."
-msgstr "有些想法比模式本身所允许的程度更加复杂，如果我们希望简要地表达这些想法，就必须把匹配守卫视为独立的语法功能。"
+msgstr ""
+"有些想法比模式本身所允许的程度更加复杂，如果我们希望简要地表达这些想法，就必"
+"须把匹配守卫视为独立的语法功能。"
 
 #: src/pattern-matching/match-guards.md:24
 msgid ""
@@ -5223,7 +5254,9 @@ msgid ""
 "match arm is selected. Failing the `if` condition inside of that block won't "
 "result in other arms of the original `match` expression being considered."
 msgstr ""
-"它们与匹配分支中的单独“if”表达式不同。选择匹配分支后，分支块内（在“=>”之后）会出现“if”表达式。如果该分支块内的“if”条件失败，系统不会考虑原始“match”表达式的其他分支。"
+"它们与匹配分支中的单独“if”表达式不同。选择匹配分支后，分支块内（在“=>”之后）"
+"会出现“if”表达式。如果该分支块内的“if”条件失败，系统不会考虑原始“match”表达式"
+"的其他分支。"
 
 #: src/pattern-matching/match-guards.md:26
 msgid "You can use the variables defined in the pattern in your if expression."
@@ -5253,14 +5286,13 @@ msgstr "Luhn 算法"
 msgid "An exercise on pattern matching."
 msgstr "枚举和模式匹配。"
 
-#: src/exercises/day-1/afternoon.md:11
-#: src/exercises/day-2/afternoon.md:7
+#: src/exercises/day-1/afternoon.md:11 src/exercises/day-2/afternoon.md:7
 #: src/exercises/bare-metal/afternoon.md:7
 #: src/exercises/concurrency/afternoon.md:13
 #, fuzzy
 msgid ""
-"After looking at the exercises, you can look at the "
-"[solutions](solutions-afternoon.md) provided."
+"After looking at the exercises, you can look at the [solutions](solutions-"
+"afternoon.md) provided."
 msgstr "读完习题后，可以阅读本书提供的 \\[题解\\]。"
 
 #: src/exercises/day-1/luhn.md:3
@@ -5269,7 +5301,8 @@ msgid ""
 "to validate credit card numbers. The algorithm takes a string as input and "
 "does the following to validate the credit card number:"
 msgstr ""
-"[卢恩算法](https://zh.wikipedia.org/wiki/卢恩算法)用于验证信用卡号。该算法将字符串作为输入内容，并执行以下操作来验证信用卡号："
+"[卢恩算法](https://zh.wikipedia.org/wiki/卢恩算法)用于验证信用卡号。该算法将"
+"字符串作为输入内容，并执行以下操作来验证信用卡号："
 
 #: src/exercises/day-1/luhn.md:7
 msgid "Ignore all spaces. Reject number with less than two digits."
@@ -5279,13 +5312,17 @@ msgstr "忽略所有空格。拒绝少于两位的号码。"
 msgid ""
 "Moving from **right to left**, double every second digit: for the number "
 "`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
-msgstr "从**右到左**，将偶数位的数字乘二。对于数字“1234”，我们将“3”和“1”乘二；对于数字“98765”，将“6”和“8”乘二。"
+msgstr ""
+"从**右到左**，将偶数位的数字乘二。对于数字“1234”，我们将“3”和“1”乘二；对于数"
+"字“98765”，将“6”和“8”乘二。"
 
 #: src/exercises/day-1/luhn.md:12
 msgid ""
 "After doubling a digit, sum the digits if the result is greater than 9. So "
 "doubling `7` becomes `14` which becomes `1 + 4 = 5`."
-msgstr "将一个数字乘二后，如果结果大于 9，则将每位数字相加。因此，将“7”乘二得“14”，然后“1 + 4 = 5”。"
+msgstr ""
+"将一个数字乘二后，如果结果大于 9，则将每位数字相加。因此，将“7”乘二得“14”，然"
+"后“1 + 4 = 5”。"
 
 #: src/exercises/day-1/luhn.md:15
 msgid "Sum all the undoubled and doubled digits."
@@ -5306,7 +5343,9 @@ msgstr "将下面的代码复制到 <https://play.rust-lang.org/> 并实现上�
 msgid ""
 "Try to solve the problem the \"simple\" way first, using `for` loops and "
 "integers. Then, revisit the solution and try to implement it with iterators."
-msgstr "使用“for”循环和整数，先尝试以简单的方式解决问题。然后，再次查看该解决方案，并尝试使用迭代器来实现它。"
+msgstr ""
+"使用“for”循环和整数，先尝试以简单的方式解决问题。然后，再次查看该解决方案，并"
+"尝试使用迭代器来实现它。"
 
 #: src/exercises/day-1/luhn.md:25
 msgid ""
@@ -5510,8 +5549,11 @@ msgid ""
 msgstr "内存管理：栈与堆，手动内存管理，基于作用域的内存管理，以及垃圾回收。"
 
 #: src/welcome-day-2.md:8
-msgid "Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
-msgstr "所有权：移动（move）的语义，复制（copy）和克隆（clone），借用（borrow），以及生命周期。"
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"所有权：移动（move）的语义，复制（copy）和克隆（clone），借用（borrow），以及"
+"生命周期。"
 
 #: src/welcome-day-2.md:10
 #, fuzzy
@@ -5523,8 +5565,8 @@ msgid ""
 "The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
 "`Rc` and `Arc`."
 msgstr ""
-"标准库: `字符串（String）`, `选项（Option）` 和 `结果（Result）`, `动态数组（Vec）`, "
-"`散列表（HashMap）`, `引用计数（Rc）` 和 `共享引用计数（Arc）`。"
+"标准库: `字符串（String）`, `选项（Option）` 和 `结果（Result）`, `动态数组"
+"（Vec）`, `散列表（HashMap）`, `引用计数（Rc）` 和 `共享引用计数（Arc）`。"
 
 #: src/welcome-day-2.md:15
 msgid "Modules: visibility, paths, and filesystem hierarchy."
@@ -5612,7 +5654,8 @@ msgstr "栈 vs 堆"
 msgid ""
 "Creating a `String` puts fixed-sized metadata on the stack and dynamically "
 "sized data, the actual string, on the heap:"
-msgstr "创建 `String` 时将固定大小的数据存储在栈上， 并将动态大小的数据存储在堆上："
+msgstr ""
+"创建 `String` 时将固定大小的数据存储在栈上， 并将动态大小的数据存储在堆上："
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -5632,24 +5675,27 @@ msgstr ""
 msgid ""
 "Mention that a `String` is backed by a `Vec`, so it has a capacity and "
 "length and can grow if mutable via reallocation on the heap."
-msgstr "指出 `String` 底层由 `Vec` 实现，因此它具有容量和长度，如果值可变，则可以通过在堆上重新分配存储空间进行增长。"
+msgstr ""
+"指出 `String` 底层由 `Vec` 实现，因此它具有容量和长度，如果值可变，则可以通过"
+"在堆上重新分配存储空间进行增长。"
 
 #: src/memory-management/stack.md:30
 msgid ""
 "If students ask about it, you can mention that the underlying memory is heap "
-"allocated using the [System "
-"Allocator](https://doc.rust-lang.org/std/alloc/struct.System.html) and "
-"custom allocators can be implemented using the [Allocator "
-"API](https://doc.rust-lang.org/std/alloc/index.html)"
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
-"如果学员提出相关问题，你可以提及我们不仅能使用\\[系统分配器\\]在堆上分配底层内存，还能使用 [Allocator "
-"API](https://doc.rust-lang.org/std/alloc/index.html) 实现自定义分配器"
+"如果学员提出相关问题，你可以提及我们不仅能使用\\[系统分配器\\]在堆上分配底层"
+"内存，还能使用 [Allocator API](https://doc.rust-lang.org/std/alloc/index."
+"html) 实现自定义分配器"
 
 #: src/memory-management/stack.md:32
 msgid ""
 "We can inspect the memory layout with `unsafe` code. However, you should "
 "point out that this is rightfully unsafe!"
-msgstr "我们可以使用 `unsafe` 代码检查内存布局。不过，你应该指出，这种做法不安全！"
+msgstr ""
+"我们可以使用 `unsafe` 代码检查内存布局。不过，你应该指出，这种做法不安全！"
 
 #: src/memory-management/stack.md:34
 #, fuzzy
@@ -5664,8 +5710,8 @@ msgid ""
 "to\n"
 "    // undefined behavior.\n"
 "    unsafe {\n"
-"        let (ptr, capacity, len): (usize, usize, usize) = "
-"std::mem::transmute(s1);\n"
+"        let (ptr, capacity, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
@@ -5681,8 +5727,8 @@ msgstr ""
 "to\n"
 "    // undefined behavior.\n"
 "    unsafe {\n"
-"        let (capacity, ptr, len): (usize, usize, usize) = "
-"std::mem::transmute(s1);\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
@@ -5736,10 +5782,13 @@ msgid ""
 "the pointer is lost and we cannot deallocate the memory. Worse, freeing the "
 "pointer twice, or accessing a freed pointer can lead to exploitable security "
 "vulnerabilities."
-msgstr "如果函数在 `malloc` 和 `free` 之间提前返回，则会导致内存泄漏： 指针丢失，而我们无法释放对应的内存。"
+msgstr ""
+"如果函数在 `malloc` 和 `free` 之间提前返回，则会导致内存泄漏： 指针丢失，而我"
+"们无法释放对应的内存。"
 
 #: src/memory-management/scope-based.md:3
-msgid "Constructors and destructors let you hook into the lifetime of an object."
+msgid ""
+"Constructors and destructors let you hook into the lifetime of an object."
 msgstr "构造函数和析构函数让你可以钩入对象的生命周期。"
 
 #: src/memory-management/scope-based.md:5
@@ -5747,14 +5796,17 @@ msgid ""
 "By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
 "is raised."
-msgstr "通过将指针封装在对象中，你可以在该对象 被销毁时释放内存。编译器可保证这一点的实现，即使引发了异常也不例外。"
+msgstr ""
+"通过将指针封装在对象中，你可以在该对象 被销毁时释放内存。编译器可保证这一点的"
+"实现，即使引发了异常也不例外。"
 
 #: src/memory-management/scope-based.md:9
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
 "gives you smart pointers."
 msgstr ""
-"这通常称为“资源获取即初始化 (resource acquisition is initialization, RAII)”， 并为你提供智能指针。"
+"这通常称为“资源获取即初始化 (resource acquisition is initialization, "
+"RAII)”， 并为你提供智能指针。"
 
 #: src/memory-management/scope-based.md:12
 msgid "C++ Example"
@@ -5789,7 +5841,8 @@ msgid "The destructor frees the `Person` object it points to."
 msgstr "析构函数释放它所指向的 `Person` 对象。"
 
 #: src/memory-management/scope-based.md:25
-msgid "Special move constructors are used when passing ownership to a function:"
+msgid ""
+"Special move constructors are used when passing ownership to a function:"
 msgstr "将所有权传递给函数时，使用特殊的 move 构造函数："
 
 #: src/memory-management/garbage-collection.md:1
@@ -5854,7 +5907,8 @@ msgstr "像 C++ 一样基于作用域，但编译器会强制完全遵循规则�
 msgid ""
 "A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
-msgstr "Rust 用户可以根据具体情况选择合适的抽象，有些甚至没有像 C 那样的运行时开销。"
+msgstr ""
+"Rust 用户可以根据具体情况选择合适的抽象，有些甚至没有像 C 那样的运行时开销。"
 
 #: src/memory-management/rust.md:9
 #, fuzzy
@@ -5864,28 +5918,27 @@ msgstr "它通过对“所有权”进行显式建模来实现这一点。"
 #: src/memory-management/rust.md:13
 msgid ""
 "If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as "
-"[Box](https://doc.rust-lang.org/std/boxed/struct.Box.html), "
-"[Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html), "
-"[Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or "
-"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
 "ownership and memory allocation via various means, and prevent the potential "
 "errors in C."
 msgstr ""
-"如果此时被问及如何操作，你可以提及在 Rust 中，这通常由 RAII 封装容器类型（例如 "
-"[Box](https://doc.rust-lang.org/std/boxed/struct.Box.html)、[Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html)、[Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html) "
-"或 "
-"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html)）处理。这些类型通过各种方式封装了所有权和内存分配，并防止了 "
-"C 中潜在错误的发生。"
+"如果此时被问及如何操作，你可以提及在 Rust 中，这通常由 RAII 封装容器类型（例"
+"如 [Box](https://doc.rust-lang.org/std/boxed/struct.Box.html)、[Vec](https://"
+"doc.rust-lang.org/std/vec/struct.Vec.html)、[Rc](https://doc.rust-lang.org/"
+"std/rc/struct.Rc.html) 或 [Arc](https://doc.rust-lang.org/std/sync/struct."
+"Arc.html)）处理。这些类型通过各种方式封装了所有权和内存分配，并防止了 C 中潜"
+"在错误的发生。"
 
 #: src/memory-management/rust.md:15
 msgid ""
-"You may be asked about destructors here, the "
-"[Drop](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait is the Rust "
-"equivalent."
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
 msgstr ""
-"你可能会被问及析构函数，此处 [Drop](https://doc.rust-lang.org/std/ops/trait.Drop.html) "
-"trait 是 Rust 等效项。"
+"你可能会被问及析构函数，此处 [Drop](https://doc.rust-lang.org/std/ops/trait."
+"Drop.html) trait 是 Rust 等效项。"
 
 #: src/ownership.md:3
 msgid ""
@@ -5894,7 +5947,8 @@ msgid ""
 msgstr "所有变量绑定都有一个有效的“作用域”，使用 超出其作用域的变量是错误的："
 
 #: src/ownership.md:19
-msgid "At the end of the scope, the variable is _dropped_ and the data is freed."
+msgid ""
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr "作用域结束时，变量会“被丢弃”，数据会被释放。"
 
 #: src/ownership.md:20
@@ -5951,17 +6005,22 @@ msgstr "变量绑定在任一时刻有且“只有”一个值。"
 msgid ""
 "Mention that this is the opposite of the defaults in C++, which copies by "
 "value unless you use `std::move` (and the move constructor is defined!)."
-msgstr "指出这与 C++ 中的默认值相反。除非你使用 `std::move`（并已定义 move 构造函数！），否则 C++ 中的默认值是按值复制的。"
+msgstr ""
+"指出这与 C++ 中的默认值相反。除非你使用 `std::move`（并已定义 move 构造函"
+"数！），否则 C++ 中的默认值是按值复制的。"
 
 #: src/ownership/move-semantics.md:23
 msgid ""
 "It is only the ownership that moves. Whether any machine code is generated "
 "to manipulate the data itself is a matter of optimization, and such copies "
 "are aggressively optimized away."
-msgstr "只有所有权发生了转移。是否会生成任何机器码来操控数据本身是一个优化方面的问题，系统会主动优化此类副本。"
+msgstr ""
+"只有所有权发生了转移。是否会生成任何机器码来操控数据本身是一个优化方面的问"
+"题，系统会主动优化此类副本。"
 
 #: src/ownership/move-semantics.md:25
-msgid "Simple values (such as integers) can be marked `Copy` (see later slides)."
+msgid ""
+"Simple values (such as integers) can be marked `Copy` (see later slides)."
 msgstr "简单的值（例如整数）可以标记为“Copy”（请看后续幻灯片）。"
 
 #: src/ownership/move-semantics.md:27
@@ -6071,7 +6130,9 @@ msgid ""
 "C++ has made a slightly different choice than Rust. Because `=` copies data, "
 "the string data has to be cloned. Otherwise we would get a double-free when "
 "either string goes out of scope."
-msgstr "C++ 做出了与 Rust 略有不同的选择。由于“=”会复制数据，因此必须克隆字符串数据。否则，当任一字符串超出范围时，便会出现二次释放。"
+msgstr ""
+"C++ 做出了与 Rust 略有不同的选择。由于“=”会复制数据，因此必须克隆字符串数据。"
+"否则，当任一字符串超出范围时，便会出现二次释放。"
 
 #: src/ownership/double-free-modern-cpp.md:61
 msgid ""
@@ -6081,15 +6142,17 @@ msgid ""
 "move, `s1` would be in a valid but unspecified state. Unlike Rust, the "
 "programmer is allowed to keep using `s1`."
 msgstr ""
-"C++ "
-"还包含[“std::move”](https://en.cppreference.com/w/cpp/utility/move)，它用于指示何时可以移动某个值。如果示例为“s2 "
-"= std::move(s1)”，则不会发生堆分配。移动后，“s1”将处于有效但未指定的状态。与 Rust 不同，程序员可以继续使用“s1”。"
+"C++ 还包含[“std::move”](https://en.cppreference.com/w/cpp/utility/move)，它用"
+"于指示何时可以移动某个值。如果示例为“s2 = std::move(s1)”，则不会发生堆分配。"
+"移动后，“s1”将处于有效但未指定的状态。与 Rust 不同，程序员可以继续使用“s1”。"
 
 #: src/ownership/double-free-modern-cpp.md:66
 msgid ""
 "Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
 "which is being copied or moved."
-msgstr "与 Rust 不同，使用 C++ 时，“=”可以运行任意代码，具体取决于要复制或移动的类型。"
+msgstr ""
+"与 Rust 不同，使用 C++ 时，“=”可以运行任意代码，具体取决于要复制或移动的类"
+"型。"
 
 #: src/ownership/moves-function-calls.md:3
 msgid ""
@@ -6127,7 +6190,9 @@ msgstr ""
 msgid ""
 "With the first call to `say_hello`, `main` gives up ownership of `name`. "
 "Afterwards, `name` cannot be used anymore within `main`."
-msgstr "首次调用 `say_hello` 时，`main` 便放弃了 `name` 的所有权。此后，`main` 中不能再使用 `name`。"
+msgstr ""
+"首次调用 `say_hello` 时，`main` 便放弃了 `name` 的所有权。此后，`main` 中不能"
+"再使用 `name`。"
 
 #: src/ownership/moves-function-calls.md:21
 msgid ""
@@ -6139,19 +6204,23 @@ msgstr "在 `say_hello` 函数结束时，系统会释放为 `name` 分配的堆
 msgid ""
 "`main` can retain ownership if it passes `name` as a reference (`&name`) and "
 "if `say_hello` accepts a reference as a parameter."
-msgstr "如果 `main` 将 `name` 作为引用 (`&name`) 传递过去，且 `say_hello` 接受作为参数的引用，则可保留所有权。"
+msgstr ""
+"如果 `main` 将 `name` 作为引用 (`&name`) 传递过去，且 `say_hello` 接受作为参"
+"数的引用，则可保留所有权。"
 
 #: src/ownership/moves-function-calls.md:23
 msgid ""
-"Alternatively, `main` can pass a clone of `name` in the first call "
-"(`name.clone()`)."
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
 msgstr "此外，`main` 也可以在首次调用时传递 `name` 的克隆 (`name.clone()`)。"
 
 #: src/ownership/moves-function-calls.md:24
 msgid ""
 "Rust makes it harder than C++ to inadvertently create copies by making move "
 "semantics the default, and by forcing programmers to make clones explicit."
-msgstr "相较于 C++，Rust 通过将移动语义设为默认值，并强制程序员进行显式克隆，更难以无意中创建副本。"
+msgstr ""
+"相较于 C++，Rust 通过将移动语义设为默认值，并强制程序员进行显式克隆，更难以无"
+"意中创建副本。"
 
 #: src/ownership/copy-clone.md:3
 msgid ""
@@ -6199,8 +6268,7 @@ msgstr "克隆是一种更通用的操作，也允许通过实现 `Clone` trait 
 msgid "Copying does not work on types that implement the `Drop` trait."
 msgstr "复制不适用于实现 `Drop` trait 的类型。"
 
-#: src/ownership/copy-clone.md:44
-#: src/ownership/lifetimes-function-calls.md:30
+#: src/ownership/copy-clone.md:44 src/ownership/lifetimes-function-calls.md:30
 msgid "In the above example, try the following:"
 msgstr "在上述示例中，请尝试以下操作："
 
@@ -6208,13 +6276,16 @@ msgstr "在上述示例中，请尝试以下操作："
 msgid ""
 "Add a `String` field to `struct Point`. It will not compile because `String` "
 "is not a `Copy` type."
-msgstr "在 `struct Point` 中添加 `String` 字段。由于 `String` 不属于 `Copy` 类型，因此无法编译。"
+msgstr ""
+"在 `struct Point` 中添加 `String` 字段。由于 `String` 不属于 `Copy` 类型，因"
+"此无法编译。"
 
 #: src/ownership/copy-clone.md:47
 msgid ""
 "Remove `Copy` from the `derive` attribute. The compiler error is now in the "
 "`println!` for  `p1`."
-msgstr "从 `derive` 属性中移除 `Copy`。现在，编译器错误位于 `p1`的 `println!` 中。"
+msgstr ""
+"从 `derive` 属性中移除 `Copy`。现在，编译器错误位于 `p1`的 `println!` 中。"
 
 #: src/ownership/copy-clone.md:48
 msgid "Show that it works if you clone `p1` instead."
@@ -6226,8 +6297,8 @@ msgid ""
 "to generate code in Rust at compile time. In this case the default "
 "implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
-"如果学员问起 `derive`，只需说这是一种 在编译时生成 Rust 代码的方法。在这种情况下，系统会生成 `Copy` 和 `Clone` "
-"trait 的默认实现。"
+"如果学员问起 `derive`，只需说这是一种 在编译时生成 Rust 代码的方法。在这种情"
+"况下，系统会生成 `Copy` 和 `Clone` trait 的默认实现。"
 
 #: src/ownership/borrowing.md:3
 msgid ""
@@ -6257,9 +6328,9 @@ msgid ""
 "optimization level, the addresses should change, while they stay the same "
 "when changing to the \"RELEASE\" setting:"
 msgstr ""
-"证明从 `add` 返回的开销很低，因为编译器可以消除复制操作。更改上述代码以输出栈地址，并在 "
-"[Playground](https://play.rust-lang.org/) "
-"上运行它。在“调试”优化级别中，地址应发生变化，而在改成“发布”设置时保持不变："
+"证明从 `add` 返回的开销很低，因为编译器可以消除复制操作。更改上述代码以输出栈"
+"地址，并在 [Playground](https://play.rust-lang.org/) 上运行它。在“调试”优化级"
+"别中，地址应发生变化，而在改成“发布”设置时保持不变："
 
 #: src/ownership/borrowing.md:50
 msgid "The Rust compiler can do return value optimization (RVO)."
@@ -6273,8 +6344,9 @@ msgid ""
 "RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
 "copy."
 msgstr ""
-"在 C++ 中，必须在语言规范中定义复制省略，因为构造函数可能会有附带效应。在 Rust 中，这完全不是问题。如果 RVO 未发生，Rust "
-"将始终执行简单且高效的 `memcpy` 复制。"
+"在 C++ 中，必须在语言规范中定义复制省略，因为构造函数可能会有附带效应。在 "
+"Rust 中，这完全不是问题。如果 RVO 未发生，Rust 将始终执行简单且高效的 "
+"`memcpy` 复制。"
 
 #: src/ownership/shared-unique-borrows.md:3
 msgid "Rust puts constraints on the ways you can borrow values:"
@@ -6292,13 +6364,16 @@ msgstr "你可以有且只有一个 `&mut T` 值。"
 msgid ""
 "The above code does not compile because `a` is borrowed as mutable (through "
 "`c`) and as immutable (through `b`) at the same time."
-msgstr "上述代码无法编译，因为 `a` 同时作为可变值（通过 `c`）和不可变值（通过 `b`）被借用。"
+msgstr ""
+"上述代码无法编译，因为 `a` 同时作为可变值（通过 `c`）和不可变值（通过 `b`）被"
+"借用。"
 
 #: src/ownership/shared-unique-borrows.md:27
 msgid ""
 "Move the `println!` statement for `b` before the scope that introduces `c` "
 "to make the code compile."
-msgstr "将`b` 的 `println!` 语句移到引入 `c` 的作用域之前，这段代码就可以编译。"
+msgstr ""
+"将`b` 的 `println!` 语句移到引入 `c` 的作用域之前，这段代码就可以编译。"
 
 #: src/ownership/shared-unique-borrows.md:28
 msgid ""
@@ -6306,7 +6381,8 @@ msgid ""
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"这样更改后，编译器会发现 `b` 只在通过 `c` 对 `a` 进行新可变借用之前使用过。这是借用检查器的一个功能，名为“非词法作用域生命周期”。"
+"这样更改后，编译器会发现 `b` 只在通过 `c` 对 `a` 进行新可变借用之前使用过。这"
+"是借用检查器的一个功能，名为“非词法作用域生命周期”。"
 
 #: src/ownership/lifetimes.md:3
 msgid "A borrowed value has a _lifetime_:"
@@ -6320,8 +6396,7 @@ msgstr "生命周期可以是隐式的：add(p1: &Point, p2: &Point) -> Point\\`
 msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
 msgstr "生命周期也可以是显式的：`&'a Point`、`&'document str`。"
 
-#: src/ownership/lifetimes.md:7
-#: src/ownership/lifetimes-function-calls.md:24
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:24
 msgid ""
 "Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
 "lifetime `a`\"."
@@ -6346,8 +6421,9 @@ msgid ""
 "but Rust allows lifetimes to be elided in most cases with [a few simple "
 "rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
 msgstr ""
-"必须完全指定函数参数和返回值的生命周期， 但 Rust 允许在大多数情况下通过\\[一些简单的 "
-"规则\\](https://doc.rust-lang.org/nomicon/lifetime-elision.html）来省略此操作。"
+"必须完全指定函数参数和返回值的生命周期， 但 Rust 允许在大多数情况下通过\\[一"
+"些简单的 规则\\](https://doc.rust-lang.org/nomicon/lifetime-elision.html）来"
+"省略此操作。"
 
 #: src/ownership/lifetimes-function-calls.md:3
 msgid ""
@@ -6364,7 +6440,8 @@ msgid "Lifetimes start with `'` and `'a` is a typical default name."
 msgstr "以 `'` 和 `'a` 开头的生命周期是典型的默认名称。"
 
 #: src/ownership/lifetimes-function-calls.md:26
-msgid "The _at least_ part is important when parameters are in different scopes."
+msgid ""
+"The _at least_ part is important when parameters are in different scopes."
 msgstr "当参数在不同的作用域时，“至少”部分至关重要。"
 
 #: src/ownership/lifetimes-function-calls.md:32
@@ -6383,8 +6460,9 @@ msgid ""
 "'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
 "because the relationship between the lifetimes `'a` and `'b` is unclear."
 msgstr ""
-"重置工作区，然后将函数签名更改为 `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b "
-"Point`。这不会被编译，因为 `'a` 和 `'b` 生命周期之间的关系不明确。"
+"重置工作区，然后将函数签名更改为 `fn left_most<'a, 'b>(p1: &'a Point, p2: "
+"&'a Point) -> &'b Point`。这不会被编译，因为 `'a` 和 `'b` 生命周期之间的关系"
+"不明确。"
 
 #: src/ownership/lifetimes-function-calls.md:55
 msgid "Another way to explain it:"
@@ -6406,7 +6484,9 @@ msgid ""
 "Which one is it? The compiler needs to know, so at the call site the "
 "returned reference is not used for longer than a variable from where the "
 "reference came from."
-msgstr "是哪一个呢？编译器需要知道这一点，因此在调用点，返回的引用 的使用时间不会超过引用的来源中的变量。"
+msgstr ""
+"是哪一个呢？编译器需要知道这一点，因此在调用点，返回的引用 的使用时间不会超过"
+"引用的来源中的变量。"
 
 #: src/ownership/lifetimes-data-structures.md:3
 msgid ""
@@ -6424,8 +6504,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy "
-"dog.\");\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
 "    let fox = Highlight(&text[4..19]);\n"
 "    let dog = Highlight(&text[35..43]);\n"
 "    // erase(text);\n"
@@ -6443,8 +6523,8 @@ msgstr ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy "
-"dog.\");\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
 "    let fox = Highlight(&text[4..19]);\n"
 "    let dog = Highlight(&text[35..43]);\n"
 "    // erase(text);\n"
@@ -6459,20 +6539,25 @@ msgid ""
 "underlying the contained `&str` lives at least as long as any instance of "
 "`Highlight` that uses that data."
 msgstr ""
-"在上述示例中，`Highlight` 注释会强制包含 `&str` 的底层数据的生命周期至少与使用该数据的任何 `Highlight` 实例一样长。"
+"在上述示例中，`Highlight` 注释会强制包含 `&str` 的底层数据的生命周期至少与使"
+"用该数据的任何 `Highlight` 实例一样长。"
 
 #: src/ownership/lifetimes-data-structures.md:26
 msgid ""
 "If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
 "the borrow checker throws an error."
-msgstr "如果 `text` 在 `fox`（或 `dog`）的生命周期结束前被消耗，借用检查器将抛出一个错误。"
+msgstr ""
+"如果 `text` 在 `fox`（或 `dog`）的生命周期结束前被消耗，借用检查器将抛出一个"
+"错误。"
 
 #: src/ownership/lifetimes-data-structures.md:27
 msgid ""
 "Types with borrowed data force users to hold on to the original data. This "
 "can be useful for creating lightweight views, but it generally makes them "
 "somewhat harder to use."
-msgstr "借用数据的类型会迫使用户保留原始数据。这对于创建轻量级视图很有用，但通常会使它们更难使用。"
+msgstr ""
+"借用数据的类型会迫使用户保留原始数据。这对于创建轻量级视图很有用，但通常会使"
+"它们更难使用。"
 
 #: src/ownership/lifetimes-data-structures.md:28
 msgid "When possible, make data structures own their data directly."
@@ -6485,7 +6570,9 @@ msgid ""
 "relationships between the references themselves, in addition to the lifetime "
 "of the struct itself. Those are very advanced use cases."
 msgstr ""
-"一些包含多个引用的结构可以有多个生命周期注释。除了结构体本身的生命周期之外，如果需要描述引用之间的生命周期关系，则可能需要这样做。这些都是非常高级的用例。"
+"一些包含多个引用的结构可以有多个生命周期注释。除了结构体本身的生命周期之外，"
+"如果需要描述引用之间的生命周期关系，则可能需要这样做。这些都是非常高级的用"
+"例。"
 
 #: src/structs.md:3
 msgid "Like C and C++, Rust has support for custom structs:"
@@ -6547,7 +6634,9 @@ msgid ""
 "Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
 "value itself. "
-msgstr "针对某类型实现 trait 时，可能会使用大小为零的结构体“e.g., struct Foo;”，但其中没有任何您要储存在值本身中的数据。"
+msgstr ""
+"针对某类型实现 trait 时，可能会使用大小为零的结构体“e.g., struct Foo;”，但其"
+"中没有任何您要储存在值本身中的数据。"
 
 #: src/structs.md:39
 msgid ""
@@ -6560,7 +6649,9 @@ msgid ""
 "The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
-msgstr "通过语法“..peter”，我们可以从旧结构体复制大部分字段，而无需明确地输入所有字段。它必须始终是最后一个元素。"
+msgstr ""
+"通过语法“..peter”，我们可以从旧结构体复制大部分字段，而无需明确地输入所有字"
+"段。它必须始终是最后一个元素。"
 
 #: src/structs/tuple-structs.md:3
 msgid "If the field names are unimportant, you can use a tuple struct:"
@@ -6608,7 +6699,9 @@ msgstr ""
 msgid ""
 "Newtypes are a great way to encode additional information about the value in "
 "a primitive type, for example:"
-msgstr "如需对基元类型中的值的额外信息进行编码，使用 newtype 是一种非常好的方式，例如："
+msgstr ""
+"如需对基元类型中的值的额外信息进行编码，使用 newtype 是一种非常好的方式，例"
+"如："
 
 #: src/structs/tuple-structs.md:38
 msgid "The number is measured in some units: `Newtons` in the example above."
@@ -6619,13 +6712,15 @@ msgid ""
 "The value passed some validation when it was created, so you no longer have "
 "to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
 msgstr ""
-"值在创建时已通过一些验证，因此您不再需要在每次使用时都再次验证它：`PhoneNumber(String)` 或 `OddNumber(u32)`。"
+"值在创建时已通过一些验证，因此您不再需要在每次使用时都再次验证它："
+"`PhoneNumber(String)` 或 `OddNumber(u32)`。"
 
 #: src/structs/tuple-structs.md:40
 msgid ""
 "Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
 "single field in the newtype."
-msgstr "展示如何通过访问 newtype 中的单个字段，将 `f64` 值添加到 `Newtons` 类型。"
+msgstr ""
+"展示如何通过访问 newtype 中的单个字段，将 `f64` 值添加到 `Newtons` 类型。"
 
 #: src/structs/tuple-structs.md:41
 msgid ""
@@ -6639,11 +6734,12 @@ msgstr "运算符过载在第 3 天（泛型）讨论。"
 
 #: src/structs/tuple-structs.md:43
 msgid ""
-"The example is a subtle reference to the [Mars Climate "
-"Orbiter](https://en.wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
-"此示例巧妙地引用了[火星气候探测者号](https://zh.wikipedia.org/wiki/%E7%81%AB%E6%98%9F%E6%B0%A3%E5%80%99%E6%8E%A2%E6%B8%AC%E8%80%85%E8%99%9F) "
-"的失败事故。"
+"此示例巧妙地引用了[火星气候探测者号](https://zh.wikipedia.org/wiki/"
+"%E7%81%AB%E6%98%9F%E6%B0%A3%E5%80%99%E6%8E%A2%E6%B8%AC%E8%80%85%E8%99%9F) 的"
+"失败事故。"
 
 #: src/structs/field-shorthand.md:3
 msgid ""
@@ -6677,7 +6773,8 @@ msgstr ""
 msgid ""
 "The `new` function could be written using `Self` as a type, as it is "
 "interchangeable with the struct type name"
-msgstr "在编写“new”函数时可以使用“Self”作为类型，因为它可以与结构体类型名称互换"
+msgstr ""
+"在编写“new”函数时可以使用“Self”作为类型，因为它可以与结构体类型名称互换"
 
 #: src/structs/field-shorthand.md:41
 msgid ""
@@ -6721,10 +6818,13 @@ msgstr "方法是在“impl”块中进行定义的。"
 msgid ""
 "Use struct update syntax to define a new structure using `peter`. Note that "
 "the variable `peter` will no longer be accessible afterwards."
-msgstr "使用结构体更新语法以利用“peter”定义一个新结构。请注意，之后将无法再访问变量“peter”。"
+msgstr ""
+"使用结构体更新语法以利用“peter”定义一个新结构。请注意，之后将无法再访问变"
+"量“peter”。"
 
 #: src/structs/field-shorthand.md:70
-msgid "Use `{:#?}` when printing structs to request the `Debug` representation."
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
 msgstr "在输出结构体时，使用“{:#?}”来请求“Debug”表示法。"
 
 #: src/methods.md:3
@@ -6766,14 +6866,18 @@ msgstr "引入方法时，将方法与函数进行比较会很有帮助。"
 msgid ""
 "Methods are called on an instance of a type (such as a struct or enum), the "
 "first parameter represents the instance as `self`."
-msgstr "在某种类型（例如结构体或枚举）的实例上调用方法，第一个参数将该实例表示为“self”。"
+msgstr ""
+"在某种类型（例如结构体或枚举）的实例上调用方法，第一个参数将该实例表示"
+"为“self”。"
 
 #: src/methods.md:33
 msgid ""
 "Developers may choose to use methods to take advantage of method receiver "
 "syntax and to help keep them more organized. By using methods we can keep "
 "all the implementation code in one predictable place."
-msgstr "开发者可能会选择使用方法，以便利用方法接收器语法并让方法更有条理。通过使用方法，我们可以将所有实现代码保存在一个可预测的位置。"
+msgstr ""
+"开发者可能会选择使用方法，以便利用方法接收器语法并让方法更有条理。通过使用方"
+"法，我们可以将所有实现代码保存在一个可预测的位置。"
 
 #: src/methods.md:34
 msgid "Point out the use of the keyword `self`, a method receiver."
@@ -6795,13 +6899,16 @@ msgstr "说明“Self”是“impl”块所属类型的类型别名，可以在�
 msgid ""
 "Note how `self` is used like other structs and dot notation can be used to "
 "refer to individual fields."
-msgstr "指出“self”的使用方式与其他结构体一样，并且可以使用点表示法来指代各个字段。"
+msgstr ""
+"指出“self”的使用方式与其他结构体一样，并且可以使用点表示法来指代各个字段。"
 
 #: src/methods.md:38
 msgid ""
 "This might be a good time to demonstrate how the `&self` differs from `self` "
 "by modifying the code and trying to run say_hello twice."
-msgstr "这可能是演示“&self”和“self”差别的好时机，您只要修改代码并尝试执行 say_hello 两次即可。"
+msgstr ""
+"这可能是演示“&self”和“self”差别的好时机，您只要修改代码并尝试执行 say_hello "
+"两次即可。"
 
 #: src/methods.md:39
 msgid "We describe the distinction between method receivers next."
@@ -6811,19 +6918,22 @@ msgstr "下面，我们将介绍方法接收器之间的区别。"
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
 "There are other possible receivers for a method:"
-msgstr "上面的“&self”表明该方法以不可变的方式借用了对象。还有其他可能的方法接收器："
+msgstr ""
+"上面的“&self”表明该方法以不可变的方式借用了对象。还有其他可能的方法接收器："
 
 #: src/methods/receiver.md:6
 msgid ""
 "`&self`: borrows the object from the caller using a shared and immutable "
 "reference. The object can be used again afterwards."
-msgstr "“&self”：使用不可变的共享引用从调用方借用对象。之后可以再次使用该对象。"
+msgstr ""
+"“&self”：使用不可变的共享引用从调用方借用对象。之后可以再次使用该对象。"
 
 #: src/methods/receiver.md:8
 msgid ""
 "`&mut self`: borrows the object from the caller using a unique and mutable "
 "reference. The object can be used again afterwards."
-msgstr "“&mut self”：使用唯一的可变引用从调用方借用对象。之后可以再次使用该对象。"
+msgstr ""
+"“&mut self”：使用唯一的可变引用从调用方借用对象。之后可以再次使用该对象。"
 
 #: src/methods/receiver.md:10
 msgid ""
@@ -6832,7 +6942,9 @@ msgid ""
 "(deallocated) when the method returns, unless its ownership is explicitly "
 "transmitted. Complete ownership does not automatically mean mutability."
 msgstr ""
-"“self”：获取对象的所有权并将其从调用方移出。该方法会成为对象的所有者。除非明确转移对象的所有权，否则在该方法返回时，对象将被丢弃（取消分配）。具备完全所有权，不自动等同于具备可变性。"
+"“self”：获取对象的所有权并将其从调用方移出。该方法会成为对象的所有者。除非明"
+"确转移对象的所有权，否则在该方法返回时，对象将被丢弃（取消分配）。具备完全所"
+"有权，不自动等同于具备可变性。"
 
 #: src/methods/receiver.md:14
 msgid "`mut self`: same as above, but the method can mutate the object. "
@@ -6842,16 +6954,19 @@ msgstr "“mut self”：同上，但该方法可以改变对象。"
 msgid ""
 "No receiver: this becomes a static method on the struct. Typically used to "
 "create constructors which are called `new` by convention."
-msgstr "无接收器：这将变为结构体上的静态方法。通常用于创建构造函数，按惯例被称为“new”。"
+msgstr ""
+"无接收器：这将变为结构体上的静态方法。通常用于创建构造函数，按惯例被称"
+"为“new”。"
 
 #: src/methods/receiver.md:18
 #, fuzzy
 msgid ""
-"Beyond variants on `self`, there are also [special wrapper "
-"types](https://doc.rust-lang.org/reference/special-types-and-traits.html) "
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
-"除“self”的变体外，还可以将[特殊封装容器类型](https://doc.rust-lang.org/reference/special-types-and-traits.html)作为接收器类型，例如“Box\n"
+"除“self”的变体外，还可以将[特殊封装容器类型](https://doc.rust-lang.org/"
+"reference/special-types-and-traits.html)作为接收器类型，例如“Box\n"
 "\n"
 "”。"
 
@@ -6862,8 +6977,9 @@ msgid ""
 "and `self` is no exception. It isn't possible to reference a struct from "
 "multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
-"建议强调“共享且不可变”和“唯一且可变”。由于借用检查器规则的原因，这些约束在 Rust "
-"中总是一起出现，而“self”也不例外。您无法从多个位置引用结构体并对其调用一项改变（“&mut self”）方法。"
+"建议强调“共享且不可变”和“唯一且可变”。由于借用检查器规则的原因，这些约束在 "
+"Rust 中总是一起出现，而“self”也不例外。您无法从多个位置引用结构体并对其调用一"
+"项改变（“&mut self”）方法。"
 
 #: src/methods/example.md:3
 msgid ""
@@ -6919,7 +7035,9 @@ msgstr "这里的所有四种方法都使用一个不同的方法接收器。"
 msgid ""
 "You can point out how that changes what the function can do with the "
 "variable values and if/how it can be used again in `main`."
-msgstr "您可以指出这会如何改变函数可对变量值采取的操作，以及是否/如何能够在“main”中再次使用该函数。"
+msgstr ""
+"您可以指出这会如何改变函数可对变量值采取的操作，以及是否/如何能够在“main”中再"
+"次使用该函数。"
 
 #: src/methods/example.md:49
 msgid ""
@@ -6933,14 +7051,17 @@ msgid ""
 "referencing and dereferencing when calling methods. Rust automatically adds "
 "in the `&`, `*`, `muts` so that that object matches the method signature."
 msgstr ""
-"请注意，尽管方法接收器不同，但是非静态函数在 main 函数体中的调用方式相同。Rust "
-"支持在调用方法时自动引用和解引用，并会自动加入“&”“\\*”和“muts”以便该对象与方法签名匹配。"
+"请注意，尽管方法接收器不同，但是非静态函数在 main 函数体中的调用方式相同。"
+"Rust 支持在调用方法时自动引用和解引用，并会自动加入“&”“\\*”和“muts”以便该对象"
+"与方法签名匹配。"
 
 #: src/methods/example.md:51
 msgid ""
 "You might point out that `print_laps` is using a vector that is iterated "
 "over. We describe vectors in more detail in the afternoon. "
-msgstr "您或许可以指出“print_laps”使用的是不断迭代的矢量。我们将在下午详细说明这些矢量。"
+msgstr ""
+"您或许可以指出“print_laps”使用的是不断迭代的矢量。我们将在下午详细说明这些矢"
+"量。"
 
 #: src/exercises/day-2/morning.md:1
 msgid "Day 2: Morning Exercises"
@@ -7080,7 +7201,9 @@ msgstr ""
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
 "you need to keep track of users' health statistics."
-msgstr "你正在实现一个健康监控系统。作为其中的一部分，你需要对用户的健康统计数据进行追踪。"
+msgstr ""
+"你正在实现一个健康监控系统。作为其中的一部分，你需要对用户的健康统计数据进行"
+"追踪。"
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
@@ -7088,8 +7211,8 @@ msgid ""
 "`User` struct definition. Your goal is to implement the stubbed out methods "
 "on the `User` `struct` defined in the `impl` block."
 msgstr ""
-"`User` 结构体的定义和 `impl` 块中一些函数的框架已经给出。你的目标是实现在 `impl` 块中定义的 `User` `struct` "
-"的方法。"
+"`User` 结构体的定义和 `impl` 块中一些函数的框架已经给出。你的目标是实现在 "
+"`impl` 块中定义的 `User` `struct` 的方法。"
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
@@ -7208,8 +7331,8 @@ msgid ""
 "types used by Rust library and programs. This way, two libraries can work "
 "together smoothly because they both use the same `String` type."
 msgstr ""
-"Rust 附带一个标准库，此库有助于建立一个供 Rust 库和程序 使用的常用类型集。这样一来，两个库便可顺畅地搭配运作， 因为它们使用相同的 "
-"`String` 类型。"
+"Rust 附带一个标准库，此库有助于建立一个供 Rust 库和程序 使用的常用类型集。这"
+"样一来，两个库便可顺畅地搭配运作， 因为它们使用相同的 `String` 类型。"
 
 #: src/std.md:7
 msgid "The common vocabulary types include:"
@@ -7220,8 +7343,8 @@ msgid ""
 "[`Option` and `Result`](std/option-result.md) types: used for optional "
 "values and [error handling](error-handling.md)."
 msgstr ""
-"[`Option` 和 `Result`](std/option-result.md) 类型：用于可选值和 "
-"[错误处理](error-handling.md)。"
+"[`Option` 和 `Result`](std/option-result.md) 类型：用于可选值和 [错误处理]"
+"(error-handling.md)。"
 
 #: src/std.md:12
 msgid "[`String`](std/string.md): the default string type used for owned data."
@@ -7257,7 +7380,9 @@ msgstr "Rust 实际上含有多个层级的标准库，分别是 `core`、`alloc
 msgid ""
 "`core` includes the most basic types and functions that don't depend on "
 "`libc`, allocator or even the presence of an operating system. "
-msgstr "`core` 包括最基本的类型与函数，这些类型与函数不依赖于 `libc`、分配器 或是否存在操作系统。"
+msgstr ""
+"`core` 包括最基本的类型与函数，这些类型与函数不依赖于 `libc`、分配器 或是否存"
+"在操作系统。"
 
 #: src/std.md:28
 msgid ""
@@ -7266,7 +7391,8 @@ msgid ""
 msgstr "`alloc` 包括需要全局堆分配器的类型，例如 `Vec`、`Box` 和 `Arc`。"
 
 #: src/std.md:29
-msgid "Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr "嵌入式 Rust 应用通常只使用 `core`，偶尔会使用 `alloc`。"
 
 #: src/std/option-result.md:1
@@ -7336,8 +7462,8 @@ msgid ""
 "[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
 "standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
-"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) "
-"是标准堆分配的可扩容 UTF-8 字符串缓冲区："
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) 是标准堆"
+"分配的可扩容 UTF-8 字符串缓冲区："
 
 #: src/std/string.md:5
 msgid ""
@@ -7361,34 +7487,40 @@ msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = "
-"str>`](https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str), "
-"which means that you can call all `str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` 会实现 [`Deref<Target = "
-"str>`](https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str)，这意味着您可以 "
-"对 `String` 调用所有 `str` 方法。"
+"`String` 会实现 [`Deref<Target = str>`](https://doc.rust-lang.org/std/string/"
+"struct.String.html#deref-methods-str)，这意味着您可以 对 `String` 调用所有 "
+"`str` 方法。"
 
 #: src/std/string.md:30
 msgid ""
 "`String::new` returns a new empty string, use `String::with_capacity` when "
 "you know how much data you want to push to the string."
-msgstr "“String::new”会返回一个新的空字符串，如果您知道自己想要推送到字符串的数据量，请使用“String::with_capacity”。"
+msgstr ""
+"“String::new”会返回一个新的空字符串，如果您知道自己想要推送到字符串的数据量，"
+"请使用“String::with_capacity”。"
 
 #: src/std/string.md:31
 msgid ""
 "`String::len` returns the size of the `String` in bytes (which can be "
 "different from its length in characters)."
-msgstr "“String::len”会返回“String”的大小（以字节为单位，可能不同于以字符为单位的长度）。"
+msgstr ""
+"“String::len”会返回“String”的大小（以字节为单位，可能不同于以字符为单位的长"
+"度）。"
 
 #: src/std/string.md:32
 msgid ""
 "`String::chars` returns an iterator over the actual characters. Note that a "
 "`char` can be different from what a human will consider a \"character\" due "
-"to [grapheme "
-"clusters](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html)."
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
 msgstr ""
-"“String::chars”会针对实际字符返回一个迭代器。请注意，由于[字素簇](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html)，“char”可能与人们所认为的“字符”有所不同。"
+"“String::chars”会针对实际字符返回一个迭代器。请注意，由于[字素簇](https://"
+"docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes."
+"html)，“char”可能与人们所认为的“字符”有所不同。"
 
 #: src/std/string.md:33
 msgid ""
@@ -7400,13 +7532,17 @@ msgstr "当人们提到字符串时，可能是指“&str”或“String”。"
 msgid ""
 "When a type implements `Deref<Target = T>`, the compiler will let you "
 "transparently call methods from `T`."
-msgstr "当某个类型实现“Deref\\<Target = T>”时，编译器会让您以公开透明方式从“T”调用方法。"
+msgstr ""
+"当某个类型实现“Deref\\<Target = T>”时，编译器会让您以公开透明方式从“T”调用方"
+"法。"
 
 #: src/std/string.md:35
 msgid ""
 "`String` implements `Deref<Target = str>` which transparently gives it "
 "access to `str`'s methods."
-msgstr "“String”会实现“Deref\\<Target = str>”，后者可公开透明地授予其访问“str”方法的权限。"
+msgstr ""
+"“String”会实现“Deref\\<Target = str>”，后者可公开透明地授予其访问“str”方法的"
+"权限。"
 
 #: src/std/string.md:36
 msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
@@ -7417,7 +7553,9 @@ msgid ""
 "`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
 "with some extra guarantees."
-msgstr "“String”是作为字节矢量的封装容器实现的，矢量上支持的许多操作在“String”上也受支持，但有一些额外保证。"
+msgstr ""
+"“String”是作为字节矢量的封装容器实现的，矢量上支持的许多操作在“String”上也受"
+"支持，但有一些额外保证。"
 
 #: src/std/string.md:38
 msgid "Compare the different ways to index a `String`:"
@@ -7433,7 +7571,8 @@ msgstr "使用“s3.chars().nth(i).unwrap()”转换为字符，其中“i”代
 msgid ""
 "To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
-msgstr "通过使用“s3\\[0..4\\]”转换为子字符串，其中该 Slice 在或不在字符边界上。"
+msgstr ""
+"通过使用“s3\\[0..4\\]”转换为子字符串，其中该 Slice 在或不在字符边界上。"
 
 #: src/std/vec.md:1
 msgid "`Vec`"
@@ -7444,7 +7583,8 @@ msgid ""
 "[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
 "resizable heap-allocated buffer:"
 msgstr ""
-"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 是标准的可调整大小堆分配缓冲区："
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 是标准的可调整大小"
+"堆分配缓冲区："
 
 #: src/std/vec.md:5
 msgid ""
@@ -7475,13 +7615,13 @@ msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = "
-"[T]>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-%5BT%5D), "
-"which means that you can call slice methods on a `Vec`."
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
+"methods on a `Vec`."
 msgstr ""
-"`Vec` 会实现 [`Deref<Target = "
-"[T]>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-%5BT%5D)，这意味着您可以对 "
-"`Vec` 调用 slice 方法。"
+"`Vec` 会实现 [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D)，这意味着您可以对 `Vec` 调用 slice 方"
+"法。"
 
 #: src/std/vec.md:37
 msgid ""
@@ -7489,7 +7629,8 @@ msgid ""
 "it contains is stored on the heap. This means the amount of data doesn't "
 "need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
-"“Vec”以及“String”和“HashMap”都是一种集合。它包含的数据会存储在堆上。这意味着在编译时不需要知道数据量。它可以在运行时增大或缩小。"
+"“Vec”以及“String”和“HashMap”都是一种集合。它包含的数据会存储在堆上。这意味着"
+"在编译时不需要知道数据量。它可以在运行时增大或缩小。"
 
 #: src/std/vec.md:40
 #, fuzzy
@@ -7500,13 +7641,15 @@ msgid ""
 msgstr ""
 "请注意，“Vec\n"
 "\n"
-"”也是一种泛型，但您不必明确指定“T”。和往常的 Rust 类别推断一样，系统会在第一次“push”调用期间建立“T”。"
+"”也是一种泛型，但您不必明确指定“T”。和往常的 Rust 类别推断一样，系统会在第一"
+"次“push”调用期间建立“T”。"
 
 #: src/std/vec.md:42
 msgid ""
 "`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
 "supports adding initial elements to the vector."
-msgstr "“vec![...\\]”是用来代替“Vec::new()”的规范化宏，它支持向矢量添加初始元素。"
+msgstr ""
+"“vec![...\\]”是用来代替“Vec::new()”的规范化宏，它支持向矢量添加初始元素。"
 
 #: src/std/vec.md:44
 msgid ""
@@ -7523,8 +7666,7 @@ msgid ""
 "+= 50; }`"
 msgstr "介绍如何迭代矢量并更改它的值：“for e in &mut v { \\*e += 50; }”"
 
-#: src/std/hashmap.md:1
-#: src/bare-metal/no_std.md:46
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
 msgid "`HashMap`"
 msgstr "`HashMap`"
 
@@ -7560,8 +7702,8 @@ msgid ""
 "    // Use the .entry() method to insert a value if nothing is found.\n"
 "    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
 "Wonderland\"] {\n"
-"        let page_count: &mut i32 = "
-"page_counts.entry(book.to_string()).or_insert(0);\n"
+"        let page_count: &mut i32 = page_counts.entry(book.to_string())."
+"or_insert(0);\n"
 "        *page_count += 1;\n"
 "    }\n"
 "\n"
@@ -7581,7 +7723,8 @@ msgid ""
 "hashmap and if not return an alternative value. The second line will insert "
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
-"请尝试使用以下代码行。第一行将查看图书是否在 hashmap 中；如果不在，则返回替代值。如果未找到图书，第二行会在 hashmap 中插入替代值。"
+"请尝试使用以下代码行。第一行将查看图书是否在 hashmap 中；如果不在，则返回替代"
+"值。如果未找到图书，第二行会在 hashmap 中插入替代值。"
 
 #: src/std/hashmap.md:41
 msgid ""
@@ -7601,12 +7744,15 @@ msgstr "遗憾的是，与“vec!”不同，不存在标准的“hashmap!”宏
 
 #: src/std/hashmap.md:50
 msgid ""
-"Although, since Rust 1.56, HashMap implements [`From<[(K, V); "
-"N]>`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), "
-"which allows us to easily initialize a hash map from a literal array:"
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
 msgstr ""
-"不过，从 Rust 1.56 开始，HashMap 实现了[“From\\<\\[(K, V); "
-"N\\]\\>”](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E)，让我们能够轻松地从字面量数组初始化哈希映射："
+"不过，从 Rust 1.56 开始，HashMap 实现了[“From\\<\\[(K, V); N\\]\\>”](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E)，让我们能够轻松"
+"地从字面量数组初始化哈希映射："
 
 #: src/std/hashmap.md:52
 msgid ""
@@ -7620,8 +7766,8 @@ msgstr ""
 
 #: src/std/hashmap.md:59
 msgid ""
-"Alternatively HashMap can be built from any `Iterator` which yields "
-"key-value tuples."
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
 msgstr "或者，HashMap 也可以基于任何可生成键-值元组的“Iterator”进行构建。"
 
 #: src/std/hashmap.md:60
@@ -7630,24 +7776,27 @@ msgid ""
 "examples easier. Using references in collections can, of course, be done, "
 "but it can lead into complications with the borrow checker."
 msgstr ""
-"我们要展示“HashMap\\<String, "
-"i32>”，避免将“&str”用作键，以便简化示例。当然，可以在集合中使用引用，但可能会导致借用检查器出现复杂问题。"
+"我们要展示“HashMap\\<String, i32>”，避免将“&str”用作键，以便简化示例。当然，"
+"可以在集合中使用引用，但可能会导致借用检查器出现复杂问题。"
 
 #: src/std/hashmap.md:62
 msgid ""
 "Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
-msgstr "尝试从上述示例中移除“to_string()”，看看它是否仍可编译。您认为我们可能会在哪些方面遇到问题？"
+msgstr ""
+"尝试从上述示例中移除“to_string()”，看看它是否仍可编译。您认为我们可能会在哪些"
+"方面遇到问题？"
 
 #: src/std/hashmap.md:64
 msgid ""
-"This type has several \"method-specific\" return types, such as "
-"`std::collections::hash_map::Keys`. These types often appear in searches of "
-"the Rust docs. Show students the docs for this type, and the helpful link "
-"back to the `keys` method."
+"This type has several \"method-specific\" return types, such as `std::"
+"collections::hash_map::Keys`. These types often appear in searches of the "
+"Rust docs. Show students the docs for this type, and the helpful link back "
+"to the `keys` method."
 msgstr ""
-"此类型具有几种特定于方法的返回值类型，例如“std::collections::hash_map::Keys”。这些类型通常会出现在 Rust "
-"文档的搜索结果中。向学员展示此类型的文档，以及指向“keys”方法的实用链接。"
+"此类型具有几种特定于方法的返回值类型，例如“std::collections::hash_map::"
+"Keys”。这些类型通常会出现在 Rust 文档的搜索结果中。向学员展示此类型的文档，以"
+"及指向“keys”方法的实用链接。"
 
 #: src/std/box.md:1
 msgid "`Box`"
@@ -7658,7 +7807,8 @@ msgid ""
 "[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
 "pointer to data on the heap:"
 msgstr ""
-"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 是指向堆上数据的自有指针："
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 是指向堆上数据的"
+"自有指针："
 
 #: src/std/box.md:5
 msgid ""
@@ -7673,23 +7823,26 @@ msgstr ""
 #: src/std/box.md:26
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods from `T` directly on a "
-"`Box<T>`](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion)."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
-"`Box<T>` 会实现 `Deref<Target = T>`，这意味着您可以[直接在 `Box<T>` 上通过 `T` "
-"调用相应方法](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion)。"
+"`Box<T>` 会实现 `Deref<Target = T>`，这意味着您可以[直接在 `Box<T>` 上通过 "
+"`T` 调用相应方法](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-"
+"deref-coercion)。"
 
 #: src/std/box.md:34
 msgid ""
 "`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
 "not null. "
-msgstr "在 C++ 中，`Box` 与 `std::unique_ptr` 类似，除了它一定会不为 null 以外。"
+msgstr ""
+"在 C++ 中，`Box` 与 `std::unique_ptr` 类似，除了它一定会不为 null 以外。"
 
 #: src/std/box.md:35
 msgid ""
 "In the above example, you can even leave out the `*` in the `println!` "
 "statement thanks to `Deref`. "
-msgstr "在上面的示例中，因为有 `Deref`，您甚至可以在 `println!` 语句中省略 `*`。"
+msgstr ""
+"在上面的示例中，因为有 `Deref`，您甚至可以在 `println!` 语句中省略 `*`。"
 
 #: src/std/box.md:36
 msgid "A `Box` can be useful when you:"
@@ -7706,7 +7859,9 @@ msgid ""
 "want to transfer ownership of a large amount of data. To avoid copying large "
 "amounts of data on the stack, instead store the data on the heap in a `Box` "
 "so only the pointer is moved."
-msgstr "想要转让大量数据的所有权。为避免在堆栈上复制大量数据，请改为将数据存储在 `Box` 中的堆上，以便仅移动指针。"
+msgstr ""
+"想要转让大量数据的所有权。为避免在堆栈上复制大量数据，请改为将数据存储在 "
+"`Box` 中的堆上，以便仅移动指针。"
 
 #: src/std/box-recursive.md:1
 msgid "Box with Recursive Data Structures"
@@ -7717,8 +7872,7 @@ msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr "递归数据类型或具有动态大小的数据类型需要使用 `Box`："
 
-#: src/std/box-recursive.md:5
-#: src/std/box-niche.md:3
+#: src/std/box-recursive.md:5 src/std/box-niche.md:3
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
@@ -7728,8 +7882,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, "
-"Box::new(List::Nil))));\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::"
+"new(List::Nil))));\n"
 "    println!(\"{list:?}\");\n"
 "}\n"
 "```"
@@ -7741,20 +7895,17 @@ msgid ""
 " Stack                           Heap\n"
 ".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
 "- -.\n"
-":                         :     :                                            "
-"   :\n"
-":    list                 :     :                                            "
-"   :\n"
-":   +------+----+----+    :     :    +------+----+----+    "
-"+------+----+----+   :\n"
+":                         :     :                                               :\n"
+":    "
+"list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
 ":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
 "|   :\n"
-":   +------+----+----+    :     :    +------+----+----+    "
-"+------+----+----+   :\n"
-":                         :     :                                            "
-"   :\n"
-":                         :     :                                            "
-"   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
+":                         :     :                                               :\n"
+":                         :     :                                               :\n"
 "'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
 "- -'\n"
 "```"
@@ -7767,13 +7918,16 @@ msgid ""
 "`List`, the compiler would not compute a fixed size of the struct in memory "
 "(`List` would be of infinite size)."
 msgstr ""
-"如果这里未使用 `Box`，且我们曾尝试将一个 `List` 直接嵌入 `List`， 编译器就不会计算内存中结构体的固定大小，结构体看起来会像是无限大。"
+"如果这里未使用 `Box`，且我们曾尝试将一个 `List` 直接嵌入 `List`， 编译器就不"
+"会计算内存中结构体的固定大小，结构体看起来会像是无限大。"
 
 #: src/std/box-recursive.md:36
 msgid ""
 "`Box` solves this problem as it has the same size as a regular pointer and "
 "just points at the next element of the `List` in the heap."
-msgstr "`Box` 大小与一般指针相同，并且只会指向堆中的下一个 `List` 元素， 因此可以解决这个问题。"
+msgstr ""
+"`Box` 大小与一般指针相同，并且只会指向堆中的下一个 `List` 元素， 因此可以解决"
+"这个问题。"
 
 #: src/std/box-recursive.md:39
 msgid ""
@@ -7781,14 +7935,17 @@ msgid ""
 "\"Recursive with indirection\" is a hint you might want to use a Box or "
 "reference of some kind, instead of storing a value directly."
 msgstr ""
-"将 `Box` 从 List 定义中移除后，画面上会显示编译器错误。如果您看到“Recursive with "
-"indirection”错误消息，这是在提示您使用 Box 或其他类型的引用，而不是直接储存值。"
+"将 `Box` 从 List 定义中移除后，画面上会显示编译器错误。如果您看到“Recursive "
+"with indirection”错误消息，这是在提示您使用 Box 或其他类型的引用，而不是直接"
+"储存值。"
 
 #: src/std/box-niche.md:16
 msgid ""
 "A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
-msgstr "`Box` 不得为空，因此指针始终有效且非 `null`。这样， 编译器就可以优化内存布局："
+msgstr ""
+"`Box` 不得为空，因此指针始终有效且非 `null`。这样， 编译器就可以优化内存布"
+"局："
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -7796,20 +7953,17 @@ msgid ""
 " Stack                           Heap\n"
 ".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
 "-.\n"
-":                         :     :                                            "
-" :\n"
-":    list                 :     :                                            "
-" :\n"
-":   +----+----+           :     :    +----+----+    +----+------+            "
-" :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |            "
-" :\n"
-":   +----+----+           :     :    +----+----+    +----+------+            "
-" :\n"
-":                         :     :                                            "
-" :\n"
-":                         :     :                                            "
-" :\n"
+":                         :     :                                             :\n"
+":    "
+"list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
+"|             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":                         :     :                                             :\n"
+":                         :     :                                             :\n"
 "`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
 "-'\n"
 "```"
@@ -7821,12 +7975,12 @@ msgstr "`Rc`"
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a "
-"reference-counted shared pointer. Use this when you need to refer to the "
-"same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) "
-"是引用计数的共享指针。如果您需要从多个位置 引用相同的数据，请使用此指针："
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) 是引用计数的共享指"
+"针。如果您需要从多个位置 引用相同的数据，请使用此指针："
 
 #: src/std/rc.md:6
 msgid ""
@@ -7846,20 +8000,20 @@ msgstr ""
 #: src/std/rc.md:18
 #, fuzzy
 msgid ""
-"See [`Arc`](../concurrency/shared_state/arc.md) and "
-"[`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
-"in a multi-threaded context."
+"See [`Arc`](../concurrency/shared_state/arc.md) and [`Mutex`](https://doc."
+"rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
+"context."
 msgstr ""
-"如果您在多线程情境中，请参阅 [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)。"
+"如果您在多线程情境中，请参阅 [`Arc`](https://doc.rust-lang.org/std/sync/"
+"struct.Mutex.html)。"
 
 #: src/std/rc.md:19
 msgid ""
-"You can _downgrade_ a shared pointer into a "
-"[`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) pointer to "
-"create cycles that will get dropped."
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
-"您可以将共享指针_降级_为 [`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) "
-"指针， 以便创建之后会被舍弃的循环引用。"
+"您可以将共享指针_降级_为 [`Weak`](https://doc.rust-lang.org/std/rc/struct."
+"Weak.html) 指针， 以便创建之后会被舍弃的循环引用。"
 
 #: src/std/rc.md:29
 msgid ""
@@ -7876,13 +8030,16 @@ msgid ""
 "`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
 "be ignored when looking for performance issues in code."
-msgstr "`Rc::clone` 的成本很低：这个做法会创建指向相同分配的指针，并增加引用计数，而不会产生深层的克隆，排查代码性能问题时通常可以忽略。"
+msgstr ""
+"`Rc::clone` 的成本很低：这个做法会创建指向相同分配的指针，并增加引用计数，而"
+"不会产生深层的克隆，排查代码性能问题时通常可以忽略。"
 
 #: src/std/rc.md:32
 msgid ""
 "`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
 "and returns a mutable reference."
-msgstr "`make_mut` 实际上会在必要时克隆内部值（“clone-on-write”），并返回可变的引用。"
+msgstr ""
+"`make_mut` 实际上会在必要时克隆内部值（“clone-on-write”），并返回可变的引用。"
 
 #: src/std/rc.md:33
 msgid "Use `Rc::strong_count` to check the reference count."
@@ -7894,7 +8051,9 @@ msgid ""
 "`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
 "cycles that will be dropped properly (likely in combination with `RefCell`, "
 "on the next slide)."
-msgstr "`Rc::downgrade` 会向您提供 _弱引用计数_ 对象， 以便创建之后会被适当舍弃的周期（可能会与 `RefCell` 组合）。"
+msgstr ""
+"`Rc::downgrade` 会向您提供 _弱引用计数_ 对象， 以便创建之后会被适当舍弃的周期"
+"（可能会与 `RefCell` 组合）。"
 
 #: src/std/cell.md:1
 msgid "`Cell` and `RefCell`"
@@ -7903,14 +8062,13 @@ msgstr "“Cell”和“RefCell”"
 #: src/std/cell.md:3
 #, fuzzy
 msgid ""
-"[`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and "
-"[`RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html) "
-"implement what Rust calls _interior mutability:_ mutation of values in an "
-"immutable context."
+"[`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and [`RefCell`]"
+"(https://doc.rust-lang.org/std/cell/struct.RefCell.html) implement what Rust "
+"calls _interior mutability:_ mutation of values in an immutable context."
 msgstr ""
 "您可以使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
-"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` "
-"来源进行抽象化处理："
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` 来源"
+"进行抽象化处理："
 
 #: src/std/cell.md:8
 msgid ""
@@ -7918,8 +8076,8 @@ msgid ""
 "values. More complex interior types typically use `RefCell`, which tracks "
 "shared and exclusive references at runtime and panics if they are misused."
 msgstr ""
-"“Cell”通常用于简单类型，因为它需要复制或移动值。更复杂的内部类型通常使用“RefCell”，它会在运行时跟踪已共享和专有的引用，并在这些引用被滥用时 "
-"panic。"
+"“Cell”通常用于简单类型，因为它需要复制或移动值。更复杂的内部类型通常使"
+"用“RefCell”，它会在运行时跟踪已共享和专有的引用，并在这些引用被滥用时 panic。"
 
 #: src/std/cell.md:12
 msgid ""
@@ -7939,8 +8097,8 @@ msgid ""
 "    }\n"
 "\n"
 "    fn sum(&self) -> i64 {\n"
-"        self.value + self.children.iter().map(|c| "
-"c.borrow().sum()).sum::<i64>()\n"
+"        self.value + self.children.iter().map(|c| c.borrow().sum()).sum::"
+"<i64>()\n"
 "    }\n"
 "}\n"
 "\n"
@@ -7965,19 +8123,25 @@ msgid ""
 "This is safe because there's always one, un-referenced value in the cell, "
 "but it's not ergonomic."
 msgstr ""
-"在此示例中，如果我们使用的是“Cell”而非“RefCell”，则必须将“Node”从“Rc”中移出以推送子项，然后再将其移回原位。这是安全的做法，因为单元格中总是有一个未引用的值，但这不符合人体工程学。"
+"在此示例中，如果我们使用的是“Cell”而非“RefCell”，则必须将“Node”从“Rc”中移出以"
+"推送子项，然后再将其移回原位。这是安全的做法，因为单元格中总是有一个未引用的"
+"值，但这不符合人体工程学。"
 
 #: src/std/cell.md:48
 msgid ""
 "To do anything with a Node, you must call a `RefCell` method, usually "
 "`borrow` or `borrow_mut`."
-msgstr "如需使用 Node 执行任何操作，您必须调用“RefCell”方法，通常为“borrow”或“borrow_mut”。"
+msgstr ""
+"如需使用 Node 执行任何操作，您必须调用“RefCell”方法，通常"
+"为“borrow”或“borrow_mut”。"
 
 #: src/std/cell.md:49
 msgid ""
-"Demonstrate that reference loops can be created by adding `root` to "
-"`subtree.children` (don't try to print it!)."
-msgstr "演示可以通过向“subtree.children”添加“root”来创建引用循环（不要尝试输出它！）。"
+"Demonstrate that reference loops can be created by adding `root` to `subtree."
+"children` (don't try to print it!)."
+msgstr ""
+"演示可以通过向“subtree.children”添加“root”来创建引用循环（不要尝试输出"
+"它！）。"
 
 #: src/std/cell.md:50
 msgid ""
@@ -7986,9 +8150,9 @@ msgid ""
 "the presence of the reference loop, with `thread 'main' panicked at 'already "
 "borrowed: BorrowMutError'`."
 msgstr ""
-"为了演示运行时 panic，请添加一个会递增“self.value”并以相同方法调用其子项的“fn inc(&mut "
-"self)”。如果存在引用循环，就会 panic，并且“thread”“main”会因“already borrowed: "
-"BorrowMutError”而 panic。"
+"为了演示运行时 panic，请添加一个会递增“self.value”并以相同方法调用其子项"
+"的“fn inc(&mut self)”。如果存在引用循环，就会 panic，并且“thread”“main”会"
+"因“already borrowed: BorrowMutError”而 panic。"
 
 #: src/modules.md:3
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
@@ -8024,13 +8188,17 @@ msgstr ""
 msgid ""
 "Packages provide functionality and include a `Cargo.toml` file that "
 "describes how to build a bundle of 1+ crates."
-msgstr "包提供功能，并包含一个描述如何构建包含 1 个以上 crate 的捆绑包的“Cargo.toml”文件。"
+msgstr ""
+"包提供功能，并包含一个描述如何构建包含 1 个以上 crate 的捆绑包的“Cargo."
+"toml”文件。"
 
 #: src/modules.md:29
 msgid ""
 "Crates are a tree of modules, where a binary crate creates an executable and "
 "a library crate compiles to a library."
-msgstr "crate 是一种模块树，其中的二进制 crate 会创建一个可执行文件，而库 crate 会编译为库。"
+msgstr ""
+"crate 是一种模块树，其中的二进制 crate 会创建一个可执行文件，而库 crate 会编"
+"译为库。"
 
 #: src/modules.md:30
 msgid "Modules define organization, scope, and are the focus of this section."
@@ -8052,7 +8220,8 @@ msgstr "父项和同级子项始终可见。"
 msgid ""
 "In other words, if an item is visible in module `foo`, it's visible in all "
 "the descendants of `foo`."
-msgstr "换言之，如果某个项在模块“foo”中可见，那么该项在“foo”的所有后代中均可见。"
+msgstr ""
+"换言之，如果某个项在模块“foo”中可见，那么该项在“foo”的所有后代中均可见。"
 
 #: src/modules/visibility.md:10
 msgid ""
@@ -8096,11 +8265,11 @@ msgstr "此外，您还可以使用高级“pub(...)”说明符来限制公开�
 
 #: src/modules/visibility.md:43
 msgid ""
-"See the [Rust "
-"Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
-"请参阅 [Rust "
-"参考](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)。"
+"请参阅 [Rust 参考](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)。"
 
 #: src/modules/visibility.md:44
 msgid "Configuring `pub(crate)` visibility is a common pattern."
@@ -8148,7 +8317,9 @@ msgstr "“bar::foo”是指“bar”crate 中的“foo”。"
 msgid ""
 "A module can bring symbols from another module into scope with `use`. You "
 "will typically see something like this at the top of each module:"
-msgstr "一个模块可以使用“use”将另一个模块的符号全部纳入。您通常在每个模块的顶部会看到如下内容："
+msgstr ""
+"一个模块可以使用“use”将另一个模块的符号全部纳入。您通常在每个模块的顶部会看到"
+"如下内容："
 
 #: src/modules/filesystem.md:3
 msgid ""
@@ -8157,12 +8328,12 @@ msgstr "如果省略模块内容，则会指示 Rust 在另一个文件中查找
 
 #: src/modules/filesystem.md:9
 msgid ""
-"This tells rust that the `garden` module content is found at "
-"`src/garden.rs`. Similarly, a `garden::vegetables` module can be found at "
-"`src/garden/vegetables.rs`."
+"This tells rust that the `garden` module content is found at `src/garden."
+"rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
+"vegetables.rs`."
 msgstr ""
-"这会告知 Rust "
-"可以在“src/garden.rs”中找到“garden”模块内容。同样，您可以在“src/garden/vegetables.rs”中找到“garden::vegetables”模块。"
+"这会告知 Rust 可以在“src/garden.rs”中找到“garden”模块内容。同样，您可以"
+"在“src/garden/vegetables.rs”中找到“garden::vegetables”模块。"
 
 #: src/modules/filesystem.md:12
 msgid "The `crate` root is in:"
@@ -8181,7 +8352,9 @@ msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
 "comments\". These document the item that contains them -- in this case, a "
 "module."
-msgstr "也可以使用“内部文档注释”对文件中定义的模块进行记录。这些用于记录包含它们的项（在本例中为模块）。"
+msgstr ""
+"也可以使用“内部文档注释”对文件中定义的模块进行记录。这些用于记录包含它们的项"
+"（在本例中为模块）。"
 
 #: src/modules/filesystem.md:20
 msgid ""
@@ -8207,15 +8380,16 @@ msgid ""
 "Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
 "`module.rs`, and this is still a working alternative for editions after 2018."
 msgstr ""
-"在 Rust 2018 之前的版本中，模块需要位于“module/mod.rs”而非“module.rs”中，对于 2018 "
-"年之后的版本而言，这仍是有效的替代方案。"
+"在 Rust 2018 之前的版本中，模块需要位于“module/mod.rs”而非“module.rs”中，对"
+"于 2018 年之后的版本而言，这仍是有效的替代方案。"
 
 #: src/modules/filesystem.md:39
 msgid ""
-"The main reason to introduce `filename.rs` as alternative to "
-"`filename/mod.rs` was because many files named `mod.rs` can be hard to "
-"distinguish in IDEs."
-msgstr "引入“filename.rs”来替代“filename/mod.rs”的主要原因是，许多名为“mod.rs”的文件在 IDE 中可能难以区分。"
+"The main reason to introduce `filename.rs` as alternative to `filename/mod."
+"rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
+msgstr ""
+"引入“filename.rs”来替代“filename/mod.rs”的主要原因是，许多名为“mod.rs”的文件"
+"在 IDE 中可能难以区分。"
 
 #: src/modules/filesystem.md:42
 msgid "Deeper nesting can use folders, even if the main module is a file:"
@@ -8239,7 +8413,9 @@ msgstr ""
 msgid ""
 "This is useful, for example, if you would like to place tests for a module "
 "in a file named `some_module_test.rs`, similar to the convention in Go."
-msgstr "例如，如果您想将某个模块的测试放在名为“some_module_test.rs”的文件中（类似于 Go 中的惯例），这样做很有用。"
+msgstr ""
+"例如，如果您想将某个模块的测试放在名为“some_module_test.rs”的文件中（类似于 "
+"Go 中的惯例），这样做很有用。"
 
 #: src/exercises/day-2/afternoon.md:1
 msgid "Day 2: Afternoon Exercises"
@@ -8256,12 +8432,11 @@ msgid ""
 "[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
-"Rust 的所有权模式会影响许多 "
-"API。例如，[“Iterator”](https://doc.rust-lang.org/std/iter/trait.Iterator.html)和[“IntoIterator”](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
-"trait。"
+"Rust 的所有权模式会影响许多 API。例如，[“Iterator”](https://doc.rust-lang."
+"org/std/iter/trait.Iterator.html)和[“IntoIterator”](https://doc.rust-lang."
+"org/std/iter/trait.IntoIterator.html) trait。"
 
-#: src/exercises/day-2/iterators-and-ownership.md:8
-#: src/bare-metal/no_std.md:28
+#: src/exercises/day-2/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
 msgid "`Iterator`"
 msgstr "“Iterator”"
 
@@ -8270,7 +8445,9 @@ msgid ""
 "Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
-msgstr "trait 类似于接口：它们描述某类型的行为（方法）。“Iterator”trait 只是告知您可以调用“next”，直到返回“None”："
+msgstr ""
+"trait 类似于接口：它们描述某类型的行为（方法）。“Iterator”trait 只是告知您可"
+"以调用“next”，直到返回“None”："
 
 #: src/exercises/day-2/iterators-and-ownership.md:20
 msgid "You use this trait like this:"
@@ -8321,7 +8498,9 @@ msgid ""
 "The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
-msgstr "“Iterator”trait会告知您在创建迭代器后如何进行迭代。相关 trait“IntoIterator”会告知您如何创建迭代器："
+msgstr ""
+"“Iterator”trait会告知您在创建迭代器后如何进行迭代。相关 trait“IntoIterator”会"
+"告知您如何创建迭代器："
 
 #: src/exercises/day-2/iterators-and-ownership.md:62
 msgid ""
@@ -8343,7 +8522,8 @@ msgid ""
 "Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
-"请注意，“IntoIter”和“Item”已关联：迭代器必须具有相同的“Item”类型，这意味着它会返回“Option\n"
+"请注意，“IntoIter”和“Item”已关联：迭代器必须具有相同的“Item”类型，这意味着它"
+"会返回“Option\n"
 "\n"
 "”"
 
@@ -8355,8 +8535,8 @@ msgstr "和之前一样，迭代器返回的类型是什么？"
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), "
-"String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "    let mut iter = v.into_iter();\n"
 "\n"
 "    let v0: Option<..> = iter.next();\n"
@@ -8375,14 +8555,15 @@ msgid ""
 "loops. They call `into_iter()` on an expression and iterates over the "
 "resulting iterator:"
 msgstr ""
-"现在，我们已了解了“Iterator”和“IntoIterator”，接下来可以构建“for”循环了。它们会针对表达式调用“into_iter()”，并对生成的迭代器进行迭代："
+"现在，我们已了解了“Iterator”和“IntoIterator”，接下来可以构建“for”循环了。它们"
+"会针对表达式调用“into_iter()”，并对生成的迭代器进行迭代："
 
 #: src/exercises/day-2/iterators-and-ownership.md:89
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), "
-"String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "\n"
 "    for word in &v {\n"
 "        println!(\"word: {word}\");\n"
@@ -8403,18 +8584,18 @@ msgstr "每个循环中的“word”是什么类型？"
 #, fuzzy
 msgid ""
 "Experiment with the code above and then consult the documentation for [`impl "
-"IntoIterator for "
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E) "
-"and [`impl IntoIterator for "
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT,+A%3E) "
-"to check your answers."
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E) and [`impl IntoIterator for "
+"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
+"for-Vec%3CT,+A%3E) to check your answers."
 msgstr ""
 "使用上方代码进行实验，然后参阅[“impl IntoIterator for &Vec\n"
 "\n"
-"”](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E)和[“impl "
-"IntoIterator for Vec\n"
+"”](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
+"%26'a+Vec%3CT,+A%3E)和[“impl IntoIterator for Vec\n"
 "\n"
-"”](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT,+A%3E)的相关文档来检查您的答案。"
+"”](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
+"Vec%3CT,+A%3E)的相关文档来检查您的答案。"
 
 #: src/exercises/day-2/strings-iterators.md:3
 msgid ""
@@ -8423,14 +8604,16 @@ msgid ""
 "against _request paths_. The path prefixes can contain a wildcard character "
 "which matches a full segment. See the unit tests below."
 msgstr ""
-"在本练习中，您将实现 Web "
-"服务器的路由组件。服务器配置有多个路径前缀，这些前缀与请求路径匹配。路径前缀可以包含与完整段匹配的通配符。请参阅下面的单元测试。"
+"在本练习中，您将实现 Web 服务器的路由组件。服务器配置有多个路径前缀，这些前缀"
+"与请求路径匹配。路径前缀可以包含与完整段匹配的通配符。请参阅下面的单元测试。"
 
 #: src/exercises/day-2/strings-iterators.md:8
 msgid ""
 "Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
-msgstr "将以下代码复制到 <https://play.rust-lang.org/>，然后设法通过测试。请尽量避免为中间结果分配“Vec”："
+msgstr ""
+"将以下代码复制到 <https://play.rust-lang.org/>，然后设法通过测试。请尽量避免"
+"为中间结果分配“Vec”："
 
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
@@ -8445,15 +8628,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", "
-"\"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -8471,8 +8654,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -8520,7 +8703,8 @@ msgstr "不安全 Rust：原始指针、静态变量、不安全函数和外部�
 msgid ""
 "Rust support generics, which lets you abstract algorithms or data structures "
 "(such as sorting or a binary tree) over the types used or stored."
-msgstr "Rust 支持泛型，允许您根据算法（例如排序）中使用的类型对算法进行抽象化处理。"
+msgstr ""
+"Rust 支持泛型，允许您根据算法（例如排序）中使用的类型对算法进行抽象化处理。"
 
 #: src/generics/data-types.md:3
 msgid "You can use generics to abstract over the concrete field type:"
@@ -8580,7 +8764,8 @@ msgstr ""
 msgid ""
 "_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
 "redundant?"
-msgstr "\\*问：\\*为什么 `T` 在 `impl<T> Point<T> {}` 中指定了两次？这不是多余的吗？"
+msgstr ""
+"\\*问：\\*为什么 `T` 在 `impl<T> Point<T> {}` 中指定了两次？这不是多余的吗？"
 
 #: src/generics/methods.md:26
 msgid ""
@@ -8600,7 +8785,9 @@ msgstr "可以编写 `impl Point<u32> { .. }`。"
 msgid ""
 "`Point` is still generic and you can use `Point<f64>`, but methods in this "
 "block will only be available for `Point<u32>`."
-msgstr "`Point` 依然是一个泛型，并且您可以使用 `Point<f64>`，但此块中的方法将仅适用于 `Point<u32>`。"
+msgstr ""
+"`Point` 依然是一个泛型，并且您可以使用 `Point<f64>`，但此块中的方法将仅适用"
+"于 `Point<u32>`。"
 
 #: src/generics/monomorphization.md:3
 msgid "Generic code is turned into non-generic code based on the call sites:"
@@ -8614,7 +8801,9 @@ msgstr "具体行为与您所编写的一样"
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
 "had hand-coded the data structures without the abstraction."
-msgstr "这是零成本的抽象化处理：您得到的结果不会受到影响，也就是说，与在没有进行抽象化处理的情况下，对数据结构进行手动编码时的结果一样。"
+msgstr ""
+"这是零成本的抽象化处理：您得到的结果不会受到影响，也就是说，与在没有进行抽象"
+"化处理的情况下，对数据结构进行手动编码时的结果一样。"
 
 #: src/traits.md:3
 msgid ""
@@ -8632,8 +8821,8 @@ msgid ""
 "}\n"
 "\n"
 "impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self.name) "
-"}\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
+"name) }\n"
 "}\n"
 "\n"
 "impl Pet for Cat {\n"
@@ -8671,8 +8860,8 @@ msgid ""
 "}\n"
 "\n"
 "impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self.name) "
-"}\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
+"name) }\n"
 "}\n"
 "\n"
 "impl Pet for Cat {\n"
@@ -8701,58 +8890,56 @@ msgid ""
 " Stack                             Heap\n"
 ".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
 "- -.\n"
-":                           :     :                                          "
-"   :\n"
-":    pets                   :     :                     "
-"+----+----+----+----+   :\n"
+":                           :     :                                             :\n"
+":    pets                   :     :                     +----+----+----+----"
+"+   :\n"
 ":   +-----------+-------+   :     :   +-----+-----+  .->| F  | i  | d  | o  "
 "|   :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |  |  "
-"+----+----+----+----+   :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+  `---------.             "
-"   :\n"
-":   | capacity  |     2 |   :     :     | |   | |    data      |             "
-"   :\n"
-":   +-----------+-------+   :     :     | |   | |   +-------+--|-------+     "
-"   :\n"
-":                           :     :     | |   | '-->| name  |  o, 4, 4 |     "
-"   :\n"
-":                           :     :     | |   |     | age   |        5 |     "
-"   :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |     +-------+----------+     "
-"   :\n"
-"                                  :     | |   |                              "
-"   :\n"
-"                                  :     | |   |      vtable                  "
-"   :\n"
-"                                  :     | |   |     +----------------------+ "
-"   :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o |  |  +----+----+----+----"
+"+   :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-+  "
+"`---------.                :\n"
+":   | capacity  |     2 |   :     :     | |   | |    data      "
+"|                :\n"
+":   +-----------+-------+   :     :     | |   | |   +-------+--|-------"
+"+        :\n"
+":                           :     :     | |   | '-->| name  |  o, 4, 4 "
+"|        :\n"
+":                           :     :     | |   |     | age   |        5 "
+"|        :\n"
+"`- - - - - - - - - - - - - -'     :     | |   |     +-------+----------"
+"+        :\n"
+"                                  :     | |   "
+"|                                 :\n"
+"                                  :     | |   |      "
+"vtable                     :\n"
+"                                  :     | |   |     +----------------------"
+"+    :\n"
 "                                  :     | |   '---->| \"<Dog as Pet>::talk\" "
 "|    :\n"
-"                                  :     | |         +----------------------+ "
-"   :\n"
-"                                  :     | |                                  "
-"   :\n"
-"                                  :     | |    data                          "
-"   :\n"
-"                                  :     | |   +-------+-------+              "
-"   :\n"
-"                                  :     | '-->| lives |     9 |              "
-"   :\n"
-"                                  :     |     +-------+-------+              "
-"   :\n"
-"                                  :     |                                    "
-"   :\n"
-"                                  :     |      vtable                        "
-"   :\n"
-"                                  :     |     +----------------------+       "
-"   :\n"
-"                                  :     '---->| \"<Cat as Pet>::talk\" |     "
-"     :\n"
-"                                  :           +----------------------+       "
-"   :\n"
-"                                  :                                          "
-"   :\n"
+"                                  :     | |         +----------------------"
+"+    :\n"
+"                                  :     | "
+"|                                     :\n"
+"                                  :     | |    "
+"data                             :\n"
+"                                  :     | |   +-------+-------"
+"+                 :\n"
+"                                  :     | '-->| lives |     9 "
+"|                 :\n"
+"                                  :     |     +-------+-------"
+"+                 :\n"
+"                                  :     "
+"|                                       :\n"
+"                                  :     |      "
+"vtable                           :\n"
+"                                  :     |     +----------------------"
+"+          :\n"
+"                                  :     '---->| \"<Cat as Pet>::talk\" "
+"|          :\n"
+"                                  :           +----------------------"
+"+          :\n"
+"                                  :                                             :\n"
 "                                  '- - - - - - - - - - - - - - - - - - - - - "
 "- -'\n"
 "```"
@@ -8779,9 +8966,9 @@ msgstr ""
 #: src/traits/trait-objects.md:74
 msgid ""
 "A fat pointer is a double-width pointer. It has two components: a pointer to "
-"the actual object and a pointer to the [virtual method "
-"table](https://en.wikipedia.org/wiki/Virtual_method_table) (vtable) for the "
-"`Pet` implementation of that particular object."
+"the actual object and a pointer to the [virtual method table](https://en."
+"wikipedia.org/wiki/Virtual_method_table) (vtable) for the `Pet` "
+"implementation of that particular object."
 msgstr ""
 
 #: src/traits/trait-objects.md:77
@@ -8797,10 +8984,10 @@ msgstr "比较上述示例中的这些输出："
 #: src/traits/trait-objects.md:80
 msgid ""
 "```rust,ignore\n"
-"    println!(\"{} {}\", std::mem::size_of::<Dog>(), "
-"std::mem::size_of::<Cat>());\n"
-"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), "
-"std::mem::size_of::<&Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
 "    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
 "    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
 "```"
@@ -8830,9 +9017,7 @@ msgid ""
 "fn main() {\n"
 "    let p1 = Player::default();\n"
 "    let p2 = p1.clone();\n"
-"    println!(\"Is {:?}\\n"
-"equal to {:?}?\\n"
-"The answer is {}!\", &p1, &p2,\n"
+"    println!(\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2,\n"
 "             if p1 == p2 { \"yes\" } else { \"no\" });\n"
 "}\n"
 "```"
@@ -8875,7 +9060,9 @@ msgid ""
 "Traits may specify pre-implemented (default) methods and methods that users "
 "are required to implement themselves. Methods with default implementations "
 "can rely on required methods."
-msgstr "trait 或许可指定预实现（默认）方法，以及用户需要自行实现的方法。具有默认实现的方法可以依赖于必需的方法。"
+msgstr ""
+"trait 或许可指定预实现（默认）方法，以及用户需要自行实现的方法。具有默认实现"
+"的方法可以依赖于必需的方法。"
 
 #: src/traits/default-methods.md:35
 msgid "Move method `not_equals` to a new trait `NotEquals`."
@@ -8899,7 +9086,8 @@ msgstr "借助通用实现，您不再需要将“Equals”作为“NotEqual”�
 msgid ""
 "When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
-msgstr "使用泛型时，您通常会想要利用类型来实现某些特性， 这样才能调用此特征的方法。"
+msgstr ""
+"使用泛型时，您通常会想要利用类型来实现某些特性， 这样才能调用此特征的方法。"
 
 #: src/traits/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
@@ -8949,7 +9137,8 @@ msgstr "它具有额外功能，因此也更强大。"
 msgid ""
 "If someone asks, the extra feature is that the type on the left of \":\" can "
 "be arbitrary, like `Option<T>`."
-msgstr "如果有人提问，便阐明额外功能是指“:”左侧的类别可为任意值，例如 `Option<T>`。"
+msgstr ""
+"如果有人提问，便阐明额外功能是指“:”左侧的类别可为任意值，例如 `Option<T>`。"
 
 #: src/traits/impl-trait.md:1
 msgid "`impl Trait`"
@@ -8998,7 +9187,8 @@ msgid ""
 "implements the trait, without naming the type. This can be useful when you "
 "don't want to expose the concrete type in a public API."
 msgstr ""
-"对返回值类型来说，它则意味着返回值类型就是实现该特征的某具体类型， 无需为该类型命名。如果您不想在公共 API 中公开该具体类型，便可 使用此方法。"
+"对返回值类型来说，它则意味着返回值类型就是实现该特征的某具体类型， 无需为该类"
+"型命名。如果您不想在公共 API 中公开该具体类型，便可 使用此方法。"
 
 #: src/traits/impl-trait.md:31
 msgid ""
@@ -9006,12 +9196,13 @@ msgid ""
 "the concrete type it returns, without writing it out in the source. A "
 "function returning a generic type like `collect<B>() -> B` can return any "
 "type satisfying `B`, and the caller may need to choose one, such as with "
-"`let x: Vec<_> = foo.collect()` or with the turbofish, "
-"`foo.collect::<Vec<_>>()`."
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
 msgstr ""
-"在返回位置处进行推断有一定难度。会返回 `impl Foo` 的函数会挑选 自身返回的具体类型，而不必在来源中写出此信息。会返回 泛型类型（例如 "
-"`collect<B>() -> B`）的函数则可返回符合 `B` 的任何类型，而调用方可能需要选择一个类型，例如使用 `let x: Vec<_> = "
-"foo.collect()` 或使用以下 Turbofish：`foo.collect::<Vec<_>>()`。"
+"在返回位置处进行推断有一定难度。会返回 `impl Foo` 的函数会挑选 自身返回的具体"
+"类型，而不必在来源中写出此信息。会返回 泛型类型（例如 `collect<B>() -> B`）的"
+"函数则可返回符合 `B` 的任何类型，而调用方可能需要选择一个类型，例如使用 `let "
+"x: Vec<_> = foo.collect()` 或使用以下 Turbofish：`foo.collect::<Vec<_>>()`。"
 
 #: src/traits/impl-trait.md:37
 msgid ""
@@ -9023,10 +9214,11 @@ msgid ""
 "`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
 "need two independent generic parameters."
 msgstr ""
-"这是一个非常棒的示例，因为它使用了两次 `impl Display`。这有助于说明 此处没有任何项目会强制使用相同的 `impl Display` "
-"类型。如果我们使用单个 `T: Display`，它会强制限制输入 `T` 和返回 `T` 均为同一类型。 "
-"这并不适用于这个特定函数，因为我们预期作为输入的类型可能 不会是 `format!` 返回的值。如果我们希望通过 `: Display` "
-"语法执行相同的操作，则需要两个 独立的泛型形参。"
+"这是一个非常棒的示例，因为它使用了两次 `impl Display`。这有助于说明 此处没有"
+"任何项目会强制使用相同的 `impl Display` 类型。如果我们使用单个 `T: Display`，"
+"它会强制限制输入 `T` 和返回 `T` 均为同一类型。 这并不适用于这个特定函数，因为"
+"我们预期作为输入的类型可能 不会是 `format!` 返回的值。如果我们希望通过 `: "
+"Display` 语法执行相同的操作，则需要两个 独立的泛型形参。"
 
 #: src/traits/important-traits.md:3
 msgid ""
@@ -9046,43 +9238,45 @@ msgstr ""
 
 #: src/traits/important-traits.md:6
 msgid ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) used to "
-"convert values,"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
 msgstr ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 用于转换值，"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) 用于转换值，"
 
 #: src/traits/important-traits.md:7
 msgid ""
-"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
-"[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
 msgstr ""
-"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
-"[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 用于实现 IO。"
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) 用于实现 IO。"
 
 #: src/traits/important-traits.md:8
 msgid ""
-"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), "
-"[`Mul`](https://doc.rust-lang.org/std/ops/trait.Mul.html), ... used for "
-"operator overloading, and"
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
 msgstr ""
-"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html)、[`Mul`](https://doc.rust-lang.org/std/ops/trait.Mul.html) "
-"等用于实现运算符重载，"
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html)、[`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html) 等用于实现运算符重载，"
 
 #: src/traits/important-traits.md:9
 msgid ""
 "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
 "defining destructors."
-msgstr "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 用于定义析构函数。"
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 用于定义析构函"
+"数。"
 
 #: src/traits/important-traits.md:10
 msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
 "to construct a default instance of a type."
 msgstr ""
-"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
-"用于构建相应类型的默认实例。"
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 用于构"
+"建相应类型的默认实例。"
 
 #: src/traits/iterator.md:1
 msgid "Iterators"
@@ -9090,12 +9284,11 @@ msgstr "迭代器"
 
 #: src/traits/iterator.md:3
 msgid ""
-"You can implement the "
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) trait "
-"on your own types:"
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
-"您可以自行实现 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
-"特征："
+"您可以自行实现 [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) 特征："
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -9133,8 +9326,9 @@ msgid ""
 "functions should produce the code as efficient as equivalent imperative "
 "implementations."
 msgstr ""
-"`Iterator` 特征会对集合实现许多常见的函数程序操作， 例如 ` map`filter \\``和`reduce\\` "
-"等。您可以通过此特征找到有关它们的所有 文档。在 Rust 中，这些函数应生成代码，且生成的代码应与等效命令式实现一样 高效。"
+"`Iterator` 特征会对集合实现许多常见的函数程序操作， 例如 ` map`filter \\``和"
+"`reduce\\` 等。您可以通过此特征找到有关它们的所有 文档。在 Rust 中，这些函数"
+"应生成代码，且生成的代码应与等效命令式实现一样 高效。"
 
 #: src/traits/iterator.md:37
 msgid ""
@@ -9143,19 +9337,20 @@ msgid ""
 "and `&[T]`. Ranges also implement it. This is why you can iterate over a "
 "vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
-"`IntoIterator` 是迫使 for 循环运作的特征。此特征由集合类型 （例如 `Vec<T>`）和相关引用（例如 `&Vec<T>` 和 "
-"`&[T]`）而实现。此外，范围也会实现这项特征。因此， 您可以使用 `for i in some_vec { .. }` 来遍历某矢量，但 "
-"`some_vec.next()` 不存在。"
+"`IntoIterator` 是迫使 for 循环运作的特征。此特征由集合类型 （例如 `Vec<T>`）"
+"和相关引用（例如 `&Vec<T>` 和 `&[T]`）而实现。此外，范围也会实现这项特征。因"
+"此， 您可以使用 `for i in some_vec { .. }` 来遍历某矢量，但 `some_vec."
+"next()` 不存在。"
 
 #: src/traits/from-iterator.md:3
 msgid ""
 "[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"lets you build a collection from an "
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html)."
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
 "[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"让您可通过 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
-"构建一个集合。"
+"让您可通过 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator."
+"html) 构建一个集合。"
 
 #: src/traits/from-iterator.md:5
 #, fuzzy
@@ -9184,19 +9379,19 @@ msgstr ""
 
 #: src/traits/from-iterator.md:18
 msgid ""
-"`Iterator` implements `fn collect<B>(self) -> B where B: "
-"FromIterator<Self::Item>, Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"`Iterator` 会实现 `fn collect<B>(self) -> B where B: FromIterator<Self::Item>, "
-"Self: Sized`"
+"`Iterator` 会实现 `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 
 #: src/traits/from-iterator.md:24
 msgid ""
 "There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
-"还有一些实现，让您可执行一些很酷的操作，比如 将 `Iterator<Item = Result<V, E>>` 转换成 `Result<Vec<V>, "
-"E>`。"
+"还有一些实现，让您可执行一些很酷的操作，比如 将 `Iterator<Item = Result<V, "
+"E>>` 转换成 `Result<Vec<V>, E>`。"
 
 #: src/traits/from-into.md:1
 msgid "`From` and `Into`"
@@ -9204,13 +9399,13 @@ msgstr "`From` 和 `Into`"
 
 #: src/traits/from-into.md:3
 msgid ""
-"Types implement "
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
 "facilitate type conversions:"
 msgstr ""
-"类型会实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 以加快类型转换："
+"类型会实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) "
+"和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 以加快类型"
+"转换："
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -9228,12 +9423,11 @@ msgstr ""
 #: src/traits/from-into.md:15
 msgid ""
 "[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
-"automatically implemented when "
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) is "
-"implemented:"
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
-"实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 后，系统会自动实现 "
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)："
+"实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 后，系统"
+"会自动实现 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)："
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -9261,8 +9455,9 @@ msgid ""
 "Your function will accept types that implement `From` and those that _only_ "
 "implement `Into`."
 msgstr ""
-"若要声明某个函数实参输入类型（例如“任何可转换成 `String` 的类型”），规则便会相反，此时应使用 `Into`。 您的函数会接受可实现 "
-"`From` 的类型，以及那些仅实现 `Into` 的类型。"
+"若要声明某个函数实参输入类型（例如“任何可转换成 `String` 的类型”），规则便会"
+"相反，此时应使用 `Into`。 您的函数会接受可实现 `From` 的类型，以及那些仅实现 "
+"`Into` 的类型。"
 
 #: src/traits/read-write.md:1
 msgid "`Read` and `Write`"
@@ -9275,8 +9470,8 @@ msgid ""
 "abstract over `u8` sources:"
 msgstr ""
 "您可以使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
-"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` "
-"来源进行抽象化处理："
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` 来源"
+"进行抽象化处理："
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -9289,10 +9484,7 @@ msgid ""
 "}\n"
 "\n"
 "fn main() -> Result<()> {\n"
-"    let slice: &[u8] = b\"foo\\n"
-"bar\\n"
-"baz\\n"
-"\";\n"
+"    let slice: &[u8] = b\"foo\\nbar\\nbaz\\n\";\n"
 "    println!(\"lines in slice: {}\", count_lines(slice));\n"
 "\n"
 "    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
@@ -9307,8 +9499,8 @@ msgid ""
 "Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
 "you abstract over `u8` sinks:"
 msgstr ""
-"您同样可使用 [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 对 `u8` "
-"接收器进行抽象化处理："
+"您同样可使用 [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 对 "
+"`u8` 接收器进行抽象化处理："
 
 #: src/traits/read-write.md:25
 msgid ""
@@ -9317,8 +9509,7 @@ msgid ""
 "\n"
 "fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
 "    writer.write_all(msg.as_bytes())?;\n"
-"    writer.write_all(\"\\n"
-"\".as_bytes())\n"
+"    writer.write_all(\"\\n\".as_bytes())\n"
 "}\n"
 "\n"
 "fn main() -> Result<()> {\n"
@@ -9337,12 +9528,11 @@ msgstr "`Drop` 特征"
 
 #: src/traits/drop.md:3
 msgid ""
-"Values which implement "
-"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) can specify code "
-"to run when they go out of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
-"用于实现 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) "
-"的值可以指定在超出范围时运行的代码："
+"用于实现 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 的值可以"
+"指定在超出范围时运行的代码："
 
 #: src/traits/drop.md:5
 msgid ""
@@ -9384,8 +9574,8 @@ msgstr ""
 
 #: src/traits/drop.md:36
 msgid ""
-"When a value is dropped, if it implements `std::ops::Drop` then its "
-"`Drop::drop` implementation will be called."
+"When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
+"drop` implementation will be called."
 msgstr ""
 
 #: src/traits/drop.md:38
@@ -9407,8 +9597,7 @@ msgid ""
 "closing files, etc."
 msgstr ""
 
-#: src/traits/drop.md:45
-#: src/traits/operators.md:26
+#: src/traits/drop.md:45 src/traits/operators.md:26
 msgid "Discussion points:"
 msgstr "讨论点："
 
@@ -9420,7 +9609,9 @@ msgstr "为什么 `Drop::drop` 不使用 `self`？"
 msgid ""
 "Short-answer: If it did, `std::mem::drop` would be called at the end of the "
 "block, resulting in another call to `Drop::drop`, and a stack overflow!"
-msgstr "简答：如果这样的话，系统会在代码块结尾 调用 `std::mem::drop`，进而引发再一次调用 `Drop::drop`，并引发堆栈 溢出！"
+msgstr ""
+"简答：如果这样的话，系统会在代码块结尾 调用 `std::mem::drop`，进而引发再一次"
+"调用 `Drop::drop`，并引发堆栈 溢出！"
 
 #: src/traits/drop.md:51
 msgid "Try replacing `drop(a)` with `a.drop()`."
@@ -9435,8 +9626,8 @@ msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
 "produces a default value for a type."
 msgstr ""
-"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
-"特征会为类型生成默认值。"
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 特征会"
+"为类型生成默认值。"
 
 #: src/traits/default.md:5
 msgid ""
@@ -9494,7 +9685,8 @@ msgstr "这意味着，该结构体中的所有类型也都必须实现 `Default
 msgid ""
 "Standard Rust types often implement `Default` with reasonable values (e.g. "
 "`0`, `\"\"`, etc)."
-msgstr "标准的 Rust 类型通常会以合理的值（例如 ` 0`\"\" \\``等）实现`Default\\`。"
+msgstr ""
+"标准的 Rust 类型通常会以合理的值（例如 ` 0`\"\" \\``等）实现`Default\\`。"
 
 #: src/traits/default.md:44
 msgid "The partial struct copy works nicely with default."
@@ -9508,10 +9700,13 @@ msgstr "Rust 标准库了解类型可能会实现 `Default`，因此提供了便
 
 #: src/traits/default.md:46
 msgid ""
-"the `..` syntax is called [struct update "
-"syntax](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax)"
+"the `..` syntax is called [struct update syntax](https://doc.rust-lang.org/"
+"book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
+"with-struct-update-syntax)"
 msgstr ""
-"“..”语法被称为[结构体更新语法](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax)"
+"“..”语法被称为[结构体更新语法](https://doc.rust-lang.org/book/ch05-01-"
+"defining-structs.html#creating-instances-from-other-instances-with-struct-"
+"update-syntax)"
 
 #: src/traits/operators.md:1
 msgid "`Add`, `Mul`, ..."
@@ -9519,10 +9714,11 @@ msgstr "` Add`Mul \\``…"
 
 #: src/traits/operators.md:3
 msgid ""
-"Operator overloading is implemented via traits in "
-"[`std::ops`](https://doc.rust-lang.org/std/ops/index.html):"
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
-"运算符重载是通过 [`std::ops`](https://doc.rust-lang.org/std/ops/index.html) 中的特征实现的："
+"运算符重载是通过 [`std::ops`](https://doc.rust-lang.org/std/ops/index.html) "
+"中的特征实现的："
 
 #: src/traits/operators.md:5
 msgid ""
@@ -9557,8 +9753,8 @@ msgid ""
 "the operator is not `Copy`, you should consider overloading the operator for "
 "`&T` as well. This avoids unnecessary cloning on the call site."
 msgstr ""
-"回答：`Add:add` 会耗用 `self`。如果您的运算符重载对象 （即类型 `T`）不是 `Copy`，建议您也为 `&T` "
-"重载运算符。这可避免调用点上存在不必要的 克隆任务。"
+"回答：`Add:add` 会耗用 `self`。如果您的运算符重载对象 （即类型 `T`）不是 "
+"`Copy`，建议您也为 `&T` 重载运算符。这可避免调用点上存在不必要的 克隆任务。"
 
 #: src/traits/operators.md:33
 msgid ""
@@ -9571,14 +9767,17 @@ msgid ""
 "Short answer: Function type parameters are controlled by the caller, but "
 "associated types (like `Output`) are controlled by the implementor of a "
 "trait."
-msgstr "简答：函数类型形参是由调用方控管，但 `Output` 这类关联类型则由特征实现人员 控管。"
+msgstr ""
+"简答：函数类型形参是由调用方控管，但 `Output` 这类关联类型则由特征实现人员 控"
+"管。"
 
 #: src/traits/operators.md:37
 msgid ""
 "You could implement `Add` for two different types, e.g. `impl Add<(i32, "
 "i32)> for Point` would add a tuple to a `Point`."
 msgstr ""
-"您可以针对两种不同类型实现 `Add`，例如， `impl Add<(i32, i32)> for Point` 会向 `Point` 中添加元组。"
+"您可以针对两种不同类型实现 `Add`，例如， `impl Add<(i32, i32)> for Point` 会"
+"向 `Point` 中添加元组。"
 
 #: src/traits/closures.md:1
 msgid "Closures"
@@ -9587,15 +9786,14 @@ msgstr "闭包"
 #: src/traits/closures.md:3
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they implement special "
-"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), "
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
-"闭包或 lambda 表达式具有无法命名的类型。不过，它们会 实现特殊的 "
-"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)， "
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和 "
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) 特征："
+"闭包或 lambda 表达式具有无法命名的类型。不过，它们会 实现特殊的 [`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html)， [`FnMut`](https://doc."
+"rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://doc.rust-lang."
+"org/std/ops/trait.FnOnce.html) 特征："
 
 #: src/traits/closures.md:8
 msgid ""
@@ -9629,19 +9827,25 @@ msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
 "perhaps captures nothing at all. It can be called multiple times "
 "concurrently."
-msgstr "`Fn`（例如 `add_3`）既不会耗用也不会修改捕获的值，或许 也不会捕获任何值。它可被并发调用多次。"
+msgstr ""
+"`Fn`（例如 `add_3`）既不会耗用也不会修改捕获的值，或许 也不会捕获任何值。它可"
+"被并发调用多次。"
 
 #: src/traits/closures.md:37
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
 "multiple times, but not concurrently."
-msgstr "`FnMut`（例如 `accumulate`）可能会改变捕获的值。您可以多次调用它， 但不能并发调用它。"
+msgstr ""
+"`FnMut`（例如 `accumulate`）可能会改变捕获的值。您可以多次调用它， 但不能并发"
+"调用它。"
 
 #: src/traits/closures.md:40
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
 "might consume captured values."
-msgstr "如果您使用 `FnOnce`（例如 `multiply_sum`），或许只能调用它一次。它可能会耗用 所捕获的值。"
+msgstr ""
+"如果您使用 `FnOnce`（例如 `multiply_sum`），或许只能调用它一次。它可能会耗用 "
+"所捕获的值。"
 
 #: src/traits/closures.md:43
 msgid ""
@@ -9649,20 +9853,25 @@ msgid ""
 "I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
 "use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
-"`FnMut` 是 `FnOnce` 的子类型。`Fn` 是 `FnMut` 和 `FnOnce` 的子类型。也就是说，您可以在任何 需要调用 "
-"`FnOnce` 的地方使用 `FnMut`，还可在任何需要调用 `FnMut` 或 `FnOnce` 的地方 使用 `Fn`。"
+"`FnMut` 是 `FnOnce` 的子类型。`Fn` 是 `FnMut` 和 `FnOnce` 的子类型。也就是"
+"说，您可以在任何 需要调用 `FnOnce` 的地方使用 `FnMut`，还可在任何需要调用 "
+"`FnMut` 或 `FnOnce` 的地方 使用 `Fn`。"
 
 #: src/traits/closures.md:47
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
 "`multiply_sum`), depending on what the closure captures."
-msgstr "编译器也会推断 `Copy`（例如针对 `add_3`）和 `Clone`（例如 `multiply_sum`）， 具体取决于闭包捕获的数据。"
+msgstr ""
+"编译器也会推断 `Copy`（例如针对 `add_3`）和 `Clone`（例如 `multiply_sum`）， "
+"具体取决于闭包捕获的数据。"
 
 #: src/traits/closures.md:50
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
 "keyword makes them capture by value."
-msgstr "默认情况下，闭包会依据引用来捕获数据（如果可以的话）。`move` 关键字则可让闭包依据值 来捕获数据。"
+msgstr ""
+"默认情况下，闭包会依据引用来捕获数据（如果可以的话）。`move` 关键字则可让闭包"
+"依据值 来捕获数据。"
 
 #: src/traits/closures.md:52
 msgid ""
@@ -9733,8 +9942,8 @@ msgid ""
 "Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
-"将以下代码复制到 "
-"<https://play.rust-lang.org/>，然后填入缺少的“draw_into”方法，以便实现“Widget”trait："
+"将以下代码复制到 <https://play.rust-lang.org/>，然后填入缺少的“draw_into”方"
+"法，以便实现“Widget”trait："
 
 #: src/exercises/day-3/simple-gui.md:19
 msgid ""
@@ -9839,8 +10048,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
-"demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\"\n"
 "    )));\n"
@@ -9855,12 +10064,14 @@ msgstr "上述程序的输出可能非常简单，例如："
 
 #: src/exercises/day-3/simple-gui.md:140
 msgid ""
-"If you want to draw aligned text, you can use the "
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment) "
-"formatting operators. In particular, notice how you can pad with different "
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
-"如果要绘制对齐的文本，可以使用[填充/对齐](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)格式设置运算符。需要特别注意的是您填充不同字符（此处是“/”）的方式以及控制对齐的方式："
+"如果要绘制对齐的文本，可以使用[填充/对齐](https://doc.rust-lang.org/std/fmt/"
+"index.html#fillalignment)格式设置运算符。需要特别注意的是您填充不同字符（此处"
+"是“/”）的方式以及控制对齐的方式："
 
 #: src/exercises/day-3/simple-gui.md:145
 msgid ""
@@ -9889,8 +10100,8 @@ msgid ""
 "below to <https://play.rust-lang.org/> and fill in the missing methods to "
 "make the tests pass:"
 msgstr ""
-"我们将创建一个包含一些点的“Polygon”结构体。将以下代码复制到 "
-"<https://play.rust-lang.org/>，然后填入缺少的方法，设法通过测试："
+"我们将创建一个包含一些点的“Polygon”结构体。将以下代码复制到 <https://play."
+"rust-lang.org/>，然后填入缺少的方法，设法通过测试："
 
 #: src/exercises/day-3/points-polygons.md:7
 msgid ""
@@ -10008,7 +10219,9 @@ msgid ""
 "Since the method signatures are missing from the problem statements, the key "
 "part of the exercise is to specify those correctly. You don't have to modify "
 "the tests."
-msgstr "由于问题语句中缺少方法签名，因此练习的关键部分是正确指定这些内容。您无需修改测试。"
+msgstr ""
+"由于问题语句中缺少方法签名，因此练习的关键部分是正确指定这些内容。您无需修改"
+"测试。"
 
 #: src/exercises/day-3/points-polygons.md:120
 msgid "Other interesting parts of the exercise:"
@@ -10024,7 +10237,9 @@ msgstr "为某些结构体派生“Copy”trait，因为在测试中，方法有
 msgid ""
 "Discover that `Add` trait must be implemented for two objects to be addable "
 "via \"+\". Note that we do not discuss generics until Day 3."
-msgstr "发现必须实现“Add”trait 才能通过“+”添加两个对象。请注意，我们在第 3 天之前不会讨论泛型。"
+msgstr ""
+"发现必须实现“Add”trait 才能通过“+”添加两个对象。请注意，我们在第 3 天之前不会"
+"讨论泛型。"
 
 #: src/error-handling.md:3
 msgid "Error handling in Rust is done using explicit control flow:"
@@ -10098,7 +10313,8 @@ msgstr ""
 msgid ""
 "This can be useful in servers which should keep running even if a single "
 "request crashes."
-msgstr "如果服务器需要持续运行（即使是在请求发生崩溃的情况下）， 此方法十分有用。"
+msgstr ""
+"如果服务器需要持续运行（即使是在请求发生崩溃的情况下）， 此方法十分有用。"
 
 #: src/error-handling/panic-unwind.md:23
 msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
@@ -10112,7 +10328,9 @@ msgstr "使用 `Result` 进行结构化错误处理"
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
 "are expected as part of normal operation:"
-msgstr "在前面，我们看到了 `Result` 枚举。在遇到正常操作产生的预期错误时， 我们常会用到此方法："
+msgstr ""
+"在前面，我们看到了 `Result` 枚举。在遇到正常操作产生的预期错误时， 我们常会用"
+"到此方法："
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10143,15 +10361,18 @@ msgid ""
 "case where an error should never happen, `unwrap()` or `expect()` can be "
 "called, and this is a signal of the developer intent too."
 msgstr ""
-"与 `Option` 方法相同，成功值位于 `Result` 方法内部， 开发者必须显示提取成功值。因此，建议进行错误检查。在绝不应出现错误的情况下， "
-"可以调用 `unwrap()` 或 `expect()` 方法，这也是一种开发者意向信号。"
+"与 `Option` 方法相同，成功值位于 `Result` 方法内部， 开发者必须显示提取成功"
+"值。因此，建议进行错误检查。在绝不应出现错误的情况下， 可以调用 `unwrap()` "
+"或 `expect()` 方法，这也是一种开发者意向信号。"
 
 #: src/error-handling/result.md:30
 msgid ""
 "`Result` documentation is a recommended read. Not during the course, but it "
 "is worth mentioning.  It contains a lot of convenience methods and functions "
 "that help functional-style programming. "
-msgstr "我们建议阅读 `Result` 文档。虽然课程中不会涉及该文档，但是有必要提到它。 该文档中包含许多便捷的方法和函数，对于函数式编程很有帮助。"
+msgstr ""
+"我们建议阅读 `Result` 文档。虽然课程中不会涉及该文档，但是有必要提到它。 该文"
+"档中包含许多便捷的方法和函数，对于函数式编程很有帮助。"
 
 #: src/error-handling/try-operator.md:1
 msgid "Propagating Errors with `?`"
@@ -10210,7 +10431,9 @@ msgstr "`username` 变量可以是 `Ok(string)` 或 `Err(error)`。"
 msgid ""
 "Use the `fs::write` call to test out the different scenarios: no file, empty "
 "file, file with username."
-msgstr "可以使用 `fs::write` 调用来测试不同的场景：没有文件、空文件、包含用户名的文件。"
+msgstr ""
+"可以使用 `fs::write` 调用来测试不同的场景：没有文件、空文件、包含用户名的文"
+"件。"
 
 #: src/error-handling/try-operator.md:52
 #, fuzzy
@@ -10223,8 +10446,9 @@ msgid ""
 "`From<Err>`. Reciprocally, a function returning an `Option<T>` can only "
 "apply the `?` operator  on a function returning an `Option<AnyT>`."
 msgstr ""
-"函数的返回值类型必须与其调用的嵌套函数兼容。例如，一个返回“Result\\<T, Err>”的函数只能对返回“Result\\<AnyT, "
-"Err>”的函数应用“?”运算符。它无法对返回“Option\n"
+"函数的返回值类型必须与其调用的嵌套函数兼容。例如，一个返回“Result\\<T, "
+"Err>”的函数只能对返回“Result\\<AnyT, Err>”的函数应用“?”运算符。它无法对返"
+"回“Option\n"
 "\n"
 "”或“Result\\<T, OtherErr>”的函数应用“?”运算符，除非“OtherErr”实现“From\n"
 "\n"
@@ -10240,7 +10464,8 @@ msgid ""
 "`Option` and `Result` methods  such as `Option::ok_or`, `Result::ok`, "
 "`Result::err`."
 msgstr ""
-"您可以使用其他“Option”和“Result”方法（例如“Option::ok_or”“Result::ok”“Result::err”）将不兼容的类型转换为另一种类型。"
+"您可以使用其他“Option”和“Result”方法（例如“Option::ok_or”“Result::"
+"ok”“Result::err”）将不兼容的类型转换为另一种类型。"
 
 #: src/error-handling/converting-error-types.md:3
 msgid ""
@@ -10256,7 +10481,8 @@ msgstr "效果等同于"
 msgid ""
 "The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
-msgstr "此处的 `From::from` 调用表示，我们尝试将错误类型转换为 函数返回的类型："
+msgstr ""
+"此处的 `From::from` 调用表示，我们尝试将错误类型转换为 函数返回的类型："
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -10311,13 +10537,12 @@ msgstr ""
 msgid ""
 "It is good practice for all error types that don't need to be `no_std` to "
 "implement `std::error::Error`, which requires `Debug` and `Display`. The "
-"`Error` crate for `core` is only available in "
-"[nightly](https://github.com/rust-lang/rust/issues/103765), so not fully "
-"`no_std` compatible yet."
+"`Error` crate for `core` is only available in [nightly](https://github.com/"
+"rust-lang/rust/issues/103765), so not fully `no_std` compatible yet."
 msgstr ""
-"对所有不需要是“no_std”的错误类型来说，实现“std::error::Error”是一种很好的做法，而这需要“Debug”和“Display”。“core”的“Error”crate "
-"仅在 [nightly](https://github.com/rust-lang/rust/issues/103765) "
-"提供，因此尚未与“no_std”完全兼容。"
+"对所有不需要是“no_std”的错误类型来说，实现“std::error::Error”是一种很好的做"
+"法，而这需要“Debug”和“Display”。“core”的“Error”crate 仅在 [nightly](https://"
+"github.com/rust-lang/rust/issues/103765) 提供，因此尚未与“no_std”完全兼容。"
 
 #: src/error-handling/converting-error-types-example.md:57
 #, fuzzy
@@ -10326,16 +10551,18 @@ msgid ""
 "possible, to make life easier for tests and consumers of your library. In "
 "this case we can't easily do so, because `io::Error` doesn't implement them."
 msgstr ""
-"对所有错误类型实现 `std::error::Error` 是一种很好的做法，而这需要结合使用 `Debug` 和 `Display` 方法。 "
-"通常，在可能的情况下实现 `Clone` 和 `Eq` 也十分有益， 可以让库的测试和使用变得更加简单。在本例中，我们无法轻松做到这一点， 因为 "
-"`io::Error` 不能实现这些方法。"
+"对所有错误类型实现 `std::error::Error` 是一种很好的做法，而这需要结合使用 "
+"`Debug` 和 `Display` 方法。 通常，在可能的情况下实现 `Clone` 和 `Eq` 也十分有"
+"益， 可以让库的测试和使用变得更加简单。在本例中，我们无法轻松做到这一点， 因"
+"为 `io::Error` 不能实现这些方法。"
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
 "an error enum like we did on the previous page:"
 msgstr ""
-"[thiserror](https://docs.rs/thiserror/) crate 是创建错误枚举的常用方法， 就像前一页中提供的示例一样："
+"[thiserror](https://docs.rs/thiserror/) crate 是创建错误枚举的常用方法， 就像"
+"前一页中提供的示例一样："
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -10377,8 +10604,9 @@ msgid ""
 "optionally `Display` (if the `#[error(...)]` attributes are provided) and "
 "`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
-"`thiserror` 的派生宏会自动实现 `std::error::Error`，并且可以选择性地实现 `Display` （如果提供了 "
-"`#[error(...)]` 属性）和 `From`（如果添加了 `#[from]` 属性）。 此规则也适用于结构体。"
+"`thiserror` 的派生宏会自动实现 `std::error::Error`，并且可以选择性地实现 "
+"`Display` （如果提供了 `#[error(...)]` 属性）和 `From`（如果添加了 `#[from]` "
+"属性）。 此规则也适用于结构体。"
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
@@ -10390,7 +10618,8 @@ msgid ""
 "our own enum covering all the different possibilities. `std::error::Error` "
 "makes this easy."
 msgstr ""
-"有时，我们需要允许返回任意类型的错误，但又不想自己手动编写枚举来涵盖所有不同的可能性。 `std::error::Error` 可以让我们轻松做到这一点。"
+"有时，我们需要允许返回任意类型的错误，但又不想自己手动编写枚举来涵盖所有不同"
+"的可能性。 `std::error::Error` 可以让我们轻松做到这一点。"
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -10431,8 +10660,10 @@ msgid ""
 "good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
-"虽然这可以省却编写代码的麻烦，但也会导致我们无法在程序中以不同的方式正常处理不同的 错误情况。因此，在库的公共 API 中使用 `Box<dyn "
-"Error>` 通常不是一个好主意。 但是对于您只需要在某处显示错误消息的程序来说，这不失为一个 很好的选择。"
+"虽然这可以省却编写代码的麻烦，但也会导致我们无法在程序中以不同的方式正常处理"
+"不同的 错误情况。因此，在库的公共 API 中使用 `Box<dyn Error>` 通常不是一个好"
+"主意。 但是对于您只需要在某处显示错误消息的程序来说，这不失为一个 很好的选"
+"择。"
 
 #: src/error-handling/error-contexts.md:3
 msgid ""
@@ -10440,8 +10671,8 @@ msgid ""
 "contextual information to your errors and allows you to have fewer custom "
 "error types:"
 msgstr ""
-"广泛使用的 [anyhow](https://docs.rs/anyhow/) crate 可以帮助我们为错误添加 背景信息，并减少自定义错误类型的 "
-"数量。"
+"广泛使用的 [anyhow](https://docs.rs/anyhow/) crate 可以帮助我们为错误添加 背"
+"景信息，并减少自定义错误类型的 数量。"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -10498,12 +10729,13 @@ msgid ""
 "developers, as it provides similar usage patterns and ergonomics to `(T, "
 "error)` from Go."
 msgstr ""
-"”的封装容器。因此，就像前面提到的那样，在库的公共 API 中 使用它通常不是一个好主意。但是它广泛用于应用中。\n"
+"”的封装容器。因此，就像前面提到的那样，在库的公共 API 中 使用它通常不是一个好"
+"主意。但是它广泛用于应用中。\n"
 "\n"
 "如果需要，可以提取其内部的实际错误类型进行检查。\n"
 "\n"
-"Go 开发者可能会十分熟悉 `anyhow::Result<T>` 提供的功能， 因为它的使用模式和工效学设计与 Go 的 `(T, error)` "
-"方法十分相似。"
+"Go 开发者可能会十分熟悉 `anyhow::Result<T>` 提供的功能， 因为它的使用模式和工"
+"效学设计与 Go 的 `(T, error)` 方法十分相似。"
 
 #: src/testing.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
@@ -10554,9 +10786,11 @@ msgstr "使用 `cargo test` 查找并运行单元测试。"
 
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the "
-"[Playground](https://play.rust-lang.org/)):"
-msgstr "单元测试通常会放在嵌套模块中（在 [Playground](https://play.rust-lang.org/) 上运行测试）："
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
+msgstr ""
+"单元测试通常会放在嵌套模块中（在 [Playground](https://play.rust-lang.org/) 上"
+"运行测试）："
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -10619,17 +10853,17 @@ msgstr "代码会作为 `cargo test` 的一部分进行编译和执行。"
 
 #: src/testing/doc-tests.md:20
 msgid ""
-"Adding `# ` in the code will hide it from the docs, but will still "
-"compile/run it."
+"Adding `# ` in the code will hide it from the docs, but will still compile/"
+"run it."
 msgstr ""
 
 #: src/testing/doc-tests.md:21
 msgid ""
-"Test the above code on the [Rust "
-"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"在 [Rust "
-"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
+"在 [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
 "上测试上述代码。"
 
 #: src/testing/integration-tests.md:3
@@ -10661,7 +10895,8 @@ msgid ""
 "[googletest](https://docs.rs/googletest): Comprehensive test assertion "
 "library in the tradition of GoogleTest for C++."
 msgstr ""
-"[googletest](https://docs.rs/googletest)：遵从 GoogleTest for C++ 传统的综合测试断言库。"
+"[googletest](https://docs.rs/googletest)：遵从 GoogleTest for C++ 传统的综合"
+"测试断言库。"
 
 #: src/testing/useful-crates.md:8
 msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
@@ -10691,13 +10926,16 @@ msgstr "\\*\\*不安全 Rust：\\*\\*如果违反了前提条件，可能会触�
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
 "know what Unsafe Rust is."
-msgstr "本课程中出现的大多为“安全 Rust”，但是了解“不安全 Rust”的定义 非常重要。"
+msgstr ""
+"本课程中出现的大多为“安全 Rust”，但是了解“不安全 Rust”的定义 非常重要。"
 
 #: src/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
 "carefully documented. It is usually wrapped in a safe abstraction layer."
-msgstr "不安全的代码通常内容很少而且与其他代码隔离， 其正确性也应得到仔细记录。这类代码通常封装在安全的抽象层中。"
+msgstr ""
+"不安全的代码通常内容很少而且与其他代码隔离， 其正确性也应得到仔细记录。这类代"
+"码通常封装在安全的抽象层中。"
 
 #: src/unsafe.md:14
 msgid "Unsafe Rust gives you access to five new capabilities:"
@@ -10726,12 +10964,11 @@ msgstr "实现 `unsafe` trait。"
 #: src/unsafe.md:22
 msgid ""
 "We will briefly cover unsafe capabilities next. For full details, please see "
-"[Chapter 19.1 in the Rust "
-"Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) and the "
-"[Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
-"下面，我们将简要介绍这些不安全功能。如需了解完整详情，请参阅 [《Rust 手册》第 19.1 "
-"章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) 和 "
+"下面，我们将简要介绍这些不安全功能。如需了解完整详情，请参阅 [《Rust 手册》"
+"第 19.1 章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) 和 "
 "[Rustonomicon](https://doc.rust-lang.org/nomicon/)。"
 
 #: src/unsafe.md:28
@@ -10741,8 +10978,8 @@ msgid ""
 "by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
-"不安全 Rust 并不意味着代码不正确，而是这意味着开发者已停用 编译器的安全功能，必须自行编写正确的 代码。也就是说，编译器不再强制执行 Rust "
-"的内存安全规则。"
+"不安全 Rust 并不意味着代码不正确，而是这意味着开发者已停用 编译器的安全功能，"
+"必须自行编写正确的 代码。也就是说，编译器不再强制执行 Rust 的内存安全规则。"
 
 #: src/unsafe/raw-pointers.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
@@ -10778,16 +11015,16 @@ msgid ""
 "a comment for each `unsafe` block explaining how the code inside it "
 "satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
-"我们建议（而且 Android Rust 样式指南要求）为每个 `unsafe` 代码块编写一条注释， "
-"说明该代码块中的代码如何满足其所执行的不安全操作的 安全要求。"
+"我们建议（而且 Android Rust 样式指南要求）为每个 `unsafe` 代码块编写一条注"
+"释， 说明该代码块中的代码如何满足其所执行的不安全操作的 安全要求。"
 
 #: src/unsafe/raw-pointers.md:31
 msgid ""
 "In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
-"对于指针解除引用，这意味着指针必须为 "
-"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety)，即："
+"对于指针解除引用，这意味着指针必须为 [_valid_](https://doc.rust-lang.org/std/"
+"ptr/index.html#safety)，即："
 
 #: src/unsafe/raw-pointers.md:34
 msgid "The pointer must be non-null."
@@ -10811,7 +11048,9 @@ msgstr "不得并发访问相同位置。"
 msgid ""
 "If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
-msgstr "如果通过转换引用类型来获取指针，则底层对象必须处于活跃状态， 而且不得使用任何引用来访问内存。"
+msgstr ""
+"如果通过转换引用类型来获取指针，则底层对象必须处于活跃状态， 而且不得使用任何"
+"引用来访问内存。"
 
 #: src/unsafe/raw-pointers.md:41
 msgid "In most cases the pointer must also be properly aligned."
@@ -10860,7 +11099,9 @@ msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
-msgstr "通常，我们不建议使用可变的静态变量，但在某些情况下，在低层级 `no_std` 代码中可能需要这样做， 例如实现堆分配器或使用某些 C API。"
+msgstr ""
+"通常，我们不建议使用可变的静态变量，但在某些情况下，在低层级 `no_std` 代码中"
+"可能需要这样做， 例如实现堆分配器或使用某些 C API。"
 
 #: src/unsafe/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
@@ -10887,24 +11128,28 @@ msgstr ""
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
-msgstr "在 Rust 中很少需要用到联合体，因为您通常可以使用枚举。联合体只是偶尔用于 与 C 库 API 进行交互。"
+msgstr ""
+"在 Rust 中很少需要用到联合体，因为您通常可以使用枚举。联合体只是偶尔用于 与 "
+"C 库 API 进行交互。"
 
 #: src/unsafe/unions.md:24
 msgid ""
 "If you just want to reinterpret bytes as a different type, you probably want "
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
-"or a safe wrapper such as the "
-"[`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
-"如果您只是想将字节重新解释为其他类型，则可能需要使用 "
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
-"或 安全的封装容器，例如 [`zerocopy`](https://crates.io/crates/zerocopy) crate。"
+"如果您只是想将字节重新解释为其他类型，则可能需要使用 [`std::mem::transmute`]"
+"(https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) 或 安全的封装容"
+"器，例如 [`zerocopy`](https://crates.io/crates/zerocopy) crate。"
 
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
 "you must uphold to avoid undefined behaviour:"
-msgstr "如果函数或方法具有额外的前提条件，您必须遵守这些前提条件来避免未定义的行为， 则可以将该函数或方法标记为 `unsafe`："
+msgstr ""
+"如果函数或方法具有额外的前提条件，您必须遵守这些前提条件来避免未定义的行为， "
+"则可以将该函数或方法标记为 `unsafe`："
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
@@ -10921,13 +11166,13 @@ msgid ""
 "        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
 "    }\n"
 "\n"
-"    println!(\"char count: {}\", count_chars(unsafe { "
-"emojis.get_unchecked(0..7) }));\n"
+"    println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..7) }));\n"
 "\n"
 "    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe { "
-"emojis.get_unchecked(0..3) }));\n"
+"    // println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..3) }));\n"
 "}\n"
 "\n"
 "fn count_chars(s: &str) -> usize {\n"
@@ -10940,7 +11185,9 @@ msgstr ""
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
 "conditions to avoid undefined behaviour."
-msgstr "如果您自己编写的函数需要满足特定条件以避免未定义的行为， 您可以将这些函数标记为 `unsafe`。"
+msgstr ""
+"如果您自己编写的函数需要满足特定条件以避免未定义的行为， 您可以将这些函数标记"
+"为 `unsafe`。"
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -10982,8 +11229,9 @@ msgid ""
 "`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
 "Try adding it and see what happens."
 msgstr ""
-"请注意，在不安全函数中，可以在没有 `unsafe` 代码块的情况下使用不安全代码。我们可以 使用 "
-"`#[deny(unsafe_op_in_unsafe_fn)]` 来禁止此行为。请尝试添加该命令，看看会出现什么情况。"
+"请注意，在不安全函数中，可以在没有 `unsafe` 代码块的情况下使用不安全代码。我"
+"们可以 使用 `#[deny(unsafe_op_in_unsafe_fn)]` 来禁止此行为。请尝试添加该命"
+"令，看看会出现什么情况。"
 
 #: src/unsafe/extern-functions.md:1
 msgid "Calling External Code"
@@ -10993,7 +11241,8 @@ msgstr "调用外部代码"
 msgid ""
 "Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
-msgstr "基于其他语言的函数可能会违反 Rust 的保证。因此， 调用这类函数是不安全的："
+msgstr ""
+"基于其他语言的函数可能会违反 Rust 的保证。因此， 调用这类函数是不安全的："
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
@@ -11016,29 +11265,33 @@ msgid ""
 "This is usually only a problem for extern functions which do things with "
 "pointers which might violate Rust's memory model, but in general any C "
 "function might have undefined behaviour under any arbitrary circumstances."
-msgstr "这个问题通常仅存在于使用指针执行违反 Rust 内存模型的操作的外部函数中。 但一般而言，任何 C 函数都有可能在任意情况下出现未定义行为。"
+msgstr ""
+"这个问题通常仅存在于使用指针执行违反 Rust 内存模型的操作的外部函数中。 但一般"
+"而言，任何 C 函数都有可能在任意情况下出现未定义行为。"
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI; [other ABIs are available "
-"too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-"本例中的“C”是 ABI；[也可以使用其他 "
-"ABI](https://doc.rust-lang.org/reference/items/external-blocks.html)。"
+"本例中的“C”是 ABI；[也可以使用其他 ABI](https://doc.rust-lang.org/reference/"
+"items/external-blocks.html)。"
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
 "must guarantee particular conditions to avoid undefined behaviour."
-msgstr "与函数一样，如果您在实现某个 trait 时必须保证特定条件来避免未定义的行为， 您也可以将该 trait 标记为 `unsafe`。"
+msgstr ""
+"与函数一样，如果您在实现某个 trait 时必须保证特定条件来避免未定义的行为， 您"
+"也可以将该 trait 标记为 `unsafe`。"
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
 "For example, the `zerocopy` crate has an unsafe trait that looks [something "
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
-"例如，`zerocopy` crate 包含一个不安全的 trait， "
-"[大致内容是这样的](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html)："
+"例如，`zerocopy` crate 包含一个不安全的 trait， [大致内容是这样的](https://"
+"docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html)："
 
 #: src/unsafe/unsafe-traits.md:9
 msgid ""
@@ -11067,7 +11320,9 @@ msgstr ""
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
-msgstr "在 Rustdoc 中有关 trait 的章节下，有一个标题为 `# 安全` 的部分介绍了 安全实现 trait 的要求。"
+msgstr ""
+"在 Rustdoc 中有关 trait 的章节下，有一个标题为 `# 安全` 的部分介绍了 安全实"
+"现 trait 的要求。"
 
 #: src/unsafe/unsafe-traits.md:33
 msgid ""
@@ -11091,7 +11346,9 @@ msgstr "让我们构建一个用于读取目录内容的安全封装容器！"
 msgid ""
 "For this exercise, we suggest using a local dev environment instead of the "
 "Playground. This will allow you to run your binary on your own machine."
-msgstr "在本练习中，我们建议您使用本地开发环境，而不是 Playground。这样，您就可以在自己的机器上运行二进制文件。"
+msgstr ""
+"在本练习中，我们建议您使用本地开发环境，而不是 Playground。这样，您就可以在自"
+"己的机器上运行二进制文件。"
 
 #: src/exercises/day-3/afternoon.md:8
 msgid ""
@@ -11101,8 +11358,8 @@ msgstr "首先，请按照[在本地运行](../../cargo/running-locally.md)中�
 
 #: src/exercises/day-3/afternoon.md:14
 msgid ""
-"After looking at the exercise, you can look at the "
-"[solution](solutions-afternoon.md) provided."
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr "看过练习后，您可以查看所提供的[解题方法](solutions-afternoon.md)。"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
@@ -11130,11 +11387,12 @@ msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the "
-"[`std::ffi`](https://doc.rust-lang.org/std/ffi/) module. There you find a "
-"number of string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
-"您还需要浏览[“std::ffi”](https://doc.rust-lang.org/std/ffi/)模块。在下方，您会发现完成这个练习所需的多种字符串类型："
+"您还需要浏览[“std::ffi”](https://doc.rust-lang.org/std/ffi/)模块。在下方，您"
+"会发现完成这个练习所需的多种字符串类型："
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
 msgid "Encoding"
@@ -11146,10 +11404,11 @@ msgstr "使用"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and "
-"[`String`](https://doc.rust-lang.org/std/string/struct.String.html)"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
 msgstr ""
-"[“str”](https://doc.rust-lang.org/std/primitive.str.html)和[“String”](https://doc.rust-lang.org/std/string/struct.String.html)"
+"[“str”](https://doc.rust-lang.org/std/primitive.str.html)和[“String”]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid "UTF-8"
@@ -11161,10 +11420,11 @@ msgstr "用 Rust 进行文本处理"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:19
 msgid ""
-"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and "
-"[`CString`](https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 msgstr ""
-"[“CStr”](https://doc.rust-lang.org/std/ffi/struct.CStr.html)和[“CString”](https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+"[“CStr”](https://doc.rust-lang.org/std/ffi/struct.CStr.html)和[“CString”]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:19
 msgid "NUL-terminated"
@@ -11179,7 +11439,8 @@ msgid ""
 "[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
 "[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
 msgstr ""
-"[“OsStr”](https://doc.rust-lang.org/std/ffi/struct.OsStr.html)和[“OsString”](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+"[“OsStr”](https://doc.rust-lang.org/std/ffi/struct.OsStr.html)和[“OsString”]"
+"(https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:20
 msgid "OS-specific"
@@ -11213,33 +11474,40 @@ msgstr "将“\\*const i8”转换为“&CStr”：您需要一些能够找到�
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
 "unknow data\","
-msgstr "将“&CStr”转换为“&\\[u8\\]”：一个字节 Slice 是“一些未知数据”的通用接口，"
+msgstr ""
+"将“&CStr”转换为“&\\[u8\\]”：一个字节 Slice 是“一些未知数据”的通用接口，"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28
 msgid ""
-"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use "
-"[`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) "
-"to create it,"
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
 msgstr ""
-"将“&\\[u8\\]”转换为“&OsStr”：“&OsStr”是向“OsString”迈进的一步，请使用[“OsStrExt”](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html)来创建它，"
+"将“&\\[u8\\]”转换为“&OsStr”：“&OsStr”是向“OsString”迈进的一步，请使用"
+"[“OsStrExt”](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html)来"
+"创建它，"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:31
 msgid ""
 "`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
 "return it and call `readdir` again."
-msgstr "将“&OsStr”转换为“OsString”：您需要克隆“&OsStr”中的数据，以便能够返回它并再次调用“readdir”。"
+msgstr ""
+"将“&OsStr”转换为“OsString”：您需要克隆“&OsStr”中的数据，以便能够返回它并再次"
+"调用“readdir”。"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
 msgid ""
 "The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
 "useful chapter about FFI."
-msgstr "[秘典](https://doc.rust-lang.org/nomicon/ffi.html) 中也有一个关于 FFI 的非常实用的章节。"
+msgstr ""
+"[秘典](https://doc.rust-lang.org/nomicon/ffi.html) 中也有一个关于 FFI 的非常"
+"实用的章节。"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
-msgstr "将以下代码复制到 <https://play.rust-lang.org/>，并填入缺少的函数和方法："
+msgstr ""
+"将以下代码复制到 <https://play.rust-lang.org/>，并填入缺少的函数和方法："
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:48
 msgid ""
@@ -11256,8 +11524,8 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, "
-"core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
 "    // Layout according to the Linux man page for readdir(3), where ino_t "
@@ -11357,7 +11625,9 @@ msgid ""
 "Rust is supported for native platform development on Android. This means "
 "that you can write new operating system services in Rust, as well as "
 "extending existing services."
-msgstr "Rust 支持Android 的原生平台开发。这意味着您可以在Rust 中编写新的操作系统服务，以及扩展现有服务。"
+msgstr ""
+"Rust 支持Android 的原生平台开发。这意味着您可以在Rust 中编写新的操作系统服"
+"务，以及扩展现有服务。"
 
 #: src/android.md:7
 msgid ""
@@ -11366,23 +11636,25 @@ msgid ""
 "to Rust. The fewer dependencies and \"exotic\" types the better. Something "
 "that parses some raw bytes would be ideal."
 msgstr ""
-"今天我们会尝试在你自己的项目中调用Rust。 所以试着在你的代码中找一小段来改成Rust。 "
-"代码中越少依赖(dependencies)，越少“独特”的类型，越好。比如 一段解析原始字符的代码就很理想。"
+"今天我们会尝试在你自己的项目中调用Rust。 所以试着在你的代码中找一小段来改成"
+"Rust。 代码中越少依赖(dependencies)，越少“独特”的类型，越好。比如 一段解析原"
+"始字符的代码就很理想。"
 
 #: src/android/setup.md:3
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
 "have access to one or create a new one with:"
 msgstr ""
-"我们将会使用Android 虚拟设备（Android Virtual Device）来测试我们的代码。 确保你有权限访问一个，或者用以下命令创建一个新的："
+"我们将会使用Android 虚拟设备（Android Virtual Device）来测试我们的代码。 确保"
+"你有权限访问一个，或者用以下命令创建一个新的："
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer "
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-"更多细节请参考 [Android Developer "
-"Codelab](https://source.android.com/docs/setup/start)."
+"更多细节请参考 [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start)."
 
 #: src/android/build-rules.md:3
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
@@ -11392,18 +11664,21 @@ msgstr "Android 构建系统（Soong）通过一系列模块来支持Rust："
 #, fuzzy
 msgid "Module Type"
 msgstr ""
-"\\| 模块类型      | 描述                                                           "
-"                             | "
-"\\|—————————|——————————————————————————————————————————————————| \\| "
-"`rust_binary`     | Rust 二进制文件。                                              "
-"                             | \\| `rust_library`    | 生成Rust 库，并且提供 `rlib` "
-"和 `dylib` 变体。                       | \\| `rust_ffi`        | 生成可由 cc 模块使用的 "
-"Rust C 库，并提供静态和共享变体。    | \\| `rust_proc_macro` | 生成 proc-macro Rust 库。 "
-"这些宏与编译器插件类似。                     | \\| `rust_test`       | 生成使用标准 Rust "
-"自动化测试框架的 Rust 测试二进制文件。                             | \\| `rust_fuzz`       | "
-"生成使用 libfuzzer 的 Rust 模糊测试二进制文件。                                         | "
-"\\| `rust_protobuf`   | 生成源代码，并生成为特定 protobuf 提供接口的 Rust 库。| \\| "
-"`rust_bindgen`    | 生成源代码，并生成包含与 C 库的 Rust 绑定的 Rust 库。｜"
+"\\| 模块类型      | 描"
+"述                                                                                        "
+"| \\|—————————|——————————————————————————————————————————————————| \\| "
+"`rust_binary`     | Rust 二进制文"
+"件。                                                                           "
+"| \\| `rust_library`    | 生成Rust 库，并且提供 `rlib` 和 `dylib` 变"
+"体。                       | \\| `rust_ffi`        | 生成可由 cc 模块使用的 "
+"Rust C 库，并提供静态和共享变体。    | \\| `rust_proc_macro` | 生成 proc-"
+"macro Rust 库。 这些宏与编译器插件类似。                     | \\| "
+"`rust_test`       | 生成使用标准 Rust 自动化测试框架的 Rust 测试二进制文"
+"件。                             | \\| `rust_fuzz`       | 生成使用 "
+"libfuzzer 的 Rust 模糊测试二进制文"
+"件。                                         | \\| `rust_protobuf`   | 生成源"
+"代码，并生成为特定 protobuf 提供接口的 Rust 库。| \\| `rust_bindgen`    | 生"
+"成源代码，并生成包含与 C 库的 Rust 绑定的 Rust 库。｜"
 
 #: src/android/build-rules.md:5
 msgid "Description"
@@ -11495,8 +11770,7 @@ msgid ""
 "create the following files:"
 msgstr "让我们从一个简单的应用程序开始。在 AOSP 签出的根目录下，创建以下文件："
 
-#: src/android/build-rules/binary.md:6
-#: src/android/build-rules/library.md:13
+#: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 msgid "_hello_rust/Android.bp_:"
 msgstr "_hello_rust/Android.bp_:"
 
@@ -11518,8 +11792,7 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/android/build-rules/binary.md:16
-#: src/android/build-rules/library.md:34
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
 msgid "_hello_rust/src/main.rs_:"
 msgstr "_hello_rust/src/main.rs_:"
 
@@ -11574,12 +11847,13 @@ msgstr "`libgreeting`, 我们在下面进行了定义，"
 
 #: src/android/build-rules/library.md:8
 msgid ""
-"`libtextwrap`, which is a crate already vendored in "
-"[`external/rust/crates/`](https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/)."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"`libtextwrap`, 一个已经在 "
-"[`external/rust/crates/`](https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/) "
-"中提供的 crate。"
+"`libtextwrap`, 一个已经在 [`external/rust/crates/`](https://cs.android.com/"
+"android/platform/superproject/+/master:external/rust/crates/) 中提供的 "
+"crate。"
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -11679,20 +11953,19 @@ msgstr "您可以像之前一样构建、推送和运行二进制文件："
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/hello_rust_with_dep\n"
 "```"
 msgstr ""
 
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language "
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
-"Rust 支持 [Android 接口定义语言 "
-"(AIDL)](https://developer.android.com/guide/components/aidl)："
+"Rust 支持 [Android 接口定义语言 (AIDL)](https://developer.android.com/guide/"
+"components/aidl)："
 
 #: src/android/aidl.md:6
 msgid "Rust code can call existing AIDL servers,"
@@ -11752,7 +12025,9 @@ msgstr ""
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
 "vendor partition."
-msgstr "如果供应商分区中的二进制文件使用了您的 AIDL 文件，请添加 `vendor_available: true`。"
+msgstr ""
+"如果供应商分区中的二进制文件使用了您的 AIDL 文件，请添加 `vendor_available: "
+"true`。"
 
 #: src/android/aidl/implementation.md:1
 msgid "Service Implementation"
@@ -11770,8 +12045,8 @@ msgstr "_birthday_service/src/lib.rs_:"
 msgid ""
 "```rust,ignore\n"
 "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "/// The `IBirthdayService` implementation.\n"
@@ -11780,11 +12055,11 @@ msgid ""
 "impl binder::Interface for BirthdayService {}\n"
 "\n"
 "impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
-"binder::Result<String> {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
+"Result<String> {\n"
 "        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} "
-"years!\"\n"
+"            \"Happy Birthday {name}, congratulations with the {years} years!"
+"\"\n"
 "        ))\n"
 "    }\n"
 "}\n"
@@ -11792,8 +12067,8 @@ msgid ""
 msgstr ""
 "```rust,ignore\n"
 "//! 实现了 `IBirthdayService` AIDL 接口。\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "/// `IBirthdayService` 接口的具体实现。\n"
@@ -11802,18 +12077,17 @@ msgstr ""
 "impl binder::Interface for BirthdayService {}\n"
 "\n"
 "impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
-"binder::Result<String> {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
+"Result<String> {\n"
 "        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} "
-"years!\"\n"
+"            \"Happy Birthday {name}, congratulations with the {years} years!"
+"\"\n"
 "        ))\n"
 "    }\n"
 "}\n"
 "```"
 
-#: src/android/aidl/implementation.md:26
-#: src/android/aidl/server.md:28
+#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
 msgid "_birthday_service/Android.bp_:"
 msgstr "_birthday_service/Android.bp_:"
@@ -11861,8 +12135,8 @@ msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
 "use birthdayservice::BirthdayService;\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
@@ -11874,8 +12148,8 @@ msgid ""
 "        birthday_service,\n"
 "        binder::BinderFeatures::default(),\n"
 "    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, "
-"birthday_service_binder.as_binder())\n"
+"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
+"as_binder())\n"
 "        .expect(\"Failed to register service\");\n"
 "    binder::ProcessState::join_thread_pool()\n"
 "}\n"
@@ -11884,8 +12158,8 @@ msgstr ""
 "```rust,ignore\n"
 "//! 生日服务。\n"
 "use birthdayservice::BirthdayService;\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
@@ -11897,8 +12171,8 @@ msgstr ""
 "        birthday_service,\n"
 "        binder::BinderFeatures::default(),\n"
 "    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, "
-"birthday_service_binder.as_binder())\n"
+"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
+"as_binder())\n"
 "        .expect(\"Failed to register service\");\n"
 "    binder::ProcessState::join_thread_pool()\n"
 "}\n"
@@ -11942,8 +12216,8 @@ msgstr "我们现在可以构建、推送和启动服务："
 msgid ""
 "```shell\n"
 "m birthday_server\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/birthday_server\n"
 "```"
 msgstr ""
@@ -11972,15 +12246,15 @@ msgstr "_birthday_service/src/client.rs_:"
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
 "\n"
 "/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
-"binder::StatusCode> {\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
+"StatusCode> {\n"
 "    binder::get_interface(SERVICE_IDENTIFIER)\n"
 "}\n"
 "\n"
@@ -12005,15 +12279,15 @@ msgid ""
 msgstr ""
 "```rust,ignore\n"
 "//! 生日服务。\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
 "\n"
 "/// 连接到 BirthdayService。\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
-"binder::StatusCode> {\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
+"StatusCode> {\n"
 "    binder::get_interface(SERVICE_IDENTIFIER)\n"
 "}\n"
 "\n"
@@ -12076,8 +12350,8 @@ msgstr "在您的设备上构建、推送并运行客户端："
 msgid ""
 "```shell\n"
 "m birthday_client\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/birthday_client Charlie 60\n"
 "```"
 msgstr ""
@@ -12092,7 +12366,9 @@ msgstr "让我们扩展API以提供更多功能：我们希望允许客户端指
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
 "or `stdout` (on-host):"
-msgstr "你应该使用 `log` crate 来自动记录日志到 `logcat` （设备上）或 `stdout`（主机上）："
+msgstr ""
+"你应该使用 `log` crate 来自动记录日志到 `logcat` （设备上）或 `stdout`（主机"
+"上）："
 
 #: src/android/logging.md:6
 msgid "_hello_rust_logs/Android.bp_:"
@@ -12170,8 +12446,7 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/android/logging.md:42
-#: src/android/interoperability/with-c/bindgen.md:98
+#: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
 #: src/android/interoperability/with-c/rust.md:73
 msgid "Build, push, and run the binary on your device:"
 msgstr "在你的设备上构建，推送，并运行二进制文件 ："
@@ -12180,8 +12455,8 @@ msgstr "在你的设备上构建，推送，并运行二进制文件 ："
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 msgstr ""
@@ -12243,8 +12518,8 @@ msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper "
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:23
@@ -12286,14 +12561,10 @@ msgid ""
 "#include \"libbirthday.h\"\n"
 "\n"
 "void print_card(const card* card) {\n"
-"  printf(\"+--------------\\n"
-"\");\n"
-"  printf(\"| Happy Birthday %s!\\n"
-"\", card->name);\n"
-"  printf(\"| Congratulations with the %i years!\\n"
-"\", card->years);\n"
-"  printf(\"+--------------\\n"
-"\");\n"
+"  printf(\"+--------------\\n\");\n"
+"  printf(\"| Happy Birthday %s!\\n\", card->name);\n"
+"  printf(\"| Congratulations with the %i years!\\n\", card->years);\n"
+"  printf(\"+--------------\\n\");\n"
 "}\n"
 "```"
 msgstr ""
@@ -12396,8 +12667,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "m print_birthday_card\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
@@ -12527,8 +12798,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "m analyze_numbers\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers "
-"/data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/"
+"tmp\"\n"
 "adb shell /data/local/tmp/analyze_numbers\n"
 "```"
 msgstr ""
@@ -12558,8 +12829,8 @@ msgstr ""
 
 #: src/android/interoperability/cpp.md:14
 msgid ""
-"At this point, the instructor should switch to the [CXX "
-"tutorial](https://cxx.rs/tutorial.html)."
+"At this point, the instructor should switch to the [CXX tutorial](https://"
+"cxx.rs/tutorial.html)."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:16
@@ -12574,16 +12845,16 @@ msgstr ""
 
 #: src/android/interoperability/cpp.md:20
 msgid ""
-"Show the correspondence between [Rust and C++ "
-"types](https://cxx.rs/bindings.html):"
+"Show the correspondence between [Rust and C++ types](https://cxx.rs/bindings."
+"html):"
 msgstr ""
 
 #: src/android/interoperability/cpp.md:22
 msgid ""
 "Explain how a Rust `String` cannot map to a C++ `std::string` (the latter "
 "does not uphold the UTF-8 invariant). Show that despite being different "
-"types, `rust::String` in C++ can be easily constructed from a C++ "
-"`std::string`, making it very ergonomic to use."
+"types, `rust::String` in C++ can be easily constructed from a C++ `std::"
+"string`, making it very ergonomic to use."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:28
@@ -12598,9 +12869,9 @@ msgstr ""
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface "
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni` "
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 
 #: src/android/interoperability/java.md:7
@@ -12722,8 +12993,8 @@ msgstr ""
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
 "who are familiar with the basics of Rust (perhaps from completing the "
-"Comprehensive Rust course), and ideally also have some experience with "
-"bare-metal programming in some other language such as C."
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/bare-metal.md:7
@@ -12750,19 +13021,21 @@ msgstr ""
 
 #: src/bare-metal.md:15
 msgid ""
-"For the microcontroller part of the course we will use the [BBC "
-"micro:bit](https://microbit.org/) v2 as an example. It's a [development "
-"board](https://tech.microbit.org/hardware/) based on the Nordic nRF51822 "
-"microcontroller with some LEDs and buttons, an I2C-connected accelerometer "
-"and compass, and an on-board SWD debugger."
+"For the microcontroller part of the course we will use the [BBC micro:bit]"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
+"an on-board SWD debugger."
 msgstr ""
 
 #: src/bare-metal.md:20
-msgid "To get started, install some tools we'll need later. On gLinux or Debian:"
+msgid ""
+"To get started, install some tools we'll need later. On gLinux or Debian:"
 msgstr ""
 
 #: src/bare-metal.md:30
-msgid "And give users in the `plugdev` group access to the micro:bit programmer:"
+msgid ""
+"And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
 
 #: src/bare-metal.md:32
@@ -12787,8 +13060,7 @@ msgstr ""
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:12
-#: src/bare-metal/alloc.md:1
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -12919,8 +13191,8 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a [global (heap) "
-"allocator](https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -13002,8 +13274,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"The `cortex_m_rt::entry` macro requires that the function have type `fn() -> "
-"!`, because returning to the reset handler doesn't make sense."
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:27
@@ -13101,8 +13373,8 @@ msgstr ""
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for memory-mapped peripherals from "
-"[CMSIS-SVD](https://www.keil.com/pack/doc/CMSIS/SVD/html/index.html) files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -13183,11 +13455,10 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
-"[HAL "
-"crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-implementation-crates) "
-"for many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits from "
-"[`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -13289,8 +13560,8 @@ msgid ""
 "        .p0_02\n"
 "        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
 "Level::Low);\n"
-"    let _pin3: P0_03<Output<PushPull>> = "
-"gpio0.p0_03.into_push_pull_output(Level::Low);\n"
+"    let _pin3: P0_03<Output<PushPull>> = gpio0.p0_03."
+"into_push_pull_output(Level::Low);\n"
 "\n"
 "    loop {}\n"
 "}\n"
@@ -13364,10 +13635,9 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement "
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-crates) "
-"in terms of these traits, e.g. an accelerometer driver might need an I2C or "
-"SPI bus implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
@@ -13393,7 +13663,8 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid "SWD (Serial Wire Debug) and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgid ""
+"SWD (Serial Wire Debug) and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:7
@@ -13407,8 +13678,8 @@ msgstr ""
 #: src/bare-metal/microcontrollers/probe-rs.md:10
 msgid ""
 "`cargo-embed` is a cargo subcommand to build and flash binaries, log RTT "
-"(Real Time Transfers) output and connect GDB. It's configured by an "
-"`Embed.toml` file in your project directory."
+"(Real Time Transfers) output and connect GDB. It's configured by an `Embed."
+"toml` file in your project directory."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
@@ -13439,9 +13710,9 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:23
 msgid ""
-"The [Microsoft Debug Adapter "
-"Protocol](https://microsoft.github.io/debug-adapter-protocol/) lets VSCode "
-"and other IDEs debug code running on any supported microcontroller."
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:25
@@ -13480,8 +13751,8 @@ msgstr ""
 #: src/bare-metal/microcontrollers/debugging.md:21
 msgid ""
 "```sh\n"
-"gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support "
-"--eval-command=\"target remote :1337\"\n"
+"gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support --eval-"
+"command=\"target remote :1337\"\n"
 "```"
 msgstr ""
 
@@ -13503,7 +13774,8 @@ msgid "\"Real-Time Interrupt-driven Concurrency\""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:5
-msgid "Shared resource management, message passing, task scheduling, timer queue"
+msgid ""
+"Shared resource management, message passing, task scheduling, timer queue"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:6
@@ -13540,8 +13812,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:13
 msgid ""
-"Some platforms have `std` implementations, e.g. "
-"[esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-library.html)."
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
@@ -13563,7 +13835,8 @@ msgid "Cortex-M only."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:23
-msgid "Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:24
@@ -13591,10 +13864,10 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"Check the documentation for the "
-"[`lsm303agr`](https://docs.rs/lsm303agr/latest/lsm303agr/) and "
-"[`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the [micro:bit hardware](https://tech.microbit.org/hardware/)."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:11
@@ -13603,29 +13876,28 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:12
-msgid "TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:13
 msgid ""
-"The LSM303AGR driver needs something implementing the "
-"`embedded_hal::blocking::i2c::WriteRead` trait. The "
-"[`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/struct.Twim.html) "
-"struct implements this."
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:17
 msgid ""
-"You have a "
-"[`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/struct.Board.html) "
-"struct with fields for the various pins and peripherals."
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:19
 msgid ""
-"You can also look at the [nRF52833 "
-"datasheet](https://infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.5.pdf) if "
-"you want, but it shouldn't be necessary for this exercise."
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23
@@ -13634,8 +13906,7 @@ msgid ""
 "look in the `compass` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:26
-#: src/exercises/bare-metal/rtc.md:19
+#: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 #, fuzzy
 msgid "_src/main.rs_:"
 msgstr "_hello_rust/src/main.rs_:"
@@ -13677,8 +13948,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:64
-#: src/exercises/bare-metal/rtc.md:385
+#: src/exercises/bare-metal/compass.md:64 src/exercises/bare-metal/rtc.md:385
 msgid "_Cargo.toml_ (you shouldn't need to change this):"
 msgstr ""
 
@@ -13720,8 +13990,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:100
-#: src/exercises/bare-metal/rtc.md:985
+#: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
 msgid "_.cargo/config.toml_ (you shouldn't need to change this):"
 msgstr ""
 
@@ -13741,7 +14010,8 @@ msgid "See the serial output on Linux with:"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:118
-msgid "Or on Mac OS something like (the device name may be slightly different):"
+msgid ""
+"Or on Mac OS something like (the device name may be slightly different):"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:124
@@ -13756,8 +14026,8 @@ msgstr ""
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
 "Now let's try writing something for Cortex-A. For simplicity we'll just work "
-"with QEMU's aarch64 "
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
@@ -13775,7 +14045,8 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:3
-msgid "Before we can start running Rust code, we need to do some initialisation."
+msgid ""
+"Before we can start running Rust code, we need to do some initialisation."
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:5
@@ -13883,10 +14154,10 @@ msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:86
 msgid ""
-"Unaligned accesses will fault. We build the Rust code for the "
-"`aarch64-unknown-none` target which sets `+strict-align` to prevent the "
-"compiler generating unaligned accesses, so it should be fine in this case, "
-"but this is not necessarily the case in general."
+"Unaligned accesses will fault. We build the Rust code for the `aarch64-"
+"unknown-none` target which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses, so it should be fine in this case, but this "
+"is not necessarily the case in general."
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:89
@@ -13970,9 +14241,8 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the "
-"[`smccc`](https://crates.io/crates/smccc) crate which has wrappers for all "
-"these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
@@ -14008,8 +14278,8 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:56
 msgid ""
-"Run the example in QEMU with `make qemu_psci` under "
-"`src/bare-metal/aps/examples`."
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
@@ -14062,9 +14332,8 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a "
-"[PL011](https://developer.arm.com/documentation/ddi0183/g) UART, so let's "
-"write a driver for that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -14115,8 +14384,8 @@ msgid ""
 "    fn read_flag_register(&self) -> u8 {\n"
 "        // Safe because we know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET).read_volatile() "
-"}\n"
+"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET)."
+"read_volatile() }\n"
 "    }\n"
 "}\n"
 "```"
@@ -14184,8 +14453,8 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:25
 msgid ""
-"Run the example in QEMU with `make qemu_minimal` under "
-"`src/bare-metal/aps/examples`."
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
@@ -14194,11 +14463,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more "
-"registers](https://developer.arm.com/documentation/ddi0183/g/programmers-model/summary-of-registers), "
-"and adding offsets to construct pointers to access them is error-prone and "
-"hard to read. Plus, some of them are bit fields which would be nice to "
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
@@ -14257,8 +14526,7 @@ msgstr ""
 msgid "ILPR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:12
-#: src/bare-metal/aps/better-uart.md:15
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
 msgid "8"
 msgstr ""
 
@@ -14270,8 +14538,7 @@ msgstr ""
 msgid "IBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:13
-#: src/bare-metal/aps/better-uart.md:16
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
 msgid "16"
 msgstr ""
 
@@ -14283,8 +14550,7 @@ msgstr ""
 msgid "FBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:14
-#: src/bare-metal/aps/better-uart.md:17
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
 msgid "6"
 msgstr ""
 
@@ -14320,10 +14586,8 @@ msgstr ""
 msgid "IMSC"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:18
-#: src/bare-metal/aps/better-uart.md:19
-#: src/bare-metal/aps/better-uart.md:20
-#: src/bare-metal/aps/better-uart.md:21
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
 msgid "11"
 msgstr ""
 
@@ -14423,11 +14687,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-representation) "
-"tells the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is necessary for our struct to have a predictable layout, "
-"as default Rust representation allows the compiler to (among other things) "
-"reorder fields however it sees fit."
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -14483,8 +14747,8 @@ msgid ""
 "        if self.read_flag_register().contains(Flags::RXFE) {\n"
 "            None\n"
 "        } else {\n"
-"            let data = unsafe { "
-"addr_of!((*self.registers).dr).read_volatile() };\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
 "            // TODO: Check for error conditions in bits 8-11.\n"
 "            Some(data as u8)\n"
 "        }\n"
@@ -14549,8 +14813,7 @@ msgid ""
 "            uart.write_byte(byte);\n"
 "            match byte {\n"
 "                b'\\r' => {\n"
-"                    uart.write_byte(b'\\n"
-"');\n"
+"                    uart.write_byte(b'\\n');\n"
 "                }\n"
 "                b'q' => break,\n"
 "                _ => {}\n"
@@ -14578,9 +14841,9 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the "
-"[`log`](https://crates.io/crates/log) crate. We can do this by implementing "
-"the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -14688,8 +14951,8 @@ msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:47
 msgid ""
-"Run the example in QEMU with `make qemu_logger` under "
-"`src/bare-metal/aps/examples`."
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:3
@@ -14777,12 +15040,11 @@ msgstr ""
 #: src/bare-metal/aps/exceptions.md:69
 msgid ""
 "We can think of exception handlers and our main execution context more or "
-"less like different threads. [`Send` and "
-"`Sync`](../../concurrency/send-sync.md) will control what we can share "
-"between them, just like with threads. For example, if we want to share some "
-"value between exception handlers and the rest of the program, and it's "
-"`Send` but not `Sync`, then we'll need to wrap it in something like a "
-"`Mutex` and put it in a static."
+"less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
+"md) will control what we can share between them, just like with threads. For "
+"example, if we want to share some value between exception handlers and the "
+"rest of the program, and it's `Send` but not `Sync`, then we'll need to wrap "
+"it in something like a `Mutex` and put it in a static."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
@@ -14803,8 +15065,8 @@ msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:7
 msgid ""
-"[Rust RaspberryPi OS "
-"tutorial](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)"
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:8
@@ -14890,14 +15152,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:49
-msgid "`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:50
 msgid ""
-"Run the example with `cargo run` under "
-"`src/bare-metal/useful-crates/zerocopy-example/`. (It won't run in the "
-"Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
@@ -14942,8 +15205,9 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:30
 msgid ""
-"This is used in Android for the [Protected VM "
-"Firmware](https://cs.android.com/android/platform/superproject/+/master:packages/modules/Virtualization/pvmfw/)."
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:31
@@ -14960,13 +15224,12 @@ msgstr ""
 msgid ""
 "[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
 "is a third-party crate implementing a basic buddy system allocator. It can "
-"be used both for "
-"[`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/buddy_system_allocator/struct.LockedHeap.html) "
-"implementing "
-"[`GlobalAlloc`](https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) "
-"so you can use the standard `alloc` crate (as we saw [before](../alloc.md)), "
-"or for allocating other address space. For example, we might want to "
-"allocate MMIO space for PCI BARs:"
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -14994,9 +15257,9 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"Run the example with `cargo run` under "
-"`src/bare-metal/useful-crates/allocator-example/`. (It won't run in the "
-"Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
@@ -15145,10 +15408,10 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the "
-"[vmbase](https://android.googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/master/vmbase/) "
-"library provides a linker script and useful defaults for the build rules, "
-"along with an entry point, UART console logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -15190,9 +15453,9 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a "
-"[PL031](https://developer.arm.com/documentation/ddi0224/c) real-time clock "
-"at 0x9010000. For this exercise, you should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:6
@@ -15204,17 +15467,15 @@ msgstr ""
 #: src/exercises/bare-metal/rtc.md:8
 msgid ""
 "Use the match register and raw interrupt status to busy-wait until a given "
-"time, e.g. 3 seconds in the future. (Call "
-"[`core::hint::spin_loop`](https://doc.rust-lang.org/core/hint/fn.spin_loop.html) "
-"inside the loop.)"
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:10
 msgid ""
 "_Extension if you have time:_ Enable and handle the interrupt generated by "
-"the RTC match. You can use the driver provided in the "
-"[`arm-gic`](https://docs.rs/arm-gic/) crate to configure the Arm Generic "
-"Interrupt Controller."
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:12
@@ -15223,9 +15484,8 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:13
 msgid ""
-"Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt."
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
@@ -15272,8 +15532,8 @@ msgid ""
 "base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) "
-"};\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
 "    gic.setup();\n"
 "\n"
 "    // TODO: Create instance of RTC driver and print current time.\n"
@@ -15590,8 +15850,8 @@ msgid ""
 "        if self.read_flag_register().contains(Flags::RXFE) {\n"
 "            None\n"
 "        } else {\n"
-"            let data = unsafe { "
-"addr_of!((*self.registers).dr).read_volatile() };\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
 "            // TODO: Check for error conditions in bits 8-11.\n"
 "            Some(data as u8)\n"
 "        }\n"
@@ -15745,10 +16005,10 @@ msgid ""
 ".set .L_TCR_RGN_IWB, 0x1 << 8\n"
 "/* Size offset for TTBR0_EL1 is 2**39 bytes (512 GiB). */\n"
 ".set .L_TCR_T0SZ_512, 64 - 39\n"
-".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | "
-".L_TCR_RGN_OWB\n"
-".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | "
-".L_TCR_T0SZ_512\n"
+".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | ."
+"L_TCR_RGN_OWB\n"
+".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | ."
+"L_TCR_T0SZ_512\n"
 "\n"
 "/* Stage 1 instruction access cacheability is unaffected. */\n"
 ".set .L_SCTLR_ELx_I, 0x1 << 12\n"
@@ -15766,10 +16026,10 @@ msgid ""
 ".set .L_SCTLR_EL1_ITD, 0x1 << 7\n"
 ".set .L_SCTLR_EL1_RES1, (0x1 << 11) | (0x1 << 20) | (0x1 << 22) | (0x1 << "
 "28) | (0x1 << 29)\n"
-".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | "
-".L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
-".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | "
-".L_SCTLR_EL1_RES1\n"
+".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | ."
+"L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
+".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | ."
+"L_SCTLR_EL1_RES1\n"
 "\n"
 "/**\n"
 " * This is a generic entry point for an image. It carries out the operations "
@@ -16293,7 +16553,8 @@ msgid ""
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
 "you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
-"Rust 类型系统能帮助我们把许多并发bug转换为编译期bug 发挥着重要作用。这通常称为“无畏并发”，因为你可以依靠编译器来确保 运行时的正确性。"
+"Rust 类型系统能帮助我们把许多并发bug转换为编译期bug 发挥着重要作用。这通常称"
+"为“无畏并发”，因为你可以依靠编译器来确保 运行时的正确性。"
 
 #: src/concurrency/threads.md:3
 msgid "Rust threads work similarly to threads in other languages:"
@@ -16361,7 +16622,9 @@ msgstr "请注意，线程在达到 10 之前就停止了，而主线程并 没�
 msgid ""
 "Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
 "the thread to finish."
-msgstr "使用 `let handle = thread::spawn(...)` 和后面的 `handle.join()` 等待 线程完成。"
+msgstr ""
+"使用 `let handle = thread::spawn(...)` 和后面的 `handle.join()` 等待 线程完"
+"成。"
 
 #: src/concurrency/threads.md:38
 msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
@@ -16370,11 +16633,11 @@ msgstr "在线程中触发紧急警报，并注意这为何不会影响到 `main
 #: src/concurrency/threads.md:40
 msgid ""
 "Use the `Result` return value from `handle.join()` to get access to the "
-"panic payload. This is a good time to talk about "
-"[`Any`](https://doc.rust-lang.org/std/any/index.html)."
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
 msgstr ""
-"使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报 载荷的访问权限。现在有必要介绍一下 "
-"[`Any`](https://doc.rust-lang.org/std/any/index.html) 了。"
+"使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报 载荷的访问权限。现在"
+"有必要介绍一下 [`Any`](https://doc.rust-lang.org/std/any/index.html) 了。"
 
 #: src/concurrency/scoped-threads.md:3
 msgid "Normal threads cannot borrow from their environment:"
@@ -16412,10 +16675,11 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:20
 msgid ""
-"However, you can use a [scoped "
-"thread](https://doc.rust-lang.org/std/thread/fn.scope.html) for this:"
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
 msgstr ""
-"不过，你可以使用[范围线程](https://doc.rust-lang.org/std/thread/fn.scope.html)来实现此目的："
+"不过，你可以使用[范围线程](https://doc.rust-lang.org/std/thread/fn.scope."
+"html)来实现此目的："
 
 #: src/concurrency/scoped-threads.md:22
 msgid ""
@@ -16451,20 +16715,25 @@ msgstr ""
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
-msgstr "其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使得线程能够返回借用的数据。"
+msgstr ""
+"其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使得"
+"线程能够返回借用的数据。"
 
 #: src/concurrency/scoped-threads.md:41
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."
-msgstr "此时须遵守常规 Rust 借用规则：你可以通过一个线程以可变的方式借用，也可以通过任意数量的线程以不可变的方式借用。"
+msgstr ""
+"此时须遵守常规 Rust 借用规则：你可以通过一个线程以可变的方式借用，也可以通过"
+"任意数量的线程以不可变的方式借用。"
 
 #: src/concurrency/channels.md:3
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
 "parts are connected via the channel, but you only see the end-points."
 msgstr ""
-"Rust 通道（Channel）包含两个部分：`Sender<T>` 和 `Receiver<T>`。这两个部分 通过通道进行连接，但你只能看到端点。"
+"Rust 通道（Channel）包含两个部分：`Sender<T>` 和 `Receiver<T>`。这两个部分 通"
+"过通道进行连接，但你只能看到端点。"
 
 #: src/concurrency/channels.md:6
 #, fuzzy
@@ -16512,16 +16781,16 @@ msgid ""
 "implement `Clone` (so you can make multiple producers) but `Receiver` does "
 "not."
 msgstr ""
-"`mpsc` 代表多个生产方，单个使用方。`Sender` 和 `SyncSender` 会实现 `Clone`（因此， 你可以设置多个生产方），但 "
-"`Receiver` 不会实现。"
+"`mpsc` 代表多个生产方，单个使用方。`Sender` 和 `SyncSender` 会实现 `Clone`"
+"（因此， 你可以设置多个生产方），但 `Receiver` 不会实现。"
 
 #: src/concurrency/channels.md:28
 msgid ""
 "`send()` and `recv()` return `Result`. If they return `Err`, it means the "
 "counterpart `Sender` or `Receiver` is dropped and the channel is closed."
 msgstr ""
-"`send()` 和 `recv()` 会返回 `Result`。如果它们返回 `Err`，则表示对应的 `Sender` 或 `Receiver` "
-"已被丢弃，且通道已关闭。"
+"`send()` 和 `recv()` 会返回 `Result`。如果它们返回 `Err`，则表示对应的 "
+"`Sender` 或 `Receiver` 已被丢弃，且通道已关闭。"
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
@@ -16579,7 +16848,8 @@ msgstr ""
 
 #: src/concurrency/channels/bounded.md:3
 #, fuzzy
-msgid "With bounded (synchronous) channels, `send` can block the current thread:"
+msgid ""
+"With bounded (synchronous) channels, `send` can block the current thread:"
 msgstr "有边界的同步通道会使 `send` 阻塞当前线程："
 
 #: src/concurrency/channels/bounded.md:5
@@ -16667,16 +16937,16 @@ msgid ""
 "[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
 "is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)：如果跨线程边界移动 `T` "
-"是安全的，则类型 `T` 为 `Send`。"
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)：如果跨线程边"
+"界移动 `T` 是安全的，则类型 `T` 为 `Send`。"
 
 #: src/concurrency/send-sync.md:7
 msgid ""
 "[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
 "is `Sync` if it is safe to move a `&T` across a thread boundary."
 msgstr ""
-"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)：如果跨线程边界移动 "
-"`&T` 是安全的，则类型 `T` 为 `Sync`。"
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)：如果跨线程边"
+"界移动 `&T` 是安全的，则类型 `T` 为 `Sync`。"
 
 #: src/concurrency/send-sync.md:10
 msgid ""
@@ -16685,13 +16955,14 @@ msgid ""
 "contain `Send` and `Sync` types. You can also implement them manually when "
 "you know it is valid."
 msgstr ""
-"`Send` 和 `Sync` 均为[不安全特征](../unsafe/unsafe-traits.md)。只要类型仅包含 `Send` 和 "
-"`Sync` 类型，编译器就会自动为类型派生 这两种特征。你也可以手动实现它们（如果你确定这样 有效的话）。"
+"`Send` 和 `Sync` 均为[不安全特征](../unsafe/unsafe-traits.md)。只要类型仅包"
+"含 `Send` 和 `Sync` 类型，编译器就会自动为类型派生 这两种特征。你也可以手动实"
+"现它们（如果你确定这样 有效的话）。"
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"One can think of these traits as markers that the type has certain "
-"thread-safety properties."
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr "不妨将这些特征视为类型包含某些线程安全属性的标记。"
 
 #: src/concurrency/send-sync.md:21
@@ -16707,8 +16978,8 @@ msgid ""
 "A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
 "if it is safe to move a `T` value to another thread."
 msgstr ""
-"如果将 `T` 值移动到另一个线程是安全的，则类型 `T` 为 "
-"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)。"
+"如果将 `T` 值移动到另一个线程是安全的，则类型 `T` 为 [`Send`](https://doc."
+"rust-lang.org/std/marker/trait.Send.html)。"
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
@@ -16716,7 +16987,8 @@ msgid ""
 "run in that thread. So the question is when you can allocate a value in one "
 "thread and deallocate it in another."
 msgstr ""
-"将所有权转移到另一个线程的影响是，“析构函数”将在相应线程中 运行。因此，问题在于你何时可以在一个线程中分配某个值，然后在 另一个线程中取消分配该值。"
+"将所有权转移到另一个线程的影响是，“析构函数”将在相应线程中 运行。因此，问题在"
+"于你何时可以在一个线程中分配某个值，然后在 另一个线程中取消分配该值。"
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
@@ -16733,8 +17005,8 @@ msgid ""
 "A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
 "if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"如果同时从多个线程访问 `T` 值是安全的，则类型 `T` 为 "
-"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)。"
+"如果同时从多个线程访问 `T` 值是安全的，则类型 `T` 为 [`Sync`](https://doc."
+"rust-lang.org/std/marker/trait.Sync.html)。"
 
 #: src/concurrency/send-sync/sync.md:6
 msgid "More precisely, the definition is:"
@@ -16749,7 +17021,9 @@ msgid ""
 "This statement is essentially a shorthand way of saying that if a type is "
 "thread-safe for shared use, it is also thread-safe to pass references of it "
 "across threads."
-msgstr "该语句实质上是一种简写形式，表示如果某个类型对于共享使用是线程安全的，那么跨线程传递对该类型的引用也是线程安全的。"
+msgstr ""
+"该语句实质上是一种简写形式，表示如果某个类型对于共享使用是线程安全的，那么跨"
+"线程传递对该类型的引用也是线程安全的。"
 
 #: src/concurrency/send-sync/sync.md:16
 msgid ""
@@ -16759,8 +17033,9 @@ msgid ""
 "is also safe to move to another thread, because the data it references can "
 "be accessed from any thread safely."
 msgstr ""
-"这是因为如果某个类型为 "
-"Sync，则意味着它可以在多个线程之间共享，而不存在数据争用或其他同步问题的风险，因此将其移动到另一个线程是安全的。对该类型的引用同样可以安全地移动到另一个线程，因为它引用的数据可以从任何线程安全地访问。"
+"这是因为如果某个类型为 Sync，则意味着它可以在多个线程之间共享，而不存在数据争"
+"用或其他同步问题的风险，因此将其移动到另一个线程是安全的。对该类型的引用同样"
+"可以安全地移动到另一个线程，因为它引用的数据可以从任何线程安全地访问。"
 
 #: src/concurrency/send-sync/examples.md:3
 msgid "`Send + Sync`"
@@ -16808,7 +17083,9 @@ msgstr "`Send + !Sync`"
 msgid ""
 "These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
-msgstr "这些类型可以移动到其他线程，但它们不是线程安全的。 这通常是由内部可变性造成的："
+msgstr ""
+"这些类型可以移动到其他线程，但它们不是线程安全的。 这通常是由内部可变性造成"
+"的："
 
 #: src/concurrency/send-sync/examples.md:22
 msgid "`mpsc::Sender<T>`"
@@ -16831,14 +17108,17 @@ msgid "`!Send + Sync`"
 msgstr "`!Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:29
-msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgid ""
+"These types are thread-safe, but they cannot be moved to another thread:"
 msgstr "这些类型是线程安全的，但它们不能移动到另一个线程："
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
 "`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
 "thread which created them."
-msgstr "`MutexGuard<T>`：使用操作系统级别的原语（必须在创建这些原语的线程上 取消分配）。"
+msgstr ""
+"`MutexGuard<T>`：使用操作系统级别的原语（必须在创建这些原语的线程上 取消分"
+"配）。"
 
 #: src/concurrency/send-sync/examples.md:34
 msgid "`!Send + !Sync`"
@@ -16850,15 +17130,17 @@ msgstr "这些类型不是线程安全的，不能移动到其他线程："
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a "
-"non-atomic reference count."
-msgstr "`Rc<T>`：每个 `Rc<T>` 都具有对 `RcBox<T>` 的引用，其中包含 非原子引用计数。"
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
+msgstr ""
+"`Rc<T>`：每个 `Rc<T>` 都具有对 `RcBox<T>` 的引用，其中包含 非原子引用计数。"
 
 #: src/concurrency/send-sync/examples.md:40
 msgid ""
 "`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
 "considerations."
-msgstr "`*const T`、`*mut T`：Rust 会假定原始指针可能 在并发方面有特殊的注意事项。"
+msgstr ""
+"`*const T`、`*mut T`：Rust 会假定原始指针可能 在并发方面有特殊的注意事项。"
 
 #: src/concurrency/shared_state.md:3
 msgid ""
@@ -16872,16 +17154,16 @@ msgid ""
 "reference counted `T`: handles sharing between threads and takes care to "
 "deallocate `T` when the last reference is dropped,"
 msgstr ""
-"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)，对 `T` "
-"进行原子计数：用于处理线程之间的共享，并负责 在最后一个引用被丢弃时取消分配 `T`。"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)，对 `T` 进行原"
+"子计数：用于处理线程之间的共享，并负责 在最后一个引用被丢弃时取消分配 `T`。"
 
 #: src/concurrency/shared_state.md:8
 msgid ""
 "[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
 "mutually exclusive access to the `T` value."
 msgstr ""
-"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)：确保对 `T` "
-"值的互斥访问。"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)：确保对 "
+"`T` 值的互斥访问。"
 
 #: src/concurrency/shared_state/arc.md:1
 msgid "`Arc`"
@@ -16949,14 +17231,16 @@ msgid ""
 "`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
 "and `Sync` if and only if `T` implements them both."
 msgstr ""
-"无论 `T` 是否实现 `Clone`，`Arc<T>` 都会实现 `Clone`。如果 `T` 实现了 `Send` 和 "
-"`Sync`，`Arc<T>` 便会 实现二者。"
+"无论 `T` 是否实现 `Clone`，`Arc<T>` 都会实现 `Clone`。如果 `T` 实现了 `Send` "
+"和 `Sync`，`Arc<T>` 便会 实现二者。"
 
 #: src/concurrency/shared_state/arc.md:33
 msgid ""
 "`Arc::clone()` has the cost of atomic operations that get executed, but "
 "after that the use of the `T` is free."
-msgstr "`Arc::clone()` 在执行原子操作方面有开销，但在此之后，`T` 便可 随意使用，而没有任何开销。"
+msgstr ""
+"`Arc::clone()` 在执行原子操作方面有开销，但在此之后，`T` 便可 随意使用，而没"
+"有任何开销。"
 
 #: src/concurrency/shared_state/arc.md:35
 msgid ""
@@ -16978,8 +17262,8 @@ msgid ""
 "mutual exclusion _and_ allows mutable access to `T` behind a read-only "
 "interface:"
 msgstr ""
-"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) "
-"能够确保互斥，并允许对只读接口 后面的 `T` 进行可变访问："
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) 能够确保互"
+"斥，并允许对只读接口 后面的 `T` 进行可变访问："
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -17017,19 +17301,19 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for "
-"Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) "
-"blanket implementation."
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
+"implementation."
 msgstr ""
-"请注意我们如何设置 [`impl<T: Send> Sync for "
-"Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) "
-"通用 实现。"
+"请注意我们如何设置 [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-lang."
+"org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) 通用 实现。"
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
 "`Mutex` in Rust looks like a collection with just one element - the "
 "protected data."
-msgstr "Rust 中的互斥器看起来就像只包含一个元素的集合，其中的元素就是受保护的数据。"
+msgstr ""
+"Rust 中的互斥器看起来就像只包含一个元素的集合，其中的元素就是受保护的数据。"
 
 #: src/concurrency/shared_state/mutex.md:32
 msgid ""
@@ -17042,8 +17326,8 @@ msgid ""
 "You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
 "`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
-"你可以通过获取锁，从 `&Mutex<T>` 中获取 `&mut T`。`MutexGuard` 能够确保 `&mut T` "
-"存在的时间不会比持有锁的时间更长。"
+"你可以通过获取锁，从 `&Mutex<T>` 中获取 `&mut T`。`MutexGuard` 能够确保 "
+"`&mut T` 存在的时间不会比持有锁的时间更长。"
 
 #: src/concurrency/shared_state/mutex.md:35
 #, fuzzy
@@ -17068,10 +17352,10 @@ msgid ""
 "[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
 "You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
-"如果持有 `Mutex` 的线程发生panic，`Mutex` 便会“中毒”并发出信号， 表明其所保护的数据可能处于不一致状态。对中毒的互斥量调用 "
-"`lock()` 将会失败， 并将显示 "
-"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html)。无论如何，你可以对该错误调用 "
-"`into_inner()` 来 恢复数据。"
+"如果持有 `Mutex` 的线程发生panic，`Mutex` 便会“中毒”并发出信号， 表明其所保护"
+"的数据可能处于不一致状态。对中毒的互斥量调用 `lock()` 将会失败， 并将显示 "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html)。"
+"无论如何，你可以对该错误调用 `into_inner()` 来 恢复数据。"
 
 #: src/concurrency/shared_state/example.md:3
 msgid "Let us see `Arc` and `Mutex` in action:"
@@ -17185,7 +17469,9 @@ msgstr "将 `Mutex` 封装在 `Arc` 中是一种在线程之间共享可变状�
 msgid ""
 "`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
 "thread. Note `move` was added to the lambda signature."
-msgstr "`v: Arc<_>` 必须先克隆为 `v2`，然后才能移动到另一个线程中。请注意，lambda 签名中添加了 `move`。"
+msgstr ""
+"`v: Arc<_>` 必须先克隆为 `v2`，然后才能移动到另一个线程中。请注意，lambda 签"
+"名中添加了 `move`。"
 
 #: src/concurrency/shared_state/example.md:54
 msgid ""
@@ -17299,9 +17585,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as "
-"[`reqwest`](https://docs.rs/reqwest/). Create a new Cargo project and "
-"`reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:17
@@ -17312,14 +17597,14 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:20
 msgid ""
-"You will also need a way to find links. We can use "
-"[`scraper`](https://docs.rs/scraper/) for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use "
-"[`thiserror`](https://docs.rs/thiserror/) for that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:33
@@ -17337,8 +17622,8 @@ msgid ""
 "publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] "
-"}\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -17346,8 +17631,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:50
 msgid ""
-"You can now download the start page. Try with a small site such as "
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:53
@@ -17413,8 +17698,8 @@ msgid ""
 "fn main() {\n"
 "    let client = Client::new();\n"
 "    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
-"    let crawl_command = CrawlCommand{ url: start_url, extract_links: true "
-"};\n"
+"    let crawl_command = CrawlCommand{ url: start_url, extract_links: "
+"true };\n"
 "    match visit_page(&client, &crawl_command) {\n"
 "        Ok(links) => println!(\"Links: {links:#?}\"),\n"
 "        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
@@ -17435,9 +17720,9 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:130
 msgid ""
-"Extend this to recursively extract links from all pages on the "
-"`www.google.org` domain. Put an upper limit of 100 pages or so so that you "
-"don't end up being blocked by the site."
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
 
 #: src/async.md:1
@@ -17520,7 +17805,9 @@ msgstr ""
 msgid ""
 "Note that this is a simplified example to show the syntax. There is no long "
 "running operation or any real concurrency in it!"
-msgstr "请注意，这只是一个简单的示例，用于展示语法。其中没有长时间运行的操作或任何真正的并发！"
+msgstr ""
+"请注意，这只是一个简单的示例，用于展示语法。其中没有长时间运行的操作或任何真"
+"正的并发！"
 
 #: src/async/async-await.md:30
 msgid "What is the return type of an async call?"
@@ -17540,19 +17827,25 @@ msgstr "\"async\" 关键字是语法糖。编译器会将返回类型替换为 f
 msgid ""
 "You cannot make `main` async, without additional instructions to the "
 "compiler on how to use the returned future."
-msgstr "你不能将 `main` 声明为异步函数，除非在编译器中加入额外的指令来告诉它如何使用返回的 future。"
+msgstr ""
+"你不能将 `main` 声明为异步函数，除非在编译器中加入额外的指令来告诉它如何使用"
+"返回的 future。"
 
 #: src/async/async-await.md:39
 msgid ""
 "You need an executor to run async code. `block_on` blocks the current thread "
 "until the provided future has run to completion. "
-msgstr "你需要一个执行器来运行异步代码。`block_on`会阻塞当前线程，直到提供的future完成为止。 "
+msgstr ""
+"你需要一个执行器来运行异步代码。`block_on`会阻塞当前线程，直到提供的future完"
+"成为止。 "
 
 #: src/async/async-await.md:42
 msgid ""
 "`.await` asynchronously waits for the completion of another operation. "
 "Unlike `block_on`, `.await` doesn't block the current thread."
-msgstr "`.await` 会异步地等待另一个操作的完成。与 `block_on` 不同，`.await` 不会阻塞当前线程。"
+msgstr ""
+"`.await` 会异步地等待另一个操作的完成。与 `block_on` 不同，`.await` 不会阻塞"
+"当前线程。"
 
 #: src/async/async-await.md:45
 msgid ""
@@ -17564,8 +17857,8 @@ msgstr "`.await` 只能在 `async` 函数（或块，这些稍后会介绍）中
 msgid ""
 "[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
 "trait, implemented by objects that represent an operation that may not be "
-"complete yet. A future can be polled, and `poll` returns a "
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
 #: src/async/futures.md:23
@@ -17617,8 +17910,8 @@ msgstr ""
 #: src/async/runtimes.md:7
 msgid ""
 "[Tokio](https://tokio.rs/): performant, with a well-developed ecosystem of "
-"functionality like [Hyper](https://hyper.rs/) for HTTP or "
-"[Tonic](https://github.com/hyperium/tonic) for gRPC."
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
 msgstr ""
 
 #: src/async/runtimes.md:10
@@ -17633,9 +17926,9 @@ msgstr ""
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example, "
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-async/src/lib.rs) "
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 
 #: src/async/runtimes.md:20
@@ -17754,8 +18047,7 @@ msgid ""
 "        println!(\"connection from {addr:?}\");\n"
 "\n"
 "        tokio::spawn(async move {\n"
-"            if let Err(e) = socket.write_all(b\"Who are you?\\n"
-"\").await {\n"
+"            if let Err(e) = socket.write_all(b\"Who are you?\\n\").await {\n"
 "                println!(\"socket error: {e:?}\");\n"
 "                return;\n"
 "            }\n"
@@ -17763,10 +18055,9 @@ msgid ""
 "            let mut buf = vec![0; 1024];\n"
 "            let reply = match socket.read(&mut buf).await {\n"
 "                Ok(n) => {\n"
-"                    let name = "
-"std::str::from_utf8(&buf[..n]).unwrap().trim();\n"
-"                    format!(\"Thanks for dialing in, {name}!\\n"
-"\")\n"
+"                    let name = std::str::from_utf8(&buf[..n]).unwrap()."
+"trim();\n"
+"                    format!(\"Thanks for dialing in, {name}!\\n\")\n"
 "                }\n"
 "                Err(e) => {\n"
 "                    println!(\"socket error: {e:?}\");\n"
@@ -17783,9 +18074,9 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/tasks.md:52
-#: src/async/control-flow/join.md:36
-msgid "Copy this example into your prepared `src/main.rs` and run it from there."
+#: src/async/tasks.md:52 src/async/control-flow/join.md:36
+msgid ""
+"Copy this example into your prepared `src/main.rs` and run it from there."
 msgstr ""
 
 #: src/async/tasks.md:54
@@ -17953,9 +18244,9 @@ msgstr ""
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to that future's result. In JavaScript, this is similar to "
-"`Promise.race`. In Python, it compares to `asyncio.wait(task_set, "
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
@@ -18120,8 +18411,8 @@ msgstr ""
 #: src/async/pitfalls/blocking-executor.md:32
 msgid ""
 "The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the effect more obvious, but the bug is still present in the "
-"multi-threaded flavor."
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:36
@@ -18249,8 +18540,8 @@ msgstr ""
 #: src/async/pitfalls/pin.md:88
 msgid ""
 "This still doesn't work. Follow the compiler errors, adding `&mut` to the "
-"`timeout_fut` in the `select!` to work around the move, then using "
-"`Box::pin`:"
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
 msgstr ""
 
 #: src/async/pitfalls/pin.md:102
@@ -18277,7 +18568,8 @@ msgstr ""
 msgid ""
 "Async methods in traits are not yet supported in the stable channel ([An "
 "experimental feature exists in nightly and should be stabilized in the mid "
-"term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html))"
+"term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-"
+"nightly.html))"
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:5
@@ -18342,18 +18634,21 @@ msgstr ""
 msgid ""
 "The challenges in language support for `async trait` are deep Rust and "
 "probably not worth describing in-depth. Niko Matsakis did a good job of "
-"explaining them in [this "
-"post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/) "
-"if you are interested in digging deeper."
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
 msgstr ""
-"对于 `async trait` 的语言支持中的挑战是深入  Rust的，并且可能不值得深入描述。如果您对深入了解感兴趣，Niko Matsakis "
-"在[这篇文章](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)中对它们做了很好的解释。"
+"对于 `async trait` 的语言支持中的挑战是深入  Rust的，并且可能不值得深入描述。"
+"如果您对深入了解感兴趣，Niko Matsakis 在[这篇文章](https://"
+"smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-"
+"hard/)中对它们做了很好的解释。"
 
 #: src/async/pitfalls/async-traits.md:60
 msgid ""
 "Try creating a new sleeper struct that will sleep for a random amount of "
 "time and adding it to the Vec."
-msgstr "尝试创建一个新的 sleeper 结构，使其随机休眠一段时间，并将其添加到 Vec 中。"
+msgstr ""
+"尝试创建一个新的 sleeper 结构，使其随机休眠一段时间，并将其添加到 Vec 中。"
 
 #: src/async/pitfalls/cancellation.md:3
 msgid ""
@@ -18384,8 +18679,7 @@ msgid ""
 "        let mut buf = [0];\n"
 "        while self.stream.read(&mut buf[..]).await? != 0 {\n"
 "            bytes.push(buf[0]);\n"
-"            if buf[0] == b'\\n"
-"' {\n"
+"            if buf[0] == b'\\n' {\n"
 "                break;\n"
 "            }\n"
 "        }\n"
@@ -18399,8 +18693,8 @@ msgid ""
 "    }\n"
 "}\n"
 "\n"
-"async fn slow_copy(source: String, mut dest: DuplexStream) -> "
-"std::io::Result<()> {\n"
+"async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::"
+"Result<()> {\n"
 "    for b in source.bytes() {\n"
 "        dest.write_u8(b).await?;\n"
 "        tokio::time::sleep(Duration::from_millis(10)).await\n"
@@ -18411,9 +18705,8 @@ msgid ""
 "#[tokio::main]\n"
 "async fn main() -> std::io::Result<()> {\n"
 "    let (client, server) = tokio::io::duplex(5);\n"
-"    let handle = tokio::spawn(slow_copy(\"hi\\n"
-"there\\n"
-"\".to_owned(), client));\n"
+"    let handle = tokio::spawn(slow_copy(\"hi\\nthere\\n\".to_owned(), "
+"client));\n"
 "\n"
 "    let mut lines = LinesReader::new(server);\n"
 "    let mut interval = tokio::time::interval(Duration::from_millis(60));\n"
@@ -18488,38 +18781,44 @@ msgstr ""
 #: src/async/pitfalls/cancellation.md:104
 #, fuzzy
 msgid ""
-"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick) "
-"is cancellation-safe because it keeps track of whether a tick has been "
-"'delivered'."
+"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
+"html#method.tick) is cancellation-safe because it keeps track of whether a "
+"tick has been 'delivered'."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/async/pitfalls/cancellation.md:107
 #, fuzzy
 msgid ""
-"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read) "
-"is cancellation-safe because it either returns or doesn't read data."
+"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncReadExt.html#method.read) is cancellation-safe because it either "
+"returns or doesn't read data."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/async/pitfalls/cancellation.md:110
 #, fuzzy
 msgid ""
-"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line) "
-"is similar to the example and _isn't_ cancellation-safe. See its "
-"documentation for details and alternatives."
+"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
+"cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/exercises/concurrency/afternoon.md:3
-msgid "To practice your Async Rust skills, we have again two exercises for you:"
+msgid ""
+"To practice your Async Rust skills, we have again two exercises for you:"
 msgstr "为了练习您的异步 Rust 技能，我们再次为您提供了两个练习："
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
 "Dining philosophers: we already saw this problem in the morning. This time "
 "you are going to implement it with Async Rust."
-msgstr "哲学家进餐：我们已经在上午看到了这个问题。这次你将使用异步 Rust 来实现它。"
+msgstr ""
+"哲学家进餐：我们已经在上午看到了这个问题。这次你将使用异步 Rust 来实现它。"
 
 #: src/exercises/concurrency/afternoon.md:8
 msgid ""
@@ -18540,14 +18839,13 @@ msgstr "查看[哲学家进餐](dining-philosophers.md)以获取问题的描述�
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 msgid ""
-"As before, you will need a local [Cargo "
-"installation](../../cargo/running-locally.md) for this exercise. Copy the "
-"code below to a file called `src/main.rs`, fill out the blanks, and test "
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
-"与之前一样，您需要一个本地的 [Cargo "
-"安装](../../cargo/running-locally.md)来进行这个练习。将下面的代码复制到一个名为 `src/main.rs` "
-"的文件中，填写空白部分，并测试确保 `cargo run` 不会死锁："
+"与之前一样，您需要一个本地的 [Cargo 安装](../../cargo/running-locally.md)来进"
+"行这个练习。将下面的代码复制到一个名为 `src/main.rs` 的文件中，填写空白部分，"
+"并测试确保 `cargo run` 不会死锁："
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
 msgid ""
@@ -18569,8 +18867,8 @@ msgid ""
 "impl Philosopher {\n"
 "    async fn think(&self) {\n"
 "        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", "
-"&self.name)).await\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
 "            .unwrap();\n"
 "    }\n"
 "\n"
@@ -18601,7 +18899,9 @@ msgstr ""
 msgid ""
 "Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
-msgstr "因为这次您正在使用异步Rust，您将需要一个 `tokio` 依赖。您可以使用以下的 `Cargo.toml`："
+msgstr ""
+"因为这次您正在使用异步Rust，您将需要一个 `tokio` 依赖。您可以使用以下的 "
+"`Cargo.toml`："
 
 #: src/exercises/concurrency/dining-philosophers-async.md:62
 msgid ""
@@ -18635,20 +18935,22 @@ msgid ""
 "input, and sends them to the server. The chat server broadcasts each message "
 "that it receives to all the clients."
 msgstr ""
-"在本练习中，我们想要使用我们的新知识来实现一个广播聊天应用。我们有一个聊天服务器，客户端连接到该服务器并发布他们的消息。客户端从标准输入读取用户消息，并将其发送到服务器。聊天服务器将收到的每条消息广播给所有客户端。"
+"在本练习中，我们想要使用我们的新知识来实现一个广播聊天应用。我们有一个聊天服"
+"务器，客户端连接到该服务器并发布他们的消息。客户端从标准输入读取用户消息，并"
+"将其发送到服务器。聊天服务器将收到的每条消息广播给所有客户端。"
 
 #: src/exercises/concurrency/chat-app.md:9
 #, fuzzy
 msgid ""
-"For this, we use [a broadcast "
-"channel](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html) "
-"on the server, and "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/) "
-"for the communication between the client and the server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
-"为此，我们在服务器上使用一个[广播 "
-"channel](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html)，并使用[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) "
-"来进行客户端与服务器之间的通信。"
+"为此，我们在服务器上使用一个[广播 channel](https://docs.rs/tokio/latest/"
+"tokio/sync/broadcast/fn.channel.html)，并使用[`tokio_websockets`](https://"
+"docs.rs/tokio-websockets/0.3.2/tokio_websockets/) 来进行客户端与服务器之间的"
+"通信。"
 
 #: src/exercises/concurrency/chat-app.md:13
 msgid "Create a new Cargo project and add the following dependencies:"
@@ -18684,46 +18986,51 @@ msgstr "所需的API"
 #, fuzzy
 msgid ""
 "You are going to need the following functions from `tokio` and "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/). "
-"Spend a few minutes to familiarize yourself with the API. "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
+"API. "
 msgstr ""
-"您将需要来自 `tokio` 和 "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) "
-"的以下函数。请花几分钟时间熟悉这些 API。"
+"您将需要来自 `tokio` 和 [`tokio_websockets`](https://docs.rs/tokio-"
+"websockets/0.3.2/tokio_websockets/) 的以下函数。请花几分钟时间熟悉这些 API。"
 
 #: src/exercises/concurrency/chat-app.md:37
 #, fuzzy
 msgid ""
-"[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/trait.StreamExt.html#method.next) "
-"implemented by `WebsocketStream`: for asynchronously reading messages from a "
-"Websocket Stream."
+"[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
+"trait.StreamExt.html#method.next) implemented by `WebsocketStream`: for "
+"asynchronously reading messages from a Websocket Stream."
 msgstr ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
-"由`WebsocketStream`实现：用于在Websocket流上异步发送消息。"
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) 由`WebsocketStream`实现：用于在Websocket流上"
+"异步发送消息。"
 
 #: src/exercises/concurrency/chat-app.md:39
 msgid ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
-"implemented by `WebsocketStream`: for asynchronously sending messages on a "
-"Websocket Stream."
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
 msgstr ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send) "
-"由`WebsocketStream`实现：用于在Websocket流上异步发送消息。"
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) 由`WebsocketStream`实现：用于在Websocket流上"
+"异步发送消息。"
 
 #: src/exercises/concurrency/chat-app.md:41
 #, fuzzy
 msgid ""
-"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line): "
-"for asynchronously reading user messages from the standard input."
+"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
 msgstr ""
-"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line)：用于从标准输入异步读取用户消息。"
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line)：用于从标准输入异步读取用户消息。"
 
 #: src/exercises/concurrency/chat-app.md:43
 msgid ""
-"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.subscribe): "
-"for subscribing to a broadcast channel."
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
-"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.subscribe)：用于订阅广播频道。"
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe)：用于订阅广播频道。"
 
 #: src/exercises/concurrency/chat-app.md:46
 msgid "Two binaries"
@@ -18731,24 +19038,29 @@ msgstr "两个可执行文件"
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one "
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client, and one for the server. You could potentially make them two separate "
-"Cargo projects, but we are going to put them in a single Cargo project with "
-"two binaries. For this to work, the client and the server code should go "
-"under `src/bin` (see the "
-"[documentation](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries)). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
-"通常在一个Cargo项目中，你只能有一个二进制文件，和一个`src/main.rs`文件。在这个项目中，我们需要两个二进制文件。一个用于客户端，另一个用于服务器。你可能会考虑将它们制作成两个单独的Cargo项目，但我们将它们放在一个包含两个二进制文件的Cargo项目中。为了使这个工作，客户端和服务器的代码应该放在`src/bin`下（参见[文档](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries)）。"
+"通常在一个Cargo项目中，你只能有一个二进制文件，和一个`src/main.rs`文件。在这"
+"个项目中，我们需要两个二进制文件。一个用于客户端，另一个用于服务器。你可能会"
+"考虑将它们制作成两个单独的Cargo项目，但我们将它们放在一个包含两个二进制文件的"
+"Cargo项目中。为了使这个工作，客户端和服务器的代码应该放在`src/bin`下（参见[文"
+"档](https://doc.rust-lang.org/cargo/reference/cargo-targets."
+"html#binaries)）。"
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and "
-"`src/bin/client.rs`, respectively. Your task is to complete these files as "
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
-"将以下服务器和客户端代码分别复制到 `src/bin/server.rs` 和 `src/bin/client.rs` "
-"中。您的任务是按照下面的描述完成这些文件。"
+"将以下服务器和客户端代码分别复制到 `src/bin/server.rs` 和 `src/bin/client."
+"rs` 中。您的任务是按照下面的描述完成这些文件。"
 
 #: src/exercises/concurrency/chat-app.md:59
 #: src/exercises/concurrency/solutions-afternoon.md:99
@@ -18853,8 +19165,8 @@ msgid ""
 "continuous loop. One task receives messages from the client and broadcasts "
 "them. The other sends messages received by the server to the client."
 msgstr ""
-"提示：使用 `tokio::select!` "
-"在一个连续的循环中并发执行两个任务。一个任务从客户端接收消息并广播它们。另一个任务将服务器接收到的消息发送给客户端。"
+"提示：使用 `tokio::select!` 在一个连续的循环中并发执行两个任务。一个任务从客"
+"户端接收消息并广播它们。另一个任务将服务器接收到的消息发送给客户端。"
 
 #: src/exercises/concurrency/chat-app.md:149
 msgid "Complete the main function in `src/bin/client.rs`."
@@ -18868,8 +19180,9 @@ msgid ""
 "sending them to the server, and (2) receiving messages from the server, and "
 "displaying them for the user."
 msgstr ""
-"提示：与之前一样，使用 `tokio::select!` 在一个连续的循环中并发执行两个任务：(1) 从标准输入读取用户消息并发送给服务器，以及 (2) "
-"从服务器接收消息并显示给用户。"
+"提示：与之前一样，使用 `tokio::select!` 在一个连续的循环中并发执行两个任务："
+"(1) 从标准输入读取用户消息并发送给服务器，以及 (2) 从服务器接收消息并显示给用"
+"户。"
 
 #: src/exercises/concurrency/chat-app.md:154
 #, fuzzy
@@ -18881,20 +19194,20 @@ msgstr "可选：完成后，将代码更改为将消息广播给除消息发送
 #: src/thanks.md:3
 #, fuzzy
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
-"it was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
 msgstr "_感谢您参与学习 Comprehensive Rust 🦀！_ 希望您喜欢并且觉得它有用。"
 
 #: src/thanks.md:6
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
 "perfect, so if you spotted any mistakes or have ideas for improvements, "
-"please get in [contact with us on "
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love to hear from you."
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
-"组织这门课程让我们收获了很多乐趣。本课程并非完美无缺，因此，如果您发现任何错误或有任何改进建议，请[在 GitHub "
-"上与我们联系](https://github.com/google/comprehensive-rust/discussions)。我们期待收到您的宝贵意见。"
+"组织这门课程让我们收获了很多乐趣。本课程并非完美无缺，因此，如果您发现任何错"
+"误或有任何改进建议，请[在 GitHub 上与我们联系](https://github.com/google/"
+"comprehensive-rust/discussions)。我们期待收到您的宝贵意见。"
 
 #: src/glossary.md:3
 msgid ""
@@ -18918,11 +19231,15 @@ msgid "Bare-metal Rust: See [Bare-metal Rust](bare-metal.md)."
 msgstr ""
 
 #: src/glossary.md:34
-msgid "block:  \nSee [Blocks](control-flow/blocks.md) and _scope_."
+msgid ""
+"block:  \n"
+"See [Blocks](control-flow/blocks.md) and _scope_."
 msgstr ""
 
 #: src/glossary.md:36
-msgid "borrow:  \nSee [Borrowing](ownership/borrowing.md)."
+msgid ""
+"borrow:  \n"
+"See [Borrowing](ownership/borrowing.md)."
 msgstr ""
 
 #: src/glossary.md:38
@@ -18932,7 +19249,9 @@ msgid ""
 msgstr ""
 
 #: src/glossary.md:40
-msgid "brace:  \n`{` and `}`. Also called _curly brace_, they delimit _blocks_."
+msgid ""
+"brace:  \n"
+"`{` and `}`. Also called _curly brace_, they delimit _blocks_."
 msgstr ""
 
 #: src/glossary.md:42
@@ -18963,7 +19282,9 @@ msgstr "并发"
 
 #: src/glossary.md:49
 #, fuzzy
-msgid "Concurrency in Rust:  \nSee [Concurrency in Rust](concurrency.md)."
+msgid ""
+"Concurrency in Rust:  \n"
+"See [Concurrency in Rust](concurrency.md)."
 msgstr "欢迎了解 Rust 中的并发"
 
 #: src/glossary.md:51
@@ -19118,12 +19439,16 @@ msgid "Rust:"
 msgstr "Rustdoc"
 
 #: src/glossary.md:84
-msgid "Rust Fundamentals:  \nDays 1 to 3 of this course."
+msgid ""
+"Rust Fundamentals:  \n"
+"Days 1 to 3 of this course."
 msgstr ""
 
 #: src/glossary.md:86
 #, fuzzy
-msgid "Rust in Android:  \nSee [Rust in Android](android.md)."
+msgid ""
+"Rust in Android:  \n"
+"See [Rust in Android](android.md)."
 msgstr "欢迎来到Android 中的Rust"
 
 #: src/glossary.md:88
@@ -19230,8 +19555,8 @@ msgid ""
 "canonical free book about Rust. Covers the language in detail and includes a "
 "few projects for people to build."
 msgstr ""
-"[Rust 程序设计语言](https://doc.rust-lang.org/book/)：一部有关 Rust "
-"的免费权威图书。书中详细介绍了该语言，并包含一些可供读者构建的项目。"
+"[Rust 程序设计语言](https://doc.rust-lang.org/book/)：一部有关 Rust 的免费权"
+"威图书。书中详细介绍了该语言，并包含一些可供读者构建的项目。"
 
 #: src/other-resources.md:13
 msgid ""
@@ -19240,8 +19565,9 @@ msgid ""
 "Sometimes includes small exercises where you are asked to expand on the code "
 "in the examples."
 msgstr ""
-"[通过例子学 Rust](https://doc.rust-lang.org/rust-by-example/)：通过一系列展示不同结构的示例介绍 "
-"Rust 语法。有时会包括一些小练习，会要求您充分地阐述示例中的代码。"
+"[通过例子学 Rust](https://doc.rust-lang.org/rust-by-example/)：通过一系列展示"
+"不同结构的示例介绍 Rust 语法。有时会包括一些小练习，会要求您充分地阐述示例中"
+"的代码。"
 
 #: src/other-resources.md:17
 msgid ""
@@ -19254,7 +19580,8 @@ msgid ""
 "[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
 "book which describes the Rust grammar and memory model."
 msgstr ""
-"[Rust 参考手册](https://doc.rust-lang.org/reference/)：一本未完成的书，介绍了 Rust 语法和内存模型。"
+"[Rust 参考手册](https://doc.rust-lang.org/reference/)：一本未完成的书，介绍"
+"了 Rust 语法和内存模型。"
 
 #: src/other-resources.md:22
 msgid "More specialized guides hosted on the official Rust site:"
@@ -19266,8 +19593,8 @@ msgid ""
 "including working with raw pointers and interfacing with other languages "
 "(FFI)."
 msgstr ""
-"[Rust 秘典](https://doc.rust-lang.org/nomicon/)：介绍了不安全 Rust，包括使用原始指针以及与其他语言 "
-"(FFI) 交互。"
+"[Rust 秘典](https://doc.rust-lang.org/nomicon/)：介绍了不安全 Rust，包括使用"
+"原始指针以及与其他语言 (FFI) 交互。"
 
 #: src/other-resources.md:27
 msgid ""
@@ -19284,9 +19611,8 @@ msgid ""
 "an introduction to using Rust on embedded devices without an operating "
 "system."
 msgstr ""
-"[嵌入式 Rust "
-"之书](https://doc.rust-lang.org/stable/embedded-book/)：介绍如何在没有操作系统的嵌入式设备上使用 "
-"Rust。"
+"[嵌入式 Rust 之书](https://doc.rust-lang.org/stable/embedded-book/)：介绍如何"
+"在没有操作系统的嵌入式设备上使用 Rust。"
 
 #: src/other-resources.md:33
 msgid "Unofficial Learning Material"
@@ -19301,17 +19627,17 @@ msgid ""
 "[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
 "from the perspective of low-level C programmers."
 msgstr ""
-"[Learn Rust the Dangerous Way（以危险的方式学 "
-"Rust）](http://cliffle.com/p/dangerust/)：从低级 C 语言程序员的角度介绍 Rust。"
+"[Learn Rust the Dangerous Way（以危险的方式学 Rust）](http://cliffle.com/p/"
+"dangerust/)：从低级 C 语言程序员的角度介绍 Rust。"
 
 #: src/other-resources.md:39
 msgid ""
-"[Rust for Embedded C "
-"Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from the perspective of developers who write firmware in C."
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
 msgstr ""
-"[面向嵌入式 C 程序员的 Rust](https://docs.opentitan.org/doc/ug/rust_for_c/)：从使用 C "
-"语言编写固件的开发者的角度介绍 Rust。"
+"[面向嵌入式 C 程序员的 Rust](https://docs.opentitan.org/doc/ug/rust_for_c/)："
+"从使用 C 语言编写固件的开发者的角度介绍 Rust。"
 
 #: src/other-resources.md:42
 msgid ""
@@ -19319,60 +19645,57 @@ msgid ""
 "covers the syntax of Rust using side-by-side comparisons with other "
 "languages such as C, C++, Java, JavaScript, and Python."
 msgstr ""
-"[Rust for professionals（面向专业人士的 "
-"Rust）](https://overexact.com/rust-for-professionals/)：通过与其他语言（例如 "
-"C、C++、Java、JavaScript 和 Python）进行并排比较，介绍 Rust 的语法。"
+"[Rust for professionals（面向专业人士的 Rust）](https://overexact.com/rust-"
+"for-professionals/)：通过与其他语言（例如 C、C++、Java、JavaScript 和 "
+"Python）进行并排比较，介绍 Rust 的语法。"
 
 #: src/other-resources.md:45
 msgid ""
 "[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
 "you learn Rust."
 msgstr ""
-"[Rust on Exercism（在 Exercism 上学 Rust）](https://exercism.org/tracks/rust)：100 "
-"多项练习助您学习 Rust。"
+"[Rust on Exercism（在 Exercism 上学 Rust）](https://exercism.org/tracks/"
+"rust)：100 多项练习助您学习 Rust。"
 
 #: src/other-resources.md:47
 msgid ""
-"[Ferrous Teaching "
-"Material](https://ferrous-systems.github.io/teaching-material/index.html): a "
-"series of small presentations covering both basic and advanced part of the "
-"Rust language. Other topics such as WebAssembly, and async/await are also "
-"covered."
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
 msgstr ""
-"[Ferrous Teaching "
-"Material](https://ferrous-systems.github.io/teaching-material/index.html)：一系列小演示文稿，涵盖 "
-"Rust 语言的基础知识和高级部分。还涵盖了 WebAssembly 和 async/await 等其他主题。"
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html)：一系列小演示文稿，涵盖 Rust 语言的基础知识和高级部分。"
+"还涵盖了 WebAssembly 和 async/await 等其他主题。"
 
 #: src/other-resources.md:52
 msgid ""
-"[Beginner's Series to "
-"Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) and "
-"[Take your first steps with "
-"Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): two "
-"Rust guides aimed at new developers. The first is a set of 35 videos and the "
-"second is a set of 11 modules which covers Rust syntax and basic constructs."
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
 msgstr ""
-"[面向 Rust "
-"的初学者系列](https://docs.microsoft.com/zh-cn/shows/beginners-series-to-rust/)和[使用 "
-"Rust "
-"迈出第一步](https://docs.microsoft.com/zh-cn/learn/paths/rust-first-steps/)：两个面向新手开发者的 "
-"Rust 指南。第一个指南包含 35 个视频，第二个指南包含 11 个模块，内容涵盖 Rust 语法和基本结构。"
+"[面向 Rust 的初学者系列](https://docs.microsoft.com/zh-cn/shows/beginners-"
+"series-to-rust/)和[使用 Rust 迈出第一步](https://docs.microsoft.com/zh-cn/"
+"learn/paths/rust-first-steps/)：两个面向新手开发者的 Rust 指南。第一个指南包"
+"含 35 个视频，第二个指南包含 11 个模块，内容涵盖 Rust 语法和基本结构。"
 
 #: src/other-resources.md:58
 msgid ""
-"[Learn Rust With Entirely Too Many Linked "
-"Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth "
-"exploration of Rust's memory management rules, through implementing a few "
-"different types of list structures."
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
 msgstr ""
-"[通过大量的链表学习Rust](https://rust-unofficial.github.io/too-many-lists/)：通过实现几种不同类型的列表结构，深入探索 "
-"Rust 的内存管理规则。"
+"[通过大量的链表学习Rust](https://rust-unofficial.github.io/too-many-lists/)："
+"通过实现几种不同类型的列表结构，深入探索 Rust 的内存管理规则。"
 
 #: src/other-resources.md:63
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
 "for even more Rust books."
-msgstr "如需更多 Rust 图书，请查看 [Rust 小册](https://lborb.github.io/book/)。"
+msgstr ""
+"如需更多 Rust 图书，请查看 [Rust 小册](https://lborb.github.io/book/)。"
 
 #: src/credits.md:3
 msgid ""
@@ -19380,18 +19703,18 @@ msgid ""
 "documentation. See the page on [other resources](other-resources.md) for a "
 "full list of useful resources."
 msgstr ""
-"本课中的资料以众多优秀的 Rust 文档资源为基础。 如需查看实用资源的完整列表， 请参阅关于[其他资源](other-resources.md)的页面。"
+"本课中的资料以众多优秀的 Rust 文档资源为基础。 如需查看实用资源的完整列表， "
+"请参阅关于[其他资源](other-resources.md)的页面。"
 
 #: src/credits.md:7
 #, fuzzy
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0 license, please see "
-"[`LICENSE`](https://github.com/google/comprehensive-rust/blob/main/LICENSE) "
-"for details."
+"2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
+"rust/blob/main/LICENSE) for details."
 msgstr ""
-"我们根据 Apache 2.0 许可条款 授权你使用“全面了解 Rust”（Comprehensive "
-"Rust）的资料。如需了解详情，请参阅[`许可`](../LICENSE)。"
+"我们根据 Apache 2.0 许可条款 授权你使用“全面了解 Rust”（Comprehensive Rust）"
+"的资料。如需了解详情，请参阅[`许可`](../LICENSE)。"
 
 #: src/credits.md:12
 msgid "Rust by Example"
@@ -19404,9 +19727,9 @@ msgid ""
 "`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
-"部分示例和练习复制并 改编自[Rust by "
-"Example](https://doc.rust-lang.org/rust-by-example/)。如需了解详情（包括许可 条款），请参阅 "
-"`third_party/rust-by-example/` 目录。"
+"部分示例和练习复制并 改编自[Rust by Example](https://doc.rust-lang.org/rust-"
+"by-example/)。如需了解详情（包括许可 条款），请参阅 `third_party/rust-by-"
+"example/` 目录。"
 
 #: src/credits.md:19
 msgid "Rust on Exercism"
@@ -19414,13 +19737,12 @@ msgstr "Rust on Exercism"
 
 #: src/credits.md:21
 msgid ""
-"Some exercises have been copied and adapted from [Rust on "
-"Exercism](https://exercism.org/tracks/rust). Please see the "
-"`third_party/rust-on-exercism/` directory for details, including the license "
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"部分练习复制并 改编自 [Rust on Exercism](https://exercism.org/tracks/rust)。如需了解详情（包括许可 "
-"条款），请参阅 `third_party/rust-on-exercism/` 目录。"
+"部分练习复制并 改编自 [Rust on Exercism](https://exercism.org/tracks/rust)。"
+"如需了解详情（包括许可 条款），请参阅 `third_party/rust-on-exercism/` 目录。"
 
 #: src/credits.md:26
 msgid "CXX"
@@ -19433,13 +19755,14 @@ msgid ""
 "directory for details, including the license terms."
 msgstr ""
 "“[与 C++ 的互操作性](android/interoperability/cpp.md)”部分引用了一张 来自 "
-"[CXX](https://cxx.rs/) 的图片。如需了解详情（包括许可条款）， 请参阅 `third_party/cxx/` 目录。"
+"[CXX](https://cxx.rs/) 的图片。如需了解详情（包括许可条款）， 请参阅 "
+"`third_party/cxx/` 目录。"
 
 #: src/credits.md:34
 msgid ""
 "The [Why Rust? - An Example in C](why-rust/an-example-in-c.md) section has "
-"been taken from the presentation slides of [Colin Finck's Master "
-"Thesis](https://colinfinck.de/Master_Thesis_Colin_Finck.pdf). It has been "
+"been taken from the presentation slides of [Colin Finck's Master Thesis]"
+"(https://colinfinck.de/Master_Thesis_Colin_Finck.pdf). It has been "
 "relicensed under the terms of the Apache 2.0 license for this course by the "
 "author."
 msgstr ""
@@ -19450,12 +19773,13 @@ msgstr "您将在下面的页面找到练习的解答。"
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on "
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
 "欢迎您在 [GitHub](https://github.com/google/comprehensive-rust/discussions) "
-"上提问关于解决方案的问题。如果您有与此处呈现的不同或更好的解决方案，请告诉我们。"
+"上提问关于解决方案的问题。如果您有与此处呈现的不同或更好的解决方案，请告诉我"
+"们。"
 
 #: src/exercises/day-1/solutions-morning.md:1
 msgid "Day 1 Morning Exercises"
@@ -19525,14 +19849,14 @@ msgstr "附加问题"
 
 #: src/exercises/day-1/solutions-morning.md:59
 msgid ""
-"It requires more advanced concepts. It might seem that we could use a "
-"slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make "
-"our function handle any size of matrix. However, this quickly breaks down: "
-"the return type cannot be `&[&[i32]]` since it needs to own the data you "
-"return."
+"It requires more advanced concepts. It might seem that we could use a slice-"
+"of-slices (`&[&[i32]]`) as the input type to transpose and thus make our "
+"function handle any size of matrix. However, this quickly breaks down: the "
+"return type cannot be `&[&[i32]]` since it needs to own the data you return."
 msgstr ""
-"这需要更高级的概念。看起来，我们可以使用切片的切片（`&[&[i32]]`）作为输入类型来进行转置，从而使我们的函数能够处理任意大小的矩阵。然而，这很快就会崩溃：返回类型不能是 "
-"`&[&[i32]]`，因为它需要拥有您返回的数据。"
+"这需要更高级的概念。看起来，我们可以使用切片的切片（`&[&[i32]]`）作为输入类型"
+"来进行转置，从而使我们的函数能够处理任意大小的矩阵。然而，这很快就会崩溃：返"
+"回类型不能是 `&[&[i32]]`，因为它需要拥有您返回的数据。"
 
 #: src/exercises/day-1/solutions-morning.md:61
 msgid ""
@@ -19540,18 +19864,19 @@ msgid ""
 "out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to "
 "`&[&[i32]]` so now you cannot easily use `pretty_print` either."
 msgstr ""
-"您可以尝试使用类似 `Vec<Vec<i32>>` 的方式，但这也无法直接工作：从 `Vec<Vec<i32>>` 转换为 `&[&[i32]]` "
-"很困难，因此您现在也不能轻松使用 `pretty_print`。"
+"您可以尝试使用类似 `Vec<Vec<i32>>` 的方式，但这也无法直接工作：从 "
+"`Vec<Vec<i32>>` 转换为 `&[&[i32]]` 很困难，因此您现在也不能轻松使用 "
+"`pretty_print`。"
 
 #: src/exercises/day-1/solutions-morning.md:63
 msgid ""
-"Once we get to traits and generics, we'll be able to use the "
-"[`std::convert::AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) "
-"trait to abstract over anything that can be referenced as a slice."
+"Once we get to traits and generics, we'll be able to use the [`std::convert::"
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
-"了解 trait "
-"和泛型后，我们就可以使用[“std::convert::AsRef”](https://doc.rust-lang.org/std/convert/trait.AsRef.html)trait "
-"来抽象化任何可作为 Slice 引用的内容了。"
+"了解 trait 和泛型后，我们就可以使用[“std::convert::AsRef”](https://doc.rust-"
+"lang.org/std/convert/trait.AsRef.html)trait 来抽象化任何可作为 Slice 引用的内"
+"容了。"
 
 #: src/exercises/day-1/solutions-morning.md:65
 msgid ""
@@ -19587,7 +19912,9 @@ msgstr ""
 msgid ""
 "In addition, the type itself would not enforce that the child slices are of "
 "the same length, so such variable could contain an invalid matrix."
-msgstr "此外，类型本身不会强制要求子切片具有相同的长度，因此这样的变量可能包含一个无效的矩阵。"
+msgstr ""
+"此外，类型本身不会强制要求子切片具有相同的长度，因此这样的变量可能包含一个无"
+"效的矩阵。"
 
 #: src/exercises/day-1/solutions-afternoon.md:1
 msgid "Day 1 Afternoon Exercises"
@@ -19603,8 +19930,8 @@ msgid ""
 "pub fn luhn(cc_number: &str) -> bool {\n"
 "    let mut digits_seen = 0;\n"
 "    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' "
-"').enumerate() {\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
 "        match ch.to_digit(10) {\n"
 "            Some(d) => {\n"
 "                sum += if i % 2 == 1 {\n"
@@ -20141,15 +20468,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", "
-"\"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -20167,8 +20494,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -20316,8 +20643,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
-"demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\"\n"
 "    )));\n"
@@ -20563,8 +20890,8 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, "
-"core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
 "    // Layout according to the Linux man page for readdir(3), where ino_t "
@@ -20702,19 +21029,17 @@ msgid ""
 "    #[test]\n"
 "    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
 "        let tmp = tempfile::TempDir::new()?;\n"
-"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo Diaries\\n"
-"\")?;\n"
-"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n"
-"\")?;\n"
-"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n"
-"\")?;\n"
+"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo "
+"Diaries\\n\")?;\n"
+"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n\")?;\n"
+"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n\")?;\n"
 "        let iter = DirectoryIterator::new(\n"
 "            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
 "        )?;\n"
 "        let mut entries = iter.collect::<Vec<_>>();\n"
 "        entries.sort();\n"
-"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", "
-"\"foo.txt\"]);\n"
+"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", \"foo."
+"txt\"]);\n"
 "        Ok(())\n"
 "    }\n"
 "}\n"
@@ -20766,8 +21091,8 @@ msgid ""
 "\n"
 "    // Set up the I2C controller and Inertial Measurement Unit.\n"
 "    writeln!(serial, \"Setting up IMU...\").unwrap();\n"
-"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), "
-"FREQUENCY_A::K100);\n"
+"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::"
+"K100);\n"
 "    let mut imu = Lsm303agr::new_with_i2c(i2c);\n"
 "    imu.init().unwrap();\n"
 "    imu.set_mag_odr(MagOutputDataRate::Hz50).unwrap();\n"
@@ -20859,8 +21184,8 @@ msgid ""
 "    }\n"
 "}\n"
 "\n"
-"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) "
-"-> i32 {\n"
+"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -"
+"> i32 {\n"
 "    let range_in = max_in - min_in;\n"
 "    let range_out = max_out - min_out;\n"
 "    cap(\n"
@@ -20934,8 +21259,8 @@ msgid ""
 "base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) "
-"};\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
 "    gic.setup();\n"
 "\n"
 "    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 "
@@ -21090,8 +21415,8 @@ msgid ""
 "    pub fn matched(&self) -> bool {\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).ris).read_volatile() "
-"};\n"
+"        let ris = unsafe { addr_of!((*self.registers).ris)."
+"read_volatile() };\n"
 "        (ris & 0x01) != 0\n"
 "    }\n"
 "\n"
@@ -21102,8 +21427,8 @@ msgid ""
 "    pub fn interrupt_pending(&self) -> bool {\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).mis).read_volatile() "
-"};\n"
+"        let ris = unsafe { addr_of!((*self.registers).mis)."
+"read_volatile() };\n"
 "        (ris & 0x01) != 0\n"
 "    }\n"
 "\n"
@@ -21116,8 +21441,8 @@ msgid ""
 "        let imsc = if mask { 0x01 } else { 0x00 };\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).imsc).write_volatile(imsc) "
-"}\n"
+"        unsafe { addr_of_mut!((*self.registers).imsc)."
+"write_volatile(imsc) }\n"
 "    }\n"
 "\n"
 "    /// Clears a pending interrupt, if any.\n"
@@ -21357,8 +21682,8 @@ msgid ""
 "    result_receiver: mpsc::Receiver<CrawlResult>,\n"
 ") -> Vec<Url> {\n"
 "    let mut crawl_state = CrawlState::new(&start_url);\n"
-"    let start_command = CrawlCommand { url: start_url, extract_links: true "
-"};\n"
+"    let start_command = CrawlCommand { url: start_url, extract_links: "
+"true };\n"
 "    command_sender.send(start_command).unwrap();\n"
 "    let mut pending_urls = 1;\n"
 "\n"
@@ -21371,8 +21696,8 @@ msgid ""
 "            Ok(link_urls) => {\n"
 "                for url in link_urls {\n"
 "                    if crawl_state.mark_visited(&url) {\n"
-"                        let extract_links = "
-"crawl_state.should_extract_links(&url);\n"
+"                        let extract_links = crawl_state."
+"should_extract_links(&url);\n"
 "                        let crawl_command = CrawlCommand { url, "
 "extract_links };\n"
 "                        command_sender.send(crawl_command).unwrap();\n"
@@ -21392,15 +21717,15 @@ msgid ""
 "\n"
 "fn check_links(start_url: Url) -> Vec<Url> {\n"
 "    let (result_sender, result_receiver) = mpsc::channel::<CrawlResult>();\n"
-"    let (command_sender, command_receiver) = "
-"mpsc::channel::<CrawlCommand>();\n"
+"    let (command_sender, command_receiver) = mpsc::channel::"
+"<CrawlCommand>();\n"
 "    spawn_crawler_threads(command_receiver, result_sender, 16);\n"
 "    control_crawl(start_url, command_sender, result_receiver)\n"
 "}\n"
 "\n"
 "fn main() {\n"
-"    let start_url = "
-"reqwest::Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let start_url = reqwest::Url::parse(\"https://www.google.org\")."
+"unwrap();\n"
 "    let bad_urls = check_links(start_url);\n"
 "    println!(\"Bad URLs: {:#?}\", bad_urls);\n"
 "}\n"
@@ -21435,8 +21760,8 @@ msgid ""
 "impl Philosopher {\n"
 "    async fn think(&self) {\n"
 "        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", "
-"&self.name)).await\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
 "            .unwrap();\n"
 "    }\n"
 "\n"
@@ -21463,8 +21788,8 @@ msgid ""
 "async fn main() {\n"
 "    // Create forks\n"
 "    let mut forks = vec![];\n"
-"    (0..PHILOSOPHERS.len()).for_each(|_| "
-"forks.push(Arc::new(Mutex::new(Fork))));\n"
+"    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::"
+"new(Fork))));\n"
 "\n"
 "    // Create philosophers\n"
 "    let (philosophers, mut rx) = {\n"
@@ -21472,8 +21797,8 @@ msgid ""
 "        let (tx, rx) = mpsc::channel(10);\n"
 "        for (i, name) in PHILOSOPHERS.iter().enumerate() {\n"
 "            let left_fork = Arc::clone(&forks[i]);\n"
-"            let right_fork = Arc::clone(&forks[(i + 1) % "
-"PHILOSOPHERS.len()]);\n"
+"            let right_fork = Arc::clone(&forks[(i + 1) % PHILOSOPHERS."
+"len()]);\n"
 "            // To avoid a deadlock, we have to break the symmetry\n"
 "            // somewhere. This will swap the forks without deinitializing\n"
 "            // either of them.\n"
@@ -21619,8 +21944,8 @@ msgid ""
 "            res = stdin.next_line() => {\n"
 "                match res {\n"
 "                    Ok(None) => return Ok(()),\n"
-"                    Ok(Some(line)) => "
-"ws_stream.send(Message::text(line.to_string())).await?,\n"
+"                    Ok(Some(line)) => ws_stream.send(Message::text(line."
+"to_string())).await?,\n"
 "                    Err(err) => return Err(err.into()),\n"
 "                }\n"
 "            }\n"
@@ -21630,4 +21955,3 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-


### PR DESCRIPTION
This will restore the regular structure format of the PO file (line breaks and wrap) and does not change the content itself. Part of #324