### PR TITLE
Test that we can always extract strings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,6 @@ jobs:
         uses: ./.github/workflows/setup-rust-cache
 
       - name: Install Gettext
-        if: matrix.language != 'en'
         run: |
           sudo apt update
           sudo apt install gettext
@@ -133,6 +132,12 @@ jobs:
       - name: Test ${{ matrix.language }} translation
         if: matrix.language != 'en'
         run: msgfmt --statistics -o /dev/null po/${{ matrix.language }}.po
+
+      - name: Test extracting English strings
+        if: matrix.language == 'en'
+        run: |
+          MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' mdbook build -d po
+          msgfmt -o /dev/null --statistics po/messages.pot
 
       - name: Build course
         run: mdbook build


### PR DESCRIPTION
This adds a check that `mdbook-xgettext` can always extract the strings of the course. Without this, it’s possible to merge a change which will make `mdbook-xgettext` error out the next time a translator tries to refresh their translation.