### PR TITLE
fr: add missing translation & correct a typo

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -950,7 +950,7 @@ msgstr "Pièges"
 
 #: src/SUMMARY.md:299
 msgid "Blocking the Executor"
-msgstr ""
+msgstr "Bloquer l'exécuteur"
 
 #: src/SUMMARY.md:300 src/async/pitfalls/pin.md:1
 msgid "Pin"
@@ -1347,6 +1347,8 @@ msgstr ""
 #: src/running-the-course/course-structure.md:10
 msgid "Day 1: Basic Rust, syntax, control flow, creating and consuming values."
 msgstr ""
+"Jour 1 : Bases de Rust, syntaxe, flux de contrôle, création et consommation "
+"de valeurs."
 
 #: src/running-the-course/course-structure.md:11
 #, fuzzy


### PR DESCRIPTION
Found an inconsistency in `fr.po` file, this PR corrects it.

See line 165 & 169 in `fr.po`.