### PR TITLE
Reset state to `inline-open` when speaker note popup is closed

### DIFF
--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -118,7 +118,7 @@
         // bind the popup to reset the speaker note state on close of the popup
         popup.onload = () => {
           popup.onbeforeunload = () => {
-            setState('inline-open');
+            setState("inline-open");
             applyState();
           };
         };

--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -116,8 +116,11 @@
         setState("popup");
         applyState();
         // bind the popup to reset the speaker note state on close of the popup
-        popup.onload = ()=>{
-          popup.onbeforeunload = ()=>{setState('inline-open'); applyState();};
+        popup.onload = () => {
+          popup.onbeforeunload = () => {
+            setState('inline-open');
+            applyState();
+          };
         };
       } else {
         window.alert(

--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -115,6 +115,10 @@
       if (popup) {
         setState("popup");
         applyState();
+        // bind the popup to reset the speaker note state on close of the popup
+        popup.onload = ()=>{
+          popup.onbeforeunload = ()=>{setState('inline-open'); applyState();};
+        };
       } else {
         window.alert(
           "Could not open popup, please check your popup blocker settings."


### PR DESCRIPTION
Partially addresses #182.