### PR TITLE
Added action to prevent changing msgid

### DIFF
--- a/.github/workflows/prevent-msgid.py
+++ b/.github/workflows/prevent-msgid.py
@@ -1,0 +1,36 @@
+import os
+
+for filename in os.popen("git diff --name-only").read().split():
+    if not filename.endswith(".po"):
+        continue
+
+    if "POT-Creation-Date" in os.popen(f"git diff --unified=0 {filename}").read():
+        print(f"Assuming {filename} was changed automatically, skipping msgid check")
+        continue
+
+    changed_lines = {
+        i + 1
+        for i, line in enumerate(os.popen(f"git blame {filename}").readlines())
+        if line.startswith("00000000")
+    }
+
+    saw_msgid = False
+    with open(filename, "r") as f:
+        line = f.readline()
+        line_number = 1
+
+        while line:
+            if line.startswith("msgid"):
+                saw_msgid = True
+            elif line.startswith("msgstr"):
+                saw_msgid = False
+
+            if saw_msgid and line_number in changed_lines:
+                print(f"Changed msgid in file {filename}:{line_number}!")
+                print(
+                    "Please read https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md#creating-and-updating-translations."
+                )
+                exit(1)
+
+            line_number += 1
+            line = f.readline()

--- a/.github/workflows/prevent-msgid.yml
+++ b/.github/workflows/prevent-msgid.yml
@@ -8,34 +8,51 @@ on:
 jobs:
   prevent-msgid-changes:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
 
-      - name: Check for changes between msgid and msgstr
-        run: |
-          git reset origin/main
-          for filename in $(git diff --name-only | grep '.po')
-          do
-            echo Checking $filename changes
-            if git diff $filename | grep -q POT-Creation-Date; then
-              echo Assuming \"$filename\" was changed automatically, skipping msgid check
-              continue
-            fi
+        - name: Reset git
+          run: git reset origin/main
 
-            changed_lines=$(git blame $filename | grep -n '^0\{8\} ' | cut -f1 -d:)
-            for changed_line in $changed_lines
-            do
-              if sed -n ${changed_line}p $filename | grep -q msgstr; then
-                continue
-              fi
+        - name: Check po file changes
+          run: |
+              import os
 
-              if sed -n "${changed_line},\$p" $filename | awk '!/^msgid/ {print} /^msgid/ {exit}' | grep -q msgstr; then
-                echo Changed msgid in file \"$filename\" \(line $changed_line\)!
-                echo Please read https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md#creating-and-updating-translations.
-                exit 1
-              fi
-            done
-          done
+              for filename in os.popen("git diff --name-only").read().split():
+                if not filename.endswith(".po"):
+                  continue
+
+                if "POT-Creation-Date" in os.popen(f"git diff --unified=0 {filename}").read():
+                  print(f"Assuming {filename} was changed automatically, skipping msgid check")
+                  continue
+
+                changed_lines = {
+                  i + 1
+                  for i, line in enumerate(os.popen(f"git blame {filename}").readlines())
+                  if line.startswith("00000000")
+                }
+
+                saw_msgid = False
+                with open(filename, "r") as f:
+                  line = f.readline()
+                  line_number = 1
+
+                  while line:
+                    if line.startswith("msgid"):
+                      saw_msgid = True
+                    elif line.startswith("msgstr"):
+                      saw_msgid = False
+
+                    if saw_msgid and line_number in changed_lines:
+                      print(f"Changed msgid in file {filename}:{line_number}!")
+                      print(
+                        "Please read https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md#creating-and-updating-translations."
+                      )
+                      exit(1)
+
+                    line_number += 1
+                    line = f.readline()
+          shell: python3 {0}

--- a/.github/workflows/prevent-msgid.yml
+++ b/.github/workflows/prevent-msgid.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Check for changes between msgid and msgstr
         run: |
           git reset origin/main
-          for filename in $(git diff --exit-code --name-only | grep '.po')
+          for filename in $(git diff --name-only | grep '.po')
           do
             echo Checking $filename changes
