### PR TITLE
Update zh-CN.po （修正25.5 impl Trait中形参实参使用错误）

### DIFF
--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -9161,7 +9161,7 @@ msgstr "`impl Trait`"
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
-msgstr "与特征边界类似，`impl Trait` 语法可以在函数实参 和返回值中使用："
+msgstr "与特征边界类似，`impl Trait` 语法可以在函数形参 和返回值中使用："
 
 #: src/traits/impl-trait.md:6
 msgid ""


### PR DESCRIPTION
25.5 impl Trait中，
“与特征边界类似，impl Trait 语法可以在函数实参 和返回值中使用”
更正为
“与特征边界类似，impl Trait 语法可以在函数形参 和返回值中使用”