### PR TITLE
Add mdbook-xgettext skip for untranslatable codeblocks in Bare Metal

### DIFF
--- a/src/bare-metal.md
+++ b/src/bare-metal.md
@@ -18,7 +18,7 @@ nRF51822 microcontroller with some LEDs and buttons, an I2C-connected accelerome
 an on-board SWD debugger.
 
 To get started, install some tools we'll need later. On gLinux or Debian:
-
+<!-- mdbook-xgettext: skip -->
 ```bash
 sudo apt install gcc-aarch64-linux-gnu gdb-multiarch libudev-dev picocom pkg-config qemu-system-arm
 rustup update
@@ -28,7 +28,7 @@ cargo install cargo-binutils cargo-embed
 ```
 
 And give users in the `plugdev` group access to the micro:bit programmer:
-
+<!-- mdbook-xgettext: skip -->
 ```bash
 echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", MODE="0664", GROUP="plugdev"' |\
   sudo tee /etc/udev/rules.d/50-microbit.rules
@@ -36,7 +36,7 @@ sudo udevadm control --reload-rules
 ```
 
 On MacOS:
-
+<!-- mdbook-xgettext: skip -->
 ```bash
 xcode-select --install
 brew install gdb picocom qemu

--- a/src/bare-metal/android.md
+++ b/src/bare-metal/android.md
@@ -3,7 +3,7 @@
 To build a bare-metal Rust binary in AOSP, you need to use a `rust_ffi_static` Soong rule to build
 your Rust code, then a `cc_binary` with a linker script to produce the binary itself, and then a
 `raw_binary` to convert the ELF to a raw binary ready to be run.
-
+<!-- mdbook-xgettext: skip -->
 ```soong
 rust_ffi_static {
     name: "libvmbase_example",

--- a/src/bare-metal/android/vmbase.md
+++ b/src/bare-metal/android/vmbase.md
@@ -2,7 +2,7 @@
 
 For VMs running under crosvm on aarch64, the [vmbase][1] library provides a linker script and useful
 defaults for the build rules, along with an entry point, UART console logging and more.
-
+<!-- mdbook-xgettext: skip -->
 ```rust,compile_fail
 #![no_main]
 #![no_std]

--- a/src/bare-metal/aps/better-uart/registers.md
+++ b/src/bare-metal/aps/better-uart/registers.md
@@ -1,7 +1,7 @@
 # Multiple registers
 
 We can use a struct to represent the memory layout of the UART's registers.
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 {{#include ../examples/src/pl011.rs:Registers}}
 ```

--- a/src/bare-metal/aps/exceptions.md
+++ b/src/bare-metal/aps/exceptions.md
@@ -4,7 +4,7 @@ AArch64 defines an exception vector table with 16 entries, for 4 types of except
 IRQ, FIQ, SError) from 4 states (current EL with SP0, current EL with SPx, lower EL using AArch64,
 lower EL using AArch32). We implement this in assembly to save volatile registers to the stack
 before calling into Rust code:
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 {{#include examples/src/exceptions.rs:exceptions}}
 ```

--- a/src/bare-metal/microcontrollers.md
+++ b/src/bare-metal/microcontrollers.md
@@ -1,7 +1,7 @@
 # Microcontrollers
 
 The `cortex_m_rt` crate provides (among other things) a reset handler for Cortex M microcontrollers.
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 {{#include microcontrollers/examples/src/bin/minimal.rs:Example}}
 ```

--- a/src/bare-metal/microcontrollers/board-support.md
+++ b/src/bare-metal/microcontrollers/board-support.md
@@ -1,7 +1,7 @@
 # Board support crates
 
 Board support crates provide a further level of wrapping for a specific board for convenience.
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 {{#include examples/src/bin/board_support.rs:Example}}
 ```

--- a/src/bare-metal/microcontrollers/debugging.md
+++ b/src/bare-metal/microcontrollers/debugging.md
@@ -1,7 +1,7 @@
 # Debugging
 
 _Embed.toml_:
-
+<!-- mdbook-xgettext: skip -->
 ```toml
 [default.general]
 chip = "nrf52833_xxAA"
@@ -11,7 +11,7 @@ enabled = true
 ```
 
 In one terminal under `src/bare-metal/microcontrollers/examples/`:
-
+<!-- mdbook-xgettext: skip -->
 ```sh
 cargo embed --bin board_support debug
 ```
@@ -19,18 +19,20 @@ cargo embed --bin board_support debug
 In another terminal in the same directory:
 
 On gLinux or Debian:
+<!-- mdbook-xgettext: skip -->
 ```sh
 gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support --eval-command="target remote :1337"
 ```
 
 On MacOS:
+<!-- mdbook-xgettext: skip -->
 ```sh
 arm-none-eabi-gdb target/thumbv7em-none-eabihf/debug/board_support --eval-command="target remote :1337"
 ```
 <details>
 
 In GDB, try running:
-
+<!-- mdbook-xgettext: skip -->
 ```gdb
 b src/bin/board_support.rs:29
 b src/bin/board_support.rs:30

--- a/src/bare-metal/minimal.md
+++ b/src/bare-metal/minimal.md
@@ -1,5 +1,5 @@
 # A minimal `no_std` program
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 #![no_main]
 #![no_std]

--- a/src/bare-metal/useful-crates/buddy_system_allocator.md
+++ b/src/bare-metal/useful-crates/buddy_system_allocator.md
@@ -4,7 +4,7 @@
 It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so you can use the
 standard `alloc` crate (as we saw [before][4]), or for allocating other address space. For example,
 we might want to allocate MMIO space for PCI BARs:
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 {{#include allocator-example/src/main.rs:main}}
 ```

--- a/src/bare-metal/useful-crates/spin.md
+++ b/src/bare-metal/useful-crates/spin.md
@@ -5,7 +5,7 @@
 state between different CPUs?
 
 The [`spin`][1] crate provides spinlock-based equivalents of many of these primitives.
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 use spin::mutex::SpinMutex;
 

--- a/src/bare-metal/useful-crates/tinyvec.md
+++ b/src/bare-metal/useful-crates/tinyvec.md
@@ -4,7 +4,7 @@ Sometimes you want something which can be resized like a `Vec`, but without heap
 [`tinyvec`][1] provides this: a vector backed by an array or slice, which could be statically
 allocated or on the stack, which keeps track of how many elements are used and panics if you try to
 use more than are allocated.
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 use tinyvec::{array_vec, ArrayVec};
 

--- a/src/bare-metal/useful-crates/zerocopy.md
+++ b/src/bare-metal/useful-crates/zerocopy.md
@@ -2,7 +2,7 @@
 
 The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for safely converting between
 byte sequences and other types.
-
+<!-- mdbook-xgettext: skip -->
 ```rust,editable,compile_fail
 {{#include zerocopy-example/src/main.rs:main}}
 ```

--- a/src/exercises/bare-metal/compass.md
+++ b/src/exercises/bare-metal/compass.md
@@ -43,7 +43,7 @@ use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};
 _Cargo.toml_ (you shouldn't need to change this):
 
 <!-- File Cargo.toml -->
-
+<!-- mdbook-xgettext: skip -->
 ```toml
 {{#include compass/Cargo.toml}}
 ```
@@ -51,7 +51,7 @@ _Cargo.toml_ (you shouldn't need to change this):
 _Embed.toml_ (you shouldn't need to change this):
 
 <!-- File Embed.toml -->
-
+<!-- mdbook-xgettext: skip -->
 ```toml
 {{#include compass/Embed.toml}}
 ```
@@ -59,19 +59,19 @@ _Embed.toml_ (you shouldn't need to change this):
 _.cargo/config.toml_ (you shouldn't need to change this):
 
 <!-- File .cargo/config.toml -->
-
+<!-- mdbook-xgettext: skip -->
 ```toml
 {{#include compass/.cargo/config.toml}}
 ```
 
 See the serial output on Linux with:
-
+<!-- mdbook-xgettext: skip -->
 ```sh
 picocom --baud 115200 --imap lfcrlf /dev/ttyACM0
 ```
 
 Or on Mac OS something like (the device name may be slightly different):
-
+<!-- mdbook-xgettext: skip -->
 ```sh
 picocom --baud 115200 --imap lfcrlf /dev/tty.usbmodem14502
 ```

--- a/src/exercises/bare-metal/rtc.md
+++ b/src/exercises/bare-metal/rtc.md
@@ -61,7 +61,7 @@ _src/pl011.rs_ (you shouldn't need to change this):
 _Cargo.toml_ (you shouldn't need to change this):
 
 <!-- File Cargo.toml -->
-
+<!-- mdbook-xgettext: skip -->
 ```toml
 {{#include rtc/Cargo.toml}}
 ```
@@ -117,7 +117,7 @@ _Makefile_ (you shouldn't need to change this):
 _.cargo/config.toml_ (you shouldn't need to change this):
 
 <!-- File .cargo/config.toml -->
-
+<!-- mdbook-xgettext: skip -->
 ```toml
 {{#include rtc/.cargo/config.toml}}
 ```


### PR DESCRIPTION
See #1327

Removes 280 lines from `messages.pot`.