### PR TITLE
Add trait bound to example for MutexGuard that is !Send + Sync

### DIFF
--- a/src/concurrency/send-sync/examples.md
+++ b/src/concurrency/send-sync/examples.md
@@ -28,7 +28,7 @@ Typically because of interior mutability:
 
 These types are thread-safe, but they cannot be moved to another thread:
 
-* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on the
+* `MutexGuard<T: Sync>`: Uses OS level primitives which must be deallocated on the
   thread which created them.
 
 ## `!Send + !Sync`


### PR DESCRIPTION
This example only makes sense (and is therefore easier to understand logically :) ) if T is Sync. See https://github.com/rust-lang/rust/issues/41622 - this used to be a bug initially.