### PR TITLE
Revert "Fix typo: missing n in unknown"

### DIFF
--- a/po/da.po
+++ b/po/da.po
@@ -11109,7 +11109,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/de.po
+++ b/po/de.po
@@ -12167,7 +12167,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/el.po
+++ b/po/el.po
@@ -12698,7 +12698,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/es.po
+++ b/po/es.po
@@ -12764,7 +12764,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 "De `&CStr` a `&[u8]`: un slice de bytes es la interfaz universal para "
 "\"algunos datos desconocidos\"."

--- a/po/fa.po
+++ b/po/fa.po
@@ -10811,7 +10811,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/fr.po
+++ b/po/fr.po
@@ -12893,7 +12893,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/id.po
+++ b/po/id.po
@@ -10780,7 +10780,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/it.po
+++ b/po/it.po
@@ -12382,7 +12382,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 "da `&CStr` a `&[u8]`: una fetta di byte è l'interfaccia universale per "
 "\"alcuni dati sconosciuti\","

--- a/po/ja.po
+++ b/po/ja.po
@@ -11168,7 +11168,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/ko.po
+++ b/po/ko.po
@@ -15160,7 +15160,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 "`&CStr`에서 `&[u8]`로의 변환: 바이트 슬라이스는 \"알수없는 데이터\"에 대한 일"
 "반적인 인터페이스입니다,"

--- a/po/pl.po
+++ b/po/pl.po
@@ -13366,7 +13366,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/pt-BR.po
+++ b/po/pt-BR.po
@@ -15048,7 +15048,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 "`&CStr` para `&[u8]`: um _slice_ de bytes é a interface universal para "
 "\"algum dado desconhecido\","

--- a/po/ru.po
+++ b/po/ru.po
@@ -11611,7 +11611,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/tr.po
+++ b/po/tr.po
@@ -10789,7 +10789,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/uk.po
+++ b/po/uk.po
@@ -10992,7 +10992,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28

--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -11473,7 +11473,7 @@ msgstr "将“\\*const i8”转换为“&CStr”：您需要一些能够找到�
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 "将“&CStr”转换为“&\\[u8\\]”：一个字节 Slice 是“一些未知数据”的通用接口，"
 

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -11750,7 +11750,7 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:27
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknown data\","
+"unknow data\","
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:28


### PR DESCRIPTION
Reverts most of google/comprehensive-rust#1344.

The edit to the Markdown file has been kept since we _do_ want to fix the typo!