### PR TITLE
Adds Chinese Traditional to the language drop-down

### DIFF
--- a/src/running-the-course/translations.md
+++ b/src/running-the-course/translations.md
@@ -5,6 +5,7 @@ volunteers:
 
 * [Brazilian Portuguese][pt-BR] by [@rastringer], [@hugojacob], [@joaovicmendes], and [@henrif75].
 * [Chinese (Simplified)][zh-CN] by [@suetfei], [@wnghl], [@anlunx], [@kongy], [@noahdragon], [@superwhd], [@SketchK], and [@nodmp].
+* [Chinese (Traditional)][zh-TW] by [@hueich], [@victorhsieh], [@mingyc], [@kuanhungchen], and [@johnathan79717].
 * [Korean][ko] by [@keispace], [@jiyongp], and [@jooyunghan].
 * [Spanish][es] by [@deavid].
 
@@ -16,7 +17,6 @@ There is a large number of in-progress translations. We link to the most
 recently updated translations:
 
 * [Bengali][bn] by [@raselmandol].
-* [Chinese (Traditional)][zh-TW] by [@hueich], [@victorhsieh], [@mingyc], and [@johnathan79717].
 * [French][fr] by [@KookaS] and [@vcaen].
 * [German][de] by [@Throvn] and [@ronaldfw].
 * [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105].
@@ -47,6 +47,7 @@ get going. Translations are coordinated on the [issue tracker].
 [@keispace]: https://github.com/keispace
 [@kongy]: https://github.com/kongy
 [@KookaS]: https://github.com/KookaS
+[@kuanhungchen]: https://github.com/kuanhungchen
 [@mingyc]: https://github.com/mingyc
 [@momotaro1105]: https://github.com/momotaro1105
 [@noahdragon]: https://github.com/noahdragon

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -184,6 +184,9 @@
                               <a id="zh-CN">Chinese Simplified (汉语)</a>
                           </button></li>
                           <li role="none"><button role="menuitem" class="theme">
+                              <a id="zh-CN">Chinese Traditional (漢語)</a>
+                          </button></li>
+                          <li role="none"><button role="menuitem" class="theme">
                               <a id="ko">Korean (한국어)</a>
                           </button></li>
                           <li role="none"><button role="menuitem" class="theme">


### PR DESCRIPTION
Graduates the Chinese Traditional translation to the language drop-down selector.
Part of Chinese (Traditional) translation #684.

File stats (Rust Fundamentals):

```
msggrep -v --location=src/{exercises/,}{android,bare-metal,concurrency,async}{.md,"/*","/*/*","/*/*/*"} po/zh-CN.po | msgfmt -o /dev/null --statistics -

1315 translated messages, 146 fuzzy translations, 149 untranslated messages.
```
