### PR TITLE
Delete some inactive reviewers from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,16 +3,16 @@ po/bn.po @mirwasi @sudiptachatterjee
 po/da.po @mgeisler @voss @thedataking
 po/de.po @ronaldfw @fechu
 po/el.po @Mandragorian
-po/es.po @deavid @vzz1x2 @JaviSorribes
+po/es.po @deavid @JaviSorribes
 po/fr.po @sakex @lb034582341
 po/id.po @tjonganthony @nurlitadf
 po/it.po @detro @nicomazz @bznein
 po/ja.po @keiichiw @chikoski
 po/ko.po @jiyongp @jooyunghan
-po/pl.po @jkotur @pawelpaa @dyeroshenko
+po/pl.po @jkotur @dyeroshenko
 po/pt-BR.po @rastringer @hugojacob @henrif75 @joaovicmendes
 po/ru.po @istolga @baltuky @zvonden @dyeroshenko
 po/tr.po @duyguisler
-po/uk.po @git-user-cpp @dyeroshenko
+po/uk.po @dyeroshenko
 po/zh-CN.po @suetfei @wnghl @anlunx @kongy @noahdragon @superwhd @emmali01 @SketchK
 po/zh-TW.po @edong @hueich @kuanhungchen @victorhsieh @mingyc @johnathan79717


### PR DESCRIPTION
These users don't have write permission to the repository, therefore they haven't done any review so far.