### PR TITLE
Update `dprint` config

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -20,7 +20,7 @@
   "plugins": [
     "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072",
     "https://plugins.dprint.dev/json-0.17.4.wasm",
-    "https://plugins.dprint.dev/markdown-0.16.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.16.2.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
     "https://plugins.dprint.dev/prettier-0.27.0.json@3557a62b4507c55a47d8cde0683195b14d13c41dda66d0f0b0e111aed107e2fe"
   ]


### PR DESCRIPTION
The new version of the Markdown plugin has the fix for https://github.com/dprint/dprint-plugin-markdown/issues/87.

Fixes #1308.