### PR TITLE
Filled missing glossary terms with their explanations

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -30,6 +30,7 @@ Also, please keep the hard line breaks to ensure a nice formatting.
 - allocate:\
   Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md).
 - argument:\
+  Information that is passed into a function or method.
 - Bare-metal Rust:\
   Low-level Rust development, often deployed to a system without an operating
   system. See [Bare-metal Rust](bare-metal.md).
@@ -42,28 +43,45 @@ Also, please keep the hard line breaks to ensure a nice formatting.
 - brace:\
   `{` and `}`. Also called _curly brace_, they delimit _blocks_.
 - build:\
+  The process of converting source code into executable code or a usable program.
 - call:\
+  To invoke or execute a function or method.
 - channel:\
   Used to safely pass messages [between threads](concurrency/channels.md).
 - Comprehensive Rust 🦀:\
   The courses here are jointly called Comprehensive Rust 🦀.
 - concurrency:\
+  The execution of multiple tasks or processes at the same time.
 - Concurrency in Rust:\
   See [Concurrency in Rust](concurrency.md).
 - constant:\
+  A value that does not change during the execution of a program.
 - control flow:\
+  The order in which the individual statements or instructions are executed in a program.
 - crash:\
+  An unexpected and unhandled failure or termination of a program.
 - enumeration:\
+  A data type that consists of named constant values.
 - error:\
+  An unexpected condition or result that deviates from the expected behavior.
 - error handling:\
+  The process of managing and responding to errors that occur during program execution.
 - exercise:\
+  A task or problem designed to practice and test programming skills.
 - function:\
+  A reusable block of code that performs a specific task.
 - garbage collector:\
+  A mechanism that automatically frees up memory occupied by objects that are no longer in use.
 - generics:\
+  A feature that allows writing code with placeholders for types, enabling code reuse with different data types.
 - immutable:\
+  Unable to be changed after creation.
 - integration test:\
+  A type of test that verifies the interactions between different parts or components of a system.
 - keyword:\
+  A reserved word in a programming language that has a specific meaning and cannot be used as an identifier.
 - library:\
+  A collection of precompiled routines or code that can be used by programs.
 - macro:\
   Rust macros can be recognized by a `!` in the name. Macros are used
   when normal functions are not enough. A typical example is `format!`,
@@ -72,47 +90,75 @@ Also, please keep the hard line breaks to ensure a nice formatting.
 - `main` function:\
   Rust programs start executing with the `main` function.
 - match:\
+  A control flow construct in Rust that allows for pattern matching on the value of an expression.
 - memory leak:\
+  A situation where a program fails to release memory that is no longer needed, leading to a gradual increase in memory usage.
 - method:\
+  A function associated with an object or a type in Rust.
 - module:\
+  A namespace that contains definitions, such as functions, types, or traits, to organize code in Rust.
 - move:\
+  The transfer of ownership of a value from one variable to another in Rust.
 - mutable:\
+  A property in Rust that allows variables to be modified after they have been declared.
 - ownership:\
+  The concept in Rust that defines which part of the code is responsible for managing the memory associated with a value.
 - panic:\
+  An unrecoverable error condition in Rust that results in the termination of the program.
 - parameter:\
+  A value that is passed into a function or method when it is called.
 - pattern:\
+  A combination of values, literals, or structures that can be matched against an expression in Rust.
 - payload:\
+  The data or information carried by a message, event, or data structure.
 - program:\
+  A set of instructions that a computer can execute to perform a specific task or solve a particular problem.
 - programming language:\
+  A formal system used to communicate instructions to a computer, such as Rust.
 - receiver:\
+  The first parameter in a Rust method that represents the instance on which the method is called.
 - reference counting:\
+  A memory management technique in which the number of references to an object is tracked, and the object is deallocated when the count reaches zero.
 - return:\
+  A keyword in Rust used to indicate the value to be returned from a function.
 - Rust:\
+  A systems programming language that focuses on safety, performance, and concurrency.
 - Rust Fundamentals:\
   Days 1 to 3 of this course.
 - Rust in Android:\
   See [Rust in Android](android.md).
 - safe:\
+  Refers to code that adheres to Rust's ownership and borrowing rules, preventing memory-related errors.
 - scope:\
+  The region of a program where a variable is valid and can be used.
 - standard library:\
+  A collection of modules providing essential functionality in Rust.
 - static:\
+  A keyword in Rust used to define static variables or items with a `'static` lifetime.
 - string:\
-  A data type storing textual data. See
-  [`String` vs `str`](basic-syntax/string-slices.html) for more.
+  A data type storing textual data. See [`String` vs `str`](basic-syntax/string-slices.html) for more.
 - struct:\
+  A composite data type in Rust that groups together variables of different types under a single name.
 - test:\
+  A Rust module containing functions that test the correctness of other functions.
 - thread:\
+  A separate sequence of execution in a program, allowing concurrent execution.
 - thread safety:\
+  The property of a program that ensures correct behavior in a multithreaded environment.
 - trait:\
+  A collection of methods defined for an unknown type, providing a way to achieve polymorphism in Rust.
 - type:\
+  A classification that specifies which operations can be performed on values of a particular kind in Rust.
 - type inference:\
+  The ability of the Rust compiler to deduce the type of a variable or expression.
 - undefined behavior:\
+  Actions or conditions in Rust that have no specified result, often leading to unpredictable program behavior.
 - union:\
+  A data type that can hold values of different types but only one at a time.
 - unit test:\
   Rust comes with built-in support for running small unit tests and larger
   integration tests. See [Unit Tests](testing/unit-tests.html).
 - unsafe:\
-  The subset of Rust which allows you to trigger _undefined behavior_.
-  See [Unsafe Rust](unsafe.html).
+  The subset of Rust which allows you to trigger _undefined behavior_. See [Unsafe Rust](unsafe.html).
 - variable:\
-  A memory location storing data. Variables are valid in a _scope_.
+  A memory location storing data. Variables are valid in a _scope_. 


### PR DESCRIPTION
Changes Made
This Pull Request addresses issue #1466  and includes the following changes:
Added Glossary Terms: Filled in missing glossary terms with their respective explanations.

Context
The glossary is a crucial reference for understanding key terms in the project. This PR enhances its completeness and readability by adding missing terms and improving the overall formatting.

Related Issues

Fixes #1466.

















