### PR TITLE
zh-CN: fix typo

### DIFF
--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -4854,7 +4854,7 @@ msgid ""
 "reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
 "repeatedly tests a value against a pattern:"
 msgstr ""
-"与 `if let` 一样，[`with let`](https://doc.rust-lang.org/reference/"
+"与 `if let` 一样，[`while let`](https://doc.rust-lang.org/reference/"
 "expressions/loop-expr.html#predicate-pattern-loops) 变体会针对一个模式重复测"
 "试一个值："
 


### PR DESCRIPTION
there is a typo in `while let loops` chapter 