### PR TITLE
Update to mdbook-i18n-helpers 0.3.0

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
 
     - name: Install mdbook-i18n-helpers
-      run: cargo install mdbook-i18n-helpers --locked --version 0.2.4
+      run: cargo install mdbook-i18n-helpers --locked --version 0.3.0
       shell: bash
 
     - name: Install mdbook-exerciser


### PR DESCRIPTION
This version has much improved support for the translation of code blocks. See https://github.com/google/mdbook-i18n-helpers/issues/95 for details.

Most PO files won’t need any update since most of them don’t translate the comments in the code blocks. Those that do, can run `mdbook-i18n-normalize` when they feel like it.