-            if git diff --exit-code $filename | grep -qE POT-Creation-Date; then
+            if git diff $filename | grep -q POT-Creation-Date; then
               echo Assuming \"$filename\" was changed automatically, skipping msgid check
               continue
             fi

--- a/.github/workflows/prevent-msgid.yml
+++ b/.github/workflows/prevent-msgid.yml
@@ -1,0 +1,41 @@
+name: Prevent msgid changes in translations
+
+on:
+  pull_request:
+    paths:
+      - "**/*.po"
+
+jobs:
+  prevent-msgid-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes between msgid and msgstr
+        run: |
+          git reset origin/main
+          for filename in $(git diff --exit-code --name-only | grep '.po')
+          do
+            echo Checking $filename changes
+            if git diff --exit-code $filename | grep -qE POT-Creation-Date; then
+              echo Assuming \"$filename\" was changed automatically, skipping msgid check
+              continue
+            fi
+
+            changed_lines=$(git blame $filename | grep -n '^0\{8\} ' | cut -f1 -d:)
+            for changed_line in $changed_lines
+            do
+              if sed -n ${changed_line}p $filename | grep -q msgstr; then
+                continue
+              fi
+
+              if sed -n "${changed_line},\$p" $filename | awk '!/^msgid/ {print} /^msgid/ {exit}' | grep -q msgstr; then
+                echo Changed msgid in file \"$filename\" \(line $changed_line\)!
+                echo Please read https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md#creating-and-updating-translations.
+                exit 1
+              fi
+            done
+          done

--- a/.github/workflows/prevent-msgid.yml
+++ b/.github/workflows/prevent-msgid.yml
@@ -8,51 +8,14 @@ on:
 jobs:
   prevent-msgid-changes:
     runs-on: ubuntu-latest
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-        - name: Reset git
-          run: git reset origin/main
+      - name: Reset git
+        run: git reset origin/main
 
-        - name: Check po file changes
-          run: |
-              import os
-
-              for filename in os.popen("git diff --name-only").read().split():
-                if not filename.endswith(".po"):
-                  continue
-
-                if "POT-Creation-Date" in os.popen(f"git diff --unified=0 {filename}").read():
-                  print(f"Assuming {filename} was changed automatically, skipping msgid check")
-                  continue
-
-                changed_lines = {
-                  i + 1
-                  for i, line in enumerate(os.popen(f"git blame {filename}").readlines())
-                  if line.startswith("00000000")
-                }
-
-                saw_msgid = False
-                with open(filename, "r") as f:
-                  line = f.readline()
-                  line_number = 1
-
-                  while line:
-                    if line.startswith("msgid"):
-                      saw_msgid = True
-                    elif line.startswith("msgstr"):
-                      saw_msgid = False
-
-                    if saw_msgid and line_number in changed_lines:
-                      print(f"Changed msgid in file {filename}:{line_number}!")
-                      print(
-                        "Please read https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md#creating-and-updating-translations."
-                      )
-                      exit(1)
-
-                    line_number += 1
-                    line = f.readline()
-          shell: python3 {0}
+      - name: Check po file changes
+        run: python3 .github/workflows/prevent-msgid.py


### PR DESCRIPTION
See discussion in #1344.

This checks that all `.po` files changed in pull requests either contain changes in POT-Creation-Date (i.e. are run by the specific tool which should change msgid's), or don't change msgid's (by checking that each line changed is NOT between msgid and msgstr)

I have tested this on my fork, see [valid changes](https://github.com/noamzaks/comprehensive-rust/pull/1/files) where the action passes, and [invalid changes](https://github.com/noamzaks/comprehensive-rust/pull/2/files) where it doesn't.

The action also has output for failing/passing:
[passing](https://github.com/noamzaks/comprehensive-rust/actions/runs/6488171290/job/17620037473?pr=1)
[failing](https://github.com/noamzaks/comprehensive-rust/actions/runs/6488175171/job/17620050716?pr=2)