### PR TITLE
fixture for svg renders in rtl contents

### DIFF
--- a/theme/css/rtl.css
+++ b/theme/css/rtl.css
@@ -5,3 +5,6 @@
 [dir="rtl"] #cookieBar {
   direction: ltr;
 }
+[dir="rtl"] svg {
+  direction: ltr;
+}


### PR DESCRIPTION
Part of:
#671 
#1433
## Issue:
When we render SVG tags in persian ( `<html dir="rtl" ...>`)  make confiliect:

![svg-rtl-issue](https://github.com/google/comprehensive-rust/assets/11869014/ce825736-4367-41fa-acd3-6e395926d7c7)
originally: *[7.2 Arrays and for Loops](https://google.github.io/comprehensive-rust/exercises/day-1/for-loops.html#arrays-and-for-loops)*
![svg-rtl-issue-2](https://github.com/google/comprehensive-rust/assets/11869014/0a494392-2407-47ec-91f1-0098414b83d3)

originally: *[16.2 Moved Strings in Rust](https://google.github.io/comprehensive-rust/ownership/moved-strings-rust.html)*

## Proposed method:

as we talked in #1433, again in there adding 
```
[dir="rtl"] svg {
  direction: ltr;
}
```
fix issue like:

![svg-rtl-issue-fix](https://github.com/google/comprehensive-rust/assets/11869014/5d82c413-709a-42dd-b24b-1ff2c8be55ba)

![svg-rtl-issue-2-fixture](https://github.com/google/comprehensive-rust/assets/11869014/da2bf319-212e-4edd-9135-82f51e5e0381)
