### PR TITLE
fix: typo in mark_visited fn docstring

### DIFF
--- a/src/exercises/concurrency/link-checker.rs
+++ b/src/exercises/concurrency/link-checker.rs
@@ -93,7 +93,7 @@ impl CrawlState {
         url_domain == self.domain
     }
 
-    /// Mark the given page as visited, returning true if it had already
+    /// Mark the given page as visited, returning false if it had already
     /// been visited.
     fn mark_visited(&mut self, url: &Url) -> bool {
         self.visited_pages.insert(url.as_str().to_string())


### PR DESCRIPTION
Fixes a typo in the `mark_visited` function docstring.

See [`HashSet.insert` documentation](https://doc.rust-lang.org/stable/std/collections/struct.HashSet.html#method.insert)