### PR TITLE
Simpler character counting

### DIFF
--- a/src/unsafe/calling-unsafe-functions.md
+++ b/src/unsafe/calling-unsafe-functions.md
@@ -23,6 +23,6 @@ fn main() {
 }
 
 fn count_chars(s: &str) -> usize {
-    s.chars().map(|_| 1).sum()
+    s.chars().count()
 }
 ```


### PR DESCRIPTION
`str.chars().map(|_| 1).sum()` is just `str.chars().count()`.