### PR TITLE
ja: Normalize by running through mdbook-i18n-normalize 0.3.0

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -1,15 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2023-11-17T12:51:38+09:00\n"
+"POT-Creation-Date: 2023-10-15T23:41:49Z\n"
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #: src/SUMMARY.md:4 src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
@@ -52,7 +53,7 @@ msgid "Day 1: Morning"
 msgstr "Day 1： AM"
 
 #: src/SUMMARY.md:19 src/SUMMARY.md:80 src/SUMMARY.md:135 src/SUMMARY.md:193
-#: src/SUMMARY.md:231 src/SUMMARY.md:281
+#: src/SUMMARY.md:219 src/SUMMARY.md:269
 msgid "Welcome"
 msgstr "Welcome"
 
@@ -135,8 +136,8 @@ msgid "Overloading"
 msgstr "オーバーロード"
 
 #: src/SUMMARY.md:39 src/SUMMARY.md:72 src/SUMMARY.md:106 src/SUMMARY.md:126
-#: src/SUMMARY.md:155 src/SUMMARY.md:185 src/SUMMARY.md:224 src/SUMMARY.md:245
-#: src/SUMMARY.md:273 src/SUMMARY.md:295 src/SUMMARY.md:316
+#: src/SUMMARY.md:155 src/SUMMARY.md:185 src/SUMMARY.md:212 src/SUMMARY.md:233
+#: src/SUMMARY.md:261 src/SUMMARY.md:283 src/SUMMARY.md:304
 #: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
 #: src/exercises/bare-metal/afternoon.md:1
 #: src/exercises/concurrency/morning.md:1
@@ -156,7 +157,7 @@ msgstr "配列とforループ"
 msgid "Day 1: Afternoon"
 msgstr "Day 1： PM"
 
-#: src/SUMMARY.md:45 src/SUMMARY.md:308 src/control-flow.md:1
+#: src/SUMMARY.md:45 src/SUMMARY.md:296 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "制御フロー"
 
@@ -346,7 +347,7 @@ msgstr "フィールドの省略"
 msgid "Method Receiver"
 msgstr "メソッドレシーバ"
 
-#: src/SUMMARY.md:105 src/SUMMARY.md:167 src/SUMMARY.md:294
+#: src/SUMMARY.md:105 src/SUMMARY.md:167 src/SUMMARY.md:282
 #: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "例"
@@ -620,7 +621,7 @@ msgstr "Unsafeなトレイトの実装"
 msgid "Safe FFI Wrapper"
 msgstr "安全なFFIラッパ"
 
-#: src/SUMMARY.md:189 src/SUMMARY.md:271 src/bare-metal/android.md:1
+#: src/SUMMARY.md:189 src/SUMMARY.md:259 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
@@ -668,7 +669,7 @@ msgstr "クライアント"
 msgid "Changing API"
 msgstr "APIの変更"
 
-#: src/SUMMARY.md:205 src/SUMMARY.md:261 src/android/logging.md:1
+#: src/SUMMARY.md:205 src/SUMMARY.md:249 src/android/logging.md:1
 #: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "ログ出力"
@@ -693,399 +694,346 @@ msgstr "CからRust呼び出し"
 msgid "With C++"
 msgstr "C++"
 
-#: src/SUMMARY.md:211 src/android/interoperability/cpp/bridge.md:1
-#, fuzzy
-msgid "The Bridge Module"
-msgstr "テストモジュール"
-
-#: src/SUMMARY.md:212
-#, fuzzy
-msgid "Rust Bridge"
-msgstr "Android"
-
-#: src/SUMMARY.md:213 src/android/interoperability/cpp/generated-cpp.md:1
-msgid "Generated C++"
-msgstr ""
-
-#: src/SUMMARY.md:214
-msgid "C++ Bridge"
-msgstr ""
-
-#: src/SUMMARY.md:215 src/android/interoperability/cpp/shared-types.md:1
-#, fuzzy
-msgid "Shared Types"
-msgstr "状態共有"
-
-#: src/SUMMARY.md:216 src/android/interoperability/cpp/shared-enums.md:1
-msgid "Shared Enums"
-msgstr ""
-
-#: src/SUMMARY.md:217 src/android/interoperability/cpp/rust-result.md:1
-#, fuzzy
-msgid "Rust Error Handling"
-msgstr "エラー処理"
-
-#: src/SUMMARY.md:218 src/android/interoperability/cpp/cpp-exception.md:1
-#, fuzzy
-msgid "C++ Error Handling"
-msgstr "エラー処理"
-
-#: src/SUMMARY.md:219 src/android/interoperability/cpp/type-mapping.md:1
-msgid "Additional Types"
-msgstr ""
-
-#: src/SUMMARY.md:220
-msgid "Building for Android: C++"
-msgstr ""
-
-#: src/SUMMARY.md:221
-msgid "Building for Android: Genrules"
-msgstr ""
-
-#: src/SUMMARY.md:222
-msgid "Building for Android: Rust"
-msgstr ""
-
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:211
 msgid "With Java"
 msgstr "Java"
 
-#: src/SUMMARY.md:227
+#: src/SUMMARY.md:215
 msgid "Bare Metal: Morning"
 msgstr "ベアメタル： AM"
 
-#: src/SUMMARY.md:232
+#: src/SUMMARY.md:220
 msgid "no_std"
 msgstr "no_std"
 
-#: src/SUMMARY.md:233
+#: src/SUMMARY.md:221
 msgid "A Minimal Example"
 msgstr "例"
 
-#: src/SUMMARY.md:234
+#: src/SUMMARY.md:222
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:235 src/bare-metal/microcontrollers.md:1
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "マイクロコントローラ"
 
-#: src/SUMMARY.md:236 src/bare-metal/microcontrollers/mmio.md:1
+#: src/SUMMARY.md:224 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "生MMIO（メモリマップドI/O）"
 
-#: src/SUMMARY.md:237
+#: src/SUMMARY.md:225
 msgid "PACs"
 msgstr "PACs"
 
-#: src/SUMMARY.md:238
+#: src/SUMMARY.md:226
 msgid "HAL Crates"
 msgstr "HALクレート"
 
-#: src/SUMMARY.md:239
+#: src/SUMMARY.md:227
 msgid "Board Support Crates"
 msgstr "ボードサポートクレート"
 
-#: src/SUMMARY.md:240
+#: src/SUMMARY.md:228
 msgid "The Type State Pattern"
 msgstr "タイプステートパターン"
 
-#: src/SUMMARY.md:241
+#: src/SUMMARY.md:229
 msgid "embedded-hal"
 msgstr "embedded-hal"
 
-#: src/SUMMARY.md:242
+#: src/SUMMARY.md:230
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs, cargo-embed"
 
-#: src/SUMMARY.md:243 src/bare-metal/microcontrollers/debugging.md:1
+#: src/SUMMARY.md:231 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: src/SUMMARY.md:244 src/SUMMARY.md:264
+#: src/SUMMARY.md:232 src/SUMMARY.md:252
 msgid "Other Projects"
 msgstr "他のプロジェクト"
 
-#: src/SUMMARY.md:246 src/exercises/bare-metal/compass.md:1
+#: src/SUMMARY.md:234 src/exercises/bare-metal/compass.md:1
 #: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "コンパス"
 
-#: src/SUMMARY.md:248
+#: src/SUMMARY.md:236
 msgid "Bare Metal: Afternoon"
 msgstr "ベアメタル： PM"
 
-#: src/SUMMARY.md:250
+#: src/SUMMARY.md:238
 msgid "Application Processors"
 msgstr "アプリケーションプロセッサ"
 
-#: src/SUMMARY.md:251 src/bare-metal/aps/entry-point.md:1
+#: src/SUMMARY.md:239 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr ""
 
-#: src/SUMMARY.md:252
+#: src/SUMMARY.md:240
 msgid "Inline Assembly"
 msgstr "インラインアセンブリ"
 
-#: src/SUMMARY.md:253
+#: src/SUMMARY.md:241
 msgid "MMIO"
 msgstr "MMIO"
 
-#: src/SUMMARY.md:254
+#: src/SUMMARY.md:242
 msgid "Let's Write a UART Driver"
 msgstr "UARTドライバを書いてみよう"
 
-#: src/SUMMARY.md:255
+#: src/SUMMARY.md:243
 msgid "More Traits"
 msgstr "他のトレイト"
 
-#: src/SUMMARY.md:256
+#: src/SUMMARY.md:244
 msgid "A Better UART Driver"
 msgstr "UARTドライバの改善"
 
-#: src/SUMMARY.md:257 src/bare-metal/aps/better-uart/bitflags.md:1
+#: src/SUMMARY.md:245 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "ビットフラッグ"
 
-#: src/SUMMARY.md:258
+#: src/SUMMARY.md:246
 msgid "Multiple Registers"
 msgstr "複数のレジスタ"
 
-#: src/SUMMARY.md:259 src/bare-metal/aps/better-uart/driver.md:1
+#: src/SUMMARY.md:247 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "ドライバ"
 
-#: src/SUMMARY.md:260 src/SUMMARY.md:262
+#: src/SUMMARY.md:248 src/SUMMARY.md:250
 msgid "Using It"
 msgstr "使用例"
 
-#: src/SUMMARY.md:263 src/bare-metal/aps/exceptions.md:1
+#: src/SUMMARY.md:251 src/bare-metal/aps/exceptions.md:1
 #, fuzzy
 msgid "Exceptions"
 msgstr "関数"
 
-#: src/SUMMARY.md:265
+#: src/SUMMARY.md:253
 msgid "Useful Crates"
 msgstr "便利クレート"
 
-#: src/SUMMARY.md:266
+#: src/SUMMARY.md:254
 msgid "zerocopy"
 msgstr "zerocopy"
 
-#: src/SUMMARY.md:267
+#: src/SUMMARY.md:255
 msgid "aarch64-paging"
 msgstr "aarch64-paging"
 
-#: src/SUMMARY.md:268
+#: src/SUMMARY.md:256
 msgid "buddy_system_allocator"
 msgstr "buddy_system_allocator"
 
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md:257
 msgid "tinyvec"
 msgstr "tinyvec"
 
-#: src/SUMMARY.md:270
+#: src/SUMMARY.md:258
 msgid "spin"
 msgstr "spin"
 
-#: src/SUMMARY.md:272 src/bare-metal/android/vmbase.md:1
+#: src/SUMMARY.md:260 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
-#: src/SUMMARY.md:274
+#: src/SUMMARY.md:262
 msgid "RTC Driver"
 msgstr "RTC（リアルタイムクロック）ドライバ"
 
-#: src/SUMMARY.md:277
+#: src/SUMMARY.md:265
 msgid "Concurrency: Morning"
 msgstr "並行性： AM"
 
-#: src/SUMMARY.md:282 src/concurrency/threads.md:1
+#: src/SUMMARY.md:270 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "スレッド"
 
-#: src/SUMMARY.md:283 src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:271 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "スコープ付きスレッド"
 
-#: src/SUMMARY.md:284 src/concurrency/channels.md:1
+#: src/SUMMARY.md:272 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "チャネル"
 
-#: src/SUMMARY.md:285 src/concurrency/channels/unbounded.md:1
+#: src/SUMMARY.md:273 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Unboundedチャネル"
 
-#: src/SUMMARY.md:286 src/concurrency/channels/bounded.md:1
+#: src/SUMMARY.md:274 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Boundedチャネル"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:275
 msgid "Send and Sync"
 msgstr "SendとSync"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:275
 msgid "Send"
 msgstr "Send"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:275
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:290 src/concurrency/send-sync/examples.md:1
+#: src/SUMMARY.md:278 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "例"
 
-#: src/SUMMARY.md:291 src/concurrency/shared_state.md:1
+#: src/SUMMARY.md:279 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "状態共有"
 
-#: src/SUMMARY.md:292
+#: src/SUMMARY.md:280
 msgid "Arc"
 msgstr "Arc"
 
-#: src/SUMMARY.md:293
+#: src/SUMMARY.md:281
 msgid "Mutex"
 msgstr "Mutex"
 
-#: src/SUMMARY.md:296 src/SUMMARY.md:317
+#: src/SUMMARY.md:284 src/SUMMARY.md:305
 #: src/exercises/concurrency/dining-philosophers.md:1
 #: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "食事する哲学者"
 
-#: src/SUMMARY.md:297 src/exercises/concurrency/link-checker.md:1
+#: src/SUMMARY.md:285 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "マルチスレッド・リンクチェッカー"
 
-#: src/SUMMARY.md:299
+#: src/SUMMARY.md:287
 msgid "Concurrency: Afternoon"
 msgstr "並行性： PM"
 
-#: src/SUMMARY.md:301
+#: src/SUMMARY.md:289
 msgid "Async Basics"
 msgstr "Asyncの基礎"
 
-#: src/SUMMARY.md:302
+#: src/SUMMARY.md:290
 msgid "async/await"
 msgstr "async/await"
 
-#: src/SUMMARY.md:303 src/async/futures.md:1
+#: src/SUMMARY.md:291 src/async/futures.md:1
 msgid "Futures"
 msgstr "Future"
 
-#: src/SUMMARY.md:304 src/async/runtimes.md:1
+#: src/SUMMARY.md:292 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "ランタイム"
 
-#: src/SUMMARY.md:305 src/async/runtimes/tokio.md:1
+#: src/SUMMARY.md:293 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:306 src/exercises/concurrency/link-checker.md:126
+#: src/SUMMARY.md:294 src/exercises/concurrency/link-checker.md:126
 #: src/async/tasks.md:1 src/exercises/concurrency/chat-app.md:143
 msgid "Tasks"
 msgstr "タスク"
 
-#: src/SUMMARY.md:307 src/async/channels.md:1
+#: src/SUMMARY.md:295 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "Asyncチャネル"
 
-#: src/SUMMARY.md:309 src/async/control-flow/join.md:1
+#: src/SUMMARY.md:297 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:310 src/async/control-flow/select.md:1
+#: src/SUMMARY.md:298 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
-#: src/SUMMARY.md:311
+#: src/SUMMARY.md:299
 msgid "Pitfalls"
 msgstr "落とし穴"
 
-#: src/SUMMARY.md:312
+#: src/SUMMARY.md:300
 msgid "Blocking the Executor"
 msgstr "エグゼキュータのブロッキング"
 
-#: src/SUMMARY.md:313 src/async/pitfalls/pin.md:1
+#: src/SUMMARY.md:301 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr "Pin"
 
-#: src/SUMMARY.md:314 src/async/pitfalls/async-traits.md:1
+#: src/SUMMARY.md:302 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "Asyncトレイト"
 
-#: src/SUMMARY.md:315 src/async/pitfalls/cancellation.md:1
+#: src/SUMMARY.md:303 src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
 msgstr "インストール"
 
-#: src/SUMMARY.md:318 src/exercises/concurrency/chat-app.md:1
+#: src/SUMMARY.md:306 src/exercises/concurrency/chat-app.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:95
 msgid "Broadcast Chat Application"
 msgstr "ブロードキャスト・チャットアプリ"
 
-#: src/SUMMARY.md:321
+#: src/SUMMARY.md:309
 msgid "Final Words"
 msgstr "最後に"
 
-#: src/SUMMARY.md:325 src/thanks.md:1
+#: src/SUMMARY.md:313 src/thanks.md:1
 msgid "Thanks!"
 msgstr "ありがとうございました！"
 
-#: src/SUMMARY.md:326 src/glossary.md:1
+#: src/SUMMARY.md:314 src/glossary.md:1
 msgid "Glossary"
 msgstr ""
 
-#: src/SUMMARY.md:327
+#: src/SUMMARY.md:315
 msgid "Other Resources"
 msgstr "参考資料"
 
-#: src/SUMMARY.md:328 src/credits.md:1
+#: src/SUMMARY.md:316 src/credits.md:1
 msgid "Credits"
 msgstr "クレジット"
 
-#: src/SUMMARY.md:331 src/exercises/solutions.md:1
+#: src/SUMMARY.md:319 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "解答"
 
-#: src/SUMMARY.md:336
+#: src/SUMMARY.md:324
 msgid "Day 1 Morning"
 msgstr "Day 1 AM"
 
-#: src/SUMMARY.md:337
+#: src/SUMMARY.md:325
 msgid "Day 1 Afternoon"
 msgstr "Day 1 PM"
 
-#: src/SUMMARY.md:338
+#: src/SUMMARY.md:326
 msgid "Day 2 Morning"
 msgstr "Day 2 AM"
 
-#: src/SUMMARY.md:339
+#: src/SUMMARY.md:327
 msgid "Day 2 Afternoon"
 msgstr "Day 2 PM"
 
-#: src/SUMMARY.md:340
+#: src/SUMMARY.md:328
 msgid "Day 3 Morning"
 msgstr "Day 3 AM"
 
-#: src/SUMMARY.md:341
+#: src/SUMMARY.md:329
 msgid "Day 3 Afternoon"
 msgstr "Day 3 PM"
 
-#: src/SUMMARY.md:342
+#: src/SUMMARY.md:330
 msgid "Bare Metal Rust Morning"
 msgstr "ベアメタルRust AM"
 
-#: src/SUMMARY.md:343 src/exercises/bare-metal/solutions-afternoon.md:1
+#: src/SUMMARY.md:331 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "ベアメタルRust PM"
 
-#: src/SUMMARY.md:344
+#: src/SUMMARY.md:332
 msgid "Concurrency Morning"
 msgstr "並行性 AM"
 
-#: src/SUMMARY.md:345
+#: src/SUMMARY.md:333
 msgid "Concurrency Afternoon"
 msgstr "並行性 PM"
 
@@ -1555,56 +1503,54 @@ msgstr ""
 
 #: src/running-the-course/translations.md:7
 msgid ""
-"[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
-"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
-"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
-"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
-"github.com/superwhd), [@SketchK](https://github.com/SketchK), and [@nodmp]"
-"(https://github.com/nodmp)."
-msgstr ""
-
-#: src/running-the-course/translations.md:8
-msgid ""
-"[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
-"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
-"victorhsieh), [@mingyc](https://github.com/mingyc), [@kuanhungchen](https://"
-"github.com/kuanhungchen), and [@johnathan79717](https://github.com/"
-"johnathan79717)."
-msgstr ""
-
-#: src/running-the-course/translations.md:9
-msgid ""
 "[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
 "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
 
-#: src/running-the-course/translations.md:10
+#: src/running-the-course/translations.md:8
 msgid ""
 "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
 "(https://github.com/deavid)."
 msgstr ""
 
-#: src/running-the-course/translations.md:12
+#: src/running-the-course/translations.md:10
 msgid ""
 "Use the language picker in the top-right corner to switch between languages."
 msgstr "画面右上の言語切り替えボタンから、切り替えを行なってください。"
 
-#: src/running-the-course/translations.md:14
+#: src/running-the-course/translations.md:12
 #, fuzzy
 msgid "Incomplete Translations"
 msgstr "翻訳"
 
-#: src/running-the-course/translations.md:16
+#: src/running-the-course/translations.md:14
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
 
-#: src/running-the-course/translations.md:19
+#: src/running-the-course/translations.md:17
 msgid ""
 "[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
 "(https://github.com/raselmandol)."
+msgstr ""
+
+#: src/running-the-course/translations.md:18
+msgid ""
+"[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
+"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
+"victorhsieh), [@mingyc](https://github.com/mingyc), and [@johnathan79717]"
+"(https://github.com/johnathan79717)."
+msgstr ""
+
+#: src/running-the-course/translations.md:19
+msgid ""
+"[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
+"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
+"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
+"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
+"github.com/superwhd), and [@SketchK](https://github.com/SketchK)."
 msgstr ""
 
 #: src/running-the-course/translations.md:20
@@ -1892,16 +1838,21 @@ msgstr ""
 msgid "The code blocks in this course are fully interactive:"
 msgstr "講座のコードブロックはインタラクティブです："
 
-#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:45
-msgid "\"Edit me!\""
-msgstr "\"Edit me!\""
+#: src/cargo/code-samples.md:13
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/cargo/code-samples.md:19
 msgid "You can use "
 msgstr "ボックス内にフォーカスがある状態で"
 
 #: src/cargo/code-samples.md:19
-msgid "to execute the code when focus is in the text box."
+msgid " to execute the code when focus is in the text box."
 msgstr "を押すと、コードが実行されます。"
 
 #: src/cargo/code-samples.md:24
@@ -1985,6 +1936,20 @@ msgid ""
 msgstr ""
 "`src/main.rs`のボイラープレートコードを、コピーしたコードで置き換えてくださ"
 "い。例えば、前のページの例を使った場合、`src/main.rs`は以下のようになります。"
+
+#: src/cargo/running-locally.md:43
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
 
 #: src/cargo/running-locally.md:49
 msgid "Use `cargo run` to build and run your updated binary:"
@@ -2222,8 +2187,13 @@ msgid ""
 msgstr ""
 "さっそく一番シンプルなプログラムである定番のHello Worldからみてみましょう："
 
-#: src/hello-world.md:8
-msgid "\"Hello 🌍!\""
+#: src/hello-world.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Hello 🌍!\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/hello-world.md:12
@@ -2309,33 +2279,39 @@ msgstr ""
 msgid "Here is a small example program in Rust:"
 msgstr "ここでは、Rustによる小さなサンプルプログラムを紹介します："
 
-#: src/hello-world/small-example.md:6
-msgid "// Program entry point\n"
-msgstr "// プログラムのエントリーポイント\n"
-
-#: src/hello-world/small-example.md:7
-msgid "// Mutable variable binding\n"
-msgstr "// 可変変数のバインディング\n"
-
-#: src/hello-world/small-example.md:8 src/traits/impl-trait.md:15
-msgid "\"{x}\""
-msgstr "\"{x}\""
-
-#: src/hello-world/small-example.md:8
-msgid "// Macro for printing, like printf\n"
-msgstr "// printfのような、出力用マクロ\n"
-
-#: src/hello-world/small-example.md:9
-msgid "// No parenthesis around expression\n"
-msgstr "// 式を囲む括弧は不要\n"
-
-#: src/hello-world/small-example.md:10
-msgid "// Math like in other languages\n"
-msgstr "// 他の言語と同様の演算\n"
-
-#: src/hello-world/small-example.md:15
-msgid "\" -> {x}\""
-msgstr "\" -> {x}\""
+#: src/hello-world/small-example.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {              // Program entry point\n"
+"    let mut x: i32 = 6;  // Mutable variable binding\n"
+"    print!(\"{x}\");       // Macro for printing, like printf\n"
+"    while x != 1 {       // No parenthesis around expression\n"
+"        if x % 2 == 0 {  // Math like in other languages\n"
+"            x = x / 2;\n"
+"        } else {\n"
+"            x = 3 * x + 1;\n"
+"        }\n"
+"        print!(\" -> {x}\");\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {              // プログラムのエントリーポイント\n"
+"    let mut x: i32 = 6;  // 可変変数のバインディング\n"
+"    print!(\"{x}\");       // printfのような、出力用マクロ\n"
+"    while x != 1 {       // 式を囲む括弧は不要\n"
+"        if x % 2 == 0 {  // 他の言語と同様の演算\n"
+"            x = x / 2;\n"
+"        } else {\n"
+"            x = 3 * x + 1;\n"
+"        }\n"
+"        print!(\" -> {x}\");\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
 
 #: src/hello-world/small-example.md:23
 msgid ""
@@ -2446,41 +2422,49 @@ msgstr ""
 msgid "Let's consider the following \"minimum wrong example\" program in C:"
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:7
-#: src/android/interoperability/with-c/bindgen.md:22
-msgid "<stdio.h>"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:8
-msgid "<stdlib.h>"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:9
-msgid "<sys/stat.h>"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:19
-msgid "\"Too few arguments!\\n\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:29
-msgid "\"malloc failed!\\n\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:32
-msgid "\"rb\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:35
-msgid "\"%s\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:37
-msgid "\"fread failed!\\n\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:40
-msgid "\"Too many arguments!\\n\""
+#: src/why-rust/an-example-in-c.md:6
+msgid ""
+"```c,editable\n"
+"#include <stdio.h>\n"
+"#include <stdlib.h>\n"
+"#include <sys/stat.h>\n"
+"\n"
+"int main(int argc, char* argv[]) {\n"
+"\tchar *buf, *filename;\n"
+"\tFILE *fp;\n"
+"\tsize_t bytes, len;\n"
+"\tstruct stat st;\n"
+"\n"
+"\tswitch (argc) {\n"
+"\t\tcase 1:\n"
+"\t\t\tprintf(\"Too few arguments!\\n\");\n"
+"\t\t\treturn 1;\n"
+"\n"
+"\t\tcase 2:\n"
+"\t\t\tfilename = argv[argc];\n"
+"\t\t\tstat(filename, &st);\n"
+"\t\t\tlen = st.st_size;\n"
+"\t\t\t\n"
+"\t\t\tbuf = (char*)malloc(len);\n"
+"\t\t\tif (!buf)\n"
+"\t\t\t\tprintf(\"malloc failed!\\n\", len);\n"
+"\t\t\t\treturn 1;\n"
+"\n"
+"\t\t\tfp = fopen(filename, \"rb\");\n"
+"\t\t\tbytes = fread(buf, 1, len, fp);\n"
+"\t\t\tif (bytes = st.st_size)\n"
+"\t\t\t\tprintf(\"%s\", buf);\n"
+"\t\t\telse\n"
+"\t\t\t\tprintf(\"fread failed!\\n\");\n"
+"\n"
+"\t\tcase 3:\n"
+"\t\t\tprintf(\"Too many arguments!\\n\");\n"
+"\t\t\treturn 1;\n"
+"\t}\n"
+"\n"
+"\treturn 0;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:48
@@ -2565,8 +2549,8 @@ msgstr ""
 #: src/why-rust/an-example-in-c.md:73
 msgid ""
 "Forgotten `break` in a `switch` statement: [The break that broke sudo]"
-"(https://www.lufsec.com/anatomy-of-a-security-hole-the-break-that-broke-"
-"sudo/)"
+"(https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-"
+"break-that-broke-sudo)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:75
@@ -2712,8 +2696,8 @@ msgid ""
 "For the purpose of this course, \"No memory leaks\" should be understood as "
 "\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"本講座での「メモリリークが起きない」は「\\_意図しない_メモリリークはほとんど"
-"起きない」と解釈すべきです。"
+"本講座での「メモリリークが起きない」は「_意図しない_メモリリークはほとんど起"
+"きない」と解釈すべきです。"
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
@@ -2970,7 +2954,6 @@ msgid "Strings"
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:8
-#: src/android/interoperability/cpp/type-mapping.md:6
 msgid "`&str`"
 msgstr ""
 
@@ -3094,11 +3077,10 @@ msgstr ""
 
 #: src/basic-syntax/compound-types.md:42
 msgid ""
-"The `println!` macro asks for the debug implementation with the `?` format "
-"parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"Types such as integers and strings implement the default output, but arrays "
-"only implement the debug output. This means that we must use debug output "
-"here."
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:47
@@ -3258,27 +3240,22 @@ msgstr ""
 msgid "We can now understand the two string types in Rust:"
 msgstr ""
 
-#: src/basic-syntax/string-slices.md:7 src/traits/read-write.md:36
-#: src/testing/test-modules.md:12
-msgid "\"World\""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:8
-msgid "\"s1: {s1}\""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:10 src/memory-management/scope-based.md:16
-#: src/memory-management/garbage-collection.md:15
-msgid "\"Hello \""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:11 src/basic-syntax/string-slices.md:13
-#: src/ownership/move-semantics.md:9
-msgid "\"s2: {s2}\""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:16
-msgid "\"s3: {s3}\""
+#: src/basic-syntax/string-slices.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: &str = \"World\";\n"
+"    println!(\"s1: {s1}\");\n"
+"\n"
+"    let mut s2: String = String::from(\"Hello \");\n"
+"    println!(\"s2: {s2}\");\n"
+"    s2.push_str(s1);\n"
+"    println!(\"s2: {s2}\");\n"
+"    \n"
+"    let s3: &str = &s2[6..];\n"
+"    println!(\"s3: {s3}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:20
@@ -3374,8 +3351,9 @@ msgid ""
 "All language items in Rust can be documented using special `///` syntax."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:6
+#: src/basic-syntax/rustdoc.md:5
 msgid ""
+"```rust,editable\n"
 "/// Determine whether the first argument is divisible by the second "
 "argument.\n"
 "///\n"
@@ -3385,14 +3363,14 @@ msgid ""
 "/// ```\n"
 "/// assert!(is_divisible_by(42, 2));\n"
 "/// ```\n"
-msgstr ""
-
-#: src/basic-syntax/rustdoc.md:16
-msgid "// Corner case, early return\n"
-msgstr ""
-
-#: src/basic-syntax/rustdoc.md:18
-msgid "// The last expression in a block is the return value\n"
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
+"    if rhs == 0 {\n"
+"        return false;  // Corner case, early return\n"
+"    }\n"
+"    lhs % rhs == 0     // The last expression in a block is the return "
+"value\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:22
@@ -3435,12 +3413,31 @@ msgid ""
 "method is an instance of the type it is associated with:"
 msgstr ""
 
-#: src/basic-syntax/methods.md:24
-msgid "\"old area: {}\""
-msgstr ""
-
-#: src/basic-syntax/methods.md:26
-msgid "\"new area: {}\""
+#: src/basic-syntax/methods.md:6
+msgid ""
+"```rust,editable\n"
+"struct Rectangle {\n"
+"    width: u32,\n"
+"    height: u32,\n"
+"}\n"
+"\n"
+"impl Rectangle {\n"
+"    fn area(&self) -> u32 {\n"
+"        self.width * self.height\n"
+"    }\n"
+"\n"
+"    fn inc_width(&mut self, delta: u32) {\n"
+"        self.width += delta;\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut rect = Rectangle { width: 10, height: 5 };\n"
+"    println!(\"old area: {}\", rect.area());\n"
+"    rect.inc_width(5);\n"
+"    println!(\"new area: {}\", rect.area());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/methods.md:30
@@ -3503,20 +3500,18 @@ msgstr ""
 msgid "However, function parameters can be generic:"
 msgstr ""
 
-#: src/basic-syntax/functions-interlude.md:20
-msgid "\"coin toss: {}\""
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:20
-msgid "\"heads\""
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:20
-msgid "\"tails\""
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:21
-msgid "\"cash prize: {}\""
+#: src/basic-syntax/functions-interlude.md:14
+msgid ""
+"```rust,editable\n"
+"fn pick_one<T>(a: T, b: T) -> T {\n"
+"    if std::process::id() % 2 == 0 { a } else { b }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
+"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
@@ -3643,20 +3638,24 @@ msgid ""
 "keyword:"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:25
-msgid "\"Iterating over array:\""
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:27
-msgid "\" {n}\""
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:31
-msgid "\"Iterating over range:\""
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:33
-msgid "\" {}\""
+#: src/exercises/day-1/for-loops.md:22
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    print!(\"Iterating over array:\");\n"
+"    for n in &array {\n"
+"        print!(\" {n}\");\n"
+"    }\n"
+"    println!();\n"
+"\n"
+"    print!(\"Iterating over range:\");\n"
+"    for i in 0..3 {\n"
+"        print!(\" {}\", array[i]);\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:39
@@ -3676,28 +3675,35 @@ msgid ""
 "functions:"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:55 src/exercises/day-1/luhn.md:26
-#: src/exercises/day-2/health-statistics.md:14
-#: src/exercises/day-2/strings-iterators.md:13
-#: src/exercises/day-3/simple-gui.md:20
-#: src/exercises/day-3/points-polygons.md:8
-#: src/exercises/day-3/safe-ffi-wrapper.md:49
-msgid "// TODO: remove this when you're done with your implementation.\n"
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:68
-#: src/exercises/day-1/solutions-morning.md:44
-msgid "// <-- the comment makes rustfmt add a newline\n"
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:73
-#: src/exercises/day-1/solutions-morning.md:49
-msgid "\"matrix:\""
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:77
-#: src/exercises/day-1/solutions-morning.md:53
-msgid "\"transposed:\""
+#: src/exercises/day-1/for-loops.md:54
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"\n"
+"    println!(\"matrix:\");\n"
+"    pretty_print(&matrix);\n"
+"\n"
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:82
@@ -4052,12 +4058,15 @@ msgid ""
 "therefore will not move:"
 msgstr ""
 
-#: src/basic-syntax/static-and-const.md:39
-msgid "\"Welcome to RustOS 3.14\""
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:42
-msgid "\"{BANNER}\""
+#: src/basic-syntax/static-and-const.md:38
+msgid ""
+"```rust,editable\n"
+"static BANNER: &str = \"Welcome to RustOS 3.14\";\n"
+"\n"
+"fn main() {\n"
+"    println!(\"{BANNER}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:46
@@ -4174,25 +4183,24 @@ msgid ""
 "the same scope:"
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:9
-msgid "\"before: {a}\""
-msgstr ""
-
-#: src/basic-syntax/scopes-shadowing.md:12 src/traits/from-into.md:7
-#: src/traits/from-into.md:19
-msgid "\"hello\""
-msgstr ""
-
-#: src/basic-syntax/scopes-shadowing.md:13
-msgid "\"inner scope: {a}\""
-msgstr ""
-
-#: src/basic-syntax/scopes-shadowing.md:16
-msgid "\"shadowed in inner scope: {a}\""
-msgstr ""
-
-#: src/basic-syntax/scopes-shadowing.md:19
-msgid "\"after: {a}\""
+#: src/basic-syntax/scopes-shadowing.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a = 10;\n"
+"    println!(\"before: {a}\");\n"
+"\n"
+"    {\n"
+"        let a = \"hello\";\n"
+"        println!(\"inner scope: {a}\");\n"
+"\n"
+"        let a = true;\n"
+"        println!(\"shadowed in inner scope: {a}\");\n"
+"    }\n"
+"\n"
+"    println!(\"after: {a}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
@@ -4225,16 +4233,33 @@ msgid ""
 "variants:"
 msgstr ""
 
-#: src/enums.md:8
-msgid "// Implementation based on https://xkcd.com/221/\n"
-msgstr ""
-
-#: src/enums.md:9
-msgid "// Chosen by fair dice roll. Guaranteed to be random.\n"
-msgstr ""
-
-#: src/enums.md:28
-msgid "\"You got: {:?}\""
+#: src/enums.md:6
+msgid ""
+"```rust,editable\n"
+"fn generate_random_number() -> i32 {\n"
+"    // Implementation based on https://xkcd.com/221/\n"
+"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"enum CoinFlip {\n"
+"    Heads,\n"
+"    Tails,\n"
+"}\n"
+"\n"
+"fn flip_coin() -> CoinFlip {\n"
+"    let random_number = generate_random_number();\n"
+"    if random_number % 2 == 0 {\n"
+"        return CoinFlip::Heads;\n"
+"    } else {\n"
+"        return CoinFlip::Tails;\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    println!(\"You got: {:?}\", flip_coin());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/enums.md:36
@@ -4274,32 +4299,34 @@ msgid ""
 "the `match` statement to extract the data from each variant:"
 msgstr ""
 
-#: src/enums/variant-payloads.md:8
-msgid "// Variant without payload\n"
-msgstr ""
-
-#: src/enums/variant-payloads.md:9
-msgid "// Tuple struct variant\n"
-msgstr ""
-
-#: src/enums/variant-payloads.md:10
-msgid "// Full struct variant\n"
-msgstr ""
-
-#: src/enums/variant-payloads.md:16
-msgid "\"page loaded\""
-msgstr ""
-
-#: src/enums/variant-payloads.md:17
-msgid "\"pressed '{c}'\""
-msgstr ""
-
-#: src/enums/variant-payloads.md:18
-msgid "\"clicked at x={x}, y={y}\""
-msgstr ""
-
-#: src/enums/variant-payloads.md:24 src/pattern-matching.md:10
-msgid "'x'"
+#: src/enums/variant-payloads.md:6
+msgid ""
+"```rust,editable\n"
+"enum WebEvent {\n"
+"    PageLoad,                 // Variant without payload\n"
+"    KeyPress(char),           // Tuple struct variant\n"
+"    Click { x: i64, y: i64 }, // Full struct variant\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(event: WebEvent) {\n"
+"    match event {\n"
+"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
+"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
+"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let load = WebEvent::PageLoad;\n"
+"    let press = WebEvent::KeyPress('x');\n"
+"    let click = WebEvent::Click { x: 20, y: 80 };\n"
+"\n"
+"    inspect(load);\n"
+"    inspect(press);\n"
+"    inspect(click);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/enums/variant-payloads.md:35
@@ -4362,8 +4389,26 @@ msgid ""
 "account:"
 msgstr ""
 
-#: src/enums/sizes.md:10
-msgid "\"{}: size {} bytes, align: {} bytes\""
+#: src/enums/sizes.md:5
+msgid ""
+"```rust,editable\n"
+"use std::any::type_name;\n"
+"use std::mem::{align_of, size_of};\n"
+"\n"
+"fn dbg_size<T>() {\n"
+"    println!(\"{}: size {} bytes, align: {} bytes\",\n"
+"        type_name::<T>(), size_of::<T>(), align_of::<T>());\n"
+"}\n"
+"\n"
+"enum Foo {\n"
+"    A,\n"
+"    B,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    dbg_size::<Foo>();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:24
@@ -4413,37 +4458,27 @@ msgid ""
 "optimization, see below)."
 msgstr ""
 
-#: src/enums/sizes.md:61 src/memory-management/stack.md:32
-msgid "More to Explore"
-msgstr ""
-
-#: src/enums/sizes.md:63
-msgid ""
-"Rust has several optimizations it can employ to make enums take up less "
-"space."
-msgstr ""
-
-#: src/enums/sizes.md:65
+#: src/enums/sizes.md:61
 msgid ""
 "Niche optimization: Rust will merge unused bit patterns for the enum "
 "discriminant."
 msgstr ""
 
-#: src/enums/sizes.md:68
+#: src/enums/sizes.md:64
 msgid ""
 "Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
 "option/#representation), Rust guarantees that `size_of::<T>()` equals "
 "`size_of::<Option<T>>()`."
 msgstr ""
 
-#: src/enums/sizes.md:72
+#: src/enums/sizes.md:68
 msgid ""
 "Example code if you want to show how the bitwise representation _may_ look "
 "like in practice. It's important to note that the compiler provides no "
 "guarantees regarding this representation, therefore this is totally unsafe."
 msgstr ""
 
-#: src/enums/sizes.md:109
+#: src/enums/sizes.md:105
 msgid ""
 "More complex example if you want to discuss what happens when we chain more "
 "than 256 `Option`s together."
@@ -4475,12 +4510,18 @@ msgid ""
 "whether a value matches a pattern:"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:11
-msgid "\"Program name: {value}\""
-msgstr ""
-
-#: src/control-flow/if-let-expressions.md:13
-msgid "\"Missing name?\""
+#: src/control-flow/if-let-expressions.md:7
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let arg = std::env::args().next();\n"
+"    if let Some(value) = arg {\n"
+"        println!(\"Program name: {value}\");\n"
+"    } else {\n"
+"        println!(\"Missing name?\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:18
@@ -4553,44 +4594,20 @@ msgid ""
 "sense, it works like a series of `if let` expressions:"
 msgstr ""
 
-#: src/control-flow/match-expressions.md:10
-msgid "\"cat\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:10
-msgid "\"Will do cat things\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:11
-msgid "\"ls\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:11
-msgid "\"Will ls some files\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:12
-msgid "\"mv\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:12
-msgid "\"Let's move some files\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:13
-msgid "\"rm\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:13
-msgid "\"Uh, dangerous!\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:14
-msgid "\"Hmm, no program name?\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:15
-msgid "\"Unknown program name!\""
+#: src/control-flow/match-expressions.md:7
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    match std::env::args().next().as_deref() {\n"
+"        Some(\"cat\") => println!(\"Will do cat things\"),\n"
+"        Some(\"ls\")  => println!(\"Will ls some files\"),\n"
+"        Some(\"mv\")  => println!(\"Let's move some files\"),\n"
+"        Some(\"rm\")  => println!(\"Uh, dangerous!\"),\n"
+"        None        => println!(\"Hmm, no program name?\"),\n"
+"        _           => println!(\"Unknown program name!\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/control-flow/match-expressions.md:20
@@ -4626,7 +4643,7 @@ msgstr ""
 
 #: src/pattern-matching.md:3
 msgid ""
-"The `match` keyword lets you match a value against one or more _patterns_. "
+"The `match` keyword let you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
@@ -4634,48 +4651,20 @@ msgstr ""
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
 msgstr ""
 
-#: src/pattern-matching.md:13
-msgid "'q'"
-msgstr ""
-
-#: src/pattern-matching.md:13
-msgid "\"Quitting\""
-msgstr ""
-
-#: src/pattern-matching.md:14
-msgid "'a'"
-msgstr ""
-
-#: src/pattern-matching.md:14
-msgid "'s'"
-msgstr ""
-
-#: src/pattern-matching.md:14
-msgid "'w'"
-msgstr ""
-
-#: src/pattern-matching.md:14
-msgid "'d'"
-msgstr ""
-
-#: src/pattern-matching.md:14
-msgid "\"Moving around\""
-msgstr ""
-
-#: src/pattern-matching.md:15
-msgid "'0'"
-msgstr ""
-
-#: src/pattern-matching.md:15
-msgid "'9'"
-msgstr ""
-
-#: src/pattern-matching.md:15
-msgid "\"Number input\""
-msgstr ""
-
-#: src/pattern-matching.md:16
-msgid "\"Something else\""
+#: src/pattern-matching.md:8
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let input = 'x';\n"
+"\n"
+"    match input {\n"
+"        'q'                   => println!(\"Quitting\"),\n"
+"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
+"        '0'..='9'             => println!(\"Number input\"),\n"
+"        _                     => println!(\"Something else\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching.md:21
@@ -4727,16 +4716,30 @@ msgid ""
 "`enum` type:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:16
-msgid "\"cannot divide {n} into two equal parts\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:23
-msgid "\"{n} divided in two is {half}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:24
-msgid "\"sorry, an error happened: {msg}\""
+#: src/pattern-matching/destructuring-enums.md:6
+msgid ""
+"```rust,editable\n"
+"enum Result {\n"
+"    Ok(i32),\n"
+"    Err(String),\n"
+"}\n"
+"\n"
+"fn divide_in_two(n: i32) -> Result {\n"
+"    if n % 2 == 0 {\n"
+"        Result::Ok(n / 2)\n"
+"    } else {\n"
+"        Result::Err(format!(\"cannot divide {n} into two equal parts\"))\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let n = 100;\n"
+"    match divide_in_two(n) {\n"
+"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
+"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
@@ -4763,16 +4766,25 @@ msgstr ""
 msgid "You can also destructure `structs`:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:15
-msgid "\"x.0 = 1, b = {b}, y = {y}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:16
-msgid "\"y = 2, x = {i:?}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:17
-msgid "\"y = {y}, other fields were ignored\""
+#: src/pattern-matching/destructuring-structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Foo {\n"
+"    x: (u32, u32),\n"
+"    y: u32,\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let foo = Foo { x: (1, 2), y: 3 };\n"
+"    match foo {\n"
+"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
+"        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
@@ -4795,23 +4807,20 @@ msgid ""
 "You can destructure arrays, tuples, and slices by matching on their elements:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:9
-msgid "\"Tell me about {triple:?}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:11
-#: src/pattern-matching/destructuring-arrays.md:34
-msgid "\"First is 0, y = {y}, and z = {z}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:12
-#: src/pattern-matching/destructuring-arrays.md:35
-msgid "\"First is 1 and the rest were ignored\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:13
-#: src/pattern-matching/destructuring-arrays.md:36
-msgid "\"All elements were ignored\""
+#: src/pattern-matching/destructuring-arrays.md:5
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let triple = [0, -2, 3];\n"
+"    println!(\"Tell me about {triple:?}\");\n"
+"    match triple {\n"
+"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _         => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
@@ -4820,8 +4829,24 @@ msgid ""
 "length."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:32
-msgid "\"Tell me about {slice:?}\""
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:41
@@ -4848,24 +4873,21 @@ msgid ""
 "Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:10
-msgid "\"Tell me about {pair:?}\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:12
-msgid "\"These are twins\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:13
-msgid "\"Antimatter, kaboom!\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:14
-msgid "\"The first one is odd\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:15
-msgid "\"No correlation...\""
+#: src/pattern-matching/match-guards.md:6
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let pair = (2, -2);\n"
+"    println!(\"Tell me about {pair:?}\");\n"
+"    match pair {\n"
+"        (x, y) if x == y     => println!(\"These are twins\"),\n"
+"        (x, y) if x + y == 0 => println!(\"Antimatter, kaboom!\"),\n"
+"        (x, _) if x % 2 == 1 => println!(\"The first one is odd\"),\n"
+"        _                    => println!(\"No correlation...\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
@@ -4962,72 +4984,57 @@ msgid ""
 "integers. Then, revisit the solution and try to implement it with iterators."
 msgstr ""
 
-#: src/exercises/day-1/luhn.md:35
-#: src/exercises/day-2/iterators-and-ownership.md:75
-#: src/exercises/day-2/iterators-and-ownership.md:91
-#: src/traits/trait-bounds.md:22 src/traits/impl-trait.md:14
-#: src/exercises/day-3/simple-gui.md:148 src/exercises/day-3/simple-gui.md:149
-#: src/exercises/day-3/simple-gui.md:150 src/testing/test-modules.md:21
-#: src/exercises/day-1/solutions-afternoon.md:49
-msgid "\"foo\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:36 src/exercises/day-1/solutions-afternoon.md:50
-msgid "\"foo 0 0\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:41 src/testing/unit-tests.md:15
-#: src/exercises/day-1/solutions-afternoon.md:55
-#: src/exercises/day-3/solutions-morning.md:90
-#: src/exercises/day-3/solutions-morning.md:92
-#: src/exercises/day-3/solutions-morning.md:96
-#: src/exercises/day-3/solutions-morning.md:110
-#: src/exercises/day-3/solutions-morning.md:114
-msgid "\"\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:42 src/exercises/day-1/solutions-afternoon.md:56
-msgid "\" \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:43 src/exercises/day-1/solutions-afternoon.md:57
-msgid "\"  \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:44 src/exercises/day-1/solutions-afternoon.md:58
-msgid "\"    \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:49 src/exercises/day-1/solutions-afternoon.md:63
-msgid "\"0\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:54 src/exercises/day-1/solutions-afternoon.md:68
-msgid "\" 0 0 \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:59 src/exercises/day-1/solutions-afternoon.md:73
-msgid "\"4263 9826 4026 9299\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:60 src/exercises/day-1/solutions-afternoon.md:74
-msgid "\"4539 3195 0343 6467\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:61 src/exercises/day-1/solutions-afternoon.md:75
-msgid "\"7992 7398 713\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:66 src/exercises/day-1/solutions-afternoon.md:80
-msgid "\"4223 9826 4026 9299\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:67 src/exercises/day-1/solutions-afternoon.md:81
-msgid "\"4539 3195 0343 6476\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:68 src/exercises/day-1/solutions-afternoon.md:82
-msgid "\"8273 1232 7352 0569\""
+#: src/exercises/day-1/luhn.md:25
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"    assert!(!luhn(\"foo 0 0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"\n"
+"#[allow(dead_code)]\n"
+"fn main() {}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/pattern-matching.md:1
@@ -5038,50 +5045,102 @@ msgstr ""
 msgid "Let's write a simple recursive evaluator for arithmetic expressions. "
 msgstr ""
 
-#: src/exercises/day-1/pattern-matching.md:6
-#: src/exercises/day-1/solutions-afternoon.md:89
-msgid "/// An operation to perform on two subexpressions.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:14
-#: src/exercises/day-1/solutions-afternoon.md:97
-msgid "/// An expression, in tree form.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:18
-#: src/exercises/day-1/solutions-afternoon.md:101
-msgid "/// An operation on two subexpressions.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:25
-#: src/exercises/day-1/solutions-afternoon.md:108
-msgid "/// A literal value\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:28
-#: src/exercises/day-1/solutions-afternoon.md:111
-msgid "/// The result of evaluating an expression.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:32
-#: src/exercises/day-1/solutions-afternoon.md:115
-msgid "/// Evaluation was successful, with the given result.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:34
-#: src/exercises/day-1/solutions-afternoon.md:117
-msgid "/// Evaluation failed, with the given error message.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:36
-#: src/exercises/day-1/solutions-afternoon.md:119
-msgid "// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:95
-#: src/exercises/day-1/solutions-afternoon.md:140
-#: src/exercises/day-1/solutions-afternoon.md:202
-msgid "\"division by zero\""
+#: src/exercises/day-1/pattern-matching.md:5
+msgid ""
+"```rust\n"
+"/// An operation to perform on two subexpressions.\n"
+"#[derive(Debug)]\n"
+"enum Operation {\n"
+"    Add,\n"
+"    Sub,\n"
+"    Mul,\n"
+"    Div,\n"
+"}\n"
+"\n"
+"/// An expression, in tree form.\n"
+"#[derive(Debug)]\n"
+"enum Expression {\n"
+"    /// An operation on two subexpressions.\n"
+"    Op {\n"
+"        op: Operation,\n"
+"        left: Box<Expression>,\n"
+"        right: Box<Expression>,\n"
+"    },\n"
+"\n"
+"    /// A literal value\n"
+"    Value(i64),\n"
+"}\n"
+"\n"
+"/// The result of evaluating an expression.\n"
+"#[derive(Debug, PartialEq, Eq)]\n"
+"enum Res {\n"
+"    /// Evaluation was successful, with the given result.\n"
+"    Ok(i64),\n"
+"    /// Evaluation failed, with the given error message.\n"
+"    Err(String),\n"
+"}\n"
+"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
+"use Res::{Err, Ok};\n"
+"\n"
+"fn eval(e: Expression) -> Res {\n"
+"    todo!()\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_value() {\n"
+"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_sum() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(Expression::Value(10)),\n"
+"            right: Box::new(Expression::Value(20)),\n"
+"        }),\n"
+"        Ok(30)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_recursion() {\n"
+"    let term1 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Value(10)),\n"
+"        right: Box::new(Expression::Value(9)),\n"
+"    };\n"
+"    let term2 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Op {\n"
+"            op: Operation::Sub,\n"
+"            left: Box::new(Expression::Value(3)),\n"
+"            right: Box::new(Expression::Value(4)),\n"
+"        }),\n"
+"        right: Box::new(Expression::Value(5)),\n"
+"    };\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(term1),\n"
+"            right: Box::new(term2),\n"
+"        }),\n"
+"        Ok(85)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_error() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Div,\n"
+"            left: Box::new(Expression::Value(99)),\n"
+"            right: Box::new(Expression::Value(0)),\n"
+"        }),\n"
+"        Err(String::from(\"division by zero\"))\n"
+"    );\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/pattern-matching.md:100
@@ -5231,11 +5290,13 @@ msgid ""
 "sized data, the actual string, on the heap:"
 msgstr ""
 
-#: src/memory-management/stack.md:8 src/memory-management/stack.md:39
-#: src/std/string.md:8 src/traits/read-write.md:35 src/testing/unit-tests.md:20
-#: src/testing/unit-tests.md:25 src/testing/test-modules.md:12
-#: src/concurrency/scoped-threads.md:9 src/concurrency/scoped-threads.md:26
-msgid "\"Hello\""
+#: src/memory-management/stack.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1 = String::from(\"Hello\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/memory-management/stack.md:28
@@ -5252,31 +5313,30 @@ msgid ""
 "[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
 
-#: src/memory-management/stack.md:34
+#: src/memory-management/stack.md:32
 msgid ""
-"We can inspect the memory layout with `unsafe` Rust. However, you should "
+"We can inspect the memory layout with `unsafe` code. However, you should "
 "point out that this is rightfully unsafe!"
 msgstr ""
 
-#: src/memory-management/stack.md:40 src/testing/unit-tests.md:7
-#: src/exercises/day-1/solutions-afternoon.md:13
-msgid "' '"
-msgstr ""
-
-#: src/memory-management/stack.md:41
-msgid "\"world\""
-msgstr ""
-
-#: src/memory-management/stack.md:42
+#: src/memory-management/stack.md:34
 msgid ""
-"// DON'T DO THIS AT HOME! For educational purposes only.\n"
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
 "    // String provides no guarantees about its layout, so this could lead "
 "to\n"
 "    // undefined behavior.\n"
-msgstr ""
-
-#: src/memory-management/stack.md:47
-msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
+"    unsafe {\n"
+"        let (ptr, capacity, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/memory-management/manual.md:3
@@ -5297,11 +5357,17 @@ msgstr ""
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
 msgstr ""
 
-#: src/memory-management/manual.md:14
+#: src/memory-management/manual.md:11
 msgid ""
-"//\n"
+"```c\n"
+"void foo(size_t n) {\n"
+"    int* int_array = malloc(n * sizeof(int));\n"
+"    //\n"
 "    // ... lots of code\n"
 "    //\n"
+"    free(int_array);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/memory-management/manual.md:21
@@ -5332,6 +5398,15 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:12
 msgid "C++ Example"
+msgstr ""
+
+#: src/memory-management/scope-based.md:14
+msgid ""
+"```c++\n"
+"void say_hello(std::unique_ptr<Person> person) {\n"
+"  std::cout << \"Hello \" << person->name << std::endl;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/memory-management/scope-based.md:20
@@ -5379,6 +5454,15 @@ msgstr ""
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
+msgstr ""
+
+#: src/memory-management/garbage-collection.md:13
+msgid ""
+"```java\n"
+"void sayHello(Person person) {\n"
+"  System.out.println(\"Hello \" + person.getName());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/memory-management/rust.md:1
@@ -5447,12 +5531,16 @@ msgstr ""
 msgid "An assignment will transfer _ownership_ between variables:"
 msgstr ""
 
-#: src/ownership/move-semantics.md:7
-msgid "\"Hello!\""
-msgstr ""
-
-#: src/ownership/move-semantics.md:10
-msgid "// println!(\"s1: {s1}\");\n"
+#: src/ownership/move-semantics.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Hello!\");\n"
+"    let s2: String = s1;\n"
+"    println!(\"s2: {s2}\");\n"
+"    // println!(\"s1: {s1}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/ownership/move-semantics.md:14
@@ -5542,12 +5630,12 @@ msgstr "現代C++の二重解放"
 msgid "Modern C++ solves this differently:"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:6
-msgid "\"Cpp\""
-msgstr ""
-
-#: src/ownership/double-free-modern-cpp.md:7
-msgid "// Duplicate the data in s1.\n"
+#: src/ownership/double-free-modern-cpp.md:5
+msgid ""
+"```c++\n"
+"std::string s1 = \"Cpp\";\n"
+"std::string s2 = s1;  // Duplicate the data in s1.\n"
+"```"
 msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
@@ -5595,17 +5683,19 @@ msgid ""
 "parameter. This transfers ownership:"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:8 src/traits/impl-trait.md:10
-msgid "\"Hello {name}\""
-msgstr ""
-
-#: src/ownership/moves-function-calls.md:12
-#: src/android/interoperability/java.md:56
-msgid "\"Alice\""
-msgstr ""
-
-#: src/ownership/moves-function-calls.md:14
-msgid "// say_hello(name);\n"
+#: src/ownership/moves-function-calls.md:6
+msgid ""
+"```rust,editable\n"
+"fn say_hello(name: String) {\n"
+"    println!(\"Hello {name}\")\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let name = String::from(\"Alice\");\n"
+"    say_hello(name);\n"
+"    // say_hello(name);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
@@ -5882,24 +5972,26 @@ msgid ""
 "If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:10
-msgid "\"Bye {text}!\""
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:14
-msgid "\"The quick brown fox jumps over the lazy dog.\""
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:17
-msgid "// erase(text);\n"
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:18
-msgid "\"{fox:?}\""
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:19
-msgid "\"{dog:?}\""
+#: src/ownership/lifetimes-data-structures.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(text);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
@@ -5938,17 +6030,31 @@ msgstr ""
 msgid "Like C and C++, Rust has support for custom structs:"
 msgstr ""
 
-#: src/structs.md:13 src/structs/field-shorthand.md:20 src/methods.md:21
-#: src/android/interoperability/with-c/bindgen.md:87
-msgid "\"Peter\""
-msgstr ""
-
-#: src/structs.md:16 src/structs.md:19 src/structs.md:25
-msgid "\"{} is {} years old\""
-msgstr ""
-
-#: src/structs.md:22
-msgid "\"Jackie\""
+#: src/structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    peter.age = 28;\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    let jackie = Person {\n"
+"        name: String::from(\"Jackie\"),\n"
+"        ..peter\n"
+"    };\n"
+"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/structs.md:33
@@ -5977,7 +6083,7 @@ msgstr ""
 
 #: src/structs.md:38
 msgid ""
-"Zero-sized structs (e.g. `struct Foo;`) might be used when implementing a "
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
 "value itself. "
 msgstr ""
@@ -5999,23 +6105,42 @@ msgstr ""
 msgid "If the field names are unimportant, you can use a tuple struct:"
 msgstr ""
 
-#: src/structs/tuple-structs.md:10
-msgid "\"({}, {})\""
+#: src/structs/tuple-structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn main() {\n"
+"    let p = Point(17, 23);\n"
+"    println!(\"({}, {})\", p.0, p.1);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/structs/tuple-structs.md:14
 msgid "This is often used for single-field wrappers (called newtypes):"
 msgstr ""
 
-#: src/structs/tuple-structs.md:21
-msgid "\"Ask a rocket scientist at NASA\""
-msgstr ""
-
-#: src/structs/tuple-structs.md:25
-#: src/android/interoperability/cpp/cpp-bridge.md:50
-#: src/bare-metal/microcontrollers/type-state.md:14
-#: src/async/pitfalls/cancellation.md:99
-msgid "// ...\n"
+#: src/structs/tuple-structs.md:16
+msgid ""
+"```rust,editable,compile_fail\n"
+"struct PoundsOfForce(f64);\n"
+"struct Newtons(f64);\n"
+"\n"
+"fn compute_thruster_force() -> PoundsOfForce {\n"
+"    todo!(\"Ask a rocket scientist at NASA\")\n"
+"}\n"
+"\n"
+"fn set_thruster_force(force: Newtons) {\n"
+"    // ...\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let force = compute_thruster_force();\n"
+"    set_thruster_force(force);\n"
+"}\n"
+"\n"
+"```"
 msgstr ""
 
 #: src/structs/tuple-structs.md:37
@@ -6031,7 +6156,7 @@ msgstr ""
 #: src/structs/tuple-structs.md:39
 msgid ""
 "The value passed some validation when it was created, so you no longer have "
-"to validate it again at every use: `PhoneNumber(String)` or `OddNumber(u32)`."
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
 msgstr ""
 
 #: src/structs/tuple-structs.md:40
@@ -6062,8 +6187,26 @@ msgid ""
 "struct using a shorthand:"
 msgstr ""
 
-#: src/structs/field-shorthand.md:21
-msgid "\"{peter:?}\""
+#: src/structs/field-shorthand.md:6
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Person {\n"
+"        Person { name, age }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
+"    println!(\"{peter:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/structs/field-shorthand.md:27
@@ -6078,12 +6221,32 @@ msgid ""
 "default values for the other fields."
 msgstr ""
 
-#: src/structs/field-shorthand.md:52
-msgid "\"Bot\""
-msgstr ""
-
-#: src/structs/field-shorthand.md:62
-msgid "\"Sam\""
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Person::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Person::default()\n"
+"    };\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/structs/field-shorthand.md:68
@@ -6107,8 +6270,29 @@ msgid ""
 "an `impl` block:"
 msgstr ""
 
-#: src/methods.md:15
-msgid "\"Hello, my name is {}\""
+#: src/methods.md:6
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"\n"
+"impl Person {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Hello, my name is {}\", self.name);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    peter.say_hello();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods.md:31
@@ -6211,40 +6395,50 @@ msgid ""
 "multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 
-#: src/methods/example.md:11
-msgid "// No receiver, a static method\n"
-msgstr ""
-
-#: src/methods/example.md:15
-msgid "// Exclusive borrowed read-write access to self\n"
-msgstr ""
-
-#: src/methods/example.md:19
-msgid "// Shared and read-only borrowed access to self\n"
-msgstr ""
-
-#: src/methods/example.md:20
-msgid "\"Recorded {} laps for {}:\""
-msgstr ""
-
-#: src/methods/example.md:22
-msgid "\"Lap {idx}: {lap} sec\""
-msgstr ""
-
-#: src/methods/example.md:26
-msgid "// Exclusive ownership of self\n"
-msgstr ""
-
-#: src/methods/example.md:28
-msgid "\"Race {} is finished, total lap time: {}\""
-msgstr ""
-
-#: src/methods/example.md:33
-msgid "\"Monaco Grand Prix\""
-msgstr ""
-
-#: src/methods/example.md:40
-msgid "// race.add_lap(42);\n"
+#: src/methods/example.md:3
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Race {\n"
+"    name: String,\n"
+"    laps: Vec<i32>,\n"
+"}\n"
+"\n"
+"impl Race {\n"
+"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
+"        Race { name: String::from(name), laps: Vec::new() }\n"
+"    }\n"
+"\n"
+"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
+"access to self\n"
+"        self.laps.push(lap);\n"
+"    }\n"
+"\n"
+"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
+"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
+"        for (idx, lap) in self.laps.iter().enumerate() {\n"
+"            println!(\"Lap {idx}: {lap} sec\");\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn finish(self) {  // Exclusive ownership of self\n"
+"        let total = self.laps.iter().sum::<i32>();\n"
+"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"total);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
+"    race.add_lap(70);\n"
+"    race.add_lap(68);\n"
+"    race.print_laps();\n"
+"    race.add_lap(71);\n"
+"    race.print_laps();\n"
+"    race.finish();\n"
+"    // race.add_lap(42);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods/example.md:47
@@ -6298,12 +6492,19 @@ msgid ""
 "now, you just need to know part of its API:"
 msgstr ""
 
-#: src/exercises/day-2/book-library.md:11
-msgid "\"middle value: {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:13
-msgid "\"item: {item}\""
+#: src/exercises/day-2/book-library.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut vec = vec![10, 20];\n"
+"    vec.push(30);\n"
+"    let midpoint = vec.len() / 2;\n"
+"    println!(\"middle value: {}\", vec[midpoint]);\n"
+"    for item in &vec {\n"
+"        println!(\"item: {item}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/book-library.md:18
@@ -6312,14 +6513,28 @@ msgid ""
 "<https://play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 
-#: src/exercises/day-2/book-library.md:32
-#: src/exercises/day-2/solutions-morning.md:18
-msgid "// This is a constructor, used below.\n"
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:40
-#: src/exercises/day-2/solutions-morning.md:26
+#: src/exercises/day-2/book-library.md:21
 msgid ""
+"```rust,should_panic\n"
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}\n"
+"\n"
+"struct Book {\n"
+"    title: String,\n"
+"    year: u16,\n"
+"}\n"
+"\n"
+"impl Book {\n"
+"    // This is a constructor, used below.\n"
+"    fn new(title: &str, year: u16) -> Book {\n"
+"        Book {\n"
+"            title: String::from(title),\n"
+"            year,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
 "// Implement the methods below. Notice how the `self` parameter\n"
 "// changes type to indicate the method's required level of ownership\n"
 "// over the object:\n"
@@ -6327,74 +6542,61 @@ msgid ""
 "// - `&self` for shared read-only access,\n"
 "// - `&mut self` for unique and mutable access,\n"
 "// - `self` for unique access by value.\n"
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:50
-msgid "\"Initialize and return a `Library` value\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:54
-msgid "\"Return the length of `self.books`\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:58
-msgid "\"Return `true` if `self.books` is empty\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:62
-msgid "\"Add a new book to `self.books`\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:66
-msgid "\"Iterate over `self.books` and print each book's title and year\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:70
-msgid "\"Return a reference to the oldest book (if any)\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:78
-#: src/exercises/day-2/solutions-morning.md:78
-msgid "\"The library is empty: library.is_empty() -> {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:82
-#: src/exercises/day-2/solutions-morning.md:82
-#: src/exercises/day-2/solutions-morning.md:107
-#: src/exercises/day-2/solutions-morning.md:118
-#: src/exercises/day-2/solutions-morning.md:125
-#: src/exercises/day-2/solutions-morning.md:137
-#: src/exercises/day-2/solutions-morning.md:140
-msgid "\"Lord of the Rings\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:83
-#: src/exercises/day-2/solutions-morning.md:83
-#: src/exercises/day-2/solutions-morning.md:108
-#: src/exercises/day-2/solutions-morning.md:126
-#: src/exercises/day-2/solutions-morning.md:143
-#: src/exercises/day-2/solutions-morning.md:146
-msgid "\"Alice's Adventures in Wonderland\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:86
-#: src/exercises/day-2/solutions-morning.md:86
-msgid "\"The library is no longer empty: library.is_empty() -> {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:93
-#: src/exercises/day-2/solutions-morning.md:93
-msgid "\"The oldest book is {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:94
-#: src/exercises/day-2/solutions-morning.md:94
-msgid "\"The library is empty!\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:97
-#: src/exercises/day-2/solutions-morning.md:97
-msgid "\"The library has {} books\""
+"impl Library {\n"
+"    fn new() -> Library {\n"
+"        todo!(\"Initialize and return a `Library` value\")\n"
+"    }\n"
+"\n"
+"    fn len(&self) -> usize {\n"
+"        todo!(\"Return the length of `self.books`\")\n"
+"    }\n"
+"\n"
+"    fn is_empty(&self) -> bool {\n"
+"        todo!(\"Return `true` if `self.books` is empty\")\n"
+"    }\n"
+"\n"
+"    fn add_book(&mut self, book: Book) {\n"
+"        todo!(\"Add a new book to `self.books`\")\n"
+"    }\n"
+"\n"
+"    fn print_books(&self) {\n"
+"        todo!(\"Iterate over `self.books` and print each book's title and "
+"year\")\n"
+"    }\n"
+"\n"
+"    fn oldest_book(&self) -> Option<&Book> {\n"
+"        todo!(\"Return a reference to the oldest book (if any)\")\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut library = Library::new();\n"
+"\n"
+"    println!(\n"
+"        \"The library is empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"\n"
+"    println!(\n"
+"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.print_books();\n"
+"\n"
+"    match library.oldest_book() {\n"
+"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
+"        None => println!(\"The library is empty!\"),\n"
+"    }\n"
+"\n"
+"    println!(\"The library has {} books\", library.len());\n"
+"    library.print_books();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
@@ -6416,63 +6618,115 @@ msgid ""
 "methods:"
 msgstr ""
 
-#: src/exercises/day-2/health-statistics.md:39
-msgid "\"Create a new User instance\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:43
-msgid "\"Return the user's name\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:47
-msgid "\"Return the user's age\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:51
-msgid "\"Return the user's height\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:55
-msgid "\"Return the number of time the user has visited the doctor\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:59
-msgid "\"Set the user's age\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:63
-msgid "\"Set the user's height\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:67
+#: src/exercises/day-2/health-statistics.md:13
 msgid ""
-"\"Update a user's statistics based on measurements from a visit to the "
-"doctor\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:72
-#: src/exercises/day-2/health-statistics.md:78
-#: src/exercises/day-2/health-statistics.md:84
-#: src/exercises/day-2/health-statistics.md:92
-#: src/exercises/day-2/health-statistics.md:98
-#: src/android/build-rules/library.md:43 src/android/aidl/client.md:23
-#: src/exercises/day-2/solutions-morning.md:233
-#: src/exercises/day-2/solutions-morning.md:239
-#: src/exercises/day-2/solutions-morning.md:245
-#: src/exercises/day-2/solutions-morning.md:253
-#: src/exercises/day-2/solutions-morning.md:259
-msgid "\"Bob\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:73
-#: src/exercises/day-2/solutions-morning.md:234
-msgid "\"I'm {} and my age is {}\""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    height: f32,\n"
+"    visit_count: usize,\n"
+"    last_blood_pressure: Option<(u32, u32)>,\n"
+"}\n"
+"\n"
+"pub struct Measurements {\n"
+"    height: f32,\n"
+"    blood_pressure: (u32, u32),\n"
+"}\n"
+"\n"
+"pub struct HealthReport<'a> {\n"
+"    patient_name: &'a str,\n"
+"    visit_count: u32,\n"
+"    height_change: f32,\n"
+"    blood_pressure_change: Option<(i32, i32)>,\n"
+"}\n"
+"\n"
+"impl User {\n"
+"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
+"        todo!(\"Create a new User instance\")\n"
+"    }\n"
+"\n"
+"    pub fn name(&self) -> &str {\n"
+"        todo!(\"Return the user's name\")\n"
+"    }\n"
+"\n"
+"    pub fn age(&self) -> u32 {\n"
+"        todo!(\"Return the user's age\")\n"
+"    }\n"
+"\n"
+"    pub fn height(&self) -> f32 {\n"
+"        todo!(\"Return the user's height\")\n"
+"    }\n"
+"\n"
+"    pub fn doctor_visits(&self) -> u32 {\n"
+"        todo!(\"Return the number of time the user has visited the "
+"doctor\")\n"
+"    }\n"
+"\n"
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        todo!(\"Set the user's age\")\n"
+"    }\n"
+"\n"
+"    pub fn set_height(&mut self, new_height: f32) {\n"
+"        todo!(\"Set the user's height\")\n"
+"    }\n"
+"\n"
+"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
+"HealthReport {\n"
+"        todo!(\"Update a user's statistics based on measurements from a "
+"visit to the doctor\")\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_height() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.height(), 155.2);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_set_age() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.age(), 32);\n"
+"    bob.set_age(33);\n"
+"    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_visit() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.doctor_visits(), 0);\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (120, 80),\n"
+"    });\n"
+"    assert_eq!(report.patient_name, \"Bob\");\n"
+"    assert_eq!(report.visit_count, 1);\n"
+"    assert_eq!(report.blood_pressure_change, None);\n"
+"\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (115, 76),\n"
+"    });\n"
+"\n"
+"    assert_eq!(report.visit_count, 2);\n"
+"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std.md:3
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types used by Rust libraries and programs. This way, two libraries can work "
+"types used by Rust library and programs. This way, two libraries can work "
 "together smoothly because they both use the same `String` type."
 msgstr ""
 
@@ -6541,12 +6795,18 @@ msgstr ""
 msgid "The types represent optional data:"
 msgstr ""
 
-#: src/std/option-result.md:9
-msgid "\"first: {first:?}\""
-msgstr ""
-
-#: src/std/option-result.md:12
-msgid "\"arr: {arr:?}\""
+#: src/std/option-result.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let numbers = vec![10, 20, 30];\n"
+"    let first: Option<&i8> = numbers.first();\n"
+"    println!(\"first: {first:?}\");\n"
+"\n"
+"    let arr: Result<[i8; 3], Vec<i8>> = numbers.try_into();\n"
+"    println!(\"arr: {arr:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/option-result.md:18
@@ -6584,24 +6844,24 @@ msgid ""
 "standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
 
-#: src/std/string.md:9
-msgid "\"s1: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/string.md:13
-msgid "'!'"
-msgstr ""
-
-#: src/std/string.md:14
-msgid "\"s2: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/string.md:16
-msgid "\"🇨🇭\""
-msgstr ""
-
-#: src/std/string.md:17
-msgid "\"s3: len = {}, number of chars = {}\""
+#: src/std/string.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::new();\n"
+"    s1.push_str(\"Hello\");\n"
+"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());\n"
+"\n"
+"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
+"    s2.push_str(&s1);\n"
+"    s2.push('!');\n"
+"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());\n"
+"\n"
+"    let s3 = String::from(\"🇨🇭\");\n"
+"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
+"             s3.chars().count());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/string.md:22
@@ -6686,28 +6946,31 @@ msgid ""
 "resizable heap-allocated buffer:"
 msgstr ""
 
-#: src/std/vec.md:9
-msgid "\"v1: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/vec.md:14
-msgid "\"v2: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/vec.md:16
-msgid "// Canonical macro to initialize a vector with elements.\n"
-msgstr ""
-
-#: src/std/vec.md:19
-msgid "// Retain only the even elements.\n"
-msgstr ""
-
-#: src/std/vec.md:21 src/std/vec.md:25
-msgid "\"{v3:?}\""
-msgstr ""
-
-#: src/std/vec.md:23
-msgid "// Remove consecutive duplicates.\n"
+#: src/std/vec.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut v1 = Vec::new();\n"
+"    v1.push(42);\n"
+"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());\n"
+"\n"
+"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
+"    v2.extend(v1.iter());\n"
+"    v2.push(9999);\n"
+"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
+"\n"
+"    // Canonical macro to initialize a vector with elements.\n"
+"    let mut v3 = vec![0, 0, 1, 2, 3, 4];\n"
+"\n"
+"    // Retain only the even elements.\n"
+"    v3.retain(|x| x % 2 == 0);\n"
+"    println!(\"{v3:?}\");\n"
+"\n"
+"    // Remove consecutive duplicates.\n"
+"    v3.dedup();\n"
+"    println!(\"{v3:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:29
@@ -6758,44 +7021,42 @@ msgstr ""
 msgid "Standard hash map with protection against HashDoS attacks:"
 msgstr ""
 
-#: src/std/hashmap.md:10
-msgid "\"Adventures of Huckleberry Finn\""
-msgstr ""
-
-#: src/std/hashmap.md:11
-msgid "\"Grimms' Fairy Tales\""
-msgstr ""
-
-#: src/std/hashmap.md:12 src/std/hashmap.md:19 src/std/hashmap.md:27
-msgid "\"Pride and Prejudice\""
-msgstr ""
-
-#: src/std/hashmap.md:14
-msgid "\"Les Misérables\""
-msgstr ""
-
-#: src/std/hashmap.md:15
-msgid "\"We know about {} books, but not Les Misérables.\""
-msgstr ""
-
-#: src/std/hashmap.md:19 src/std/hashmap.md:27
-msgid "\"Alice's Adventure in Wonderland\""
-msgstr ""
-
-#: src/std/hashmap.md:21
-msgid "\"{book}: {count} pages\""
-msgstr ""
-
-#: src/std/hashmap.md:22
-msgid "\"{book} is unknown.\""
-msgstr ""
-
-#: src/std/hashmap.md:26
-msgid "// Use the .entry() method to insert a value if nothing is found.\n"
-msgstr ""
-
-#: src/std/hashmap.md:32
-msgid "\"{page_counts:#?}\""
+#: src/std/hashmap.md:5
+msgid ""
+"```rust,editable\n"
+"use std::collections::HashMap;\n"
+"\n"
+"fn main() {\n"
+"    let mut page_counts = HashMap::new();\n"
+"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
+"207);\n"
+"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
+"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);\n"
+"\n"
+"    if !page_counts.contains_key(\"Les Misérables\") {\n"
+"        println!(\"We know about {} books, but not Les Misérables.\",\n"
+"                 page_counts.len());\n"
+"    }\n"
+"\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        match page_counts.get(book) {\n"
+"            Some(count) => println!(\"{book}: {count} pages\"),\n"
+"            None => println!(\"{book} is unknown.\")\n"
+"        }\n"
+"    }\n"
+"\n"
+"    // Use the .entry() method to insert a value if nothing is found.\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        let page_count: &mut i32 = page_counts.entry(book.to_string())."
+"or_insert(0);\n"
+"        *page_count += 1;\n"
+"    }\n"
+"\n"
+"    println!(\"{page_counts:#?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:38
@@ -6810,12 +7071,16 @@ msgid ""
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
 
-#: src/std/hashmap.md:43 src/std/hashmap.md:54
-msgid "\"Harry Potter and the Sorcerer's Stone\""
-msgstr ""
-
-#: src/std/hashmap.md:46 src/std/hashmap.md:55
-msgid "\"The Hunger Games\""
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:49
@@ -6828,6 +7093,16 @@ msgid ""
 "doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
 "From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
 "us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:59
@@ -6867,8 +7142,14 @@ msgid ""
 "pointer to data on the heap:"
 msgstr ""
 
-#: src/std/box.md:8
-msgid "\"five: {}\""
+#: src/std/box.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let five = Box::new(5);\n"
+"    println!(\"five: {}\", *five);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/box.md:26
@@ -6916,8 +7197,21 @@ msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
-#: src/std/box-recursive.md:14 src/std/box-niche.md:12
-msgid "\"{list:?}\""
+#: src/std/box-recursive.md:5 src/std/box-niche.md:3
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"enum List<T> {\n"
+"    Cons(T, Box<List<T>>),\n"
+"    Nil,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::"
+"new(List::Nil))));\n"
+"    println!(\"{list:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/box-recursive.md:18
@@ -7001,12 +7295,19 @@ msgid ""
 "from multiple places:"
 msgstr ""
 
-#: src/std/rc.md:13
-msgid "\"a: {a}\""
-msgstr ""
-
-#: src/std/rc.md:14
-msgid "\"b: {b}\""
+#: src/std/rc.md:6
+msgid ""
+"```rust,editable\n"
+"use std::rc::Rc;\n"
+"\n"
+"fn main() {\n"
+"    let mut a = Rc::new(10);\n"
+"    let mut b = Rc::clone(&a);\n"
+"\n"
+"    println!(\"a: {a}\");\n"
+"    println!(\"b: {b}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/rc.md:18
@@ -7074,12 +7375,41 @@ msgid ""
 "shared and exclusive references at runtime and panics if they are misused."
 msgstr ""
 
-#: src/std/cell.md:40
-msgid "\"graph: {root:#?}\""
-msgstr ""
-
-#: src/std/cell.md:41
-msgid "\"graph sum: {}\""
+#: src/std/cell.md:12
+msgid ""
+"```rust,editable\n"
+"use std::cell::RefCell;\n"
+"use std::rc::Rc;\n"
+"\n"
+"#[derive(Debug, Default)]\n"
+"struct Node {\n"
+"    value: i64,\n"
+"    children: Vec<Rc<RefCell<Node>>>,\n"
+"}\n"
+"\n"
+"impl Node {\n"
+"    fn new(value: i64) -> Rc<RefCell<Node>> {\n"
+"        Rc::new(RefCell::new(Node { value, ..Node::default() }))\n"
+"    }\n"
+"\n"
+"    fn sum(&self) -> i64 {\n"
+"        self.value + self.children.iter().map(|c| c.borrow().sum()).sum::"
+"<i64>()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let root = Node::new(1);\n"
+"    root.borrow_mut().children.push(Node::new(5));\n"
+"    let subtree = Node::new(10);\n"
+"    subtree.borrow_mut().children.push(Node::new(11));\n"
+"    subtree.borrow_mut().children.push(Node::new(12));\n"
+"    root.borrow_mut().children.push(subtree);\n"
+"\n"
+"    println!(\"graph: {root:#?}\");\n"
+"    println!(\"graph sum: {}\", root.borrow().sum());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/cell.md:47
@@ -7118,12 +7448,26 @@ msgstr ""
 msgid "Similarly, `mod` lets us namespace types and functions:"
 msgstr ""
 
-#: src/modules.md:10
-msgid "\"In the foo module\""
-msgstr ""
-
-#: src/modules.md:16
-msgid "\"In the bar module\""
+#: src/modules.md:7
+msgid ""
+"```rust,editable\n"
+"mod foo {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the foo module\");\n"
+"    }\n"
+"}\n"
+"\n"
+"mod bar {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the bar module\");\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    foo::do_something();\n"
+"    bar::do_something();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/modules.md:28
@@ -7160,20 +7504,34 @@ msgid ""
 "the descendants of `foo`."
 msgstr ""
 
-#: src/modules/visibility.md:13
-msgid "\"outer::private\""
-msgstr ""
-
-#: src/modules/visibility.md:17
-msgid "\"outer::public\""
-msgstr ""
-
-#: src/modules/visibility.md:22
-msgid "\"outer::inner::private\""
-msgstr ""
-
-#: src/modules/visibility.md:26
-msgid "\"outer::inner::public\""
+#: src/modules/visibility.md:10
+msgid ""
+"```rust,editable\n"
+"mod outer {\n"
+"    fn private() {\n"
+"        println!(\"outer::private\");\n"
+"    }\n"
+"\n"
+"    pub fn public() {\n"
+"        println!(\"outer::public\");\n"
+"    }\n"
+"\n"
+"    mod inner {\n"
+"        fn private() {\n"
+"            println!(\"outer::inner::private\");\n"
+"        }\n"
+"\n"
+"        pub fn public() {\n"
+"            println!(\"outer::inner::public\");\n"
+"            super::private();\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    outer::public();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/modules/visibility.md:39
@@ -7271,23 +7629,23 @@ msgid ""
 "module."
 msgstr ""
 
-#: src/modules/filesystem.md:21
+#: src/modules/filesystem.md:20
 msgid ""
+"```rust,editable,compile_fail\n"
 "//! This module implements the garden, including a highly performant "
 "germination\n"
 "//! implementation.\n"
-msgstr ""
-
-#: src/modules/filesystem.md:23
-msgid "// Re-export types from this module.\n"
-msgstr ""
-
-#: src/modules/filesystem.md:27
-msgid "/// Sow the given seed packets.\n"
-msgstr ""
-
-#: src/modules/filesystem.md:30
-msgid "/// Harvest the produce in the garden that is ready.\n"
+"\n"
+"// Re-export types from this module.\n"
+"pub use seeds::SeedPacket;\n"
+"pub use garden::Garden;\n"
+"\n"
+"/// Sow the given seed packets.\n"
+"pub fn sow(seeds: Vec<SeedPacket>) { todo!() }\n"
+"\n"
+"/// Harvest the produce in the garden that is ready.\n"
+"pub fn harvest(garden: &mut Garden) { todo!() }\n"
+"```"
 msgstr ""
 
 #: src/modules/filesystem.md:37
@@ -7312,8 +7670,12 @@ msgid ""
 "directive:"
 msgstr ""
 
-#: src/modules/filesystem.md:55
-msgid "\"some/path.rs\""
+#: src/modules/filesystem.md:54
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module;\n"
+"```"
 msgstr ""
 
 #: src/modules/filesystem.md:59
@@ -7353,29 +7715,36 @@ msgstr ""
 msgid "You use this trait like this:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:27
-msgid "\"v[0]: {:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:28
-msgid "\"v[1]: {:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:29
-msgid "\"v[2]: {:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:30
-msgid "\"No more items: {:?}\""
+#: src/exercises/day-2/iterators-and-ownership.md:22
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();\n"
+"\n"
+"    println!(\"v[0]: {:?}\", iter.next());\n"
+"    println!(\"v[1]: {:?}\", iter.next());\n"
+"    println!(\"v[2]: {:?}\", iter.next());\n"
+"    println!(\"No more items: {:?}\", iter.next());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:34
 msgid "What is the type returned by the iterator? Test your answer here:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:42
-#: src/exercises/day-2/iterators-and-ownership.md:79
-msgid "\"v0: {v0:?}\""
+#: src/exercises/day-2/iterators-and-ownership.md:36
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();\n"
+"\n"
+"    let v0: Option<..> = iter.next();\n"
+"    println!(\"v0: {v0:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:46
@@ -7417,10 +7786,18 @@ msgstr ""
 msgid "Like before, what  is the type returned by the iterator?"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:75
-#: src/exercises/day-2/iterators-and-ownership.md:91
-#: src/testing/test-modules.md:21
-msgid "\"bar\""
+#: src/exercises/day-2/iterators-and-ownership.md:73
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"    let mut iter = v.into_iter();\n"
+"\n"
+"    let v0: Option<..> = iter.next();\n"
+"    println!(\"v0: {v0:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:83
@@ -7434,9 +7811,22 @@ msgid ""
 "resulting iterator:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:94
-#: src/exercises/day-2/iterators-and-ownership.md:98
-msgid "\"word: {word}\""
+#: src/exercises/day-2/iterators-and-ownership.md:89
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"\n"
+"    for word in &v {\n"
+"        println!(\"word: {word}\");\n"
+"    }\n"
+"\n"
+"    for word in v {\n"
+"        println!(\"word: {word}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:103
@@ -7466,79 +7856,53 @@ msgid ""
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:22
-#: src/exercises/day-2/strings-iterators.md:23
-#: src/exercises/day-2/strings-iterators.md:24
-#: src/exercises/day-2/strings-iterators.md:26
-#: src/exercises/day-2/strings-iterators.md:27
-#: src/exercises/day-2/strings-iterators.md:28
-#: src/exercises/day-2/strings-iterators.md:46
-#: src/exercises/day-2/solutions-afternoon.md:32
-#: src/exercises/day-2/solutions-afternoon.md:33
-#: src/exercises/day-2/solutions-afternoon.md:34
-#: src/exercises/day-2/solutions-afternoon.md:36
-#: src/exercises/day-2/solutions-afternoon.md:37
-#: src/exercises/day-2/solutions-afternoon.md:38
-#: src/exercises/day-2/solutions-afternoon.md:56
-msgid "\"/v1/publishers\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:23
-#: src/exercises/day-2/solutions-afternoon.md:33
-msgid "\"/v1/publishers/abc-123\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:24
-#: src/exercises/day-2/solutions-afternoon.md:34
-msgid "\"/v1/publishers/abc/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:26
-#: src/exercises/day-2/solutions-afternoon.md:36
-msgid "\"/v1\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:27
-#: src/exercises/day-2/solutions-afternoon.md:37
-msgid "\"/v1/publishersBooks\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:28
-#: src/exercises/day-2/solutions-afternoon.md:38
-msgid "\"/v1/parent/publishers\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:34
-#: src/exercises/day-2/strings-iterators.md:38
-#: src/exercises/day-2/strings-iterators.md:42
-#: src/exercises/day-2/strings-iterators.md:46
-#: src/exercises/day-2/strings-iterators.md:48
-#: src/exercises/day-2/solutions-afternoon.md:44
-#: src/exercises/day-2/solutions-afternoon.md:48
-#: src/exercises/day-2/solutions-afternoon.md:52
-#: src/exercises/day-2/solutions-afternoon.md:56
-#: src/exercises/day-2/solutions-afternoon.md:58
-msgid "\"/v1/publishers/*/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:35
-#: src/exercises/day-2/solutions-afternoon.md:45
-msgid "\"/v1/publishers/foo/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:39
-#: src/exercises/day-2/solutions-afternoon.md:49
-msgid "\"/v1/publishers/bar/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:43
-#: src/exercises/day-2/solutions-afternoon.md:53
-msgid "\"/v1/publishers/foo/books/book1\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:49
-#: src/exercises/day-2/solutions-afternoon.md:59
-msgid "\"/v1/publishers/foo/booksByAuthor\""
+#: src/exercises/day-2/strings-iterators.md:12
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/welcome-day-3.md:1
@@ -7589,8 +7953,21 @@ msgid "You can use generics to abstract over the concrete field type:"
 msgstr ""
 "ジェネリクスを使って、具体的なフィールドの型を抽象化することができます："
 
-#: src/generics/data-types.md:15
-msgid "\"{integer:?} and {float:?}\""
+#: src/generics/data-types.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T> {\n"
+"    x: T,\n"
+"    y: T,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let integer = Point { x: 5, y: 10 };\n"
+"    let float = Point { x: 1.0, y: 4.0 };\n"
+"    println!(\"{integer:?} and {float:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/data-types.md:21
@@ -7607,16 +7984,25 @@ msgstr "異なる型の要素を持つ点を許容するように、コードを
 msgid "You can declare a generic type on your `impl` block:"
 msgstr "`impl`に対して、ジェネリックな型を宣言することもできます："
 
-#: src/generics/methods.md:11
-msgid "// + 10\n"
-msgstr ""
-
-#: src/generics/methods.md:14
-msgid "// fn set_x(&mut self, x: T)\n"
-msgstr ""
-
-#: src/generics/methods.md:19
-msgid "\"p.x = {}\""
+#: src/generics/methods.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T>(T, T);\n"
+"\n"
+"impl<T> Point<T> {\n"
+"    fn x(&self) -> &T {\n"
+"        &self.0  // + 10\n"
+"    }\n"
+"\n"
+"    // fn set_x(&mut self, x: T)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p = Point(5, 10);\n"
+"    println!(\"p.x = {}\", p.x());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/methods.md:25
@@ -7676,24 +8062,37 @@ msgid ""
 "Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
-#: src/traits.md:7 src/traits/trait-objects.md:7
-msgid "// No name needed, cats won't respond anyway.\n"
-msgstr ""
-
-#: src/traits.md:14 src/traits/trait-objects.md:14
-msgid "\"Woof, my name is {}!\""
-msgstr ""
-
-#: src/traits.md:18 src/traits/trait-objects.md:18
-msgid "\"Miau!\""
-msgstr ""
-
-#: src/traits.md:22
-msgid "\"Oh you're a cutie! What's your name? {}\""
-msgstr ""
-
-#: src/traits.md:27 src/traits/trait-objects.md:24
-msgid "\"Fido\""
+#: src/traits.md:5
+msgid ""
+"```rust,editable\n"
+"struct Dog { name: String, age: i8 }\n"
+"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
+"\n"
+"trait Pet {\n"
+"    fn talk(&self) -> String;\n"
+"}\n"
+"\n"
+"impl Pet for Dog {\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
+"name) }\n"
+"}\n"
+"\n"
+"impl Pet for Cat {\n"
+"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
+"}\n"
+"\n"
+"fn greet<P: Pet>(pet: &P) {\n"
+"    println!(\"Oh you're a cutie! What's your name? {}\", pet.talk());\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let captain_floof = Cat { lives: 9 };\n"
+"    let fido = Dog { name: String::from(\"Fido\"), age: 5 };\n"
+"\n"
+"    greet(&captain_floof);\n"
+"    greet(&fido);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/trait-objects.md:3
@@ -7702,8 +8101,35 @@ msgid ""
 "collection:"
 msgstr ""
 
-#: src/traits/trait-objects.md:27
-msgid "\"Hello, who are you? {}\""
+#: src/traits/trait-objects.md:5
+msgid ""
+"```rust,editable\n"
+"struct Dog { name: String, age: i8 }\n"
+"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
+"\n"
+"trait Pet {\n"
+"    fn talk(&self) -> String;\n"
+"}\n"
+"\n"
+"impl Pet for Dog {\n"
+"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
+"name) }\n"
+"}\n"
+"\n"
+"impl Pet for Cat {\n"
+"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let pets: Vec<Box<dyn Pet>> = vec![\n"
+"        Box::new(Cat { lives: 9 }),\n"
+"        Box::new(Dog { name: String::from(\"Fido\"), age: 5 }),\n"
+"    ];\n"
+"    for pet in pets {\n"
+"        println!(\"Hello, who are you? {}\", pet.talk());\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/trait-objects.md:32
@@ -7807,17 +8233,16 @@ msgstr ""
 msgid "Compare these outputs in the above example:"
 msgstr ""
 
-#: src/traits/trait-objects.md:81 src/traits/trait-objects.md:82
-#: src/traits/closures.md:54
-msgid "\"{} {}\""
-msgstr ""
-
-#: src/traits/trait-objects.md:83 src/traits/trait-objects.md:84
-#: src/testing/test-modules.md:12 src/android/build-rules/library.md:43
-#: src/android/interoperability/cpp/rust-bridge.md:17
-#: src/async/pitfalls/cancellation.md:59
-#: src/exercises/day-3/solutions-morning.md:128
-msgid "\"{}\""
+#: src/traits/trait-objects.md:80
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
 msgstr ""
 
 #: src/traits/deriving-traits.md:3
@@ -7830,30 +8255,55 @@ msgstr ""
 msgid "You can let the compiler derive a number of traits as follows:"
 msgstr ""
 
-#: src/traits/deriving-traits.md:18
-msgid "\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\""
-msgstr ""
-
-#: src/traits/deriving-traits.md:19
-#: src/exercises/day-1/solutions-afternoon.md:43
-msgid "\"yes\""
-msgstr ""
-
-#: src/traits/deriving-traits.md:19
-#: src/exercises/day-1/solutions-afternoon.md:43
-msgid "\"no\""
+#: src/traits/deriving-traits.md:7
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Clone, PartialEq, Eq, Default)]\n"
+"struct Player {\n"
+"    name: String,\n"
+"    strength: u8,\n"
+"    hit_points: u8,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Player::default();\n"
+"    let p2 = p1.clone();\n"
+"    println!(\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2,\n"
+"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/default-methods.md:3
 msgid "Traits can implement behavior in terms of other trait methods:"
 msgstr ""
 
-#: src/traits/default-methods.md:25
-msgid "\"{a:?} equals {b:?}: {}\""
-msgstr ""
-
-#: src/traits/default-methods.md:26
-msgid "\"{a:?} not_equals {b:?}: {}\""
+#: src/traits/default-methods.md:5
+msgid ""
+"```rust,editable\n"
+"trait Equals {\n"
+"    fn equals(&self, other: &Self) -> bool;\n"
+"    fn not_equals(&self, other: &Self) -> bool {\n"
+"        !self.equals(other)\n"
+"    }\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct Centimeter(i16);\n"
+"\n"
+"impl Equals for Centimeter {\n"
+"    fn equals(&self, other: &Centimeter) -> bool {\n"
+"        self.0 == other.0\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let a = Centimeter(10);\n"
+"    let b = Centimeter(20);\n"
+"    println!(\"{a:?} equals {b:?}: {}\", a.equals(&b));\n"
+"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equals(&b));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/default-methods.md:32
@@ -7891,26 +8341,32 @@ msgstr ""
 msgid "You can do this with `T: Trait` or `impl Trait`:"
 msgstr ""
 
-#: src/traits/trait-bounds.md:12
+#: src/traits/trait-bounds.md:8
 msgid ""
+"```rust,editable\n"
+"fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
+"    (a.clone(), a.clone())\n"
+"}\n"
+"\n"
 "// Syntactic sugar for:\n"
 "//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
-msgstr ""
-
-#: src/traits/trait-bounds.md:18
-msgid "// struct NotClonable;\n"
-msgstr ""
-
-#: src/traits/trait-bounds.md:24
-msgid "\"{pair:?}\""
-msgstr ""
-
-#: src/traits/trait-bounds.md:27
-msgid "\"{many}\""
-msgstr ""
-
-#: src/traits/trait-bounds.md:29
-msgid "\"{many_more}\""
+"fn add_42_millions(x: impl Into<i32>) -> i32 {\n"
+"    x.into() + 42_000_000\n"
+"}\n"
+"\n"
+"// struct NotClonable;\n"
+"\n"
+"fn main() {\n"
+"    let foo = String::from(\"foo\");\n"
+"    let pair = duplicate(foo);\n"
+"    println!(\"{pair:?}\");\n"
+"\n"
+"    let many = add_42_millions(42_i8);\n"
+"    println!(\"{many}\");\n"
+"    let many_more = add_42_millions(10_000_000);\n"
+"    println!(\"{many_more}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/trait-bounds.md:35
@@ -7939,6 +8395,22 @@ msgstr ""
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
+msgstr ""
+
+#: src/traits/impl-trait.md:6
+msgid ""
+"```rust,editable\n"
+"use std::fmt::Display;\n"
+"\n"
+"fn get_x(name: impl Display) -> impl Display {\n"
+"    format!(\"Hello {name}\")\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let x = get_x(\"foo\");\n"
+"    println!(\"{x}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/impl-trait.md:19
@@ -8039,8 +8511,32 @@ msgid ""
 "Iterator.html) trait on your own types:"
 msgstr ""
 
-#: src/traits/iterator.md:25
-msgid "\"fib({i}): {n}\""
+#: src/traits/iterator.md:5
+msgid ""
+"```rust,editable\n"
+"struct Fibonacci {\n"
+"    curr: u32,\n"
+"    next: u32,\n"
+"}\n"
+"\n"
+"impl Iterator for Fibonacci {\n"
+"    type Item = u32;\n"
+"\n"
+"    fn next(&mut self) -> Option<Self::Item> {\n"
+"        let new_next = self.curr + self.next;\n"
+"        self.curr = self.next;\n"
+"        self.next = new_next;\n"
+"        Some(self.curr)\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let fib = Fibonacci { curr: 0, next: 1 };\n"
+"    for (i, n) in fib.enumerate().take(5) {\n"
+"        println!(\"fib({i}): {n}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/iterator.md:32
@@ -8067,8 +8563,18 @@ msgid ""
 "std/iter/trait.Iterator.html)."
 msgstr ""
 
-#: src/traits/from-iterator.md:12
-msgid "\"prime_squares: {prime_squares:?}\""
+#: src/traits/from-iterator.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let primes = vec![2, 3, 5, 7];\n"
+"    let prime_squares = primes\n"
+"        .into_iter()\n"
+"        .map(|prime| prime * prime)\n"
+"        .collect::<Vec<_>>();\n"
+"    println!(\"prime_squares: {prime_squares:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/from-iterator.md:18
@@ -8094,8 +8600,17 @@ msgid ""
 "facilitate type conversions:"
 msgstr ""
 
-#: src/traits/from-into.md:11 src/traits/from-into.md:23
-msgid "\"{s}, {addr}, {one}, {bigger}\""
+#: src/traits/from-into.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s = String::from(\"hello\");\n"
+"    let addr = std::net::Ipv4Addr::from([127, 0, 0, 1]);\n"
+"    let one = i16::from(true);\n"
+"    let bigger = i32::from(123i16);\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/from-into.md:15
@@ -8103,6 +8618,19 @@ msgid ""
 "[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
 "automatically implemented when [`From`](https://doc.rust-lang.org/std/"
 "convert/trait.From.html) is implemented:"
+msgstr ""
+
+#: src/traits/from-into.md:17
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s: String = \"hello\".into();\n"
+"    let addr: std::net::Ipv4Addr = [127, 0, 0, 1].into();\n"
+"    let one: i16 = true.into();\n"
+"    let bigger: i32 = 123i16.into();\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/from-into.md:29
@@ -8130,16 +8658,25 @@ msgid ""
 "abstract over `u8` sources:"
 msgstr ""
 
-#: src/traits/read-write.md:14
-msgid "b\"foo\\nbar\\nbaz\\n\""
-msgstr ""
-
-#: src/traits/read-write.md:15
-msgid "\"lines in slice: {}\""
-msgstr ""
-
-#: src/traits/read-write.md:18
-msgid "\"lines in file: {}\""
+#: src/traits/read-write.md:5
+msgid ""
+"```rust,editable\n"
+"use std::io::{BufRead, BufReader, Read, Result};\n"
+"\n"
+"fn count_lines<R: Read>(reader: R) -> usize {\n"
+"    let buf_reader = BufReader::new(reader);\n"
+"    buf_reader.lines().count()\n"
+"}\n"
+"\n"
+"fn main() -> Result<()> {\n"
+"    let slice: &[u8] = b\"foo\\nbar\\nbaz\\n\";\n"
+"    println!(\"lines in slice: {}\", count_lines(slice));\n"
+"\n"
+"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
+"    println!(\"lines in file: {}\", count_lines(file));\n"
+"    Ok(())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/read-write.md:23
@@ -8148,12 +8685,24 @@ msgid ""
 "you abstract over `u8` sinks:"
 msgstr ""
 
-#: src/traits/read-write.md:30
-msgid "\"\\n\""
-msgstr ""
-
-#: src/traits/read-write.md:37
-msgid "\"Logged: {:?}\""
+#: src/traits/read-write.md:25
+msgid ""
+"```rust,editable\n"
+"use std::io::{Result, Write};\n"
+"\n"
+"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
+"    writer.write_all(msg.as_bytes())?;\n"
+"    writer.write_all(\"\\n\".as_bytes())\n"
+"}\n"
+"\n"
+"fn main() -> Result<()> {\n"
+"    let mut buffer = Vec::new();\n"
+"    log(&mut buffer, \"Hello\")?;\n"
+"    log(&mut buffer, \"World\")?;\n"
+"    println!(\"Logged: {:?}\", buffer);\n"
+"    Ok(())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/drop.md:1
@@ -8166,38 +8715,34 @@ msgid ""
 "html) can specify code to run when they go out of scope:"
 msgstr ""
 
-#: src/traits/drop.md:12
-msgid "\"Dropping {}\""
-msgstr ""
-
-#: src/traits/drop.md:17 src/exercises/concurrency/link-checker.md:92
-#: src/exercises/day-1/solutions-morning.md:86
-#: src/exercises/concurrency/solutions-morning.md:123
-msgid "\"a\""
-msgstr ""
-
-#: src/traits/drop.md:19 src/exercises/day-1/solutions-morning.md:86
-msgid "\"b\""
-msgstr ""
-
-#: src/traits/drop.md:21 src/exercises/day-1/solutions-morning.md:86
-msgid "\"c\""
-msgstr ""
-
-#: src/traits/drop.md:22 src/exercises/day-1/solutions-morning.md:86
-msgid "\"d\""
-msgstr ""
-
-#: src/traits/drop.md:23
-msgid "\"Exiting block B\""
-msgstr ""
-
-#: src/traits/drop.md:25
-msgid "\"Exiting block A\""
-msgstr ""
-
-#: src/traits/drop.md:28
-msgid "\"Exiting main\""
+#: src/traits/drop.md:5
+msgid ""
+"```rust,editable\n"
+"struct Droppable {\n"
+"    name: &'static str,\n"
+"}\n"
+"\n"
+"impl Drop for Droppable {\n"
+"    fn drop(&mut self) {\n"
+"        println!(\"Dropping {}\", self.name);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let a = Droppable { name: \"a\" };\n"
+"    {\n"
+"        let b = Droppable { name: \"b\" };\n"
+"        {\n"
+"            let c = Droppable { name: \"c\" };\n"
+"            let d = Droppable { name: \"d\" };\n"
+"            println!(\"Exiting block B\");\n"
+"        }\n"
+"        println!(\"Exiting block A\");\n"
+"    }\n"
+"    drop(a);\n"
+"    println!(\"Exiting main\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/drop.md:34
@@ -8261,24 +8806,40 @@ msgid ""
 "produces a default value for a type."
 msgstr ""
 
-#: src/traits/default.md:18
-msgid "\"John Smith\""
-msgstr ""
-
-#: src/traits/default.md:24
-msgid "\"{default_struct:#?}\""
-msgstr ""
-
-#: src/traits/default.md:27
-msgid "\"Y is set!\""
-msgstr ""
-
-#: src/traits/default.md:30
-msgid "\"{almost_default_struct:#?}\""
-msgstr ""
-
-#: src/traits/default.md:33
-msgid "\"{:#?}\""
+#: src/traits/default.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Default)]\n"
+"struct Derived {\n"
+"    x: u32,\n"
+"    y: String,\n"
+"    z: Implemented,\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct Implemented(String);\n"
+"\n"
+"impl Default for Implemented {\n"
+"    fn default() -> Self {\n"
+"        Self(\"John Smith\".into())\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let default_struct = Derived::default();\n"
+"    println!(\"{default_struct:#?}\");\n"
+"\n"
+"    let almost_default_struct = Derived {\n"
+"        y: \"Y is set!\".into(),\n"
+"        ..Derived::default()\n"
+"    };\n"
+"    println!(\"{almost_default_struct:#?}\");\n"
+"\n"
+"    let nothing: Option<Derived> = None;\n"
+"    println!(\"{:#?}\", nothing.unwrap_or_default());\n"
+"}\n"
+"\n"
+"```"
 msgstr ""
 
 #: src/traits/default.md:40
@@ -8329,8 +8890,26 @@ msgid ""
 "rust-lang.org/std/ops/index.html):"
 msgstr ""
 
-#: src/traits/operators.md:20
-msgid "\"{:?} + {:?} = {:?}\""
+#: src/traits/operators.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Copy, Clone)]\n"
+"struct Point { x: i32, y: i32 }\n"
+"\n"
+"impl std::ops::Add for Point {\n"
+"    type Output = Self;\n"
+"\n"
+"    fn add(self, other: Self) -> Self {\n"
+"        Self {x: self.x + other.x, y: self.y + other.y}\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point { x: 10, y: 20 };\n"
+"    let p2 = Point { x: 100, y: 200 };\n"
+"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/operators.md:28
@@ -8376,20 +8955,31 @@ msgid ""
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
-#: src/traits/closures.md:10
-msgid "\"Calling function on {input}\""
-msgstr ""
-
-#: src/traits/closures.md:16 src/traits/closures.md:17
-msgid "\"add_3: {}\""
-msgstr ""
-
-#: src/traits/closures.md:24 src/traits/closures.md:25
-msgid "\"accumulate: {}\""
-msgstr ""
-
-#: src/traits/closures.md:28
-msgid "\"multiply_sum: {}\""
+#: src/traits/closures.md:8
+msgid ""
+"```rust,editable\n"
+"fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
+"    println!(\"Calling function on {input}\");\n"
+"    func(input)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let add_3 = |x| x + 3;\n"
+"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
+"    println!(\"add_3: {}\", apply_with_log(add_3, 20));\n"
+"\n"
+"    let mut v = Vec::new();\n"
+"    let mut accumulate = |x: i32| {\n"
+"        v.push(x);\n"
+"        v.iter().sum::<i32>()\n"
+"    };\n"
+"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 4));\n"
+"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 5));\n"
+"\n"
+"    let multiply_sum = |x| x * v.into_iter().sum::<i32>();\n"
+"    println!(\"multiply_sum: {}\", apply_with_log(multiply_sum, 3));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/closures.md:34
@@ -8430,12 +9020,18 @@ msgid ""
 "keyword makes them capture by value."
 msgstr ""
 
-#: src/traits/closures.md:58
-msgid "\"Hi\""
-msgstr ""
-
-#: src/traits/closures.md:59
-msgid "\"there\""
+#: src/traits/closures.md:52
+msgid ""
+"```rust,editable\n"
+"fn make_greeter(prefix: String) -> impl Fn(&str) {\n"
+"    return move |name| println!(\"{} {}\", prefix, name)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let hi = make_greeter(\"Hi\".to_string());\n"
+"    hi(\"there\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
@@ -8494,39 +9090,117 @@ msgid ""
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:24
-#: src/exercises/day-3/solutions-morning.md:9
-msgid "/// Natural width of `self`.\n"
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:27
-#: src/exercises/day-3/solutions-morning.md:12
-msgid "/// Draw the widget into a buffer.\n"
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:30
-#: src/exercises/day-3/solutions-morning.md:15
-msgid "/// Draw the widget on standard output.\n"
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:34
-#: src/exercises/day-3/solutions-morning.md:19
-msgid "\"{buffer}\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:119
-#: src/exercises/day-3/solutions-morning.md:133
-msgid "\"Rust GUI Demo 1.23\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:120
-#: src/exercises/day-3/solutions-morning.md:134
-msgid "\"This is a small text GUI demo.\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:122
-#: src/exercises/day-3/solutions-morning.md:136
-msgid "\"Click me!\""
+#: src/exercises/day-3/simple-gui.md:19
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_imports, unused_variables, dead_code)]\n"
+"\n"
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;\n"
+"\n"
+"    /// Draw the widget into a buffer.\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
+"\n"
+"    /// Draw the widget on standard output.\n"
+"    fn draw(&self) {\n"
+"        let mut buffer = String::new();\n"
+"        self.draw_into(&mut buffer);\n"
+"        println!(\"{buffer}\");\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Label {\n"
+"    label: String,\n"
+"}\n"
+"\n"
+"impl Label {\n"
+"    fn new(label: &str) -> Label {\n"
+"        Label {\n"
+"            label: label.to_owned(),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Button {\n"
+"    label: Label,\n"
+"}\n"
+"\n"
+"impl Button {\n"
+"    fn new(label: &str) -> Button {\n"
+"        Button {\n"
+"            label: Label::new(label),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Window {\n"
+"    title: String,\n"
+"    widgets: Vec<Box<dyn Widget>>,\n"
+"}\n"
+"\n"
+"impl Window {\n"
+"    fn new(title: &str) -> Window {\n"
+"        Window {\n"
+"            title: title.to_owned(),\n"
+"            widgets: Vec::new(),\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"        self.widgets.push(widget);\n"
+"    }\n"
+"\n"
+"    fn inner_width(&self) -> usize {\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }\n"
+"}\n"
+"\n"
+"\n"
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\"\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:128
@@ -8541,16 +9215,16 @@ msgid ""
 "and how you can control alignment:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:148
-msgid "\"left aligned:  |{:/<width$}|\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:149
-msgid "\"centered:      |{:/^width$}|\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:150
-msgid "\"right aligned: |{:/>width$}|\""
+#: src/exercises/day-3/simple-gui.md:145
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let width = 10;\n"
+"    println!(\"left aligned:  |{:/<width$}|\", \"foo\");\n"
+"    println!(\"centered:      |{:/^width$}|\", \"foo\");\n"
+"    println!(\"right aligned: |{:/>width$}|\", \"foo\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:154
@@ -8569,16 +9243,115 @@ msgid ""
 "make the tests pass:"
 msgstr ""
 
-#: src/exercises/day-3/points-polygons.md:12
-#: src/exercises/day-3/points-polygons.md:20
-#: src/exercises/day-3/points-polygons.md:28
-msgid "// add fields\n"
-msgstr ""
-
-#: src/exercises/day-3/points-polygons.md:16
-#: src/exercises/day-3/points-polygons.md:24
-#: src/exercises/day-3/points-polygons.md:32
-msgid "// add methods\n"
+#: src/exercises/day-3/points-polygons.md:7
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"pub struct Point {\n"
+"    // add fields\n"
+"}\n"
+"\n"
+"impl Point {\n"
+"    // add methods\n"
+"}\n"
+"\n"
+"pub struct Polygon {\n"
+"    // add fields\n"
+"}\n"
+"\n"
+"impl Polygon {\n"
+"    // add methods\n"
+"}\n"
+"\n"
+"pub struct Circle {\n"
+"    // add fields\n"
+"}\n"
+"\n"
+"impl Circle {\n"
+"    // add methods\n"
+"}\n"
+"\n"
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"\n"
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100.0).round() / 100.0\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_magnitude() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_dist() {\n"
+"        let p1 = Point::new(10, 10);\n"
+"        let p2 = Point::new(14, 13);\n"
+"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_add() {\n"
+"        let p1 = Point::new(16, 16);\n"
+"        let p2 = p1 + Point::new(-4, 3);\n"
+"        assert_eq!(p2, Point::new(12, 19));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_left_most_point() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"        assert_eq!(poly.left_most_point(), Some(p1));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_iter() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"\n"
+"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}\n"
+"\n"
+"#[allow(dead_code)]\n"
+"fn main() {}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/points-polygons.md:117
@@ -8620,8 +9393,14 @@ msgstr ""
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
 msgstr ""
 
-#: src/error-handling/panics.md:8
-msgid "\"v[100]: {}\""
+#: src/error-handling/panics.md:5
+msgid ""
+"```rust,editable,should_panic\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    println!(\"v[100]: {}\", v[100]);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/error-handling/panics.md:12
@@ -8647,16 +9426,23 @@ msgid ""
 "caught:"
 msgstr ""
 
-#: src/error-handling/panic-unwind.md:10
-msgid "\"No problem here!\""
-msgstr ""
-
-#: src/error-handling/panic-unwind.md:12 src/error-handling/panic-unwind.md:17
-msgid "\"{result:?}\""
-msgstr ""
-
-#: src/error-handling/panic-unwind.md:15
-msgid "\"oh no!\""
+#: src/error-handling/panic-unwind.md:5
+msgid ""
+"```rust,editable\n"
+"use std::panic;\n"
+"\n"
+"fn main() {\n"
+"    let result = panic::catch_unwind(|| {\n"
+"        \"No problem here!\"\n"
+"    });\n"
+"    println!(\"{result:?}\");\n"
+"\n"
+"    let result = panic::catch_unwind(|| {\n"
+"        panic!(\"oh no!\");\n"
+"    });\n"
+"    println!(\"{result:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:21
@@ -8679,16 +9465,26 @@ msgid ""
 "are expected as part of normal operation:"
 msgstr ""
 
-#: src/error-handling/result.md:11
-msgid "\"diary.txt\""
-msgstr ""
-
-#: src/error-handling/result.md:16
-msgid "\"Dear diary: {contents}\""
-msgstr ""
-
-#: src/error-handling/result.md:19
-msgid "\"The diary could not be opened: {err}\""
+#: src/error-handling/result.md:6
+msgid ""
+"```rust,editable\n"
+"use std::fs;\n"
+"use std::io::Read;\n"
+"\n"
+"fn main() {\n"
+"    let file = fs::File::open(\"diary.txt\");\n"
+"    match file {\n"
+"        Ok(mut file) => {\n"
+"            let mut contents = String::new();\n"
+"            file.read_to_string(&mut contents);\n"
+"            println!(\"Dear diary: {contents}\");\n"
+"        },\n"
+"        Err(err) => {\n"
+"            println!(\"The diary could not be opened: {err}\");\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/error-handling/result.md:27
@@ -8724,21 +9520,32 @@ msgstr ""
 msgid "We can use this to simplify our error handling code:"
 msgstr ""
 
-#: src/error-handling/try-operator.md:40
-msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
-msgstr ""
-
-#: src/error-handling/try-operator.md:41
-#: src/error-handling/converting-error-types-example.md:43
-#: src/error-handling/deriving-error-enums.md:30
-#: src/error-handling/dynamic-errors.md:27
-#: src/error-handling/error-contexts.md:26
-msgid "\"config.dat\""
-msgstr ""
-
-#: src/error-handling/try-operator.md:42
-#: src/error-handling/converting-error-types-example.md:44
-msgid "\"username or error: {username:?}\""
+#: src/error-handling/try-operator.md:21
+msgid ""
+"```rust,editable\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, io::Error> {\n"
+"    let username_file_result = fs::File::open(path);\n"
+"    let mut username_file = match username_file_result {\n"
+"        Ok(file) => file,\n"
+"        Err(err) => return Err(err),\n"
+"    };\n"
+"\n"
+"    let mut username = String::new();\n"
+"    match username_file.read_to_string(&mut username) {\n"
+"        Ok(_) => Ok(username),\n"
+"        Err(err) => Err(err),\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/error-handling/try-operator.md:50
@@ -8784,22 +9591,56 @@ msgstr ""
 #: src/error-handling/converting-error-types.md:18
 msgid ""
 "The `From::from` call here means we attempt to convert the error type to the "
-"type returned by the function."
+"type returned by the function:"
 msgstr ""
 
-#: src/error-handling/converting-error-types-example.md:20
-msgid "\"IO error: {e}\""
-msgstr ""
-
-#: src/error-handling/converting-error-types-example.md:21
-msgid "\"Found no username in {filename}\""
-msgstr ""
-
-#: src/error-handling/converting-error-types-example.md:42
-#: src/error-handling/deriving-error-enums.md:29
-#: src/error-handling/dynamic-errors.md:26
-#: src/error-handling/error-contexts.md:25
-msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
+#: src/error-handling/converting-error-types-example.md:3
+msgid ""
+"```rust,editable\n"
+"use std::error::Error;\n"
+"use std::fmt::{self, Display, Formatter};\n"
+"use std::fs::{self, File};\n"
+"use std::io::{self, Read};\n"
+"\n"
+"#[derive(Debug)]\n"
+"enum ReadUsernameError {\n"
+"    IoError(io::Error),\n"
+"    EmptyUsername(String),\n"
+"}\n"
+"\n"
+"impl Error for ReadUsernameError {}\n"
+"\n"
+"impl Display for ReadUsernameError {\n"
+"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
+"        match self {\n"
+"            Self::IoError(e) => write!(f, \"IO error: {e}\"),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
+"in {filename}\"),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"impl From<io::Error> for ReadUsernameError {\n"
+"    fn from(err: io::Error) -> ReadUsernameError {\n"
+"        ReadUsernameError::IoError(err)\n"
+"    }\n"
+"}\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:55
@@ -8823,24 +9664,38 @@ msgid ""
 "an error enum like we did on the previous page:"
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:13
-msgid "\"Could not read: {0}\""
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:15
-#: src/error-handling/dynamic-errors.md:13
-msgid "\"Found no username in {0}\""
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:31
-#: src/error-handling/dynamic-errors.md:28
-#: src/error-handling/error-contexts.md:27
-msgid "\"Username: {username}\""
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:32
-#: src/error-handling/dynamic-errors.md:29
-msgid "\"Error: {err}\""
+#: src/error-handling/deriving-error-enums.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use thiserror::Error;\n"
+"\n"
+"#[derive(Debug, Error)]\n"
+"enum ReadUsernameError {\n"
+"    #[error(\"Could not read: {0}\")]\n"
+"    IoError(#[from] io::Error),\n"
+"    #[error(\"Found no username in {0}\")]\n"
+"    EmptyUsername(String),\n"
+"}\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
+"    let mut username = String::new();\n"
+"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err}\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:39
@@ -8861,6 +9716,37 @@ msgid ""
 "makes this easy."
 msgstr ""
 
+#: src/error-handling/dynamic-errors.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::fs;\n"
+"use std::io::Read;\n"
+"use thiserror::Error;\n"
+"use std::error::Error;\n"
+"\n"
+"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
+"#[error(\"Found no username in {0}\")]\n"
+"struct EmptyUsernameError(String);\n"
+"\n"
+"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
+"    let mut username = String::new();\n"
+"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(EmptyUsernameError(String::from(path)).into());\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
@@ -8877,20 +9763,33 @@ msgid ""
 "error types:"
 msgstr ""
 
-#: src/error-handling/error-contexts.md:15
-msgid "\"Failed to open {path}\""
-msgstr ""
-
-#: src/error-handling/error-contexts.md:17
-msgid "\"Failed to read\""
-msgstr ""
-
-#: src/error-handling/error-contexts.md:19
-msgid "\"Found no username in {path}\""
-msgstr ""
-
-#: src/error-handling/error-contexts.md:28
-msgid "\"Error: {err:?}\""
+#: src/error-handling/error-contexts.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use anyhow::{Context, Result, bail};\n"
+"\n"
+"fn read_username(path: &str) -> Result<String> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::File::open(path)\n"
+"        .with_context(|| format!(\"Failed to open {path}\"))?\n"
+"        .read_to_string(&mut username)\n"
+"        .context(\"Failed to read\")?;\n"
+"    if username.is_empty() {\n"
+"        bail!(\"Found no username in {path}\");\n"
+"    }\n"
+"    Ok(username)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err:?}\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
@@ -8932,8 +9831,31 @@ msgstr ""
 msgid "Mark unit tests with `#[test]`:"
 msgstr ""
 
-#: src/testing/unit-tests.md:25
-msgid "\"Hello World\""
+#: src/testing/unit-tests.md:5
+msgid ""
+"```rust,editable,ignore\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_multiple_words() {\n"
+"    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/testing/unit-tests.md:29
@@ -8946,12 +9868,27 @@ msgid ""
 "(https://play.rust-lang.org/)):"
 msgstr ""
 
-#: src/testing/test-modules.md:8
-msgid "\"{a} {b}\""
-msgstr ""
-
-#: src/testing/test-modules.md:21
-msgid "\"foo bar\""
+#: src/testing/test-modules.md:6
+msgid ""
+"```rust,editable\n"
+"fn helper(a: &str, b: &str) -> String {\n"
+"    format!(\"{a} {b}\")\n"
+"}\n"
+"\n"
+"pub fn main() {\n"
+"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"\n"
+"    #[test]\n"
+"    fn test_helper() {\n"
+"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/testing/test-modules.md:26
@@ -8966,8 +9903,9 @@ msgstr ""
 msgid "Rust has built-in support for documentation tests:"
 msgstr ""
 
-#: src/testing/doc-tests.md:6
+#: src/testing/doc-tests.md:5
 msgid ""
+"```rust\n"
 "/// Shortens a string to the given length.\n"
 "///\n"
 "/// ```\n"
@@ -8975,6 +9913,10 @@ msgid ""
 "/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
 "/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
 "/// ```\n"
+"pub fn shorten_string(s: &str, length: usize) -> &str {\n"
+"    &s[..std::cmp::min(length, s.len())]\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/testing/doc-tests.md:18
@@ -9106,22 +10048,28 @@ msgstr ""
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:12
+#: src/unsafe/raw-pointers.md:5
 msgid ""
-"// Safe because r1 and r2 were obtained from references and so are\n"
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut num = 5;\n"
+"\n"
+"    let r1 = &mut num as *mut i32;\n"
+"    let r2 = r1 as *const i32;\n"
+"\n"
+"    // Safe because r1 and r2 were obtained from references and so are\n"
 "    // guaranteed to be non-null and properly aligned, the objects "
 "underlying\n"
 "    // the references from which they were obtained are live throughout the\n"
 "    // whole unsafe block, and they are not accessed either through the\n"
 "    // references or concurrently through any other pointers.\n"
-msgstr ""
-
-#: src/unsafe/raw-pointers.md:18
-msgid "\"r1 is: {}\""
-msgstr ""
-
-#: src/unsafe/raw-pointers.md:20
-msgid "\"r2 is: {}\""
+"    unsafe {\n"
+"        println!(\"r1 is: {}\", *r1);\n"
+"        *r1 = 10;\n"
+"        println!(\"r2 is: {}\", *r2);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:27
@@ -9169,12 +10117,15 @@ msgstr ""
 msgid "It is safe to read an immutable static variable:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:6
-msgid "\"Hello, world!\""
-msgstr ""
-
-#: src/unsafe/mutable-static-variables.md:9
-msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
+#: src/unsafe/mutable-static-variables.md:5
+msgid ""
+"```rust,editable\n"
+"static HELLO_WORLD: &str = \"Hello, world!\";\n"
+"\n"
+"fn main() {\n"
+"    println!(\"HELLO_WORLD: {HELLO_WORLD}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
@@ -9183,13 +10134,21 @@ msgid ""
 "static variables:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:20
-#: src/unsafe/mutable-static-variables.md:26
-msgid "// Potential data race!\n"
-msgstr ""
-
-#: src/unsafe/mutable-static-variables.md:26
-msgid "\"COUNTER: {COUNTER}\""
+#: src/unsafe/mutable-static-variables.md:16
+msgid ""
+"```rust,editable\n"
+"static mut COUNTER: u32 = 0;\n"
+"\n"
+"fn add_to_counter(inc: u32) {\n"
+"    unsafe { COUNTER += inc; }  // Potential data race!\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    add_to_counter(42);\n"
+"\n"
+"    unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:32
@@ -9211,16 +10170,21 @@ msgstr ""
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
 
-#: src/unsafe/unions.md:14
-msgid "\"int: {}\""
-msgstr ""
-
-#: src/unsafe/unions.md:15
-msgid "\"bool: {}\""
-msgstr ""
-
-#: src/unsafe/unions.md:15
-msgid "// Undefined behavior!\n"
+#: src/unsafe/unions.md:5
+msgid ""
+"```rust,editable\n"
+"#[repr(C)]\n"
+"union MyUnion {\n"
+"    i: u8,\n"
+"    b: bool,\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let u = MyUnion { i: 42 };\n"
+"    println!(\"int: {}\", unsafe { u.i });\n"
+"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/unions.md:21
@@ -9243,32 +10207,34 @@ msgid ""
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:8
-msgid "\"🗻∈🌏\""
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:10
+#: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
-"// Safe because the indices are in the correct order, within the bounds of\n"
+"```rust,editable\n"
+"fn main() {\n"
+"    let emojis = \"🗻∈🌏\";\n"
+"\n"
+"    // Safe because the indices are in the correct order, within the bounds "
+"of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:13
-#: src/unsafe/calling-unsafe-functions.md:14
-#: src/unsafe/calling-unsafe-functions.md:15
-msgid "\"emoji: {}\""
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:18
-msgid "\"char count: {}\""
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:20
-msgid ""
-"// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
+"    unsafe {\n"
+"        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
+"        println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
+"        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
+"    }\n"
+"\n"
+"    println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..7) }));\n"
+"\n"
+"    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
 "    // println!(\"char count: {}\", count_chars(unsafe { emojis."
 "get_unchecked(0..3) }));\n"
+"}\n"
+"\n"
+"fn count_chars(s: &str) -> usize {\n"
+"    s.chars().map(|_| 1).sum()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:3
@@ -9277,21 +10243,32 @@ msgid ""
 "conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:7
+#: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
+"```rust,editable\n"
 "/// Swaps the values pointed to by the given pointers.\n"
 "///\n"
 "/// # Safety\n"
 "///\n"
 "/// The pointers must be valid and properly aligned.\n"
-msgstr ""
-
-#: src/unsafe/writing-unsafe-functions.md:22
-msgid "// Safe because ...\n"
-msgstr ""
-
-#: src/unsafe/writing-unsafe-functions.md:27
-msgid "\"a = {}, b = {}\""
+"unsafe fn swap(a: *mut u8, b: *mut u8) {\n"
+"    let temp = *a;\n"
+"    *a = *b;\n"
+"    *b = temp;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut a = 42;\n"
+"    let mut b = 66;\n"
+"\n"
+"    // Safe because ...\n"
+"    unsafe {\n"
+"        swap(&mut a, &mut b);\n"
+"    }\n"
+"\n"
+"    println!(\"a = {}, b = {}\", a, b);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:33
@@ -9317,30 +10294,20 @@ msgid ""
 "them is thus unsafe:"
 msgstr ""
 
-#: src/unsafe/extern-functions.md:7 src/exercises/day-3/safe-ffi-wrapper.md:89
-#: src/android/interoperability/with-c.md:9
-#: src/android/interoperability/with-c/rust.md:15
-#: src/android/interoperability/with-c/rust.md:30
-#: src/android/interoperability/cpp/cpp-bridge.md:29
-#: src/android/interoperability/cpp/cpp-bridge.md:38
-#: src/bare-metal/aps/inline-assembly.md:18
-#: src/bare-metal/aps/better-uart/using.md:24
-#: src/bare-metal/aps/logging/using.md:23 src/exercises/bare-metal/rtc.md:46
-#: src/exercises/bare-metal/rtc.md:100 src/exercises/bare-metal/rtc.md:106
-#: src/exercises/bare-metal/rtc.md:113 src/exercises/bare-metal/rtc.md:119
-#: src/exercises/bare-metal/rtc.md:125 src/exercises/bare-metal/rtc.md:131
-#: src/exercises/bare-metal/rtc.md:137 src/exercises/bare-metal/rtc.md:143
-#: src/exercises/day-3/solutions-afternoon.md:45
-#: src/exercises/bare-metal/solutions-afternoon.md:43
-msgid "\"C\""
-msgstr ""
-
-#: src/unsafe/extern-functions.md:13
-msgid "// Undefined behavior if abs misbehaves.\n"
-msgstr ""
-
-#: src/unsafe/extern-functions.md:14
-msgid "\"Absolute value of -3 according to C: {}\""
+#: src/unsafe/extern-functions.md:6
+msgid ""
+"```rust,editable\n"
+"extern \"C\" {\n"
+"    fn abs(input: i32) -> i32;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    unsafe {\n"
+"        // Undefined behavior if abs misbehaves.\n"
+"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/extern-functions.md:21
@@ -9368,15 +10335,27 @@ msgid ""
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:12
+#: src/unsafe/unsafe-traits.md:9
 msgid ""
+"```rust,editable\n"
+"use std::mem::size_of_val;\n"
+"use std::slice;\n"
+"\n"
 "/// ...\n"
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
-msgstr ""
-
-#: src/unsafe/unsafe-traits.md:23
-msgid "// Safe because u32 has a defined representation and no padding.\n"
+"pub unsafe trait AsBytes {\n"
+"    fn as_bytes(&self) -> &[u8] {\n"
+"        unsafe {\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// Safe because u32 has a defined representation and no padding.\n"
+"unsafe impl AsBytes for u32 {}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:30
@@ -9551,88 +10530,111 @@ msgid ""
 "functions and methods:"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:54
-#: src/exercises/day-3/safe-ffi-wrapper.md:67
-#: src/exercises/day-3/safe-ffi-wrapper.md:78
-#: src/exercises/day-3/safe-ffi-wrapper.md:92
-#: src/exercises/day-3/safe-ffi-wrapper.md:100
-#: src/exercises/day-3/solutions-afternoon.md:10
-#: src/exercises/day-3/solutions-afternoon.md:23
-#: src/exercises/day-3/solutions-afternoon.md:34
-#: src/exercises/day-3/solutions-afternoon.md:48
-#: src/exercises/day-3/solutions-afternoon.md:56
-msgid "\"macos\""
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:57
-#: src/exercises/day-3/solutions-afternoon.md:13
-msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:64
-#: src/exercises/day-3/solutions-afternoon.md:20
+#: src/exercises/day-3/safe-ffi-wrapper.md:48
 msgid ""
-"// Layout according to the Linux man page for readdir(3), where ino_t and\n"
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_imports, unused_variables, dead_code)]\n"
+"\n"
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int};\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
+"\n"
+"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"    #[repr(C)]\n"
+"    pub struct DIR {\n"
+"        _data: [u8; 0],\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
+"    }\n"
+"\n"
+"    // Layout according to the Linux man page for readdir(3), where ino_t "
+"and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:77
-#: src/exercises/day-3/solutions-afternoon.md:33
-msgid "// Layout according to the macOS man page for dir(5).\n"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:92
-#: src/exercises/day-3/safe-ffi-wrapper.md:100
-#: src/exercises/day-3/solutions-afternoon.md:48
-#: src/exercises/day-3/solutions-afternoon.md:56
-msgid "\"x86_64\""
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:95
-#: src/exercises/day-3/solutions-afternoon.md:51
-msgid ""
-"// See https://github.com/rust-lang/libc/issues/414 and the section on\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_ino: c_ulong,\n"
+"        pub d_off: c_long,\n"
+"        pub d_reclen: c_ushort,\n"
+"        pub d_type: c_uchar,\n"
+"        pub d_name: [c_char; 256],\n"
+"    }\n"
+"\n"
+"    // Layout according to the macOS man page for dir(5).\n"
+"    #[cfg(all(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_fileno: u64,\n"
+"        pub d_seekoff: u64,\n"
+"        pub d_reclen: u16,\n"
+"        pub d_namlen: u16,\n"
+"        pub d_type: u8,\n"
+"        pub d_name: [c_char; 1024],\n"
+"    }\n"
+"\n"
+"    extern \"C\" {\n"
+"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"\n"
+"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        // See https://github.com/rust-lang/libc/issues/414 and the section "
+"on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
 "        //\n"
 "        // \"Platforms that existed before these updates were available\" "
 "refers\n"
 "        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
 "PowerPC.\n"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:101
-#: src/exercises/day-3/solutions-afternoon.md:57
-msgid "\"readdir$INODE64\""
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:119
-#: src/exercises/day-3/solutions-afternoon.md:75
-msgid ""
-"// Call opendir and return a Ok value if that worked,\n"
+"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
+"        #[link_name = \"readdir$INODE64\"]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        pub fn closedir(s: *mut DIR) -> c_int;\n"
+"    }\n"
+"}\n"
+"\n"
+"use std::ffi::{CStr, CString, OsStr, OsString};\n"
+"use std::os::unix::ffi::OsStrExt;\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"\n"
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:128
-msgid "// Keep calling readdir until we get a NULL pointer back.\n"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:135
-#: src/exercises/day-3/solutions-afternoon.md:108
-msgid "// Call closedir as needed.\n"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:141
-#: src/android/interoperability/with-c/rust.md:44
-#: src/exercises/day-3/solutions-afternoon.md:119
-#: src/exercises/day-3/solutions-afternoon.md:143
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\".\""
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:142
-#: src/exercises/day-3/solutions-afternoon.md:120
-msgid "\"files: {:#?}\""
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android.md:1
@@ -9768,29 +10770,31 @@ msgstr ""
 msgid "_hello_rust/Android.bp_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:10 src/android/build-rules/binary.md:11
-msgid "\"hello_rust\""
+#: src/android/build-rules/binary.md:8
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust\",\n"
+"    crate_name: \"hello_rust\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/build-rules/binary.md:12 src/android/build-rules/library.md:19
-#: src/android/logging.md:12
-msgid "\"src/main.rs\""
-msgstr ""
-
-#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:33
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
 msgid "_hello_rust/src/main.rs_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:19 src/android/build-rules/library.md:36
-msgid "//! Rust demo.\n"
-msgstr ""
-
-#: src/android/build-rules/binary.md:20 src/android/build-rules/library.md:40
-msgid "/// Prints a greeting to standard output.\n"
-msgstr ""
-
-#: src/android/build-rules/binary.md:23
-msgid "\"Hello from Rust!\""
+#: src/android/build-rules/binary.md:18
+msgid ""
+"```rust\n"
+"//! Rust demo.\n"
+"\n"
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"Hello from Rust!\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/build-rules/binary.md:27
@@ -9829,48 +10833,64 @@ msgid ""
 "crates/)."
 msgstr ""
 
-#: src/android/build-rules/library.md:17 src/android/build-rules/library.md:18
-msgid "\"hello_rust_with_dep\""
+#: src/android/build-rules/library.md:15
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"\n"
+"rust_library {\n"
+"    name: \"libgreetings\",\n"
+"    crate_name: \"greetings\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/build-rules/library.md:21 src/android/build-rules/library.md:27
-msgid "\"libgreetings\""
+#: src/android/build-rules/library.md:36
+msgid ""
+"```rust,ignore\n"
+"//! Rust demo.\n"
+"\n"
+"use greetings::greeting;\n"
+"use textwrap::fill;\n"
+"\n"
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/build-rules/library.md:22
-msgid "\"libtextwrap\""
-msgstr ""
-
-#: src/android/build-rules/library.md:28
-msgid "\"greetings\""
-msgstr ""
-
-#: src/android/build-rules/library.md:29 src/android/aidl/implementation.md:31
-#: src/android/interoperability/java.md:38
-msgid "\"src/lib.rs\""
-msgstr ""
-
-#: src/android/build-rules/library.md:47
+#: src/android/build-rules/library.md:48
 msgid "_hello_rust/src/lib.rs_:"
 msgstr ""
 
 #: src/android/build-rules/library.md:50
-msgid "//! Greeting library.\n"
+msgid ""
+"```rust,ignore\n"
+"//! Greeting library.\n"
+"\n"
+"/// Greet `name`.\n"
+"pub fn greeting(name: &str) -> String {\n"
+"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/build-rules/library.md:51
-msgid "/// Greet `name`.\n"
-msgstr ""
-
-#: src/android/build-rules/library.md:54
-msgid "\"Hello {name}, it is very nice to meet you!\""
-msgstr ""
-
-#: src/android/build-rules/library.md:58
+#: src/android/build-rules/library.md:59
 msgid "You build, push, and run the binary like before:"
 msgstr ""
 
-#: src/android/build-rules/library.md:60
+#: src/android/build-rules/library.md:61
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
@@ -9911,16 +10931,20 @@ msgstr ""
 msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/interface.md:21
-msgid "\"com.example.birthdayservice\""
-msgstr ""
-
-#: src/android/aidl/interface.md:22
-msgid "\"com/example/birthdayservice/*.aidl\""
-msgstr ""
-
-#: src/android/aidl/interface.md:25
-msgid "// Rust is not enabled by default\n"
+#: src/android/aidl/interface.md:19
+msgid ""
+"```javascript\n"
+"aidl_interface {\n"
+"    name: \"com.example.birthdayservice\",\n"
+"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
+"    unstable: true,\n"
+"    backend: {\n"
+"        rust: { // Rust is not enabled by default\n"
+"            enabled: true,\n"
+"        },\n"
+"    },\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/interface.md:32
@@ -9941,16 +10965,29 @@ msgstr ""
 msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md:8
-msgid "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-msgstr ""
-
-#: src/android/aidl/implementation.md:11
-msgid "/// The `IBirthdayService` implementation.\n"
-msgstr ""
-
-#: src/android/aidl/implementation.md:20
-msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
+#: src/android/aidl/implementation.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Implementation of the `IBirthdayService` AIDL interface.\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"/// The `IBirthdayService` implementation.\n"
+"pub struct BirthdayService;\n"
+"\n"
+"impl binder::Interface for BirthdayService {}\n"
+"\n"
+"impl IBirthdayService for BirthdayService {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
+"Result<String> {\n"
+"        Ok(format!(\n"
+"            \"Happy Birthday {name}, congratulations with the {years} years!"
+"\"\n"
+"        ))\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
@@ -9958,23 +10995,19 @@ msgstr ""
 msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md:30 src/android/aidl/server.md:38
-msgid "\"libbirthdayservice\""
-msgstr ""
-
-#: src/android/aidl/implementation.md:32 src/android/aidl/server.md:13
-#: src/android/aidl/client.md:12
-msgid "\"birthdayservice\""
-msgstr ""
-
-#: src/android/aidl/implementation.md:34 src/android/aidl/server.md:36
-#: src/android/aidl/client.md:45
-msgid "\"com.example.birthdayservice-rust\""
-msgstr ""
-
-#: src/android/aidl/implementation.md:35 src/android/aidl/server.md:37
-#: src/android/aidl/client.md:46
-msgid "\"libbinder_rs\""
+#: src/android/aidl/implementation.md:28
+msgid ""
+"```javascript\n"
+"rust_library {\n"
+"    name: \"libbirthdayservice\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    crate_name: \"birthdayservice\",\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/server.md:1
@@ -9989,24 +11022,47 @@ msgstr ""
 msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
-#: src/android/aidl/server.md:8 src/android/aidl/client.md:8
-msgid "//! Birthday service.\n"
+#: src/android/aidl/server.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use birthdayservice::BirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
+"\n"
+"/// Entry point for birthday service.\n"
+"fn main() {\n"
+"    let birthday_service = BirthdayService;\n"
+"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
+"        birthday_service,\n"
+"        binder::BinderFeatures::default(),\n"
+"    );\n"
+"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
+"as_binder())\n"
+"        .expect(\"Failed to register service\");\n"
+"    binder::ProcessState::join_thread_pool()\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/aidl/server.md:14
-msgid "/// Entry point for birthday service.\n"
-msgstr ""
-
-#: src/android/aidl/server.md:23
-msgid "\"Failed to register service\""
-msgstr ""
-
-#: src/android/aidl/server.md:32 src/android/aidl/server.md:33
-msgid "\"birthday_server\""
-msgstr ""
-
-#: src/android/aidl/server.md:34
-msgid "\"src/server.rs\""
+#: src/android/aidl/server.md:30
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_server\",\n"
+"    crate_name: \"birthday_server\",\n"
+"    srcs: [\"src/server.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"        \"libbirthdayservice\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/deploy.md:3
@@ -10043,39 +11099,67 @@ msgstr ""
 msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
-#: src/android/aidl/client.md:13
-msgid "/// Connect to the BirthdayService.\n"
+#: src/android/aidl/client.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"\n"
+"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
+"\n"
+"/// Connect to the BirthdayService.\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
+"StatusCode> {\n"
+"    binder::get_interface(SERVICE_IDENTIFIER)\n"
+"}\n"
+"\n"
+"/// Call the birthday service.\n"
+"fn main() -> Result<(), binder::Status> {\n"
+"    let name = std::env::args()\n"
+"        .nth(1)\n"
+"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
+"    let years = std::env::args()\n"
+"        .nth(2)\n"
+"        .and_then(|arg| arg.parse::<i32>().ok())\n"
+"        .unwrap_or(42);\n"
+"\n"
+"    binder::ProcessState::start_thread_pool();\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
+"    let msg = service.wishHappyBirthday(&name, years)?;\n"
+"    println!(\"{msg}\");\n"
+"    Ok(())\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/aidl/client.md:18
-msgid "/// Call the birthday service.\n"
+#: src/android/aidl/client.md:39
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_client\",\n"
+"    crate_name: \"birthday_client\",\n"
+"    srcs: [\"src/client.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/aidl/client.md:30
-msgid "\"Failed to connect to BirthdayService\""
-msgstr ""
-
-#: src/android/aidl/client.md:32
-msgid "\"{msg}\""
-msgstr ""
-
-#: src/android/aidl/client.md:41 src/android/aidl/client.md:42
-msgid "\"birthday_client\""
-msgstr ""
-
-#: src/android/aidl/client.md:43
-msgid "\"src/client.rs\""
-msgstr ""
-
-#: src/android/aidl/client.md:51
+#: src/android/aidl/client.md:52
 msgid "Notice that the client does not depend on `libbirthdayservice`."
 msgstr ""
 
-#: src/android/aidl/client.md:53
+#: src/android/aidl/client.md:54
 msgid "Build, push, and run the client on your device:"
 msgstr ""
 
-#: src/android/aidl/client.md:55
+#: src/android/aidl/client.md:56
 msgid ""
 "```shell\n"
 "m birthday_client\n"
@@ -10101,52 +11185,54 @@ msgstr ""
 msgid "_hello_rust_logs/Android.bp_:"
 msgstr ""
 
-#: src/android/logging.md:10 src/android/logging.md:11
-msgid "\"hello_rust_logs\""
+#: src/android/logging.md:8
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_logs\",\n"
+"    crate_name: \"hello_rust_logs\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"liblog_rust\",\n"
+"        \"liblogger\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"    host_supported: true,\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/logging.md:14
-msgid "\"liblog_rust\""
-msgstr ""
-
-#: src/android/logging.md:15
-msgid "\"liblogger\""
-msgstr ""
-
-#: src/android/logging.md:21
+#: src/android/logging.md:22
 msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
 #: src/android/logging.md:24
-msgid "//! Rust logging demo.\n"
+msgid ""
+"```rust,ignore\n"
+"//! Rust logging demo.\n"
+"\n"
+"use log::{debug, error, info};\n"
+"\n"
+"/// Logs a greeting.\n"
+"fn main() {\n"
+"    logger::init(\n"
+"        logger::Config::default()\n"
+"            .with_tag_on_device(\"rust\")\n"
+"            .with_min_level(log::Level::Trace),\n"
+"    );\n"
+"    debug!(\"Starting program.\");\n"
+"    info!(\"Things are going fine.\");\n"
+"    error!(\"Something went wrong!\");\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/logging.md:27
-msgid "/// Logs a greeting.\n"
-msgstr ""
-
-#: src/android/logging.md:32
-msgid "\"rust\""
-msgstr ""
-
-#: src/android/logging.md:35
-msgid "\"Starting program.\""
-msgstr ""
-
-#: src/android/logging.md:36
-msgid "\"Things are going fine.\""
-msgstr ""
-
-#: src/android/logging.md:37
-msgid "\"Something went wrong!\""
-msgstr ""
-
-#: src/android/logging.md:41 src/android/interoperability/with-c/bindgen.md:98
+#: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
 #: src/android/interoperability/with-c/rust.md:73
 msgid "Build, push, and run the binary on your device:"
 msgstr ""
 
-#: src/android/logging.md:43
+#: src/android/logging.md:44
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
@@ -10156,7 +11242,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:49
+#: src/android/logging.md:50
 msgid "The logs show up in `adb logcat`:"
 msgstr ""
 
@@ -10194,8 +11280,19 @@ msgstr ""
 msgid "You can do it by hand if you want:"
 msgstr ""
 
-#: src/android/interoperability/with-c.md:16
-msgid "\"{x}, {abs_x}\""
+#: src/android/interoperability/with-c.md:8
+msgid ""
+"```rust\n"
+"extern \"C\" {\n"
+"    fn abs(x: i32) -> i32;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let x = -42;\n"
+"    let abs_x = unsafe { abs(x) };\n"
+"    println!(\"{x}, {abs_x}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:20
@@ -10236,22 +11333,19 @@ msgstr ""
 msgid "_interoperability/bindgen/libbirthday.c_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:23
-#: src/android/interoperability/with-c/bindgen.md:50
-msgid "\"libbirthday.h\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:26
-#: src/android/interoperability/with-c/bindgen.md:29
-msgid "\"+--------------\\n\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:27
-msgid "\"| Happy Birthday %s!\\n\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:28
-msgid "\"| Congratulations with the %i years!\\n\""
+#: src/android/interoperability/with-c/bindgen.md:21
+msgid ""
+"```c\n"
+"#include <stdio.h>\n"
+"#include \"libbirthday.h\"\n"
+"\n"
+"void print_card(const card* card) {\n"
+"  printf(\"+--------------\\n\");\n"
+"  printf(\"| Happy Birthday %s!\\n\", card->name);\n"
+"  printf(\"| Congratulations with the %i years!\\n\", card->years);\n"
+"  printf(\"+--------------\\n\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:33
@@ -10265,13 +11359,14 @@ msgstr ""
 msgid "_interoperability/bindgen/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:39
-#: src/android/interoperability/with-c/bindgen.md:63
-msgid "\"libbirthday\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:40
-msgid "\"libbirthday.c\""
+#: src/android/interoperability/with-c/bindgen.md:37
+msgid ""
+"```javascript\n"
+"cc_library {\n"
+"    name: \"libbirthday\",\n"
+"    srcs: [\"libbirthday.c\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
@@ -10284,45 +11379,67 @@ msgstr ""
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
 msgstr ""
 
+#: src/android/interoperability/with-c/bindgen.md:49
+msgid ""
+"```c\n"
+"#include \"libbirthday.h\"\n"
+"```"
+msgstr ""
+
 #: src/android/interoperability/with-c/bindgen.md:53
 msgid "You can now auto-generate the bindings:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:59
-#: src/android/interoperability/with-c/bindgen.md:75
-msgid "\"libbirthday_bindgen\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:60
-msgid "\"birthday_bindgen\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:61
-msgid "\"libbirthday_wrapper.h\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:62
-msgid "\"bindings\""
+#: src/android/interoperability/with-c/bindgen.md:57
+msgid ""
+"```javascript\n"
+"rust_bindgen {\n"
+"    name: \"libbirthday_bindgen\",\n"
+"    crate_name: \"birthday_bindgen\",\n"
+"    wrapper_src: \"libbirthday_wrapper.h\",\n"
+"    source_stem: \"bindings\",\n"
+"    static_libs: [\"libbirthday\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:67
 msgid "Finally, we can use the bindings in our Rust program:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:73
-msgid "\"print_birthday_card\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:74
-msgid "\"main.rs\""
+#: src/android/interoperability/with-c/bindgen.md:71
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"print_birthday_card\",\n"
+"    srcs: [\"main.rs\"],\n"
+"    rustlibs: [\"libbirthday_bindgen\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:79
 msgid "_interoperability/bindgen/main.rs_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:82
-msgid "//! Bindgen demo.\n"
+#: src/android/interoperability/with-c/bindgen.md:81
+msgid ""
+"```rust,compile_fail\n"
+"//! Bindgen demo.\n"
+"\n"
+"use birthday_bindgen::{card, print_card};\n"
+"\n"
+"fn main() {\n"
+"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
+"    let card = card {\n"
+"        name: name.as_ptr(),\n"
+"        years: 42,\n"
+"    };\n"
+"    unsafe {\n"
+"        print_card(&card as *const card);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:100
@@ -10339,26 +11456,19 @@ msgstr ""
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:112
-#: src/android/interoperability/with-c/bindgen.md:114
-msgid "\"libbirthday_bindgen_test\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:113
-msgid "\":libbirthday_bindgen\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:115
-msgid "\"general-tests\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:117
-#: src/android/interoperability/with-c/bindgen.md:118
-msgid "\"none\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md:117
-msgid "// Generated file, skip linting\n"
+#: src/android/interoperability/with-c/bindgen.md:110
+msgid ""
+"```javascript\n"
+"rust_test {\n"
+"    name: \"libbirthday_bindgen_test\",\n"
+"    srcs: [\":libbirthday_bindgen\"],\n"
+"    crate_name: \"libbirthday_bindgen_test\",\n"
+"    test_suites: [\"general-tests\"],\n"
+"    auto_gen_config: true,\n"
+"    clippy_lints: \"none\", // Generated file, skip linting\n"
+"    lints: \"none\",\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
@@ -10373,41 +11483,58 @@ msgstr ""
 msgid "_interoperability/rust/libanalyze/analyze.rs_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:8
-msgid "//! Rust FFI demo.\n"
-msgstr ""
-
-#: src/android/interoperability/with-c/rust.md:12
-msgid "/// Analyze the numbers.\n"
-msgstr ""
-
-#: src/android/interoperability/with-c/rust.md:17
-msgid "\"x ({x}) is smallest!\""
-msgstr ""
-
-#: src/android/interoperability/with-c/rust.md:19
-msgid "\"y ({y}) is probably larger than x ({x})\""
+#: src/android/interoperability/with-c/rust.md:7
+msgid ""
+"```rust,editable\n"
+"//! Rust FFI demo.\n"
+"#![deny(improper_ctypes_definitions)]\n"
+"\n"
+"use std::os::raw::c_int;\n"
+"\n"
+"/// Analyze the numbers.\n"
+"#[no_mangle]\n"
+"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
+"    if x < y {\n"
+"        println!(\"x ({x}) is smallest!\");\n"
+"    } else {\n"
+"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:24
 msgid "_interoperability/rust/libanalyze/analyze.h_"
 msgstr ""
 
+#: src/android/interoperability/with-c/rust.md:26
+msgid ""
+"```c\n"
+"#ifndef ANALYSE_H\n"
+"#define ANALYSE_H\n"
+"\n"
+"extern \"C\" {\n"
+"void analyze_numbers(int x, int y);\n"
+"}\n"
+"\n"
+"#endif\n"
+"```"
+msgstr ""
+
 #: src/android/interoperability/with-c/rust.md:37
 msgid "_interoperability/rust/libanalyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:41
-#: src/android/interoperability/with-c/rust.md:68
-msgid "\"libanalyze_ffi\""
-msgstr ""
-
-#: src/android/interoperability/with-c/rust.md:42
-msgid "\"analyze_ffi\""
-msgstr ""
-
-#: src/android/interoperability/with-c/rust.md:43
-msgid "\"analyze.rs\""
+#: src/android/interoperability/with-c/rust.md:39
+msgid ""
+"```javascript\n"
+"rust_ffi {\n"
+"    name: \"libanalyze_ffi\",\n"
+"    crate_name: \"analyze_ffi\",\n"
+"    srcs: [\"analyze.rs\"],\n"
+"    include_dirs: [\".\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:48
@@ -10418,20 +11545,32 @@ msgstr ""
 msgid "_interoperability/rust/analyze/main.c_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:53
-msgid "\"analyze.h\""
+#: src/android/interoperability/with-c/rust.md:52
+msgid ""
+"```c\n"
+"#include \"analyze.h\"\n"
+"\n"
+"int main() {\n"
+"  analyze_numbers(10, 20);\n"
+"  analyze_numbers(123, 123);\n"
+"  return 0;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:62
 msgid "_interoperability/rust/analyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:66
-msgid "\"analyze_numbers\""
-msgstr ""
-
-#: src/android/interoperability/with-c/rust.md:67
-msgid "\"main.c\""
+#: src/android/interoperability/with-c/rust.md:64
+msgid ""
+"```javascript\n"
+"cc_binary {\n"
+"    name: \"analyze_numbers\",\n"
+"    srcs: [\"main.c\"],\n"
+"    static_libs: [\"libanalyze_ffi\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:75
@@ -10461,444 +11600,46 @@ msgstr ""
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:3
+#: src/android/interoperability/cpp.md:10
 msgid ""
-"CXX relies on a description of the function signatures that will be exposed "
-"from each language to the other. You provide this description using extern "
-"blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:9
-msgid "\"org::blobstore\""
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:11
-msgid "// Shared structs with fields visible to both languages.\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:17
-#: src/android/interoperability/cpp/generated-cpp.md:6
-msgid "// Rust types and signatures exposed to C++.\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:18
-#: src/android/interoperability/cpp/rust-bridge.md:6
-#: src/android/interoperability/cpp/generated-cpp.md:7
-#: src/android/interoperability/cpp/rust-result.md:6
-msgid "\"Rust\""
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:24
-#: src/android/interoperability/cpp/cpp-bridge.md:6
-msgid "// C++ types and signatures exposed to Rust.\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:25
-#: src/android/interoperability/cpp/cpp-bridge.md:7
-#: src/android/interoperability/cpp/cpp-exception.md:6
-msgid "\"C++\""
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:26
-#: src/android/interoperability/cpp/cpp-bridge.md:8
-msgid "\"include/blobstore.h\""
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:40
-msgid "The bridge is generally declared in an `ffi` module within your crate."
-msgstr ""
-
-#: src/android/interoperability/cpp/bridge.md:41
+#: src/android/interoperability/cpp.md:14
 msgid ""
-"From the declarations made in the bridge module, CXX will generate matching "
-"Rust and C++ type/function definitions in order to expose those items to "
-"both languages."
+"At this point, the instructor should switch to the [CXX tutorial](https://"
+"cxx.rs/tutorial.html)."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:44
+#: src/android/interoperability/cpp.md:16
+msgid "Walk the students through the tutorial step by step."
+msgstr ""
+
+#: src/android/interoperability/cpp.md:18
 msgid ""
-"To view the generated Rust code, use [cargo-expand](https://github.com/"
-"dtolnay/cargo-expand) to view the expanded proc macro. For most of the "
-"examples you would use `cargo expand ::ffi` to expand just the `ffi` module "
-"(though this doesn't apply for Android projects)."
+"Highlight how CXX presents a clean interface without unsafe code in _both "
+"languages_."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:47
-msgid "To view the generated C++ code, look in `target/cxxbridge`."
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-bridge.md:1
-msgid "Rust Bridge Declarations"
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-bridge.md:7
-msgid "// Opaque type\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-bridge.md:8
-msgid "// Method on `MyType`\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-bridge.md:9
-msgid "// Free function\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-bridge.md:28
+#: src/android/interoperability/cpp.md:20
 msgid ""
-"Items declared in the `extern \"Rust\"` reference items that are in scope in "
-"the parent module."
+"Show the correspondence between [Rust and C++ types](https://cxx.rs/bindings."
+"html):"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:30
+#: src/android/interoperability/cpp.md:22
 msgid ""
-"The CXX code generator uses your `extern \"Rust\"` section(s) to produce a C+"
-"+ header file containing the corresponding C++ declarations. The generated "
-"header has the same path as the Rust source file containing the bridge, "
-"except with a .rs.h file extension."
+"Explain how a Rust `String` cannot map to a C++ `std::string` (the latter "
+"does not uphold the UTF-8 invariant). Show that despite being different "
+"types, `rust::String` in C++ can be easily constructed from a C++ `std::"
+"string`, making it very ergonomic to use."
 msgstr ""
 
-#: src/android/interoperability/cpp/generated-cpp.md:15
-msgid "Results in (roughly) the following C++:"
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-bridge.md:1
-msgid "C++ Bridge Declarations"
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-bridge.md:20
-msgid "Results in (roughly) the following Rust:"
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-bridge.md:30
-msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-bridge.md:39
-msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-bridge.md:56
+#: src/android/interoperability/cpp.md:28
 msgid ""
-"The programmer does not need to promise that the signatures they have typed "
-"in are accurate. CXX performs static assertions that the signatures exactly "
-"correspond with what is declared in C++."
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-bridge.md:59
-msgid ""
-"`unsafe extern` blocks allow you to declare C++ functions that are safe to "
-"call from Rust."
-msgstr ""
-
-#: src/android/interoperability/cpp/shared-types.md:9
-msgid "// A=1, J=11, Q=12, K=13\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/shared-types.md:23
-msgid "Only C-like (unit) enums are supported."
-msgstr ""
-
-#: src/android/interoperability/cpp/shared-types.md:24
-msgid ""
-"A limited number of traits are supported for `#[derive()]` on shared types. "
-"Corresponding functionality is also generated for the C++ code, e.g. if you "
-"derive `Hash` also generates an implementation of `std::hash` for the "
-"corresponding C++ type."
-msgstr ""
-
-#: src/android/interoperability/cpp/shared-enums.md:15
-#, fuzzy
-msgid "Generated Rust:"
-msgstr "Unsafe Rust"
-
-#: src/android/interoperability/cpp/shared-enums.md:33
-msgid "Generated C++:"
-msgstr ""
-
-#: src/android/interoperability/cpp/shared-enums.md:46
-msgid ""
-"On the Rust side, the code generated for shared enums is actually a struct "
-"wrapping a numeric value. This is because it is not UB in C++ for an enum "
-"class to hold a value different from all of the listed variants, and our "
-"Rust representation needs to have the same behavior."
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-result.md:13
-msgid "\"fallible1 requires depth > 0\""
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-result.md:16
-msgid "\"Success!\""
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-result.md:22
-msgid ""
-"Rust functions that return `Result` are translated to exceptions on the C++ "
-"side."
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-result.md:24
-msgid ""
-"The exception thrown will always be of type `rust::Error`, which primarily "
-"exposes a way to get the error message string. The error message will come "
-"from the error type's `Display` impl."
-msgstr ""
-
-#: src/android/interoperability/cpp/rust-result.md:27
-msgid ""
-"A panic unwinding from Rust to C++ will always cause the process to "
-"immediately terminate."
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-exception.md:7
-msgid "\"example/include/example.h\""
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-exception.md:14
-msgid "\"Error: {}\""
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-exception.md:22
-msgid ""
-"C++ functions declared to return a `Result` will catch any thrown exception "
-"on the C++ side and return it as an `Err` value to the calling Rust function."
-msgstr ""
-
-#: src/android/interoperability/cpp/cpp-exception.md:24
-msgid ""
-"If an exception is thrown from an extern \"C++\" function that is not "
-"declared by the CXX bridge to return `Result`, the program calls C++'s `std::"
-"terminate`. The behavior is equivalent to the same exception being thrown "
-"through a `noexcept` C++ function."
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:3
-#, fuzzy
-msgid "Rust Type"
-msgstr "再帰的データ型"
-
-#: src/android/interoperability/cpp/type-mapping.md:3
-msgid "C++ Type"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:5
-#, fuzzy
-msgid "`String`"
-msgstr "文字列（String）"
-
-#: src/android/interoperability/cpp/type-mapping.md:5
-#, fuzzy
-msgid "`rust::String`"
-msgstr "文字列（String）"
-
-#: src/android/interoperability/cpp/type-mapping.md:6
-msgid "`rust::Str`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:7
-#, fuzzy
-msgid "`CxxString`"
-msgstr "文字列（String）"
-
-#: src/android/interoperability/cpp/type-mapping.md:7
-#, fuzzy
-msgid "`std::string`"
-msgstr "文字列（String）"
-
-#: src/android/interoperability/cpp/type-mapping.md:8
-msgid "`&[T]`/`&mut [T]`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:8
-msgid "`rust::Slice`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:9
-msgid "`Box<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:9
-msgid "`rust::Box<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:10
-msgid "`UniquePtr<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:10
-msgid "`std::unique_ptr<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:11
-msgid "`Vec<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:11
-msgid "`rust::Vec<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:12
-msgid "`CxxVector<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:12
-msgid "`std::vector<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:16
-msgid ""
-"These types can be used in the fields of shared structs and the arguments "
-"and returns of extern functions."
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:18
-msgid ""
-"Note that Rust's `String` does not map directly to `std::string`. There are "
-"a few reasons for this:"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:20
-msgid ""
-"`std::string` does not uphold the UTF-8 invariant that `String` requires."
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:21
-msgid ""
-"The two types have different layouts in memory and so can't be passed "
-"directly between languages."
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md:23
-msgid ""
-"`std::string` requires move constructors that don't match Rust's move "
-"semantics, so a `std::string` can't be passed by value to Rust."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:1
-#: src/android/interoperability/cpp/android-cpp-genrules.md:1
-#: src/android/interoperability/cpp/android-build-rust.md:1
-#, fuzzy
-msgid "Building in Android"
-msgstr "Android"
-
-#: src/android/interoperability/cpp/android-build-cpp.md:3
-msgid ""
-"Create a `cc_library_static` to build the C++ library, including the CXX "
-"generated header and source file."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:8
-#: src/android/interoperability/cpp/android-build-rust.md:10
-msgid "\"libcxx_test_cpp\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:9
-msgid "\"cxx_test.cpp\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:11
-msgid "\"cxx-bridge-header\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:12
-#: src/android/interoperability/cpp/android-cpp-genrules.md:10
-msgid "\"libcxx_test_bridge_header\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:14
-#: src/android/interoperability/cpp/android-cpp-genrules.md:19
-msgid "\"libcxx_test_bridge_code\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:20
-msgid ""
-"Point out that `libcxx_test_bridge_header` and `libcxx_test_bridge_code` are "
-"the dependencies for the CXX-generated C++ bindings. We'll show how these "
-"are setup on the next slide."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:23
-msgid ""
-"Note that you also need to depend on the `cxx-bridge-header` library in "
-"order to pull in common CXX definitions."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-cpp.md:25
-msgid ""
-"Full docs for using CXX in Android can be found in [the Android docs]"
-"(https://source.android.com/docs/setup/build/rust/building-rust-modules/"
-"android-rust-patterns#rust-cpp-interop-using-cxx). You may want to share "
-"that link with the class so that students know where they can find these "
-"instructions again in the future."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:3
-msgid ""
-"Create two genrules: One to generate the CXX header, and one to generate the "
-"CXX source file. These are then used as inputs to the `cc_library_static`."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:7
-msgid ""
-"// Generate a C++ header containing the C++ bindings\n"
-"// to the Rust exported functions in lib.rs.\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:11
-#: src/android/interoperability/cpp/android-cpp-genrules.md:20
-msgid "\"cxxbridge\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:12
-msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:13
-#: src/android/interoperability/cpp/android-cpp-genrules.md:22
-#: src/android/interoperability/cpp/android-build-rust.md:8
-msgid "\"lib.rs\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:14
-msgid "\"lib.rs.h\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:16
-msgid "// Generate the C++ code that Rust calls into.\n"
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:21
-msgid "\"$(location cxxbridge) $(in) > $(out)\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:23
-msgid "\"lib.rs.cc\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:29
-msgid ""
-"The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
-"bridge module. It is included in Android and available as a Soong tool."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-cpp-genrules.md:31
-msgid ""
-"By convention, if your Rust source file is `lib.rs` your header file will be "
-"named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
-"convention isn't enforced, though."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-rust.md:3
-msgid ""
-"Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-rust.md:7
-msgid "\"cxx_test\""
-msgstr ""
-
-#: src/android/interoperability/cpp/android-build-rust.md:9
-msgid "\"libcxx\""
+"Explain that a Rust function returning `Result<T, E>` becomes a function "
+"which throws a `E` exception in C++ (and vice versa)."
 msgstr ""
 
 #: src/android/interoperability/java.md:1
@@ -10920,20 +11661,28 @@ msgstr ""
 msgid "_interoperability/java/src/lib.rs_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:12
-msgid "//! Rust <-> Java FFI demo.\n"
-msgstr ""
-
-#: src/android/interoperability/java.md:17
-msgid "/// HelloWorld::hello method implementation.\n"
-msgstr ""
-
-#: src/android/interoperability/java.md:20
-msgid "\"system\""
-msgstr ""
-
-#: src/android/interoperability/java.md:26
-msgid "\"Hello, {input}!\""
+#: src/android/interoperability/java.md:11
+msgid ""
+"```rust,compile_fail\n"
+"//! Rust <-> Java FFI demo.\n"
+"\n"
+"use jni::objects::{JClass, JString};\n"
+"use jni::sys::jstring;\n"
+"use jni::JNIEnv;\n"
+"\n"
+"/// HelloWorld::hello method implementation.\n"
+"#[no_mangle]\n"
+"pub extern \"system\" fn Java_HelloWorld_hello(\n"
+"    env: JNIEnv,\n"
+"    _class: JClass,\n"
+"    name: JString,\n"
+") -> jstring {\n"
+"    let input: String = env.get_string(name).unwrap().into();\n"
+"    let greeting = format!(\"Hello, {input}!\");\n"
+"    let output = env.new_string(greeting).unwrap();\n"
+"    output.into_inner()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:32
@@ -10941,18 +11690,16 @@ msgstr ""
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:36
-#: src/android/interoperability/java.md:69
-msgid "\"libhello_jni\""
-msgstr ""
-
-#: src/android/interoperability/java.md:37
-#: src/android/interoperability/java.md:52
-msgid "\"hello_jni\""
-msgstr ""
-
-#: src/android/interoperability/java.md:39
-msgid "\"libjni\""
+#: src/android/interoperability/java.md:34
+msgid ""
+"```javascript\n"
+"rust_ffi_shared {\n"
+"    name: \"libhello_jni\",\n"
+"    crate_name: \"hello_jni\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    rustlibs: [\"libjni\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:43
@@ -10963,16 +11710,34 @@ msgstr ""
 msgid "_interoperability/java/HelloWorld.java_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:66
-msgid "\"helloworld_jni\""
+#: src/android/interoperability/java.md:47
+msgid ""
+"```java\n"
+"class HelloWorld {\n"
+"    private static native String hello(String name);\n"
+"\n"
+"    static {\n"
+"        System.loadLibrary(\"hello_jni\");\n"
+"    }\n"
+"\n"
+"    public static void main(String[] args) {\n"
+"        String output = HelloWorld.hello(\"Alice\");\n"
+"        System.out.println(output);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/interoperability/java.md:67
-msgid "\"HelloWorld.java\""
-msgstr ""
-
-#: src/android/interoperability/java.md:68
-msgid "\"HelloWorld\""
+#: src/android/interoperability/java.md:64
+msgid ""
+"```javascript\n"
+"java_binary {\n"
+"    name: \"helloworld_jni\",\n"
+"    srcs: [\"HelloWorld.java\"],\n"
+"    main_class: \"HelloWorld\",\n"
+"    required: [\"libhello_jni\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:73
@@ -11223,21 +11988,39 @@ msgstr ""
 "`alloc`を使うためには、[グローバル（ヒープ）アロケータ](https://doc.rust-"
 "lang.org/stable/std/alloc/trait.GlobalAlloc.html)を実装しなければなりません。"
 
-#: src/bare-metal/alloc.md:23
+#: src/bare-metal/alloc.md:6
 msgid ""
-"// Safe because `HEAP` is only used here and `entry` is only called once.\n"
-msgstr ""
-
-#: src/bare-metal/alloc.md:25
-msgid "// Give the allocator some memory to allocate.\n"
-msgstr ""
-
-#: src/bare-metal/alloc.md:31
-msgid "// Now we can do things that require heap allocation.\n"
-msgstr ""
-
-#: src/bare-metal/alloc.md:33
-msgid "\"A string\""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate alloc;\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use alloc::string::ToString;\n"
+"use alloc::vec::Vec;\n"
+"use buddy_system_allocator::LockedHeap;\n"
+"\n"
+"#[global_allocator]\n"
+"static HEAP_ALLOCATOR: LockedHeap<32> = LockedHeap::<32>::new();\n"
+"\n"
+"static mut HEAP: [u8; 65536] = [0; 65536];\n"
+"\n"
+"pub fn entry() {\n"
+"    // Safe because `HEAP` is only used here and `entry` is only called "
+"once.\n"
+"    unsafe {\n"
+"        // Give the allocator some memory to allocate.\n"
+"        HEAP_ALLOCATOR\n"
+"            .lock()\n"
+"            .init(HEAP.as_mut_ptr() as usize, HEAP.len());\n"
+"    }\n"
+"\n"
+"    // Now we can do things that require heap allocation.\n"
+"    let mut v = Vec::new();\n"
+"    v.push(\"A string\".to_string());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/alloc.md:39
@@ -11318,35 +12101,69 @@ msgstr ""
 "大半のマイクロコントローラはメモリマップドRIO空間を通して周辺I/Oにアクセスし"
 "ます。micro:bitのLEDを光らせてみましょう:"
 
-#: src/bare-metal/microcontrollers/mmio.md:16
-msgid "/// GPIO port 0 peripheral address\n"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/mmio.md:19
-msgid "// GPIO peripheral offsets\n"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/mmio.md:24
-msgid "// PIN_CNF fields\n"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/mmio.md:34
-#: src/bare-metal/microcontrollers/pacs.md:21
-#: src/bare-metal/microcontrollers/hals.md:25
-msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/mmio.md:37
-#: src/bare-metal/microcontrollers/mmio.md:51
+#: src/bare-metal/microcontrollers/mmio.md:6
 msgid ""
-"// Safe because the pointers are to valid peripheral control registers, and\n"
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"mod interrupts;\n"
+"\n"
+"use core::mem::size_of;\n"
+"use cortex_m_rt::entry;\n"
+"\n"
+"/// GPIO port 0 peripheral address\n"
+"const GPIO_P0: usize = 0x5000_0000;\n"
+"\n"
+"// GPIO peripheral offsets\n"
+"const PIN_CNF: usize = 0x700;\n"
+"const OUTSET: usize = 0x508;\n"
+"const OUTCLR: usize = 0x50c;\n"
+"\n"
+"// PIN_CNF fields\n"
+"const DIR_OUTPUT: u32 = 0x1;\n"
+"const INPUT_DISCONNECT: u32 = 0x1 << 1;\n"
+"const PULL_DISABLED: u32 = 0x0 << 2;\n"
+"const DRIVE_S0S1: u32 = 0x0 << 8;\n"
+"const SENSE_DISABLED: u32 = 0x0 << 16;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+"    let pin_cnf_21 = (GPIO_P0 + PIN_CNF + 21 * size_of::<u32>()) as *mut "
+"u32;\n"
+"    let pin_cnf_28 = (GPIO_P0 + PIN_CNF + 28 * size_of::<u32>()) as *mut "
+"u32;\n"
+"    // Safe because the pointers are to valid peripheral control registers, "
+"and\n"
 "    // no aliases exist.\n"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/mmio.md:48
-#: src/bare-metal/microcontrollers/pacs.md:39
-#: src/bare-metal/microcontrollers/hals.md:29
-msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
+"    unsafe {\n"
+"        pin_cnf_21.write_volatile(\n"
+"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
+"SENSE_DISABLED,\n"
+"        );\n"
+"        pin_cnf_28.write_volatile(\n"
+"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
+"SENSE_DISABLED,\n"
+"        );\n"
+"    }\n"
+"\n"
+"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
+"    let gpio0_outset = (GPIO_P0 + OUTSET) as *mut u32;\n"
+"    let gpio0_outclr = (GPIO_P0 + OUTCLR) as *mut u32;\n"
+"    // Safe because the pointers are to valid peripheral control registers, "
+"and\n"
+"    // no aliases exist.\n"
+"    unsafe {\n"
+"        gpio0_outclr.write_volatile(1 << 28);\n"
+"        gpio0_outset.write_volatile(1 << 21);\n"
+"    }\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
@@ -11377,6 +12194,49 @@ msgstr ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) は[CMSIS-SVD](https://www."
 "keil.com/pack/doc/CMSIS/SVD/html/index.html) ファイルから、メモリマップされた"
 "周辺I/Oに対するほぼ安全（mostly-safe）なRustラッパーを生成します。"
+
+#: src/bare-metal/microcontrollers/pacs.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use cortex_m_rt::entry;\n"
+"use nrf52833_pac::Peripherals;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let p = Peripherals::take().unwrap();\n"
+"    let gpio0 = p.P0;\n"
+"\n"
+"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+"    gpio0.pin_cnf[21].write(|w| {\n"
+"        w.dir().output();\n"
+"        w.input().disconnect();\n"
+"        w.pull().disabled();\n"
+"        w.drive().s0s1();\n"
+"        w.sense().disabled();\n"
+"        w\n"
+"    });\n"
+"    gpio0.pin_cnf[28].write(|w| {\n"
+"        w.dir().output();\n"
+"        w.input().disconnect();\n"
+"        w.pull().disabled();\n"
+"        w.drive().s0s1();\n"
+"        w.sense().disabled();\n"
+"        w\n"
+"    });\n"
+"\n"
+"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
+"    gpio0.outclr.write(|w| w.pin28().clear());\n"
+"    gpio0.outset.write(|w| w.pin21().set());\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
@@ -11432,8 +12292,37 @@ msgstr ""
 "するラッパーを提供しています。これらのクレートの多くは[`embedded-hal`]"
 "(https://crates.io/crates/embedded-hal)が定義するトレイトを実装しています。"
 
-#: src/bare-metal/microcontrollers/hals.md:22
-msgid "// Create HAL wrapper for GPIO port 0.\n"
+#: src/bare-metal/microcontrollers/hals.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use cortex_m_rt::entry;\n"
+"use nrf52833_hal::gpio::{p0, Level};\n"
+"use nrf52833_hal::pac::Peripherals;\n"
+"use nrf52833_hal::prelude::*;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let p = Peripherals::take().unwrap();\n"
+"\n"
+"    // Create HAL wrapper for GPIO port 0.\n"
+"    let gpio0 = p0::Parts::new(p.P0);\n"
+"\n"
+"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+"    let mut col1 = gpio0.p0_28.into_push_pull_output(Level::High);\n"
+"    let mut row1 = gpio0.p0_21.into_push_pull_output(Level::Low);\n"
+"\n"
+"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
+"    col1.set_low().unwrap();\n"
+"    row1.set_high().unwrap();\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
@@ -11487,12 +12376,37 @@ msgstr "`microbit-v2`はマトリクスLEDに対する簡単なドライバを�
 msgid "The type state pattern"
 msgstr "タイプステートパターン"
 
-#: src/bare-metal/microcontrollers/type-state.md:11
-msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/type-state.md:19
-msgid "// pin_input.is_high(); // Error, moved.\n"
+#: src/bare-metal/microcontrollers/type-state.md:3
+msgid ""
+"```rust,editable,compile_fail\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let p = Peripherals::take().unwrap();\n"
+"    let gpio0 = p0::Parts::new(p.P0);\n"
+"\n"
+"    let pin: P0_01<Disconnected> = gpio0.p0_01;\n"
+"\n"
+"    // let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
+"    let pin_input: P0_01<Input<Floating>> = pin.into_floating_input();\n"
+"    if pin_input.is_high().unwrap() {\n"
+"        // ...\n"
+"    }\n"
+"    let mut pin_output: P0_01<Output<OpenDrain>> = pin_input\n"
+"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
+"Level::Low);\n"
+"    pin_output.set_high().unwrap();\n"
+"    // pin_input.is_high(); // Error, moved.\n"
+"\n"
+"    let _pin2: P0_02<Output<OpenDrain>> = gpio0\n"
+"        .p0_02\n"
+"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
+"Level::Low);\n"
+"    let _pin3: P0_03<Output<PushPull>> = gpio0.p0_03."
+"into_push_pull_output(Level::Low);\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
@@ -11899,26 +12813,41 @@ msgstr ""
 msgid "_src/main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:44
-#: src/exercises/bare-metal/solutions-morning.md:32
-msgid "// Configure serial port.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:52
+#: src/exercises/bare-metal/compass.md:30
 msgid ""
-"// Set up the I2C controller and Inertial Measurement Unit.\n"
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use core::fmt::Write;\n"
+"use cortex_m_rt::entry;\n"
+"use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let board = Board::take().unwrap();\n"
+"\n"
+"    // Configure serial port.\n"
+"    let mut serial = Uarte::new(\n"
+"        board.UARTE0,\n"
+"        board.uart.into(),\n"
+"        Parity::EXCLUDED,\n"
+"        Baudrate::BAUD115200,\n"
+"    );\n"
+"\n"
+"    // Set up the I2C controller and Inertial Measurement Unit.\n"
 "    // TODO\n"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:55
-#: src/exercises/bare-metal/solutions-morning.md:56
-msgid "\"Ready.\""
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:58
-msgid ""
-"// Read compass data and log it to the serial port.\n"
+"\n"
+"    writeln!(serial, \"Ready.\").unwrap();\n"
+"\n"
+"    loop {\n"
+"        // Read compass data and log it to the serial port.\n"
 "        // TODO\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:64 src/exercises/bare-metal/rtc.md:385
@@ -12131,46 +13060,40 @@ msgid ""
 "firmware to power off the system:"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:19
+#: src/bare-metal/aps/inline-assembly.md:6
 msgid ""
-"// Safe because this only uses the declared registers and doesn't do\n"
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"use core::arch::asm;\n"
+"use core::panic::PanicInfo;\n"
+"\n"
+"mod exceptions;\n"
+"\n"
+"const PSCI_SYSTEM_OFF: u32 = 0x84000008;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(_x0: u64, _x1: u64, _x2: u64, _x3: u64) {\n"
+"    // Safe because this only uses the declared registers and doesn't do\n"
 "    // anything with memory.\n"
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:22
-msgid "\"hvc #0\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:23
-msgid "\"w0\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:24
-msgid "\"w1\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:25
-msgid "\"w2\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:26
-msgid "\"w3\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:27
-msgid "\"w4\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:28
-msgid "\"w5\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:29
-msgid "\"w6\""
-msgstr ""
-
-#: src/bare-metal/aps/inline-assembly.md:30
-msgid "\"w7\""
+"    unsafe {\n"
+"        asm!(\"hvc #0\",\n"
+"            inout(\"w0\") PSCI_SYSTEM_OFF => _,\n"
+"            inout(\"w1\") 0 => _,\n"
+"            inout(\"w2\") 0 => _,\n"
+"            inout(\"w3\") 0 => _,\n"
+"            inout(\"w4\") 0 => _,\n"
+"            inout(\"w5\") 0 => _,\n"
+"            inout(\"w6\") 0 => _,\n"
+"            inout(\"w7\") 0 => _,\n"
+"            options(nomem, nostack)\n"
+"        );\n"
+"    }\n"
+"\n"
+"    loop {}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
@@ -12270,13 +13193,22 @@ msgid ""
 "documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:9
-msgid "/// Minimal driver for a PL011 UART.\n"
-msgstr ""
-
-#: src/bare-metal/aps/uart.md:17 src/bare-metal/aps/better-uart/driver.md:13
+#: src/bare-metal/aps/uart.md:5
 msgid ""
-"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
+"```rust,editable\n"
+"const FLAG_REGISTER_OFFSET: usize = 0x18;\n"
+"const FR_BUSY: u8 = 1 << 3;\n"
+"const FR_TXFF: u8 = 1 << 5;\n"
+"\n"
+"/// Minimal driver for a PL011 UART.\n"
+"#[derive(Debug)]\n"
+"pub struct Uart {\n"
+"    base_address: *mut u8,\n"
+"}\n"
+"\n"
+"impl Uart {\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -12286,32 +13218,34 @@ msgid ""
 "    /// PL011 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-msgstr ""
-
-#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:27
-#: src/exercises/bare-metal/rtc.md:336
-msgid "/// Writes a single byte to the UART.\n"
-msgstr ""
-
-#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:29
-#: src/exercises/bare-metal/rtc.md:338
-msgid "// Wait until there is room in the TX buffer.\n"
-msgstr ""
-
-#: src/bare-metal/aps/uart.md:34 src/bare-metal/aps/uart.md:46
-msgid ""
-"// Safe because we know that the base address points to the control\n"
+"    pub unsafe fn new(base_address: *mut u8) -> Self {\n"
+"        Self { base_address }\n"
+"    }\n"
+"\n"
+"    /// Writes a single byte to the UART.\n"
+"    pub fn write_byte(&self, byte: u8) {\n"
+"        // Wait until there is room in the TX buffer.\n"
+"        while self.read_flag_register() & FR_TXFF != 0 {}\n"
+"\n"
+"        // Safe because we know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-msgstr ""
-
-#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:35
-#: src/exercises/bare-metal/rtc.md:344
-msgid "// Write to the TX buffer.\n"
-msgstr ""
-
-#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:39
-#: src/exercises/bare-metal/rtc.md:348
-msgid "// Wait until the UART is no longer busy.\n"
+"        unsafe {\n"
+"            // Write to the TX buffer.\n"
+"            self.base_address.write_volatile(byte);\n"
+"        }\n"
+"\n"
+"        // Wait until the UART is no longer busy.\n"
+"        while self.read_flag_register() & FR_BUSY != 0 {}\n"
+"    }\n"
+"\n"
+"    fn read_flag_register(&self) -> u8 {\n"
+"        // Safe because we know that the base address points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET)."
+"read_volatile() }\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
@@ -12348,11 +13282,24 @@ msgid ""
 "traits too."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:16 src/exercises/bare-metal/rtc.md:379
-#: src/exercises/bare-metal/solutions-afternoon.md:231
+#: src/bare-metal/aps/uart/traits.md:5
 msgid ""
+"```rust,editable,compile_fail\n"
+"use core::fmt::{self, Write};\n"
+"\n"
+"impl Write for Uart {\n"
+"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
+"        for c in s.as_bytes() {\n"
+"            self.write_byte(*c);\n"
+"        }\n"
+"        Ok(())\n"
+"    }\n"
+"}\n"
+"\n"
 "// Safe because it just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
+"unsafe impl Send for Uart {}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
@@ -12547,54 +13494,37 @@ msgid ""
 "working with bitflags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:9
-#: src/exercises/bare-metal/rtc.md:238
-msgid "/// Flags from the UART flag register.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:13
-#: src/exercises/bare-metal/rtc.md:242
-msgid "/// Clear to send.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:15
-#: src/exercises/bare-metal/rtc.md:244
-msgid "/// Data set ready.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:17
-#: src/exercises/bare-metal/rtc.md:246
-msgid "/// Data carrier detect.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:19
-#: src/exercises/bare-metal/rtc.md:248
-msgid "/// UART busy transmitting data.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:21
-#: src/exercises/bare-metal/rtc.md:250
-msgid "/// Receive FIFO is empty.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:23
-#: src/exercises/bare-metal/rtc.md:252
-msgid "/// Transmit FIFO is full.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:25
-#: src/exercises/bare-metal/rtc.md:254
-msgid "/// Receive FIFO is full.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:27
-#: src/exercises/bare-metal/rtc.md:256
-msgid "/// Transmit FIFO is empty.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:29
-#: src/exercises/bare-metal/rtc.md:258
-msgid "/// Ring indicator.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use bitflags::bitflags;\n"
+"\n"
+"bitflags! {\n"
+"    /// Flags from the UART flag register.\n"
+"    #[repr(transparent)]\n"
+"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"    struct Flags: u16 {\n"
+"        /// Clear to send.\n"
+"        const CTS = 1 << 0;\n"
+"        /// Data set ready.\n"
+"        const DSR = 1 << 1;\n"
+"        /// Data carrier detect.\n"
+"        const DCD = 1 << 2;\n"
+"        /// UART busy transmitting data.\n"
+"        const BUSY = 1 << 3;\n"
+"        /// Receive FIFO is empty.\n"
+"        const RXFE = 1 << 4;\n"
+"        /// Transmit FIFO is full.\n"
+"        const TXFF = 1 << 5;\n"
+"        /// Receive FIFO is full.\n"
+"        const RXFF = 1 << 6;\n"
+"        /// Transmit FIFO is empty.\n"
+"        const TXFE = 1 << 7;\n"
+"        /// Ring indicator.\n"
+"        const RI = 1 << 8;\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
@@ -12625,28 +13555,69 @@ msgstr ""
 msgid "Now let's use the new `Registers` struct in our driver."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:6
-msgid "/// Driver for a PL011 UART.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:32
-#: src/bare-metal/aps/better-uart/driver.md:55
-#: src/exercises/bare-metal/rtc.md:341 src/exercises/bare-metal/rtc.md:364
+#: src/bare-metal/aps/better-uart/driver.md:5
 msgid ""
-"// Safe because we know that self.registers points to the control\n"
+"```rust,editable,compile_fail\n"
+"/// Driver for a PL011 UART.\n"
+"#[derive(Debug)]\n"
+"pub struct Uart {\n"
+"    registers: *mut Registers,\n"
+"}\n"
+"\n"
+"impl Uart {\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
+"    /// given base address.\n"
+"    ///\n"
+"    /// # Safety\n"
+"    ///\n"
+"    /// The given base address must point to the 8 MMIO control registers of "
+"a\n"
+"    /// PL011 device, which must be mapped into the address space of the "
+"process\n"
+"    /// as device memory and not have any other aliases.\n"
+"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
+"        Self {\n"
+"            registers: base_address as *mut Registers,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Writes a single byte to the UART.\n"
+"    pub fn write_byte(&self, byte: u8) {\n"
+"        // Wait until there is room in the TX buffer.\n"
+"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
+"\n"
+"        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:43
-#: src/exercises/bare-metal/rtc.md:352
-msgid ""
-"/// Reads and returns a pending byte, or `None` if nothing has been "
+"        unsafe {\n"
+"            // Write to the TX buffer.\n"
+"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
+"        }\n"
+"\n"
+"        // Wait until the UART is no longer busy.\n"
+"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
+"    }\n"
+"\n"
+"    /// Reads and returns a pending byte, or `None` if nothing has been "
 "received.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:49
-#: src/exercises/bare-metal/rtc.md:358
-msgid "// TODO: Check for error conditions in bits 8-11.\n"
+"    pub fn read_byte(&self) -> Option<u8> {\n"
+"        if self.read_flag_register().contains(Flags::RXFE) {\n"
+"            None\n"
+"        } else {\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
+"            // TODO: Check for error conditions in bits 8-11.\n"
+"            Some(data as u8)\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn read_flag_register(&self) -> Flags {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
@@ -12666,40 +13637,51 @@ msgid ""
 "and echo incoming bytes."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:19
-#: src/bare-metal/aps/logging/using.md:18 src/exercises/bare-metal/rtc.md:41
-#: src/exercises/bare-metal/solutions-afternoon.md:33
-msgid "/// Base address of the primary PL011 UART.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/using.md:25
-#: src/bare-metal/aps/logging/using.md:24 src/exercises/bare-metal/rtc.md:47
-#: src/exercises/bare-metal/solutions-afternoon.md:44
+#: src/bare-metal/aps/better-uart/using.md:6
 msgid ""
-"// Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod pl011;\n"
+"\n"
+"use crate::pl011::Uart;\n"
+"use core::fmt::Write;\n"
+"use core::panic::PanicInfo;\n"
+"use log::error;\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
 "    // and nothing else accesses that address range.\n"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/using.md:29
-#: src/bare-metal/aps/logging/using.md:29
-msgid "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/using.md:35
-msgid "b'\\r'"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/using.md:36
-#: src/async/pitfalls/cancellation.md:27
-msgid "b'\\n'"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/using.md:38
-msgid "b'q'"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/using.md:44
-msgid "\"Bye!\""
+"    let mut uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"\n"
+"    writeln!(uart, \"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\").unwrap();\n"
+"\n"
+"    loop {\n"
+"        if let Some(byte) = uart.read_byte() {\n"
+"            uart.write_byte(byte);\n"
+"            match byte {\n"
+"                b'\\r' => {\n"
+"                    uart.write_byte(b'\\n');\n"
+"                }\n"
+"                b'q' => break,\n"
+"                _ => {}\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"\n"
+"    writeln!(uart, \"Bye!\").unwrap();\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
@@ -12721,12 +13703,50 @@ msgid ""
 "`Log` trait."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:28 src/exercises/bare-metal/rtc.md:190
-msgid "\"[{}] {}\""
-msgstr ""
-
-#: src/bare-metal/aps/logging.md:37 src/exercises/bare-metal/rtc.md:199
-msgid "/// Initialises UART logger.\n"
+#: src/bare-metal/aps/logging.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use crate::pl011::Uart;\n"
+"use core::fmt::Write;\n"
+"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
+"use spin::mutex::SpinMutex;\n"
+"\n"
+"static LOGGER: Logger = Logger {\n"
+"    uart: SpinMutex::new(None),\n"
+"};\n"
+"\n"
+"struct Logger {\n"
+"    uart: SpinMutex<Option<Uart>>,\n"
+"}\n"
+"\n"
+"impl Log for Logger {\n"
+"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
+"        true\n"
+"    }\n"
+"\n"
+"    fn log(&self, record: &Record) {\n"
+"        writeln!(\n"
+"            self.uart.lock().as_mut().unwrap(),\n"
+"            \"[{}] {}\",\n"
+"            record.level(),\n"
+"            record.args()\n"
+"        )\n"
+"        .unwrap();\n"
+"    }\n"
+"\n"
+"    fn flush(&self) {}\n"
+"}\n"
+"\n"
+"/// Initialises UART logger.\n"
+"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
+"SetLoggerError> {\n"
+"    LOGGER.uart.lock().replace(uart);\n"
+"\n"
+"    log::set_logger(&LOGGER)?;\n"
+"    log::set_max_level(max_level);\n"
+"    Ok(())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
@@ -12739,9 +13759,47 @@ msgstr ""
 msgid "We need to initialise the logger before we use it."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md:38 src/exercises/bare-metal/rtc.md:69
-#: src/exercises/bare-metal/solutions-afternoon.md:121
-msgid "\"{info}\""
+#: src/bare-metal/aps/logging/using.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod logger;\n"
+"mod pl011;\n"
+"\n"
+"use crate::pl011::Uart;\n"
+"use core::panic::PanicInfo;\n"
+"use log::{error, info, LevelFilter};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
+"\n"
+"    info!(\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\");\n"
+"\n"
+"    assert_eq!(x1, 42);\n"
+"\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[panic_handler]\n"
+"fn panic(info: &PanicInfo) -> ! {\n"
+"    error!(\"{info}\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"    loop {}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
@@ -12916,16 +13974,27 @@ msgid ""
 "Architecture."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:14
-msgid "// Create a new page table with identity mapping.\n"
-msgstr ""
-
-#: src/bare-metal/useful-crates/aarch64-paging.md:16
-msgid "// Map a 2 MiB region of memory as read-only.\n"
-msgstr ""
-
-#: src/bare-metal/useful-crates/aarch64-paging.md:21
-msgid "// Set `TTBR0_EL1` to activate the page table.\n"
+#: src/bare-metal/useful-crates/aarch64-paging.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use aarch64_paging::{\n"
+"    idmap::IdMap,\n"
+"    paging::{Attributes, MemoryRegion},\n"
+"};\n"
+"\n"
+"const ASID: usize = 1;\n"
+"const ROOT_LEVEL: usize = 1;\n"
+"\n"
+"// Create a new page table with identity mapping.\n"
+"let mut idmap = IdMap::new(ASID, ROOT_LEVEL);\n"
+"// Map a 2 MiB region of memory as read-only.\n"
+"idmap.map_range(\n"
+"    &MemoryRegion::new(0x80200000, 0x80400000),\n"
+"    Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,\n"
+").unwrap();\n"
+"// Set `TTBR0_EL1` to activate the page table.\n"
+"idmap.activate();\n"
+"```"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
@@ -13117,30 +14186,62 @@ msgid ""
 "look in the `rtc` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:37
-#: src/exercises/bare-metal/solutions-afternoon.md:29
-msgid "/// Base addresses of the GICv3.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:52
-#: src/exercises/bare-metal/solutions-afternoon.md:49
-msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:54
-#: src/exercises/bare-metal/solutions-afternoon.md:51
+#: src/exercises/bare-metal/rtc.md:23
 msgid ""
-"// Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod logger;\n"
+"mod pl011;\n"
+"\n"
+"use crate::pl011::Uart;\n"
+"use arm_gic::gicv3::GicV3;\n"
+"use core::panic::PanicInfo;\n"
+"use log::{error, info, trace, LevelFilter};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base addresses of the GICv3.\n"
+"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
+"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
+"\n"
+"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
+"\n"
+"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
+"base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:60
-msgid "// TODO: Create instance of RTC driver and print current time.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:62
-msgid "// TODO: Wait for 3 seconds.\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
+"    gic.setup();\n"
+"\n"
+"    // TODO: Create instance of RTC driver and print current time.\n"
+"\n"
+"    // TODO: Wait for 3 seconds.\n"
+"\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[panic_handler]\n"
+"fn panic(info: &PanicInfo) -> ! {\n"
+"    error!(\"{info}\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"    loop {}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:75
@@ -13149,9 +14250,9 @@ msgid ""
 "the exercise):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:80 src/exercises/bare-metal/rtc.md:154
-#: src/exercises/bare-metal/rtc.md:215 src/exercises/bare-metal/rtc.md:415
+#: src/exercises/bare-metal/rtc.md:79
 msgid ""
+"```rust,compile_fail\n"
 "// Copyright 2023 Google LLC\n"
 "//\n"
 "// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
@@ -13165,106 +14266,245 @@ msgid ""
 "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
 "// See the License for the specific language governing permissions and\n"
 "// limitations under the License.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:101
-msgid "\"sync_exception_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:107
-msgid "\"irq_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:108
-msgid "\"No pending interrupt\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:109
-msgid "\"IRQ {intid:?}\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:114
-msgid "\"fiq_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:120
-msgid "\"serr_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:126
-msgid "\"sync_lower\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:132
-msgid "\"irq_lower\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:138
-msgid "\"fiq_lower\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:144
-msgid "\"serr_lower\""
+"\n"
+"use arm_gic::gicv3::GicV3;\n"
+"use log::{error, info, trace};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn sync_exception_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"sync_exception_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn irq_current(_elr: u64, _spsr: u64) {\n"
+"    trace!(\"irq_current\");\n"
+"    let intid = GicV3::get_and_acknowledge_interrupt().expect(\"No pending "
+"interrupt\");\n"
+"    info!(\"IRQ {intid:?}\");\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn fiq_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"fiq_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn serr_current(_elr: u64, _spsr: u64) {\n"
+"    error!(\"serr_current\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn sync_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"sync_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn irq_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"irq_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn fiq_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"fiq_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn serr_lower(_elr: u64, _spsr: u64) {\n"
+"    error!(\"serr_lower\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:149
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:167
-msgid "// ANCHOR: main\n"
+#: src/exercises/bare-metal/rtc.md:153
+msgid ""
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"// ANCHOR: main\n"
+"use crate::pl011::Uart;\n"
+"use core::fmt::Write;\n"
+"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
+"use spin::mutex::SpinMutex;\n"
+"\n"
+"static LOGGER: Logger = Logger {\n"
+"    uart: SpinMutex::new(None),\n"
+"};\n"
+"\n"
+"struct Logger {\n"
+"    uart: SpinMutex<Option<Uart>>,\n"
+"}\n"
+"\n"
+"impl Log for Logger {\n"
+"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
+"        true\n"
+"    }\n"
+"\n"
+"    fn log(&self, record: &Record) {\n"
+"        writeln!(\n"
+"            self.uart.lock().as_mut().unwrap(),\n"
+"            \"[{}] {}\",\n"
+"            record.level(),\n"
+"            record.args()\n"
+"        )\n"
+"        .unwrap();\n"
+"    }\n"
+"\n"
+"    fn flush(&self) {}\n"
+"}\n"
+"\n"
+"/// Initialises UART logger.\n"
+"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
+"SetLoggerError> {\n"
+"    LOGGER.uart.lock().replace(uart);\n"
+"\n"
+"    log::set_logger(&LOGGER)?;\n"
+"    log::set_max_level(max_level);\n"
+"    Ok(())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:233
-msgid "// ANCHOR: Flags\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:261
-msgid "// ANCHOR_END: Flags\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:265
+#: src/exercises/bare-metal/rtc.md:214
 msgid ""
-"/// Flags from the UART Receive Status Register / Error Clear Register.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:269
-msgid "/// Framing error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:271
-msgid "/// Parity error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:273
-msgid "/// Break error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:275
-msgid "/// Overrun error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:279
-msgid "// ANCHOR: Registers\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:311
-msgid "// ANCHOR_END: Registers\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:313
-msgid ""
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"#![allow(unused)]\n"
+"\n"
+"use core::fmt::{self, Write};\n"
+"use core::ptr::{addr_of, addr_of_mut};\n"
+"\n"
+"// ANCHOR: Flags\n"
+"use bitflags::bitflags;\n"
+"\n"
+"bitflags! {\n"
+"    /// Flags from the UART flag register.\n"
+"    #[repr(transparent)]\n"
+"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"    struct Flags: u16 {\n"
+"        /// Clear to send.\n"
+"        const CTS = 1 << 0;\n"
+"        /// Data set ready.\n"
+"        const DSR = 1 << 1;\n"
+"        /// Data carrier detect.\n"
+"        const DCD = 1 << 2;\n"
+"        /// UART busy transmitting data.\n"
+"        const BUSY = 1 << 3;\n"
+"        /// Receive FIFO is empty.\n"
+"        const RXFE = 1 << 4;\n"
+"        /// Transmit FIFO is full.\n"
+"        const TXFF = 1 << 5;\n"
+"        /// Receive FIFO is full.\n"
+"        const RXFF = 1 << 6;\n"
+"        /// Transmit FIFO is empty.\n"
+"        const TXFE = 1 << 7;\n"
+"        /// Ring indicator.\n"
+"        const RI = 1 << 8;\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: Flags\n"
+"\n"
+"bitflags! {\n"
+"    /// Flags from the UART Receive Status Register / Error Clear Register.\n"
+"    #[repr(transparent)]\n"
+"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"    struct ReceiveStatus: u16 {\n"
+"        /// Framing error.\n"
+"        const FE = 1 << 0;\n"
+"        /// Parity error.\n"
+"        const PE = 1 << 1;\n"
+"        /// Break error.\n"
+"        const BE = 1 << 2;\n"
+"        /// Overrun error.\n"
+"        const OE = 1 << 3;\n"
+"    }\n"
+"}\n"
+"\n"
+"// ANCHOR: Registers\n"
+"#[repr(C, align(4))]\n"
+"struct Registers {\n"
+"    dr: u16,\n"
+"    _reserved0: [u8; 2],\n"
+"    rsr: ReceiveStatus,\n"
+"    _reserved1: [u8; 19],\n"
+"    fr: Flags,\n"
+"    _reserved2: [u8; 6],\n"
+"    ilpr: u8,\n"
+"    _reserved3: [u8; 3],\n"
+"    ibrd: u16,\n"
+"    _reserved4: [u8; 2],\n"
+"    fbrd: u8,\n"
+"    _reserved5: [u8; 3],\n"
+"    lcr_h: u8,\n"
+"    _reserved6: [u8; 3],\n"
+"    cr: u16,\n"
+"    _reserved7: [u8; 3],\n"
+"    ifls: u8,\n"
+"    _reserved8: [u8; 3],\n"
+"    imsc: u16,\n"
+"    _reserved9: [u8; 2],\n"
+"    ris: u16,\n"
+"    _reserved10: [u8; 2],\n"
+"    mis: u16,\n"
+"    _reserved11: [u8; 2],\n"
+"    icr: u16,\n"
+"    _reserved12: [u8; 2],\n"
+"    dmacr: u8,\n"
+"    _reserved13: [u8; 3],\n"
+"}\n"
+"// ANCHOR_END: Registers\n"
+"\n"
 "// ANCHOR: Uart\n"
 "/// Driver for a PL011 UART.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:322
-msgid ""
-"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
+"#[derive(Debug)]\n"
+"pub struct Uart {\n"
+"    registers: *mut Registers,\n"
+"}\n"
+"\n"
+"impl Uart {\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -13274,46 +14514,101 @@ msgid ""
 "    /// PL011 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:368
-msgid "// ANCHOR_END: Uart\n"
+"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
+"        Self {\n"
+"            registers: base_address as *mut Registers,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Writes a single byte to the UART.\n"
+"    pub fn write_byte(&self, byte: u8) {\n"
+"        // Wait until there is room in the TX buffer.\n"
+"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
+"\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe {\n"
+"            // Write to the TX buffer.\n"
+"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
+"        }\n"
+"\n"
+"        // Wait until the UART is no longer busy.\n"
+"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
+"    }\n"
+"\n"
+"    /// Reads and returns a pending byte, or `None` if nothing has been "
+"received.\n"
+"    pub fn read_byte(&self) -> Option<u8> {\n"
+"        if self.read_flag_register().contains(Flags::RXFE) {\n"
+"            None\n"
+"        } else {\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
+"            // TODO: Check for error conditions in bits 8-11.\n"
+"            Some(data as u8)\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn read_flag_register(&self) -> Flags {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL011 device which is appropriately mapped.\n"
+"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: Uart\n"
+"\n"
+"impl Write for Uart {\n"
+"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
+"        for c in s.as_bytes() {\n"
+"            self.write_byte(*c);\n"
+"        }\n"
+"        Ok(())\n"
+"    }\n"
+"}\n"
+"\n"
+"// Safe because it just contains a pointer to device memory, which can be\n"
+"// accessed from any context.\n"
+"unsafe impl Send for Uart {}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:410
 msgid "_build.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:433 src/exercises/bare-metal/rtc.md:435
-msgid "\"linux\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:434 src/exercises/bare-metal/rtc.md:436
-msgid "\"CROSS_COMPILE\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:434
-msgid "\"aarch64-linux-gnu\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:436
-msgid "\"aarch64-none-elf\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:439
-msgid "\"entry.S\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:440
-msgid "\"exceptions.S\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:441
-msgid "\"idmap.S\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:442
-msgid "\"empty\""
+#: src/exercises/bare-metal/rtc.md:414
+msgid ""
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"use cc::Build;\n"
+"use std::env;\n"
+"\n"
+"fn main() {\n"
+"    #[cfg(target_os = \"linux\")]\n"
+"    env::set_var(\"CROSS_COMPILE\", \"aarch64-linux-gnu\");\n"
+"    #[cfg(not(target_os = \"linux\"))]\n"
+"    env::set_var(\"CROSS_COMPILE\", \"aarch64-none-elf\");\n"
+"\n"
+"    Build::new()\n"
+"        .file(\"entry.S\")\n"
+"        .file(\"exceptions.S\")\n"
+"        .file(\"idmap.S\")\n"
+"        .compile(\"empty\")\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
@@ -13852,24 +15147,49 @@ msgstr ""
 msgid "_Makefile_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:945
-msgid "# Copyright 2023 Google LLC"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:959
-msgid "$(shell uname -s)"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:961
-msgid "aarch64-linux-gnu"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:978
-msgid "stdio -display none -kernel $< -s"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:981
-msgid "cargo clean"
+#: src/exercises/bare-metal/rtc.md:944
+msgid ""
+"```makefile\n"
+"# Copyright 2023 Google LLC\n"
+"#\n"
+"# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"# you may not use this file except in compliance with the License.\n"
+"# You may obtain a copy of the License at\n"
+"#\n"
+"#      http://www.apache.org/licenses/LICENSE-2.0\n"
+"#\n"
+"# Unless required by applicable law or agreed to in writing, software\n"
+"# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"# See the License for the specific language governing permissions and\n"
+"# limitations under the License.\n"
+"\n"
+"UNAME := $(shell uname -s)\n"
+"ifeq ($(UNAME),Linux)\n"
+"\tTARGET = aarch64-linux-gnu\n"
+"else\n"
+"\tTARGET = aarch64-none-elf\n"
+"endif\n"
+"OBJCOPY = $(TARGET)-objcopy\n"
+"\n"
+".PHONY: build qemu_minimal qemu qemu_logger\n"
+"\n"
+"all: rtc.bin\n"
+"\n"
+"build:\n"
+"\tcargo build\n"
+"\n"
+"rtc.bin: build\n"
+"\t$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@\n"
+"\n"
+"qemu: rtc.bin\n"
+"\tqemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio "
+"-display none -kernel $< -s\n"
+"\n"
+"clean:\n"
+"\tcargo clean\n"
+"\trm -f *.bin\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:995
@@ -13903,12 +15223,26 @@ msgstr ""
 msgid "Rust threads work similarly to threads in other languages:"
 msgstr "Rustのスレッドは他の言語のスレッドと似た挙動をします:"
 
-#: src/concurrency/threads.md:12
-msgid "\"Count in thread: {i}!\""
-msgstr ""
-
-#: src/concurrency/threads.md:18
-msgid "\"Main thread: {i}\""
+#: src/concurrency/threads.md:5
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    thread::spawn(|| {\n"
+"        for i in 1..10 {\n"
+"            println!(\"Count in thread: {i}!\");\n"
+"            thread::sleep(Duration::from_millis(5));\n"
+"        }\n"
+"    });\n"
+"\n"
+"    for i in 1..5 {\n"
+"        println!(\"Main thread: {i}\");\n"
+"        thread::sleep(Duration::from_millis(5));\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/threads.md:24
@@ -13962,8 +15296,22 @@ msgstr ""
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "通常のスレッドはそれらの環境から借用することはできません:"
 
-#: src/concurrency/scoped-threads.md:11 src/concurrency/scoped-threads.md:30
-msgid "\"Length: {}\""
+#: src/concurrency/scoped-threads.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"\n"
+"fn foo() {\n"
+"    let s = String::from(\"Hello\");\n"
+"    thread::spawn(|| {\n"
+"        println!(\"Length: {}\", s.len());\n"
+"    });\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    foo();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:20
@@ -13973,6 +15321,23 @@ msgid ""
 msgstr ""
 "しかし、そのために[スコープ付きスレッド](https://doc.rust-lang.org/std/"
 "thread/fn.scope.html)を使うことができます:"
+
+#: src/concurrency/scoped-threads.md:22
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let s = String::from(\"Hello\");\n"
+"\n"
+"    thread::scope(|scope| {\n"
+"        scope.spawn(|| {\n"
+"            println!(\"Length: {}\", s.len());\n"
+"        });\n"
+"    });\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/concurrency/scoped-threads.md:40
 msgid ""
@@ -13999,9 +15364,25 @@ msgstr ""
 "の２つの部品はチャネルによって繋がっていますが、見ることができるのはエンドポ"
 "イントだけです。"
 
-#: src/concurrency/channels.md:15 src/concurrency/channels.md:16
-#: src/concurrency/channels.md:20
-msgid "\"Received: {:?}\""
+#: src/concurrency/channels.md:6
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::channel();\n"
+"\n"
+"    tx.send(10).unwrap();\n"
+"    tx.send(20).unwrap();\n"
+"\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"\n"
+"    let tx2 = tx.clone();\n"
+"    tx2.send(30).unwrap();\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels.md:26
@@ -14027,24 +15408,31 @@ msgstr ""
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr "Unboundedで非同期的なチャネルは`mpsc::channel()`によって得られます："
 
-#: src/concurrency/channels/unbounded.md:16
-#: src/concurrency/channels/bounded.md:16
-msgid "\"Message {i}\""
-msgstr ""
-
-#: src/concurrency/channels/unbounded.md:17
-#: src/concurrency/channels/bounded.md:17
-msgid "\"{thread_id:?}: sent Message {i}\""
-msgstr ""
-
-#: src/concurrency/channels/unbounded.md:19
-#: src/concurrency/channels/bounded.md:19
-msgid "\"{thread_id:?}: done\""
-msgstr ""
-
-#: src/concurrency/channels/unbounded.md:24
-#: src/concurrency/channels/bounded.md:24
-msgid "\"Main: got {msg}\""
+#: src/concurrency/channels/unbounded.md:5
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::channel();\n"
+"\n"
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));\n"
+"\n"
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {msg}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:3
@@ -14053,6 +15441,33 @@ msgid ""
 msgstr ""
 "Bounded（かつ同期的）なチャネルを用いたとき、`send`は現在のスレッドをブロック"
 "することがあります："
+
+#: src/concurrency/channels/bounded.md:5
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::sync_channel(3);\n"
+"\n"
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));\n"
+"\n"
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {msg}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/concurrency/channels/bounded.md:31
 msgid ""
@@ -14352,14 +15767,27 @@ msgid ""
 "read-only access via `Arc::clone`:"
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md:16
-msgid "\"{thread_id:?}: {v:?}\""
-msgstr ""
-
-#: src/concurrency/shared_state/arc.md:21
-#: src/concurrency/shared_state/example.md:17
-#: src/concurrency/shared_state/example.md:45
-msgid "\"v: {v:?}\""
+#: src/concurrency/shared_state/arc.md:5
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::sync::Arc;\n"
+"\n"
+"fn main() {\n"
+"    let v = Arc::new(vec![10, 20, 30]);\n"
+"    let mut handles = Vec::new();\n"
+"    for _ in 1..5 {\n"
+"        let v = Arc::clone(&v);\n"
+"        handles.push(thread::spawn(move || {\n"
+"            let thread_id = thread::current().id();\n"
+"            println!(\"{thread_id:?}: {v:?}\");\n"
+"        }));\n"
+"    }\n"
+"\n"
+"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
@@ -14401,9 +15829,23 @@ msgid ""
 "interface:"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:11
-#: src/concurrency/shared_state/mutex.md:18
-msgid "\"v: {:?}\""
+#: src/concurrency/shared_state/mutex.md:6
+msgid ""
+"```rust,editable\n"
+"use std::sync::Mutex;\n"
+"\n"
+"fn main() {\n"
+"    let v = Mutex::new(vec![10, 20, 30]);\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"\n"
+"    {\n"
+"        let mut guard = v.lock().unwrap();\n"
+"        guard.push(40);\n"
+"    }\n"
+"\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
@@ -14458,12 +15900,54 @@ msgstr ""
 msgid "Let us see `Arc` and `Mutex` in action:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:6
-msgid "// use std::sync::{Arc, Mutex};\n"
+#: src/concurrency/shared_state/example.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"// use std::sync::{Arc, Mutex};\n"
+"\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let handle = thread::spawn(|| {\n"
+"        v.push(10);\n"
+"    });\n"
+"    v.push(1000);\n"
+"\n"
+"    handle.join().unwrap();\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:23
 msgid "Possible solution:"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:25
+msgid ""
+"```rust,editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"\n"
+"fn main() {\n"
+"    let v = Arc::new(Mutex::new(vec![10, 20, 30]));\n"
+"\n"
+"    let v2 = Arc::clone(&v);\n"
+"    let handle = thread::spawn(move || {\n"
+"        let mut v2 = v2.lock().unwrap();\n"
+"        v2.push(10);\n"
+"    });\n"
+"\n"
+"    {\n"
+"        let mut v = v.lock().unwrap();\n"
+"        v.push(1000);\n"
+"    }\n"
+"\n"
+"    handle.join().unwrap();\n"
+"\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:49
@@ -14531,89 +16015,49 @@ msgid ""
 "out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md:28
-#: src/exercises/concurrency/dining-philosophers-async.md:23
+#: src/exercises/concurrency/dining-philosophers.md:19
 msgid ""
-"// left_fork: ...\n"
+"```rust,compile_fail\n"
+"use std::sync::{mpsc, Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // left_fork: ...\n"
 "    // right_fork: ...\n"
 "    // thoughts: ...\n"
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:36
-#: src/exercises/concurrency/dining-philosophers-async.md:31
-#: src/exercises/concurrency/solutions-morning.md:24
-#: src/exercises/concurrency/solutions-afternoon.md:25
-msgid "\"Eureka! {} has a new idea!\""
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:41
-#: src/exercises/concurrency/dining-philosophers-async.md:36
-#: src/exercises/concurrency/solutions-afternoon.md:30
-msgid "// Pick up forks...\n"
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:42
-#: src/exercises/concurrency/dining-philosophers-async.md:37
-#: src/exercises/concurrency/solutions-morning.md:33
-#: src/exercises/concurrency/solutions-afternoon.md:37
-msgid "\"{} is eating...\""
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
-#: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
-msgid "\"Socrates\""
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
-#: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
-msgid "\"Hypatia\""
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
-#: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
-msgid "\"Plato\""
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
-#: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
-msgid "\"Aristotle\""
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
-#: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
-msgid "\"Pythagoras\""
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:51
-#: src/exercises/concurrency/dining-philosophers-async.md:47
-#: src/exercises/concurrency/solutions-afternoon.md:49
-msgid "// Create forks\n"
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:53
-#: src/exercises/concurrency/dining-philosophers-async.md:49
-#: src/exercises/concurrency/solutions-afternoon.md:53
-msgid "// Create philosophers\n"
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:55
-msgid "// Make each of them think and eat 100 times\n"
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md:57
-#: src/exercises/concurrency/dining-philosophers-async.md:53
-#: src/exercises/concurrency/solutions-afternoon.md:88
-msgid "// Output their thoughts\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
+"\n"
+"fn main() {\n"
+"    // Create forks\n"
+"\n"
+"    // Create philosophers\n"
+"\n"
+"    // Make each of them think and eat 100 times\n"
+"\n"
+"    // Output their thoughts\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:61
@@ -14694,42 +16138,73 @@ msgstr ""
 msgid "Your `src/main.rs` file should look something like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:64
-#: src/exercises/concurrency/solutions-morning.md:95
-msgid "\"request error: {0}\""
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md:66
-#: src/exercises/concurrency/solutions-morning.md:97
-msgid "\"bad http response: {0}\""
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md:77
-#: src/exercises/concurrency/solutions-morning.md:108
-msgid "\"Checking {:#}\""
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md:95
-#: src/exercises/concurrency/solutions-morning.md:126
-msgid "\"href\""
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md:102
-#: src/exercises/concurrency/solutions-morning.md:133
-msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md:111
-#: src/exercises/concurrency/solutions-morning.md:246
-msgid "\"https://www.google.org\""
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md:114
-msgid "\"Links: {links:#?}\""
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md:115
-msgid "\"Could not extract links: {err:#}\""
+#: src/exercises/concurrency/link-checker.md:57
+msgid ""
+"```rust,compile_fail\n"
+"use reqwest::{blocking::Client, Url};\n"
+"use scraper::{Html, Selector};\n"
+"use thiserror::Error;\n"
+"\n"
+"#[derive(Error, Debug)]\n"
+"enum Error {\n"
+"    #[error(\"request error: {0}\")]\n"
+"    ReqwestError(#[from] reqwest::Error),\n"
+"    #[error(\"bad http response: {0}\")]\n"
+"    BadResponse(String),\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct CrawlCommand {\n"
+"    url: Url,\n"
+"    extract_links: bool,\n"
+"}\n"
+"\n"
+"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
+"Error> {\n"
+"    println!(\"Checking {:#}\", command.url);\n"
+"    let response = client.get(command.url.clone()).send()?;\n"
+"    if !response.status().is_success() {\n"
+"        return Err(Error::BadResponse(response.status().to_string()));\n"
+"    }\n"
+"\n"
+"    let mut link_urls = Vec::new();\n"
+"    if !command.extract_links {\n"
+"        return Ok(link_urls);\n"
+"    }\n"
+"\n"
+"    let base_url = response.url().to_owned();\n"
+"    let body_text = response.text()?;\n"
+"    let document = Html::parse_document(&body_text);\n"
+"\n"
+"    let selector = Selector::parse(\"a\").unwrap();\n"
+"    let href_values = document\n"
+"        .select(&selector)\n"
+"        .filter_map(|element| element.value().attr(\"href\"));\n"
+"    for href in href_values {\n"
+"        match base_url.join(href) {\n"
+"            Ok(link_url) => {\n"
+"                link_urls.push(link_url);\n"
+"            }\n"
+"            Err(err) => {\n"
+"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
+"{err}\");\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"    Ok(link_urls)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let client = Client::new();\n"
+"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let crawl_command = CrawlCommand{ url: start_url, extract_links: "
+"true };\n"
+"    match visit_page(&client, &crawl_command) {\n"
+"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
+"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:120
@@ -14824,8 +16299,25 @@ msgstr ""
 "おおまかには、Rustの非同期コードはほとんど「通常の」逐次的なコードのように見"
 "えます:"
 
-#: src/async/async-await.md:10
-msgid "\"Count is: {i}!\""
+#: src/async/async-await.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use futures::executor::block_on;\n"
+"\n"
+"async fn count_to(count: i32) {\n"
+"    for i in 1..=count {\n"
+"        println!(\"Count is: {i}!\");\n"
+"    }\n"
+"}\n"
+"\n"
+"async fn async_main(count: i32) {\n"
+"    count_to(count).await;\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    block_on(async_main(10));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/async-await.md:27
@@ -14958,9 +16450,9 @@ msgid ""
 "_reactor_) and is responsible for executing futures (an _executor_). Rust "
 "does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
-"\\_runtime_は非同期な演算（_reactor_）のサポートを提供し、また、futureを実行"
-"すること（_executor_）を担当しています。Rustには「ビルトイン」のランタイムは"
-"ありませんが、いくつかのランタイムの選択肢があります: "
+"_runtime_は非同期な演算（_reactor_）のサポートを提供し、また、futureを実行す"
+"ること（_executor_）を担当しています。Rustには「ビルトイン」のランタイムはあ"
+"りませんが、いくつかのランタイムの選択肢があります: "
 
 #: src/async/runtimes.md:7
 #, fuzzy
@@ -15035,12 +16527,28 @@ msgstr "標準ライブラリの非同期バージョン。"
 msgid "A large ecosystem of libraries."
 msgstr "大きなライブラリのエコシステム。"
 
-#: src/async/runtimes/tokio.md:15
-msgid "\"Count in task: {i}!\""
-msgstr ""
-
-#: src/async/runtimes/tokio.md:25
-msgid "\"Main task: {i}\""
+#: src/async/runtimes/tokio.md:10
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::time;\n"
+"\n"
+"async fn count_to(count: i32) {\n"
+"    for i in 1..=count {\n"
+"        println!(\"Count in task: {i}!\");\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    tokio::spawn(count_to(10));\n"
+"\n"
+"    for i in 1..5 {\n"
+"        println!(\"Main task: {i}\");\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
@@ -15099,28 +16607,48 @@ msgstr ""
 "行処理は、例えば競合タイマーや入出力操作など、複数の子のfutureをポーリングす"
 "ることにより可能になります。"
 
-#: src/async/tasks.md:16
-msgid "\"127.0.0.1:6142\""
-msgstr ""
-
-#: src/async/tasks.md:17
-msgid "\"listening on port 6142\""
-msgstr ""
-
-#: src/async/tasks.md:22
-msgid "\"connection from {addr:?}\""
-msgstr ""
-
-#: src/async/tasks.md:25
-msgid "b\"Who are you?\\n\""
-msgstr ""
-
-#: src/async/tasks.md:26 src/async/tasks.md:37 src/async/tasks.md:43
-msgid "\"socket error: {e:?}\""
-msgstr ""
-
-#: src/async/tasks.md:34
-msgid "\"Thanks for dialing in, {name}!\\n\""
+#: src/async/tasks.md:10
+msgid ""
+"```rust,compile_fail\n"
+"use tokio::io::{self, AsyncReadExt, AsyncWriteExt};\n"
+"use tokio::net::TcpListener;\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> io::Result<()> {\n"
+"    let listener = TcpListener::bind(\"127.0.0.1:6142\").await?;\n"
+"\tprintln!(\"listening on port 6142\");\n"
+"\n"
+"    loop {\n"
+"        let (mut socket, addr) = listener.accept().await?;\n"
+"\n"
+"        println!(\"connection from {addr:?}\");\n"
+"\n"
+"        tokio::spawn(async move {\n"
+"            if let Err(e) = socket.write_all(b\"Who are you?\\n\").await {\n"
+"                println!(\"socket error: {e:?}\");\n"
+"                return;\n"
+"            }\n"
+"\n"
+"            let mut buf = vec![0; 1024];\n"
+"            let reply = match socket.read(&mut buf).await {\n"
+"                Ok(n) => {\n"
+"                    let name = std::str::from_utf8(&buf[..n]).unwrap()."
+"trim();\n"
+"                    format!(\"Thanks for dialing in, {name}!\\n\")\n"
+"                }\n"
+"                Err(e) => {\n"
+"                    println!(\"socket error: {e:?}\");\n"
+"                    return;\n"
+"                }\n"
+"            };\n"
+"\n"
+"            if let Err(e) = socket.write_all(reply.as_bytes()).await {\n"
+"                println!(\"socket error: {e:?}\");\n"
+"            }\n"
+"        });\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/tasks.md:52 src/async/control-flow/join.md:36
@@ -15131,13 +16659,6 @@ msgstr ""
 
 #: src/async/tasks.md:54
 msgid ""
-"Try connecting to it with a TCP connection tool like [nc](https://www.unix."
-"com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
-"telnet/)."
-msgstr ""
-
-#: src/async/tasks.md:56
-msgid ""
 "Ask students to visualize what the state of the example server would be with "
 "a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
@@ -15145,7 +16666,7 @@ msgstr ""
 "あるのかを、可視化するように受講者に指示してください。どんなタスクが存在して"
 "いますか？それらのfutureは何ですか？"
 
-#: src/async/tasks.md:59
+#: src/async/tasks.md:57
 msgid ""
 "This is the first time we've seen an `async` block. This is similar to a "
 "closure, but does not take any arguments. Its return value is a Future, "
@@ -15155,11 +16676,10 @@ msgstr ""
 "すが、何も引数は取りません。この返り値はFutureであり、`async fn`と似ていま"
 "す。"
 
-#: src/async/tasks.md:63
-#, fuzzy
+#: src/async/tasks.md:61
 msgid ""
 "Refactor the async block into a function, and improve the error handling "
-"using `?`. "
+"using `?`."
 msgstr ""
 "mainのasyncブロックを関数にリファクタして、`?`を使ったエラーハンドリングを改"
 "善してみましょう。"
@@ -15172,24 +16692,36 @@ msgstr ""
 "いくつかのクレートは`async`/`await`をサポートしています。例えば、`tokio`チャ"
 "ネルは:"
 
-#: src/async/channels.md:13
-msgid "\"Received {count} pings so far.\""
-msgstr ""
-
-#: src/async/channels.md:16
-msgid "\"ping_handler complete\""
-msgstr ""
-
-#: src/async/channels.md:24
-msgid "\"Failed to send ping.\""
-msgstr ""
-
-#: src/async/channels.md:25
-msgid "\"Sent {} pings so far.\""
-msgstr ""
-
-#: src/async/channels.md:29
-msgid "\"Something went wrong in ping handler task.\""
+#: src/async/channels.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::sync::mpsc::{self, Receiver};\n"
+"\n"
+"async fn ping_handler(mut input: Receiver<()>) {\n"
+"    let mut count: usize = 0;\n"
+"\n"
+"    while let Some(_) = input.recv().await {\n"
+"        count += 1;\n"
+"        println!(\"Received {count} pings so far.\");\n"
+"    }\n"
+"\n"
+"    println!(\"ping_handler complete\");\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let (sender, receiver) = mpsc::channel(32);\n"
+"    let ping_handler_task = tokio::spawn(ping_handler(receiver));\n"
+"    for i in 0..10 {\n"
+"        sender.send(()).await.expect(\"Failed to send ping.\");\n"
+"        println!(\"Sent {} pings so far.\", i + 1);\n"
+"    }\n"
+"\n"
+"    drop(sender);\n"
+"    ping_handler_task.await.expect(\"Something went wrong in ping handler "
+"task.\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/channels.md:35
@@ -15262,25 +16794,34 @@ msgstr ""
 "て返します。これはJavaScriptにおける `Promise.all` やPythonにおける`asyncio."
 "gather`に似ています。"
 
-#: src/async/control-flow/join.md:21
-msgid "\"https://google.com\""
-msgstr ""
-
-#: src/async/control-flow/join.md:22
-msgid "\"https://httpbin.org/ip\""
-msgstr ""
-
-#: src/async/control-flow/join.md:23
-msgid "\"https://play.rust-lang.org/\""
-msgstr ""
-
-#: src/async/control-flow/join.md:24
-msgid "\"BAD_URL\""
-msgstr ""
-
-#: src/async/control-flow/join.md:30
-#: src/exercises/day-1/solutions-morning.md:78
-msgid "\"{:?}\""
+#: src/async/control-flow/join.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use anyhow::Result;\n"
+"use futures::future;\n"
+"use reqwest;\n"
+"use std::collections::HashMap;\n"
+"\n"
+"async fn size_of_page(url: &str) -> Result<usize> {\n"
+"    let resp = reqwest::get(url).await?;\n"
+"    Ok(resp.text().await?.len())\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let urls: [&str; 4] = [\n"
+"        \"https://google.com\",\n"
+"        \"https://httpbin.org/ip\",\n"
+"        \"https://play.rust-lang.org/\",\n"
+"        \"BAD_URL\",\n"
+"    ];\n"
+"    let futures_iter = urls.into_iter().map(size_of_page);\n"
+"    let results = future::join_all(futures_iter).await;\n"
+"    let page_sizes_dict: HashMap<&str, Result<usize>> =\n"
+"        urls.into_iter().zip(results.into_iter()).collect();\n"
+"    println!(\"{:?}\", page_sizes_dict);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/control-flow/join.md:38
@@ -15340,28 +16881,54 @@ msgstr ""
 "整った時、その`statement`は`future`の結果に紐づく`pattern`の変数を用いて実行"
 "されます。"
 
-#: src/async/control-flow/select.md:40
-msgid "\"Felix\""
-msgstr ""
-
-#: src/async/control-flow/select.md:42
-msgid "\"Failed to send cat.\""
-msgstr ""
-
-#: src/async/control-flow/select.md:47
-msgid "\"Rex\""
-msgstr ""
-
-#: src/async/control-flow/select.md:49
-msgid "\"Failed to send dog.\""
-msgstr ""
-
-#: src/async/control-flow/select.md:54
-msgid "\"Failed to receive winner\""
-msgstr ""
-
-#: src/async/control-flow/select.md:56
-msgid "\"Winner is {winner:?}\""
+#: src/async/control-flow/select.md:13
+msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::sync::mpsc::{self, Receiver};\n"
+"use tokio::time::{sleep, Duration};\n"
+"\n"
+"#[derive(Debug, PartialEq)]\n"
+"enum Animal {\n"
+"    Cat { name: String },\n"
+"    Dog { name: String },\n"
+"}\n"
+"\n"
+"async fn first_animal_to_finish_race(\n"
+"    mut cat_rcv: Receiver<String>,\n"
+"    mut dog_rcv: Receiver<String>,\n"
+") -> Option<Animal> {\n"
+"    tokio::select! {\n"
+"        cat_name = cat_rcv.recv() => Some(Animal::Cat { name: cat_name? }),\n"
+"        dog_name = dog_rcv.recv() => Some(Animal::Dog { name: dog_name? })\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let (cat_sender, cat_receiver) = mpsc::channel(32);\n"
+"    let (dog_sender, dog_receiver) = mpsc::channel(32);\n"
+"    tokio::spawn(async move {\n"
+"        sleep(Duration::from_millis(500)).await;\n"
+"        cat_sender\n"
+"            .send(String::from(\"Felix\"))\n"
+"            .await\n"
+"            .expect(\"Failed to send cat.\");\n"
+"    });\n"
+"    tokio::spawn(async move {\n"
+"        sleep(Duration::from_millis(50)).await;\n"
+"        dog_sender\n"
+"            .send(String::from(\"Rex\"))\n"
+"            .await\n"
+"            .expect(\"Failed to send dog.\");\n"
+"    });\n"
+"\n"
+"    let winner = first_animal_to_finish_race(cat_receiver, dog_receiver)\n"
+"        .await\n"
+"        .expect(\"Failed to receive winner\");\n"
+"\n"
+"    println!(\"Winner is {winner:?}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/control-flow/select.md:62
@@ -15451,12 +17018,27 @@ msgid ""
 "possible."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md:14
-msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
-msgstr ""
-
-#: src/async/pitfalls/blocking-executor.md:19
-msgid "\"current_thread\""
+#: src/async/pitfalls/blocking-executor.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use futures::future::join_all;\n"
+"use std::time::Instant;\n"
+"\n"
+"async fn sleep_ms(start: &Instant, id: u64, duration_ms: u64) {\n"
+"    std::thread::sleep(std::time::Duration::from_millis(duration_ms));\n"
+"    println!(\n"
+"        \"future {id} slept for {duration_ms}ms, finished after {}ms\",\n"
+"        start.elapsed().as_millis()\n"
+"    );\n"
+"}\n"
+"\n"
+"#[tokio::main(flavor = \"current_thread\")]\n"
+"async fn main() {\n"
+"    let start = Instant::now();\n"
+"    let sleep_futures = (1..=10).map(|t| sleep_ms(&start, t, t * 10));\n"
+"    join_all(sleep_futures).await;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
@@ -15514,42 +17096,61 @@ msgid ""
 "repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:16
+#: src/async/pitfalls/pin.md:12
 msgid ""
+"```rust,editable,compile_fail\n"
+"use tokio::sync::{mpsc, oneshot};\n"
+"use tokio::task::spawn;\n"
+"use tokio::time::{sleep, Duration};\n"
+"\n"
 "// A work item. In this case, just sleep for the given time and respond\n"
 "// with a message on the `respond_on` channel.\n"
-msgstr ""
-
-#: src/async/pitfalls/pin.md:24
-msgid "// A worker which listens for work on a queue and performs it.\n"
-msgstr ""
-
-#: src/async/pitfalls/pin.md:31
-msgid "// Pretend to work.\n"
-msgstr ""
-
-#: src/async/pitfalls/pin.md:34
-msgid "\"failed to send response\""
-msgstr ""
-
-#: src/async/pitfalls/pin.md:37
-msgid "// TODO: report number of iterations every 100ms\n"
-msgstr ""
-
-#: src/async/pitfalls/pin.md:41
-msgid "// A requester which requests work and waits for it to complete.\n"
-msgstr ""
-
-#: src/async/pitfalls/pin.md:51
-msgid "\"failed to send on work queue\""
-msgstr ""
-
-#: src/async/pitfalls/pin.md:52
-msgid "\"failed waiting for response\""
-msgstr ""
-
-#: src/async/pitfalls/pin.md:61
-msgid "\"work result for iteration {i}: {resp}\""
+"#[derive(Debug)]\n"
+"struct Work {\n"
+"    input: u32,\n"
+"    respond_on: oneshot::Sender<u32>,\n"
+"}\n"
+"\n"
+"// A worker which listens for work on a queue and performs it.\n"
+"async fn worker(mut work_queue: mpsc::Receiver<Work>) {\n"
+"    let mut iterations = 0;\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            Some(work) = work_queue.recv() => {\n"
+"                sleep(Duration::from_millis(10)).await; // Pretend to work.\n"
+"                work.respond_on\n"
+"                    .send(work.input * 1000)\n"
+"                    .expect(\"failed to send response\");\n"
+"                iterations += 1;\n"
+"            }\n"
+"            // TODO: report number of iterations every 100ms\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// A requester which requests work and waits for it to complete.\n"
+"async fn do_work(work_queue: &mpsc::Sender<Work>, input: u32) -> u32 {\n"
+"    let (tx, rx) = oneshot::channel();\n"
+"    work_queue\n"
+"        .send(Work {\n"
+"            input,\n"
+"            respond_on: tx,\n"
+"        })\n"
+"        .await\n"
+"        .expect(\"failed to send on work queue\");\n"
+"    rx.await.expect(\"failed waiting for response\")\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let (tx, rx) = mpsc::channel(10);\n"
+"    spawn(worker(rx));\n"
+"    for i in 0..100 {\n"
+"        let resp = do_work(&tx, i).await;\n"
+"        println!(\"work result for iteration {i}: {resp}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/pitfalls/pin.md:68
@@ -15616,12 +17217,50 @@ msgid ""
 "provides a workaround through a macro:"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:30
-msgid "\"running all sleepers..\""
-msgstr ""
-
-#: src/async/pitfalls/async-traits.md:34
-msgid "\"slept for {}ms\""
+#: src/async/pitfalls/async-traits.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use async_trait::async_trait;\n"
+"use std::time::Instant;\n"
+"use tokio::time::{sleep, Duration};\n"
+"\n"
+"#[async_trait]\n"
+"trait Sleeper {\n"
+"    async fn sleep(&self);\n"
+"}\n"
+"\n"
+"struct FixedSleeper {\n"
+"    sleep_ms: u64,\n"
+"}\n"
+"\n"
+"#[async_trait]\n"
+"impl Sleeper for FixedSleeper {\n"
+"    async fn sleep(&self) {\n"
+"        sleep(Duration::from_millis(self.sleep_ms)).await;\n"
+"    }\n"
+"}\n"
+"\n"
+"async fn run_all_sleepers_multiple_times(sleepers: Vec<Box<dyn Sleeper>>, "
+"n_times: usize) {\n"
+"    for _ in 0..n_times {\n"
+"        println!(\"running all sleepers..\");\n"
+"        for sleeper in &sleepers {\n"
+"            let start = Instant::now();\n"
+"            sleeper.sleep().await;\n"
+"            println!(\"slept for {}ms\", start.elapsed().as_millis());\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    let sleepers: Vec<Box<dyn Sleeper>> = vec![\n"
+"        Box::new(FixedSleeper { sleep_ms: 50 }),\n"
+"        Box::new(FixedSleeper { sleep_ms: 100 }),\n"
+"    ];\n"
+"    run_all_sleepers_multiple_times(sleepers, 5).await;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:51
@@ -15653,16 +17292,72 @@ msgid ""
 "example, it shouldn't deadlock or lose data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:35
-msgid "\"not UTF-8\""
-msgstr ""
-
-#: src/async/pitfalls/cancellation.md:51
-msgid "\"hi\\nthere\\n\""
-msgstr ""
-
-#: src/async/pitfalls/cancellation.md:57
-msgid "\"tick!\""
+#: src/async/pitfalls/cancellation.md:8
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::io::{self, ErrorKind};\n"
+"use std::time::Duration;\n"
+"use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};\n"
+"\n"
+"struct LinesReader {\n"
+"    stream: DuplexStream,\n"
+"}\n"
+"\n"
+"impl LinesReader {\n"
+"    fn new(stream: DuplexStream) -> Self {\n"
+"        Self { stream }\n"
+"    }\n"
+"\n"
+"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
+"        let mut bytes = Vec::new();\n"
+"        let mut buf = [0];\n"
+"        while self.stream.read(&mut buf[..]).await? != 0 {\n"
+"            bytes.push(buf[0]);\n"
+"            if buf[0] == b'\\n' {\n"
+"                break;\n"
+"            }\n"
+"        }\n"
+"        if bytes.is_empty() {\n"
+"            return Ok(None)\n"
+"        }\n"
+"        let s = String::from_utf8(bytes)\n"
+"            .map_err(|_| io::Error::new(ErrorKind::InvalidData, \"not "
+"UTF-8\"))?;\n"
+"        Ok(Some(s))\n"
+"    }\n"
+"}\n"
+"\n"
+"async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::"
+"Result<()> {\n"
+"    for b in source.bytes() {\n"
+"        dest.write_u8(b).await?;\n"
+"        tokio::time::sleep(Duration::from_millis(10)).await\n"
+"    }\n"
+"    Ok(())\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> std::io::Result<()> {\n"
+"    let (client, server) = tokio::io::duplex(5);\n"
+"    let handle = tokio::spawn(slow_copy(\"hi\\nthere\\n\".to_owned(), "
+"client));\n"
+"\n"
+"    let mut lines = LinesReader::new(server);\n"
+"    let mut interval = tokio::time::interval(Duration::from_millis(60));\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            _ = interval.tick() => println!(\"tick!\"),\n"
+"            line = lines.next() => if let Some(l) = line? {\n"
+"                print!(\"{}\", l)\n"
+"            } else {\n"
+"                break\n"
+"            },\n"
+"        }\n"
+"    }\n"
+"    handle.await.unwrap()?;\n"
+"    Ok(())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:72
@@ -15693,10 +17388,28 @@ msgid ""
 "struct:"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:95
+#: src/async/pitfalls/cancellation.md:83
 msgid ""
-"// prefix buf and bytes with self.\n"
+"```rust,compile_fail\n"
+"struct LinesReader {\n"
+"    stream: DuplexStream,\n"
+"    bytes: Vec<u8>,\n"
+"    buf: [u8; 1],\n"
+"}\n"
+"\n"
+"impl LinesReader {\n"
+"    fn new(stream: DuplexStream) -> Self {\n"
+"        Self { stream, bytes: Vec::new(), buf: [0] }\n"
+"    }\n"
+"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
+"        // prefix buf and bytes with self.\n"
 "        // ...\n"
+"        let raw = std::mem::take(&mut self.bytes);\n"
+"        let s = String::from_utf8(raw)\n"
+"        // ...\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:104
@@ -15755,9 +17468,52 @@ msgid ""
 "main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:51
-#: src/exercises/concurrency/solutions-afternoon.md:77
-msgid "// Make them think and eat\n"
+#: src/exercises/concurrency/dining-philosophers-async.md:13
+msgid ""
+"```rust,compile_fail\n"
+"use std::sync::Arc;\n"
+"use tokio::time;\n"
+"use tokio::sync::mpsc::{self, Sender};\n"
+"use tokio::sync::Mutex;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // thoughts: ...\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    async fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    async fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    // Create forks\n"
+"\n"
+"    // Create philosophers\n"
+"\n"
+"    // Make them think and eat\n"
+"\n"
+"    // Output their thoughts\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
@@ -15898,29 +17654,47 @@ msgstr ""
 msgid "_src/bin/server.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:78
-#: src/exercises/concurrency/chat-app.md:125
-msgid "// TODO: For a hint, see the description of the task below.\n"
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:86
-#: src/exercises/concurrency/solutions-afternoon.md:149
-msgid "\"127.0.0.1:2000\""
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:87
-#: src/exercises/concurrency/solutions-afternoon.md:150
-msgid "\"listening on port 2000\""
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:91
-#: src/exercises/concurrency/solutions-afternoon.md:154
-msgid "\"New connection from {addr:?}\""
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:94
-#: src/exercises/concurrency/solutions-afternoon.md:157
-msgid "// Wrap the raw TCP stream into a websocket.\n"
+#: src/exercises/concurrency/chat-app.md:63
+msgid ""
+"```rust,compile_fail\n"
+"use futures_util::sink::SinkExt;\n"
+"use futures_util::stream::StreamExt;\n"
+"use std::error::Error;\n"
+"use std::net::SocketAddr;\n"
+"use tokio::net::{TcpListener, TcpStream};\n"
+"use tokio::sync::broadcast::{channel, Sender};\n"
+"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
+"\n"
+"async fn handle_connection(\n"
+"    addr: SocketAddr,\n"
+"    mut ws_stream: WebsocketStream<TcpStream>,\n"
+"    bcast_tx: Sender<String>,\n"
+") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"\n"
+"    // TODO: For a hint, see the description of the task below.\n"
+"\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"    let (bcast_tx, _) = channel(16);\n"
+"\n"
+"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
+"    println!(\"listening on port 2000\");\n"
+"\n"
+"    loop {\n"
+"        let (socket, addr) = listener.accept().await?;\n"
+"        println!(\"New connection from {addr:?}\");\n"
+"        let bcast_tx = bcast_tx.clone();\n"
+"        tokio::spawn(async move {\n"
+"            // Wrap the raw TCP stream into a websocket.\n"
+"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
+"\n"
+"            handle_connection(addr, ws_stream, bcast_tx).await\n"
+"        });\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:103
@@ -15928,9 +17702,30 @@ msgstr ""
 msgid "_src/bin/client.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:117
-#: src/exercises/concurrency/solutions-afternoon.md:178
-msgid "\"ws://127.0.0.1:2000\""
+#: src/exercises/concurrency/chat-app.md:107
+msgid ""
+"```rust,compile_fail\n"
+"use futures_util::stream::StreamExt;\n"
+"use futures_util::SinkExt;\n"
+"use http::Uri;\n"
+"use tokio::io::{AsyncBufReadExt, BufReader};\n"
+"use tokio_websockets::{ClientBuilder, Message};\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), tokio_websockets::Error> {\n"
+"    let (mut ws_stream, _) =\n"
+"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
+"            .connect()\n"
+"            .await?;\n"
+"\n"
+"    let stdin = tokio::io::stdin();\n"
+"    let mut stdin = BufReader::new(stdin).lines();\n"
+"\n"
+"\n"
+"    // TODO: For a hint, see the description of the task below.\n"
+"\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:130
@@ -16002,421 +17797,308 @@ msgid ""
 msgstr ""
 
 #: src/glossary.md:32
-msgid ""
-"argument:  \n"
-"Information that is passed into a function or method."
+msgid "argument:"
 msgstr ""
 
-#: src/glossary.md:34
+#: src/glossary.md:33
 msgid ""
 "Bare-metal Rust:  \n"
 "Low-level Rust development, often deployed to a system without an operating "
 "system. See [Bare-metal Rust](bare-metal.md)."
 msgstr ""
 
-#: src/glossary.md:37
+#: src/glossary.md:36
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
 msgstr ""
 
-#: src/glossary.md:39
+#: src/glossary.md:38
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
 msgstr ""
 
-#: src/glossary.md:41
+#: src/glossary.md:40
 msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
 msgstr ""
 
-#: src/glossary.md:43
+#: src/glossary.md:42
 msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
 msgstr ""
 
+#: src/glossary.md:44
+msgid "build:"
+msgstr ""
+
 #: src/glossary.md:45
-msgid ""
-"build:  \n"
-"The process of converting source code into executable code or a usable "
-"program."
+msgid "call:"
 msgstr ""
 
-#: src/glossary.md:47
-msgid ""
-"call:  \n"
-"To invoke or execute a function or method."
-msgstr ""
-
-#: src/glossary.md:49
+#: src/glossary.md:46
 msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
 msgstr ""
 
-#: src/glossary.md:51
+#: src/glossary.md:48
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
 msgstr ""
 
-#: src/glossary.md:53
-msgid ""
-"concurrency:  \n"
-"The execution of multiple tasks or processes at the same time."
-msgstr ""
+#: src/glossary.md:50
+#, fuzzy
+msgid "concurrency:"
+msgstr "並行性"
 
-#: src/glossary.md:55
+#: src/glossary.md:51
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
 msgstr ""
 
-#: src/glossary.md:57
-msgid ""
-"constant:  \n"
-"A value that does not change during the execution of a program."
+#: src/glossary.md:53
+msgid "constant:"
 msgstr ""
+
+#: src/glossary.md:54
+#, fuzzy
+msgid "control flow:"
+msgstr "制御フロー"
+
+#: src/glossary.md:55
+msgid "crash:"
+msgstr ""
+
+#: src/glossary.md:56
+#, fuzzy
+msgid "enumeration:"
+msgstr "実装"
+
+#: src/glossary.md:57
+msgid "error:"
+msgstr ""
+
+#: src/glossary.md:58
+#, fuzzy
+msgid "error handling:"
+msgstr "エラー処理"
 
 #: src/glossary.md:59
-msgid ""
-"control flow:  \n"
-"The order in which the individual statements or instructions are executed in "
-"a program."
-msgstr ""
+#, fuzzy
+msgid "exercise:"
+msgstr "練習問題"
+
+#: src/glossary.md:60
+#, fuzzy
+msgid "function:"
+msgstr "関数"
 
 #: src/glossary.md:61
-msgid ""
-"crash:  \n"
-"An unexpected and unhandled failure or termination of a program."
-msgstr ""
+#, fuzzy
+msgid "garbage collector:"
+msgstr "ガベージコレクション"
+
+#: src/glossary.md:62
+#, fuzzy
+msgid "generics:"
+msgstr "ジェネリクス（generics）"
 
 #: src/glossary.md:63
-msgid ""
-"enumeration:  \n"
-"A data type that consists of named constant values."
+msgid "immutable:"
 msgstr ""
+
+#: src/glossary.md:64
+#, fuzzy
+msgid "integration test:"
+msgstr "インテグレーションテスト"
 
 #: src/glossary.md:65
-msgid ""
-"error:  \n"
-"An unexpected condition or result that deviates from the expected behavior."
+msgid "keyword:"
 msgstr ""
+
+#: src/glossary.md:66
+#, fuzzy
+msgid "library:"
+msgstr "ライブラリ"
 
 #: src/glossary.md:67
-msgid ""
-"error handling:  \n"
-"The process of managing and responding to errors that occur during program "
-"execution."
+msgid "macro:"
 msgstr ""
 
+#: src/glossary.md:68
+#, fuzzy
+msgid "main function:"
+msgstr "Unsafe関数の呼び出し"
+
 #: src/glossary.md:69
-msgid ""
-"exercise:  \n"
-"A task or problem designed to practice and test programming skills."
+msgid "match:"
+msgstr ""
+
+#: src/glossary.md:70
+msgid "memory leak:"
 msgstr ""
 
 #: src/glossary.md:71
-msgid ""
-"function:  \n"
-"A reusable block of code that performs a specific task."
-msgstr ""
+#, fuzzy
+msgid "method:"
+msgstr "メソッド"
+
+#: src/glossary.md:72
+#, fuzzy
+msgid "module:"
+msgstr "モジュール"
 
 #: src/glossary.md:73
-msgid ""
-"garbage collector:  \n"
-"A mechanism that automatically frees up memory occupied by objects that are "
-"no longer in use."
+msgid "move:"
+msgstr ""
+
+#: src/glossary.md:74
+msgid "mutable:"
 msgstr ""
 
 #: src/glossary.md:75
-msgid ""
-"generics:  \n"
-"A feature that allows writing code with placeholders for types, enabling "
-"code reuse with different data types."
-msgstr ""
+#, fuzzy
+msgid "ownership:"
+msgstr "所有権"
+
+#: src/glossary.md:76
+#, fuzzy
+msgid "panic:"
+msgstr "パニック（panic）"
 
 #: src/glossary.md:77
-msgid ""
-"immutable:  \n"
-"Unable to be changed after creation."
+msgid "parameter:"
+msgstr ""
+
+#: src/glossary.md:78
+msgid "pattern:"
 msgstr ""
 
 #: src/glossary.md:79
-msgid ""
-"integration test:  \n"
-"A type of test that verifies the interactions between different parts or "
-"components of a system."
+msgid "payload:"
+msgstr ""
+
+#: src/glossary.md:80
+msgid "program:"
 msgstr ""
 
 #: src/glossary.md:81
-msgid ""
-"keyword:  \n"
-"A reserved word in a programming language that has a specific meaning and "
-"cannot be used as an identifier."
+msgid "programming language:"
 msgstr ""
 
+#: src/glossary.md:82
+#, fuzzy
+msgid "receiver:"
+msgstr "ドライバ"
+
 #: src/glossary.md:83
-msgid ""
-"library:  \n"
-"A collection of precompiled routines or code that can be used by programs."
+msgid "reference counting:"
+msgstr ""
+
+#: src/glossary.md:84
+msgid "return:"
 msgstr ""
 
 #: src/glossary.md:85
-msgid ""
-"macro:  \n"
-"Rust macros can be recognized by a `!` in the name. Macros are used when "
-"normal functions are not enough. A typical example is `format!`, which takes "
-"a variable number of arguments, which isn't supported by Rust functions."
-msgstr ""
+#, fuzzy
+msgid "Rust:"
+msgstr "Rustdoc"
 
-#: src/glossary.md:90
-msgid ""
-"`main` function:  \n"
-"Rust programs start executing with the `main` function."
-msgstr ""
-
-#: src/glossary.md:92
-msgid ""
-"match:  \n"
-"A control flow construct in Rust that allows for pattern matching on the "
-"value of an expression."
-msgstr ""
-
-#: src/glossary.md:94
-msgid ""
-"memory leak:  \n"
-"A situation where a program fails to release memory that is no longer "
-"needed, leading to a gradual increase in memory usage."
-msgstr ""
-
-#: src/glossary.md:96
-msgid ""
-"method:  \n"
-"A function associated with an object or a type in Rust."
-msgstr ""
-
-#: src/glossary.md:98
-msgid ""
-"module:  \n"
-"A namespace that contains definitions, such as functions, types, or traits, "
-"to organize code in Rust."
-msgstr ""
-
-#: src/glossary.md:100
-msgid ""
-"move:  \n"
-"The transfer of ownership of a value from one variable to another in Rust."
-msgstr ""
-
-#: src/glossary.md:102
-msgid ""
-"mutable:  \n"
-"A property in Rust that allows variables to be modified after they have been "
-"declared."
-msgstr ""
-
-#: src/glossary.md:104
-msgid ""
-"ownership:  \n"
-"The concept in Rust that defines which part of the code is responsible for "
-"managing the memory associated with a value."
-msgstr ""
-
-#: src/glossary.md:106
-msgid ""
-"panic:  \n"
-"An unrecoverable error condition in Rust that results in the termination of "
-"the program."
-msgstr ""
-
-#: src/glossary.md:108
-msgid ""
-"parameter:  \n"
-"A value that is passed into a function or method when it is called."
-msgstr ""
-
-#: src/glossary.md:110
-msgid ""
-"pattern:  \n"
-"A combination of values, literals, or structures that can be matched against "
-"an expression in Rust."
-msgstr ""
-
-#: src/glossary.md:112
-msgid ""
-"payload:  \n"
-"The data or information carried by a message, event, or data structure."
-msgstr ""
-
-#: src/glossary.md:114
-msgid ""
-"program:  \n"
-"A set of instructions that a computer can execute to perform a specific task "
-"or solve a particular problem."
-msgstr ""
-
-#: src/glossary.md:116
-msgid ""
-"programming language:  \n"
-"A formal system used to communicate instructions to a computer, such as Rust."
-msgstr ""
-
-#: src/glossary.md:118
-msgid ""
-"receiver:  \n"
-"The first parameter in a Rust method that represents the instance on which "
-"the method is called."
-msgstr ""
-
-#: src/glossary.md:120
-msgid ""
-"reference counting:  \n"
-"A memory management technique in which the number of references to an object "
-"is tracked, and the object is deallocated when the count reaches zero."
-msgstr ""
-
-#: src/glossary.md:122
-msgid ""
-"return:  \n"
-"A keyword in Rust used to indicate the value to be returned from a function."
-msgstr ""
-
-#: src/glossary.md:124
-msgid ""
-"Rust:  \n"
-"A systems programming language that focuses on safety, performance, and "
-"concurrency."
-msgstr ""
-
-#: src/glossary.md:126
+#: src/glossary.md:86
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 3 of this course."
 msgstr ""
 
-#: src/glossary.md:128
+#: src/glossary.md:88
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
 msgstr ""
 
-#: src/glossary.md:130
-msgid ""
-"safe:  \n"
-"Refers to code that adheres to Rust's ownership and borrowing rules, "
-"preventing memory-related errors."
+#: src/glossary.md:90
+msgid "safe:"
 msgstr ""
 
-#: src/glossary.md:132
-msgid ""
-"scope:  \n"
-"The region of a program where a variable is valid and can be used."
+#: src/glossary.md:91
+msgid "scope:"
 msgstr ""
 
-#: src/glossary.md:134
-msgid ""
-"standard library:  \n"
-"A collection of modules providing essential functionality in Rust."
+#: src/glossary.md:92
+#, fuzzy
+msgid "standard library:"
+msgstr "標準ライブラリ"
+
+#: src/glossary.md:93
+msgid "static:"
 msgstr ""
 
-#: src/glossary.md:136
-msgid ""
-"static:  \n"
-"A keyword in Rust used to define static variables or items with a `'static` "
-"lifetime."
+#: src/glossary.md:94
+#, fuzzy
+msgid "string:"
+msgstr "文字列（String）"
+
+#: src/glossary.md:95
+#, fuzzy
+msgid "struct:"
+msgstr "構造体（structs）"
+
+#: src/glossary.md:96
+msgid "test:"
 msgstr ""
 
-#: src/glossary.md:138
-msgid ""
-"string:  \n"
-"A data type storing textual data. See [`String` vs `str`](basic-syntax/"
-"string-slices.html) for more."
+#: src/glossary.md:97
+#, fuzzy
+msgid "thread:"
+msgstr "スレッド"
+
+#: src/glossary.md:98
+msgid "thread safety:"
 msgstr ""
 
-#: src/glossary.md:140
-msgid ""
-"struct:  \n"
-"A composite data type in Rust that groups together variables of different "
-"types under a single name."
+#: src/glossary.md:99
+#, fuzzy
+msgid "trait:"
+msgstr "トレイト（trait）"
+
+#: src/glossary.md:100
+msgid "type:"
 msgstr ""
 
-#: src/glossary.md:142
-msgid ""
-"test:  \n"
-"A Rust module containing functions that test the correctness of other "
-"functions."
+#: src/glossary.md:101
+#, fuzzy
+msgid "type inference:"
+msgstr "型推論"
+
+#: src/glossary.md:102
+#, fuzzy
+msgid "undefined behavior:"
+msgstr "実行時に未定義の動作はありません："
+
+#: src/glossary.md:103
+#, fuzzy
+msgid "union:"
+msgstr "共用体"
+
+#: src/glossary.md:104
+#, fuzzy
+msgid "unit test:"
+msgstr "ユニットテスト"
+
+#: src/glossary.md:105
+msgid "unsafe:"
 msgstr ""
 
-#: src/glossary.md:144
-msgid ""
-"thread:  \n"
-"A separate sequence of execution in a program, allowing concurrent execution."
-msgstr ""
-
-#: src/glossary.md:146
-msgid ""
-"thread safety:  \n"
-"The property of a program that ensures correct behavior in a multithreaded "
-"environment."
-msgstr ""
-
-#: src/glossary.md:148
-msgid ""
-"trait:  \n"
-"A collection of methods defined for an unknown type, providing a way to "
-"achieve polymorphism in Rust."
-msgstr ""
-
-#: src/glossary.md:150
-msgid ""
-"type:  \n"
-"A classification that specifies which operations can be performed on values "
-"of a particular kind in Rust."
-msgstr ""
-
-#: src/glossary.md:152
-msgid ""
-"type inference:  \n"
-"The ability of the Rust compiler to deduce the type of a variable or "
-"expression."
-msgstr ""
-
-#: src/glossary.md:154
-msgid ""
-"undefined behavior:  \n"
-"Actions or conditions in Rust that have no specified result, often leading "
-"to unpredictable program behavior."
-msgstr ""
-
-#: src/glossary.md:156
-msgid ""
-"union:  \n"
-"A data type that can hold values of different types but only one at a time."
-msgstr ""
-
-#: src/glossary.md:158
-msgid ""
-"unit test:  \n"
-"Rust comes with built-in support for running small unit tests and larger "
-"integration tests. See [Unit Tests](testing/unit-tests.html)."
-msgstr ""
-
-#: src/glossary.md:161
-msgid ""
-"unsafe:  \n"
-"The subset of Rust which allows you to trigger _undefined behavior_. See "
-"[Unsafe Rust](unsafe.html)."
-msgstr ""
-
-#: src/glossary.md:163
-msgid ""
-"variable:  \n"
-"A memory location storing data. Variables are valid in a _scope_. "
-msgstr ""
+#: src/glossary.md:106
+#, fuzzy
+msgid "variable:\\"
+msgstr "変数"
 
 #: src/other-resources.md:1
 msgid "Other Rust Resources"
@@ -16628,13 +18310,58 @@ msgstr ""
 msgid "([back to exercise](for-loops.md))"
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:20
-msgid "\"{row:?}\""
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:27
-#: src/exercises/day-1/solutions-morning.md:35
-msgid "//\n"
+#: src/exercises/day-1/solutions-morning.md:7
+msgid ""
+"```rust\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    let mut result = [[0; 3]; 3];\n"
+"    for i in 0..3 {\n"
+"        for j in 0..3 {\n"
+"            result[j][i] = matrix[i][j];\n"
+"        }\n"
+"    }\n"
+"    return result;\n"
+"}\n"
+"\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    for row in matrix {\n"
+"        println!(\"{row:?}\");\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_transpose() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], //\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"    let transposed = transpose(matrix);\n"
+"    assert_eq!(\n"
+"        transposed,\n"
+"        [\n"
+"            [101, 201, 301], //\n"
+"            [102, 202, 302],\n"
+"            [103, 203, 303],\n"
+"        ]\n"
+"    );\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"\n"
+"    println!(\"matrix:\");\n"
+"    pretty_print(&matrix);\n"
+"\n"
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:57
@@ -16663,24 +18390,34 @@ msgid ""
 "abstract over anything that can be referenced as a slice."
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:72
-msgid "// A line references a slice of items\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:74
-msgid "// A matrix references a slice of lines\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:83
-msgid "// &[&[i32]]\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:85
-msgid "// [[&str; 2]; 2]\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:87
-msgid "// Vec<Vec<i32>>\n"
+#: src/exercises/day-1/solutions-morning.md:65
+msgid ""
+"```rust\n"
+"use std::convert::AsRef;\n"
+"use std::fmt::Debug;\n"
+"\n"
+"fn pretty_print<T, Line, Matrix>(matrix: Matrix)\n"
+"where\n"
+"    T: Debug,\n"
+"    // A line references a slice of items\n"
+"    Line: AsRef<[T]>,\n"
+"    // A matrix references a slice of lines\n"
+"    Matrix: AsRef<[Line]>\n"
+"{\n"
+"    for row in matrix.as_ref() {\n"
+"        println!(\"{:?}\", row.as_ref());\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    // &[&[i32]]\n"
+"    pretty_print(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);\n"
+"    // [[&str; 2]; 2]\n"
+"    pretty_print([[\"a\", \"b\"], [\"c\", \"d\"]]);\n"
+"    // Vec<Vec<i32>>\n"
+"    pretty_print(vec![vec![1, 2], vec![3, 4]]);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:92
@@ -16697,25 +18434,217 @@ msgstr ""
 msgid "([back to exercise](luhn.md))"
 msgstr ""
 
-#: src/exercises/day-1/solutions-afternoon.md:40
-msgid "\"1234 5678 1234 5670\""
+#: src/exercises/day-1/solutions-afternoon.md:7
+msgid ""
+"```rust\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    let mut digits_seen = 0;\n"
+"    let mut sum = 0;\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Some(d) => {\n"
+"                sum += if i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd / 10 + dd % 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                digits_seen += 1;\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    if digits_seen < 2 {\n"
+"        return false;\n"
+"    }\n"
+"\n"
+"    sum % 10 == 0\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let cc_number = \"1234 5678 1234 5670\";\n"
+"    println!(\n"
+"        \"Is {cc_number} a valid credit card number? {}\",\n"
+"        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"    assert!(!luhn(\"foo 0 0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-1/solutions-afternoon.md:42
-msgid "\"Is {cc_number} a valid credit card number? {}\""
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:86
+#: src/exercises/day-1/solutions-afternoon.md:80
 #, fuzzy
 msgid "Pattern matching"
 msgstr "パターンマッチング"
 
-#: src/exercises/day-1/solutions-afternoon.md:211
-msgid "\"expr: {:?}\""
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:212
-msgid "\"result: {:?}\""
+#: src/exercises/day-1/solutions-afternoon.md:82
+msgid ""
+"```rust\n"
+"/// An operation to perform on two subexpressions.\n"
+"#[derive(Debug)]\n"
+"enum Operation {\n"
+"    Add,\n"
+"    Sub,\n"
+"    Mul,\n"
+"    Div,\n"
+"}\n"
+"\n"
+"/// An expression, in tree form.\n"
+"#[derive(Debug)]\n"
+"enum Expression {\n"
+"    /// An operation on two subexpressions.\n"
+"    Op {\n"
+"        op: Operation,\n"
+"        left: Box<Expression>,\n"
+"        right: Box<Expression>,\n"
+"    },\n"
+"\n"
+"    /// A literal value\n"
+"    Value(i64),\n"
+"}\n"
+"\n"
+"/// The result of evaluating an expression.\n"
+"#[derive(Debug, PartialEq, Eq)]\n"
+"enum Res {\n"
+"    /// Evaluation was successful, with the given result.\n"
+"    Ok(i64),\n"
+"    /// Evaluation failed, with the given error message.\n"
+"    Err(String),\n"
+"}\n"
+"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
+"use Res::{Err, Ok};\n"
+"\n"
+"fn eval(e: Expression) -> Res {\n"
+"    match e {\n"
+"        Expression::Op { op, left, right } => {\n"
+"            let left = match eval(*left) {\n"
+"                Ok(v) => v,\n"
+"                Err(msg) => return Err(msg),\n"
+"            };\n"
+"            let right = match eval(*right) {\n"
+"                Ok(v) => v,\n"
+"                Err(msg) => return Err(msg),\n"
+"            };\n"
+"            Ok(match op {\n"
+"                Operation::Add => left + right,\n"
+"                Operation::Sub => left - right,\n"
+"                Operation::Mul => left * right,\n"
+"                Operation::Div => {\n"
+"                    if right == 0 {\n"
+"                        return Err(String::from(\"division by zero\"));\n"
+"                    } else {\n"
+"                        left / right\n"
+"                    }\n"
+"                }\n"
+"            })\n"
+"        }\n"
+"        Expression::Value(v) => Ok(v),\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_value() {\n"
+"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_sum() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(Expression::Value(10)),\n"
+"            right: Box::new(Expression::Value(20)),\n"
+"        }),\n"
+"        Ok(30)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_recursion() {\n"
+"    let term1 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Value(10)),\n"
+"        right: Box::new(Expression::Value(9)),\n"
+"    };\n"
+"    let term2 = Expression::Op {\n"
+"        op: Operation::Mul,\n"
+"        left: Box::new(Expression::Op {\n"
+"            op: Operation::Sub,\n"
+"            left: Box::new(Expression::Value(3)),\n"
+"            right: Box::new(Expression::Value(4)),\n"
+"        }),\n"
+"        right: Box::new(Expression::Value(5)),\n"
+"    };\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Add,\n"
+"            left: Box::new(term1),\n"
+"            right: Box::new(term2),\n"
+"        }),\n"
+"        Ok(85)\n"
+"    );\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_error() {\n"
+"    assert_eq!(\n"
+"        eval(Expression::Op {\n"
+"            op: Operation::Div,\n"
+"            left: Box::new(Expression::Value(99)),\n"
+"            right: Box::new(Expression::Value(0)),\n"
+"        }),\n"
+"        Err(String::from(\"division by zero\"))\n"
+"    );\n"
+"}\n"
+"fn main() {\n"
+"    let expr = Expression::Op {\n"
+"        op: Operation::Sub,\n"
+"        left: Box::new(Expression::Value(20)),\n"
+"        right: Box::new(Expression::Value(10)),\n"
+"    };\n"
+"    println!(\"expr: {:?}\", expr);\n"
+"    println!(\"result: {:?}\", eval(expr));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
@@ -16730,28 +18659,281 @@ msgstr "ライブラリをデザイン"
 msgid "([back to exercise](book-library.md))"
 msgstr ""
 
-#: src/exercises/day-2/solutions-morning.md:54
-msgid "\"{}, published in {}\""
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:59
+#: src/exercises/day-2/solutions-morning.md:7
 msgid ""
-"// Using a closure and a built-in method:\n"
+"```rust\n"
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}\n"
+"\n"
+"struct Book {\n"
+"    title: String,\n"
+"    year: u16,\n"
+"}\n"
+"\n"
+"impl Book {\n"
+"    // This is a constructor, used below.\n"
+"    fn new(title: &str, year: u16) -> Book {\n"
+"        Book {\n"
+"            title: String::from(title),\n"
+"            year,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// Implement the methods below. Notice how the `self` parameter\n"
+"// changes type to indicate the method's required level of ownership\n"
+"// over the object:\n"
+"//\n"
+"// - `&self` for shared read-only access,\n"
+"// - `&mut self` for unique and mutable access,\n"
+"// - `self` for unique access by value.\n"
+"impl Library {\n"
+"\n"
+"    fn new() -> Library {\n"
+"        Library { books: Vec::new() }\n"
+"    }\n"
+"\n"
+"    fn len(&self) -> usize {\n"
+"        self.books.len()\n"
+"    }\n"
+"\n"
+"    fn is_empty(&self) -> bool {\n"
+"        self.books.is_empty()\n"
+"    }\n"
+"\n"
+"    fn add_book(&mut self, book: Book) {\n"
+"        self.books.push(book)\n"
+"    }\n"
+"\n"
+"    fn print_books(&self) {\n"
+"        for book in &self.books {\n"
+"            println!(\"{}, published in {}\", book.title, book.year);\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn oldest_book(&self) -> Option<&Book> {\n"
+"        // Using a closure and a built-in method:\n"
 "        // self.books.iter().min_by_key(|book| book.year)\n"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:62
-msgid "// Longer hand-written solution:\n"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:127
-msgid ""
-"// We could try and capture stdout, but let us just call the\n"
+"\n"
+"        // Longer hand-written solution:\n"
+"        let mut oldest: Option<&Book> = None;\n"
+"        for book in self.books.iter() {\n"
+"            if oldest.is_none() || book.year < oldest.unwrap().year {\n"
+"                oldest = Some(book);\n"
+"            }\n"
+"        }\n"
+"\n"
+"        oldest\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut library = Library::new();\n"
+"\n"
+"    println!(\n"
+"        \"The library is empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"\n"
+"    println!(\n"
+"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
+"        library.is_empty()\n"
+"    );\n"
+"\n"
+"    library.print_books();\n"
+"\n"
+"    match library.oldest_book() {\n"
+"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
+"        None => println!(\"The library is empty!\"),\n"
+"    }\n"
+"\n"
+"    println!(\"The library has {} books\", library.len());\n"
+"    library.print_books();\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_len() {\n"
+"    let mut library = Library::new();\n"
+"    assert_eq!(library.len(), 0);\n"
+"    assert!(library.is_empty());\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(library.len(), 2);\n"
+"    assert!(!library.is_empty());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_is_empty() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.is_empty());\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert!(!library.is_empty());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_print_books() {\n"
+"    let mut library = Library::new();\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    // We could try and capture stdout, but let us just call the\n"
 "    // method to start with.\n"
+"    library.print_books();\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_library_oldest_book() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.oldest_book().is_none());\n"
+"\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Lord of the Rings\")\n"
+"    );\n"
+"\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Alice's Adventures in Wonderland\")\n"
+"    );\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:153
 msgid "([back to exercise](health-statistics.md))"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:155
+msgid ""
+"```rust\n"
+"pub struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    height: f32,\n"
+"    visit_count: usize,\n"
+"    last_blood_pressure: Option<(u32, u32)>,\n"
+"}\n"
+"\n"
+"pub struct Measurements {\n"
+"    height: f32,\n"
+"    blood_pressure: (u32, u32),\n"
+"}\n"
+"\n"
+"pub struct HealthReport<'a> {\n"
+"    patient_name: &'a str,\n"
+"    visit_count: u32,\n"
+"    height_change: f32,\n"
+"    blood_pressure_change: Option<(i32, i32)>,\n"
+"}\n"
+"\n"
+"impl User {\n"
+"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
+"        Self {\n"
+"            name,\n"
+"            age,\n"
+"            height,\n"
+"            visit_count: 0,\n"
+"            last_blood_pressure: None,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    pub fn name(&self) -> &str {\n"
+"        &self.name\n"
+"    }\n"
+"\n"
+"    pub fn age(&self) -> u32 {\n"
+"        self.age\n"
+"    }\n"
+"\n"
+"    pub fn height(&self) -> f32 {\n"
+"        self.height\n"
+"    }\n"
+"\n"
+"    pub fn doctor_visits(&self) -> u32 {\n"
+"        self.visit_count as u32\n"
+"    }\n"
+"\n"
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        self.age = new_age\n"
+"    }\n"
+"\n"
+"    pub fn set_height(&mut self, new_height: f32) {\n"
+"        self.height = new_height\n"
+"    }\n"
+"\n"
+"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
+"HealthReport {\n"
+"        self.visit_count += 1;\n"
+"        let bp = measurements.blood_pressure;\n"
+"        let report = HealthReport {\n"
+"            patient_name: &self.name,\n"
+"            visit_count: self.visit_count as u32,\n"
+"            height_change: measurements.height - self.height,\n"
+"            blood_pressure_change: match self.last_blood_pressure {\n"
+"                Some(lbp) => Some((\n"
+"                    bp.0 as i32 - lbp.0 as i32,\n"
+"                    bp.1 as i32 - lbp.1 as i32\n"
+"                )),\n"
+"                None => None,\n"
+"            }\n"
+"        };\n"
+"        self.height = measurements.height;\n"
+"        self.last_blood_pressure = Some(bp);\n"
+"        report\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_height() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.height(), 155.2);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_set_age() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.age(), 32);\n"
+"    bob.set_age(33);\n"
+"    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_visit() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.doctor_visits(), 0);\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (120, 80),\n"
+"    });\n"
+"    assert_eq!(report.patient_name, \"Bob\");\n"
+"    assert_eq!(report.visit_count, 1);\n"
+"    assert_eq!(report.blood_pressure_change, None);\n"
+"\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (115, 76),\n"
+"    });\n"
+"\n"
+"    assert_eq!(report.visit_count, 2);\n"
+"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
@@ -16762,18 +18944,24 @@ msgstr ""
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:10
-#: src/exercises/day-2/solutions-afternoon.md:12
-msgid "'/'"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:16
-msgid "\"*\""
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:22
+#: src/exercises/day-2/solutions-afternoon.md:7
 msgid ""
-"// Alternatively, Iterator::zip() lets us iterate simultaneously over "
+"```rust\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"\n"
+"    let mut request_segments = request_path.split('/');\n"
+"\n"
+"    for prefix_segment in prefix.split('/') {\n"
+"        let Some(request_segment) = request_segments.next() else {\n"
+"            return false;\n"
+"        };\n"
+"        if request_segment != prefix_segment && prefix_segment != \"*\" {\n"
+"            return false;\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"\n"
+"    // Alternatively, Iterator::zip() lets us iterate simultaneously over "
 "prefix\n"
 "    // and request segments. The zip() iterator is finished as soon as one "
 "of\n"
@@ -16784,6 +18972,47 @@ msgid ""
 "    // to produce an iterator that returns Some(str) for each pattern "
 "segments,\n"
 "    // and then returns None indefinitely.\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"\n"
+"fn main() {}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
@@ -16794,54 +19023,230 @@ msgstr ""
 msgid "([back to exercise](simple-gui.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-morning.md:75
-msgid "// Add 4 paddings for borders\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:87
+#: src/exercises/day-3/solutions-morning.md:7
 msgid ""
-"// TODO: after learning about error handling, you can change\n"
+"```rust\n"
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;\n"
+"\n"
+"    /// Draw the widget into a buffer.\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
+"\n"
+"    /// Draw the widget on standard output.\n"
+"    fn draw(&self) {\n"
+"        let mut buffer = String::new();\n"
+"        self.draw_into(&mut buffer);\n"
+"        println!(\"{buffer}\");\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Label {\n"
+"    label: String,\n"
+"}\n"
+"\n"
+"impl Label {\n"
+"    fn new(label: &str) -> Label {\n"
+"        Label {\n"
+"            label: label.to_owned(),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Button {\n"
+"    label: Label,\n"
+"}\n"
+"\n"
+"impl Button {\n"
+"    fn new(label: &str) -> Button {\n"
+"        Button {\n"
+"            label: Label::new(label),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Window {\n"
+"    title: String,\n"
+"    widgets: Vec<Box<dyn Widget>>,\n"
+"}\n"
+"\n"
+"impl Window {\n"
+"    fn new(title: &str) -> Window {\n"
+"        Window {\n"
+"            title: title.to_owned(),\n"
+"            widgets: Vec::new(),\n"
+"        }\n"
+"    }\n"
+"\n"
+"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"        self.widgets.push(widget);\n"
+"    }\n"
+"\n"
+"    fn inner_width(&self) -> usize {\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }\n"
+"}\n"
+"\n"
+"\n"
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        // Add 4 paddings for borders\n"
+"        self.inner_width() + 4\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        let mut inner = String::new();\n"
+"        for widget in &self.widgets {\n"
+"            widget.draw_into(&mut inner);\n"
+"        }\n"
+"\n"
+"        let inner_width = self.inner_width();\n"
+"\n"
+"        // TODO: after learning about error handling, you can change\n"
 "        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
 "        // the ?-operator here instead of .unwrap().\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:90
-#: src/exercises/day-3/solutions-morning.md:96
-msgid "\"+-{:-<inner_width$}-+\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:91
-msgid "\"| {:^inner_width$} |\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:92
-msgid "\"+={:=<inner_width$}=+\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:94
-msgid "\"| {:inner_width$} |\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:102
-msgid "// add a bit of padding\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:110
-#: src/exercises/day-3/solutions-morning.md:114
-msgid "\"+{:-<width$}+\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:112
-msgid "\"|{:^width$}|\""
+"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
+"        writeln!(buffer, \"| {:^inner_width$} |\", &self.title).unwrap();\n"
+"        writeln!(buffer, \"+={:=<inner_width$}=+\", \"\").unwrap();\n"
+"        for line in inner.lines() {\n"
+"            writeln!(buffer, \"| {:inner_width$} |\", line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        self.label.width() + 8 // add a bit of padding\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        let width = self.width();\n"
+"        let mut label = String::new();\n"
+"        self.label.draw_into(&mut label);\n"
+"\n"
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"        for line in label.lines() {\n"
+"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        self.label\n"
+"            .lines()\n"
+"            .map(|line| line.chars().count())\n"
+"            .max()\n"
+"            .unwrap_or(0)\n"
+"    }\n"
+"\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\"\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:144
 msgid "([back to exercise](points-polygons.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-morning.md:223
+#: src/exercises/day-3/solutions-morning.md:146
 msgid ""
-"// Alternatively, Iterator::zip() lets us iterate over the points as pairs\n"
+"```rust\n"
+"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
+"pub struct Point {\n"
+"    x: i32,\n"
+"    y: i32,\n"
+"}\n"
+"\n"
+"impl Point {\n"
+"    pub fn new(x: i32, y: i32) -> Point {\n"
+"        Point { x, y }\n"
+"    }\n"
+"\n"
+"    pub fn magnitude(self) -> f64 {\n"
+"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"    }\n"
+"\n"
+"    pub fn dist(self, other: Point) -> f64 {\n"
+"        (self - other).magnitude()\n"
+"    }\n"
+"}\n"
+"\n"
+"impl std::ops::Add for Point {\n"
+"    type Output = Self;\n"
+"\n"
+"    fn add(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x + other.x,\n"
+"            y: self.y + other.y,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"impl std::ops::Sub for Point {\n"
+"    type Output = Self;\n"
+"\n"
+"    fn sub(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x - other.x,\n"
+"            y: self.y - other.y,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Polygon {\n"
+"    points: Vec<Point>,\n"
+"}\n"
+"\n"
+"impl Polygon {\n"
+"    pub fn new() -> Polygon {\n"
+"        Polygon { points: Vec::new() }\n"
+"    }\n"
+"\n"
+"    pub fn add_point(&mut self, point: Point) {\n"
+"        self.points.push(point);\n"
+"    }\n"
+"\n"
+"    pub fn left_most_point(&self) -> Option<Point> {\n"
+"        self.points.iter().min_by_key(|p| p.x).copied()\n"
+"    }\n"
+"\n"
+"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"        self.points.iter()\n"
+"    }\n"
+"\n"
+"    pub fn length(&self) -> f64 {\n"
+"        if self.points.is_empty() {\n"
+"            return 0.0;\n"
+"        }\n"
+"\n"
+"        let mut result = 0.0;\n"
+"        let mut last_point = self.points[0];\n"
+"        for point in &self.points[1..] {\n"
+"            result += last_point.dist(*point);\n"
+"            last_point = *point;\n"
+"        }\n"
+"        result += last_point.dist(self.points[0]);\n"
+"        result\n"
+"        // Alternatively, Iterator::zip() lets us iterate over the points as "
+"pairs\n"
 "        // but we need to pair each point with the next one, and the last "
 "point\n"
 "        // with the first point. The zip() iterator is finished as soon as "
@@ -16851,6 +19256,127 @@ msgid ""
 "        // with Iterator::skip to create the second iterator for the zip and "
 "using map \n"
 "        // and sum to calculate the total length.\n"
+"    }\n"
+"}\n"
+"\n"
+"pub struct Circle {\n"
+"    center: Point,\n"
+"    radius: i32,\n"
+"}\n"
+"\n"
+"impl Circle {\n"
+"    pub fn new(center: Point, radius: i32) -> Circle {\n"
+"        Circle { center, radius }\n"
+"    }\n"
+"\n"
+"    pub fn circumference(&self) -> f64 {\n"
+"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"    }\n"
+"\n"
+"    pub fn dist(&self, other: &Self) -> f64 {\n"
+"        self.center.dist(other.center)\n"
+"    }\n"
+"}\n"
+"\n"
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}\n"
+"\n"
+"impl From<Polygon> for Shape {\n"
+"    fn from(poly: Polygon) -> Self {\n"
+"        Shape::Polygon(poly)\n"
+"    }\n"
+"}\n"
+"\n"
+"impl From<Circle> for Shape {\n"
+"    fn from(circle: Circle) -> Self {\n"
+"        Shape::Circle(circle)\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Shape {\n"
+"    pub fn perimeter(&self) -> f64 {\n"
+"        match self {\n"
+"            Shape::Polygon(poly) => poly.length(),\n"
+"            Shape::Circle(circle) => circle.circumference(),\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"\n"
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100.0).round() / 100.0\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_magnitude() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_dist() {\n"
+"        let p1 = Point::new(10, 10);\n"
+"        let p2 = Point::new(14, 13);\n"
+"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_point_add() {\n"
+"        let p1 = Point::new(16, 16);\n"
+"        let p2 = p1 + Point::new(-4, 3);\n"
+"        assert_eq!(p2, Point::new(12, 19));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_left_most_point() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"        assert_eq!(poly.left_most_point(), Some(p1));\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_polygon_iter() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);\n"
+"\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"\n"
+"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
@@ -16861,81 +19387,172 @@ msgstr ""
 msgid "([back to exercise](safe-ffi-wrapper.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-afternoon.md:77
-msgid "\"Invalid path: {err}\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:78
-msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:81
-msgid "\"Could not open {:?}\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:91
+#: src/exercises/day-3/solutions-afternoon.md:7
 msgid ""
-"// Keep calling readdir until we get a NULL pointer back.\n"
+"```rust\n"
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int};\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
+"\n"
+"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"    #[repr(C)]\n"
+"    pub struct DIR {\n"
+"        _data: [u8; 0],\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
+"    }\n"
+"\n"
+"    // Layout according to the Linux man page for readdir(3), where ino_t "
+"and\n"
+"    // off_t are resolved according to the definitions in\n"
+"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
+"    #[cfg(not(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_ino: c_ulong,\n"
+"        pub d_off: c_long,\n"
+"        pub d_reclen: c_ushort,\n"
+"        pub d_type: c_uchar,\n"
+"        pub d_name: [c_char; 256],\n"
+"    }\n"
+"\n"
+"    // Layout according to the macOS man page for dir(5).\n"
+"    #[cfg(all(target_os = \"macos\"))]\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_fileno: u64,\n"
+"        pub d_seekoff: u64,\n"
+"        pub d_reclen: u16,\n"
+"        pub d_namlen: u16,\n"
+"        pub d_type: u8,\n"
+"        pub d_name: [c_char; 1024],\n"
+"    }\n"
+"\n"
+"    extern \"C\" {\n"
+"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"\n"
+"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        // See https://github.com/rust-lang/libc/issues/414 and the section "
+"on\n"
+"        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
+"        //\n"
+"        // \"Platforms that existed before these updates were available\" "
+"refers\n"
+"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
+"PowerPC.\n"
+"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
+"        #[link_name = \"readdir$INODE64\"]\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"\n"
+"        pub fn closedir(s: *mut DIR) -> c_int;\n"
+"    }\n"
+"}\n"
+"\n"
+"use std::ffi::{CStr, CString, OsStr, OsString};\n"
+"use std::os::unix::ffi::OsStrExt;\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"\n"
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
+"        // otherwise return Err with a message.\n"
+"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
+"{err}\"))?;\n"
+"        // SAFETY: path.as_ptr() cannot be NULL.\n"
+"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
+"        if dir.is_null() {\n"
+"            Err(format!(\"Could not open {:?}\", path))\n"
+"        } else {\n"
+"            Ok(DirectoryIterator { path, dir })\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
 "        // SAFETY: self.dir is never NULL.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:95
-msgid "// We have reached the end of the directory.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:98
-msgid ""
-"// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
+"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
+"        if dirent.is_null() {\n"
+"            // We have reached the end of the directory.\n"
+"            return None;\n"
+"        }\n"
+"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
 "        // terminated.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:110
-msgid "// SAFETY: self.dir is not NULL.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:112
-msgid "\"Could not close {:?}\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:131
-msgid "\"no-such-directory\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:139
-#: src/exercises/day-3/solutions-afternoon.md:154
-msgid "\"Non UTF-8 character in path\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:143
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"..\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:150
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"foo.txt\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:150
-msgid "\"The Foo Diaries\\n\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:151
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"bar.png\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:151
-msgid "\"<PNG>\\n\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:152
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"crab.rs\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:152
-msgid "\"//! Crab\\n\""
+"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
+"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
+"        Some(os_str.to_owned())\n"
+"    }\n"
+"}\n"
+"\n"
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        if !self.dir.is_null() {\n"
+"            // SAFETY: self.dir is not NULL.\n"
+"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
+"                panic!(\"Could not close {:?}\", self.path);\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;\n"
+"    use std::error::Error;\n"
+"\n"
+"    #[test]\n"
+"    fn test_nonexisting_directory() {\n"
+"        let iter = DirectoryIterator::new(\"no-such-directory\");\n"
+"        assert!(iter.is_err());\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_empty_directory() -> Result<(), Box<dyn Error>> {\n"
+"        let tmp = tempfile::TempDir::new()?;\n"
+"        let iter = DirectoryIterator::new(\n"
+"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
+"        )?;\n"
+"        let mut entries = iter.collect::<Vec<_>>();\n"
+"        entries.sort();\n"
+"        assert_eq!(entries, &[\".\", \"..\"]);\n"
+"        Ok(())\n"
+"    }\n"
+"\n"
+"    #[test]\n"
+"    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
+"        let tmp = tempfile::TempDir::new()?;\n"
+"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo "
+"Diaries\\n\")?;\n"
+"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n\")?;\n"
+"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n\")?;\n"
+"        let iter = DirectoryIterator::new(\n"
+"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
+"        )?;\n"
+"        let mut entries = iter.collect::<Vec<_>>();\n"
+"        entries.sort();\n"
+"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", \"foo."
+"txt\"]);\n"
+"        Ok(())\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
@@ -16946,30 +19563,151 @@ msgstr ""
 msgid "([back to exercise](compass.md))"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:40
-msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:41
-msgid "\"Setting up IMU...\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:49
-msgid "// Set up display and timer.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:59
-msgid "// Read compass data and log it to the serial port.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:67
-msgid "\"{},{},{}\\t{},{},{}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:103
+#: src/exercises/bare-metal/solutions-morning.md:7
 msgid ""
-"// If button A is pressed, switch to the next mode and briefly blink all "
-"LEDs on.\n"
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"extern crate panic_halt as _;\n"
+"\n"
+"use core::fmt::Write;\n"
+"use cortex_m_rt::entry;\n"
+"use core::cmp::{max, min};\n"
+"use lsm303agr::{AccelOutputDataRate, Lsm303agr, MagOutputDataRate};\n"
+"use microbit::display::blocking::Display;\n"
+"use microbit::hal::prelude::*;\n"
+"use microbit::hal::twim::Twim;\n"
+"use microbit::hal::uarte::{Baudrate, Parity, Uarte};\n"
+"use microbit::hal::Timer;\n"
+"use microbit::pac::twim0::frequency::FREQUENCY_A;\n"
+"use microbit::Board;\n"
+"\n"
+"const COMPASS_SCALE: i32 = 30000;\n"
+"const ACCELEROMETER_SCALE: i32 = 700;\n"
+"\n"
+"#[entry]\n"
+"fn main() -> ! {\n"
+"    let board = Board::take().unwrap();\n"
+"\n"
+"    // Configure serial port.\n"
+"    let mut serial = Uarte::new(\n"
+"        board.UARTE0,\n"
+"        board.uart.into(),\n"
+"        Parity::EXCLUDED,\n"
+"        Baudrate::BAUD115200,\n"
+"    );\n"
+"\n"
+"    // Set up the I2C controller and Inertial Measurement Unit.\n"
+"    writeln!(serial, \"Setting up IMU...\").unwrap();\n"
+"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::"
+"K100);\n"
+"    let mut imu = Lsm303agr::new_with_i2c(i2c);\n"
+"    imu.init().unwrap();\n"
+"    imu.set_mag_odr(MagOutputDataRate::Hz50).unwrap();\n"
+"    imu.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();\n"
+"    let mut imu = imu.into_mag_continuous().ok().unwrap();\n"
+"\n"
+"    // Set up display and timer.\n"
+"    let mut timer = Timer::new(board.TIMER0);\n"
+"    let mut display = Display::new(board.display_pins);\n"
+"\n"
+"    let mut mode = Mode::Compass;\n"
+"    let mut button_pressed = false;\n"
+"\n"
+"    writeln!(serial, \"Ready.\").unwrap();\n"
+"\n"
+"    loop {\n"
+"        // Read compass data and log it to the serial port.\n"
+"        while !(imu.mag_status().unwrap().xyz_new_data\n"
+"            && imu.accel_status().unwrap().xyz_new_data)\n"
+"        {}\n"
+"        let compass_reading = imu.mag_data().unwrap();\n"
+"        let accelerometer_reading = imu.accel_data().unwrap();\n"
+"        writeln!(\n"
+"            serial,\n"
+"            \"{},{},{}\\t{},{},{}\",\n"
+"            compass_reading.x,\n"
+"            compass_reading.y,\n"
+"            compass_reading.z,\n"
+"            accelerometer_reading.x,\n"
+"            accelerometer_reading.y,\n"
+"            accelerometer_reading.z,\n"
+"        )\n"
+"        .unwrap();\n"
+"\n"
+"        let mut image = [[0; 5]; 5];\n"
+"        let (x, y) = match mode {\n"
+"            Mode::Compass => (\n"
+"                scale(-compass_reading.x, -COMPASS_SCALE, COMPASS_SCALE, 0, "
+"4) as usize,\n"
+"                scale(compass_reading.y, -COMPASS_SCALE, COMPASS_SCALE, 0, "
+"4) as usize,\n"
+"            ),\n"
+"            Mode::Accelerometer => (\n"
+"                scale(\n"
+"                    accelerometer_reading.x,\n"
+"                    -ACCELEROMETER_SCALE,\n"
+"                    ACCELEROMETER_SCALE,\n"
+"                    0,\n"
+"                    4,\n"
+"                ) as usize,\n"
+"                scale(\n"
+"                    -accelerometer_reading.y,\n"
+"                    -ACCELEROMETER_SCALE,\n"
+"                    ACCELEROMETER_SCALE,\n"
+"                    0,\n"
+"                    4,\n"
+"                ) as usize,\n"
+"            ),\n"
+"        };\n"
+"        image[y][x] = 255;\n"
+"        display.show(&mut timer, image, 100);\n"
+"\n"
+"        // If button A is pressed, switch to the next mode and briefly blink "
+"all LEDs on.\n"
+"        if board.buttons.button_a.is_low().unwrap() {\n"
+"            if !button_pressed {\n"
+"                mode = mode.next();\n"
+"                display.show(&mut timer, [[255; 5]; 5], 200);\n"
+"            }\n"
+"            button_pressed = true;\n"
+"        } else {\n"
+"            button_pressed = false;\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
+"enum Mode {\n"
+"    Compass,\n"
+"    Accelerometer,\n"
+"}\n"
+"\n"
+"impl Mode {\n"
+"    fn next(self) -> Self {\n"
+"        match self {\n"
+"            Self::Compass => Self::Accelerometer,\n"
+"            Self::Accelerometer => Self::Compass,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -"
+"> i32 {\n"
+"    let range_in = max_in - min_in;\n"
+"    let range_out = max_out - min_out;\n"
+"    cap(\n"
+"        min_out + range_out * (value - min_in) / range_in,\n"
+"        min_out,\n"
+"        max_out,\n"
+"    )\n"
+"}\n"
+"\n"
+"fn cap(value: i32, min_value: i32, max_value: i32) -> i32 {\n"
+"    max(min_value, min(value, max_value))\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -16980,92 +19718,174 @@ msgstr ""
 msgid "_main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:36
-msgid "/// Base address of the PL031 RTC.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:38
-msgid "/// The IRQ used by the PL031 RTC.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:57
+#: src/exercises/bare-metal/solutions-afternoon.md:9
 msgid ""
-"// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
+"```rust,compile_fail\n"
+"#![no_main]\n"
+"#![no_std]\n"
+"\n"
+"mod exceptions;\n"
+"mod logger;\n"
+"mod pl011;\n"
+"mod pl031;\n"
+"\n"
+"use crate::pl031::Rtc;\n"
+"use arm_gic::gicv3::{IntId, Trigger};\n"
+"use arm_gic::{irq_enable, wfi};\n"
+"use chrono::{TimeZone, Utc};\n"
+"use core::hint::spin_loop;\n"
+"use crate::pl011::Uart;\n"
+"use arm_gic::gicv3::GicV3;\n"
+"use core::panic::PanicInfo;\n"
+"use log::{error, info, trace, LevelFilter};\n"
+"use smccc::psci::system_off;\n"
+"use smccc::Hvc;\n"
+"\n"
+"/// Base addresses of the GICv3.\n"
+"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
+"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
+"\n"
+"/// Base address of the primary PL011 UART.\n"
+"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
+"\n"
+"/// Base address of the PL031 RTC.\n"
+"const PL031_BASE_ADDRESS: *mut u32 = 0x901_0000 as _;\n"
+"/// The IRQ used by the PL031 RTC.\n"
+"const PL031_IRQ: IntId = IntId::spi(2);\n"
+"\n"
+"#[no_mangle]\n"
+"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
 "    // and nothing else accesses that address range.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:62
-msgid "\"RTC: {time}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:70
-msgid "// Wait for 3 seconds, without interrupts.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:74
-#: src/exercises/bare-metal/solutions-afternoon.md:95
-msgid "\"Waiting for {}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:78
-#: src/exercises/bare-metal/solutions-afternoon.md:86
-#: src/exercises/bare-metal/solutions-afternoon.md:102
-#: src/exercises/bare-metal/solutions-afternoon.md:110
-msgid "\"matched={}, interrupt_pending={}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:90
-#: src/exercises/bare-metal/solutions-afternoon.md:114
-msgid "\"Finished waiting\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:92
-msgid "// Wait another 3 seconds for an interrupt.\n"
+"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
+"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
+"\n"
+"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
+"\n"
+"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
+"base\n"
+"    // addresses of a GICv3 distributor and redistributor respectively, and\n"
+"    // nothing else accesses those address ranges.\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
+"    gic.setup();\n"
+"\n"
+"    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 "
+"device,\n"
+"    // and nothing else accesses that address range.\n"
+"    let mut rtc = unsafe { Rtc::new(PL031_BASE_ADDRESS) };\n"
+"    let timestamp = rtc.read();\n"
+"    let time = Utc.timestamp_opt(timestamp.into(), 0).unwrap();\n"
+"    info!(\"RTC: {time}\");\n"
+"\n"
+"    GicV3::set_priority_mask(0xff);\n"
+"    gic.set_interrupt_priority(PL031_IRQ, 0x80);\n"
+"    gic.set_trigger(PL031_IRQ, Trigger::Level);\n"
+"    irq_enable();\n"
+"    gic.enable_interrupt(PL031_IRQ, true);\n"
+"\n"
+"    // Wait for 3 seconds, without interrupts.\n"
+"    let target = timestamp + 3;\n"
+"    rtc.set_match(target);\n"
+"    info!(\n"
+"        \"Waiting for {}\",\n"
+"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
+"    );\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    while !rtc.matched() {\n"
+"        spin_loop();\n"
+"    }\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    info!(\"Finished waiting\");\n"
+"\n"
+"    // Wait another 3 seconds for an interrupt.\n"
+"    let target = timestamp + 6;\n"
+"    info!(\n"
+"        \"Waiting for {}\",\n"
+"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
+"    );\n"
+"    rtc.set_match(target);\n"
+"    rtc.clear_interrupt();\n"
+"    rtc.enable_interrupt(true);\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    while !rtc.interrupt_pending() {\n"
+"        wfi();\n"
+"    }\n"
+"    trace!(\n"
+"        \"matched={}, interrupt_pending={}\",\n"
+"        rtc.matched(),\n"
+"        rtc.interrupt_pending()\n"
+"    );\n"
+"    info!(\"Finished waiting\");\n"
+"\n"
+"    system_off::<Hvc>().unwrap();\n"
+"}\n"
+"\n"
+"#[panic_handler]\n"
+"fn panic(info: &PanicInfo) -> ! {\n"
+"    error!(\"{info}\");\n"
+"    system_off::<Hvc>().unwrap();\n"
+"    loop {}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:127
 msgid "_pl031.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:134
-msgid "/// Data register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:136
-msgid "/// Match register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:138
-msgid "/// Load register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:140
-msgid "/// Control register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:143
-msgid "/// Interrupt Mask Set or Clear register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:146
-msgid "/// Raw Interrupt Status\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:149
-msgid "/// Masked Interrupt Status\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:152
-msgid "/// Interrupt Clear Register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:156
-msgid "/// Driver for a PL031 real-time clock.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:164
+#: src/exercises/bare-metal/solutions-afternoon.md:129
 msgid ""
-"/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
+"```rust\n"
+"use core::ptr::{addr_of, addr_of_mut};\n"
+"\n"
+"#[repr(C, align(4))]\n"
+"struct Registers {\n"
+"    /// Data register\n"
+"    dr: u32,\n"
+"    /// Match register\n"
+"    mr: u32,\n"
+"    /// Load register\n"
+"    lr: u32,\n"
+"    /// Control register\n"
+"    cr: u8,\n"
+"    _reserved0: [u8; 3],\n"
+"    /// Interrupt Mask Set or Clear register\n"
+"    imsc: u8,\n"
+"    _reserved1: [u8; 3],\n"
+"    /// Raw Interrupt Status\n"
+"    ris: u8,\n"
+"    _reserved2: [u8; 3],\n"
+"    /// Masked Interrupt Status\n"
+"    mis: u8,\n"
+"    _reserved3: [u8; 3],\n"
+"    /// Interrupt Clear Register\n"
+"    icr: u8,\n"
+"    _reserved4: [u8; 3],\n"
+"}\n"
+"\n"
+"/// Driver for a PL031 real-time clock.\n"
+"#[derive(Debug)]\n"
+"pub struct Rtc {\n"
+"    registers: *mut Registers,\n"
+"}\n"
+"\n"
+"impl Rtc {\n"
+"    /// Constructs a new instance of the RTC driver for a PL031 device at "
+"the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -17075,55 +19895,76 @@ msgid ""
 "    /// PL031 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:178
-msgid "/// Reads the current RTC value.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:180
-#: src/exercises/bare-metal/solutions-afternoon.md:188
-#: src/exercises/bare-metal/solutions-afternoon.md:196
-#: src/exercises/bare-metal/solutions-afternoon.md:207
-#: src/exercises/bare-metal/solutions-afternoon.md:219
-#: src/exercises/bare-metal/solutions-afternoon.md:226
-msgid ""
-"// Safe because we know that self.registers points to the control\n"
+"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
+"        Self {\n"
+"            registers: base_address as *mut Registers,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Reads the current RTC value.\n"
+"    pub fn read(&self) -> u32 {\n"
+"        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:185
-msgid ""
-"/// Writes a match value. When the RTC value matches this then an interrupt\n"
+"        unsafe { addr_of!((*self.registers).dr).read_volatile() }\n"
+"    }\n"
+"\n"
+"    /// Writes a match value. When the RTC value matches this then an "
+"interrupt\n"
 "    /// will be generated (if it is enabled).\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:193
-msgid ""
-"/// Returns whether the match register matches the RTC value, whether or "
+"    pub fn set_match(&mut self, value: u32) {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        unsafe { addr_of_mut!((*self.registers).mr).write_volatile(value) }\n"
+"    }\n"
+"\n"
+"    /// Returns whether the match register matches the RTC value, whether or "
 "not\n"
 "    /// the interrupt is enabled.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:202
-msgid ""
-"/// Returns whether there is currently an interrupt pending.\n"
+"    pub fn matched(&self) -> bool {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        let ris = unsafe { addr_of!((*self.registers).ris)."
+"read_volatile() };\n"
+"        (ris & 0x01) != 0\n"
+"    }\n"
+"\n"
+"    /// Returns whether there is currently an interrupt pending.\n"
 "    ///\n"
 "    /// This should be true if and only if `matched` returns true and the\n"
 "    /// interrupt is masked.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:213
-msgid ""
-"/// Sets or clears the interrupt mask.\n"
+"    pub fn interrupt_pending(&self) -> bool {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        let ris = unsafe { addr_of!((*self.registers).mis)."
+"read_volatile() };\n"
+"        (ris & 0x01) != 0\n"
+"    }\n"
+"\n"
+"    /// Sets or clears the interrupt mask.\n"
 "    ///\n"
 "    /// When the mask is true the interrupt is enabled; when it is false "
 "the\n"
 "    /// interrupt is disabled.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:224
-msgid "/// Clears a pending interrupt, if any.\n"
+"    pub fn enable_interrupt(&mut self, mask: bool) {\n"
+"        let imsc = if mask { 0x01 } else { 0x00 };\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        unsafe { addr_of_mut!((*self.registers).imsc)."
+"write_volatile(imsc) }\n"
+"    }\n"
+"\n"
+"    /// Clears a pending interrupt, if any.\n"
+"    pub fn clear_interrupt(&mut self) {\n"
+"        // Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+"        unsafe { addr_of_mut!((*self.registers).icr).write_volatile(0x01) }\n"
+"    }\n"
+"}\n"
+"\n"
+"// Safe because it just contains a pointer to device memory, which can be\n"
+"// accessed from any context.\n"
+"unsafe impl Send for Rtc {}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
@@ -17134,19 +19975,82 @@ msgstr ""
 msgid "([back to exercise](dining-philosophers.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md:29
-msgid "\"{} is trying to eat\""
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:53
+#: src/exercises/concurrency/solutions-morning.md:7
 msgid ""
-"// To avoid a deadlock, we have to break the symmetry\n"
+"```rust\n"
+"use std::sync::{mpsc, Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    thoughts: mpsc::SyncSender<String>,\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    fn eat(&self) {\n"
+"        println!(\"{} is trying to eat\", &self.name);\n"
+"        let left = self.left_fork.lock().unwrap();\n"
+"        let right = self.right_fork.lock().unwrap();\n"
+"\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
+"\n"
+"fn main() {\n"
+"    let (tx, rx) = mpsc::sync_channel(10);\n"
+"\n"
+"    let forks = (0..PHILOSOPHERS.len())\n"
+"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
+"        .collect::<Vec<_>>();\n"
+"\n"
+"    for i in 0..forks.len() {\n"
+"        let tx = tx.clone();\n"
+"        let mut left_fork = Arc::clone(&forks[i]);\n"
+"        let mut right_fork = Arc::clone(&forks[(i + 1) % forks.len()]);\n"
+"\n"
+"        // To avoid a deadlock, we have to break the symmetry\n"
 "        // somewhere. This will swap the forks without deinitializing\n"
 "        // either of them.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:77
-msgid "\"{thought}\""
+"        if i == forks.len() - 1 {\n"
+"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"        }\n"
+"\n"
+"        let philosopher = Philosopher {\n"
+"            name: PHILOSOPHERS[i].to_string(),\n"
+"            thoughts: tx,\n"
+"            left_fork,\n"
+"            right_fork,\n"
+"        };\n"
+"\n"
+"        thread::spawn(move || {\n"
+"            for _ in 0..100 {\n"
+"                philosopher.eat();\n"
+"                philosopher.think();\n"
+"            }\n"
+"        });\n"
+"    }\n"
+"\n"
+"    drop(tx);\n"
+"    for thought in rx {\n"
+"        println!(\"{thought}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:82
@@ -17158,27 +20062,181 @@ msgstr "マルチスレッド・リンクチェッカー"
 msgid "([back to exercise](link-checker.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md:155
+#: src/exercises/concurrency/solutions-morning.md:86
 msgid ""
-"/// Determine whether links within the given page should be extracted.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:163
-msgid ""
-"/// Mark the given page as visited, returning false if it had already\n"
+"```rust,compile_fail\n"
+"use std::{sync::Arc, sync::Mutex, sync::mpsc, thread};\n"
+"\n"
+"use reqwest::{blocking::Client, Url};\n"
+"use scraper::{Html, Selector};\n"
+"use thiserror::Error;\n"
+"\n"
+"#[derive(Error, Debug)]\n"
+"enum Error {\n"
+"    #[error(\"request error: {0}\")]\n"
+"    ReqwestError(#[from] reqwest::Error),\n"
+"    #[error(\"bad http response: {0}\")]\n"
+"    BadResponse(String),\n"
+"}\n"
+"\n"
+"#[derive(Debug)]\n"
+"struct CrawlCommand {\n"
+"    url: Url,\n"
+"    extract_links: bool,\n"
+"}\n"
+"\n"
+"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
+"Error> {\n"
+"    println!(\"Checking {:#}\", command.url);\n"
+"    let response = client.get(command.url.clone()).send()?;\n"
+"    if !response.status().is_success() {\n"
+"        return Err(Error::BadResponse(response.status().to_string()));\n"
+"    }\n"
+"\n"
+"    let mut link_urls = Vec::new();\n"
+"    if !command.extract_links {\n"
+"        return Ok(link_urls);\n"
+"    }\n"
+"\n"
+"    let base_url = response.url().to_owned();\n"
+"    let body_text = response.text()?;\n"
+"    let document = Html::parse_document(&body_text);\n"
+"\n"
+"    let selector = Selector::parse(\"a\").unwrap();\n"
+"    let href_values = document\n"
+"        .select(&selector)\n"
+"        .filter_map(|element| element.value().attr(\"href\"));\n"
+"    for href in href_values {\n"
+"        match base_url.join(href) {\n"
+"            Ok(link_url) => {\n"
+"                link_urls.push(link_url);\n"
+"            }\n"
+"            Err(err) => {\n"
+"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
+"{err}\");\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"    Ok(link_urls)\n"
+"}\n"
+"\n"
+"struct CrawlState {\n"
+"    domain: String,\n"
+"    visited_pages: std::collections::HashSet<String>,\n"
+"}\n"
+"\n"
+"impl CrawlState {\n"
+"    fn new(start_url: &Url) -> CrawlState {\n"
+"        let mut visited_pages = std::collections::HashSet::new();\n"
+"        visited_pages.insert(start_url.as_str().to_string());\n"
+"        CrawlState {\n"
+"            domain: start_url.domain().unwrap().to_string(),\n"
+"            visited_pages,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    /// Determine whether links within the given page should be extracted.\n"
+"    fn should_extract_links(&self, url: &Url) -> bool {\n"
+"        let Some(url_domain) = url.domain() else {\n"
+"            return false;\n"
+"        };\n"
+"        url_domain == self.domain\n"
+"    }\n"
+"\n"
+"    /// Mark the given page as visited, returning false if it had already\n"
 "    /// been visited.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:189
-msgid "// The sender got dropped. No more commands coming in.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:230
-msgid "\"Got crawling error: {:#}\""
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:248
-msgid "\"Bad URLs: {:#?}\""
+"    fn mark_visited(&mut self, url: &Url) -> bool {\n"
+"        self.visited_pages.insert(url.as_str().to_string())\n"
+"    }\n"
+"}\n"
+"\n"
+"type CrawlResult = Result<Vec<Url>, (Url, Error)>;\n"
+"fn spawn_crawler_threads(\n"
+"    command_receiver: mpsc::Receiver<CrawlCommand>,\n"
+"    result_sender: mpsc::Sender<CrawlResult>,\n"
+"    thread_count: u32,\n"
+") {\n"
+"    let command_receiver = Arc::new(Mutex::new(command_receiver));\n"
+"\n"
+"    for _ in 0..thread_count {\n"
+"        let result_sender = result_sender.clone();\n"
+"        let command_receiver = command_receiver.clone();\n"
+"        thread::spawn(move || {\n"
+"            let client = Client::new();\n"
+"            loop {\n"
+"                let command_result = {\n"
+"                    let receiver_guard = command_receiver.lock().unwrap();\n"
+"                    receiver_guard.recv()\n"
+"                };\n"
+"                let Ok(crawl_command) = command_result else {\n"
+"                    // The sender got dropped. No more commands coming in.\n"
+"                    break;\n"
+"                };\n"
+"                let crawl_result = match visit_page(&client, &crawl_command) "
+"{\n"
+"                    Ok(link_urls) => Ok(link_urls),\n"
+"                    Err(error) => Err((crawl_command.url, error)),\n"
+"                };\n"
+"                result_sender.send(crawl_result).unwrap();\n"
+"            }\n"
+"        });\n"
+"    }\n"
+"}\n"
+"\n"
+"fn control_crawl(\n"
+"    start_url: Url,\n"
+"    command_sender: mpsc::Sender<CrawlCommand>,\n"
+"    result_receiver: mpsc::Receiver<CrawlResult>,\n"
+") -> Vec<Url> {\n"
+"    let mut crawl_state = CrawlState::new(&start_url);\n"
+"    let start_command = CrawlCommand { url: start_url, extract_links: "
+"true };\n"
+"    command_sender.send(start_command).unwrap();\n"
+"    let mut pending_urls = 1;\n"
+"\n"
+"    let mut bad_urls = Vec::new();\n"
+"    while pending_urls > 0 {\n"
+"        let crawl_result = result_receiver.recv().unwrap();\n"
+"        pending_urls -= 1;\n"
+"\n"
+"        match crawl_result {\n"
+"            Ok(link_urls) => {\n"
+"                for url in link_urls {\n"
+"                    if crawl_state.mark_visited(&url) {\n"
+"                        let extract_links = crawl_state."
+"should_extract_links(&url);\n"
+"                        let crawl_command = CrawlCommand { url, "
+"extract_links };\n"
+"                        command_sender.send(crawl_command).unwrap();\n"
+"                        pending_urls += 1;\n"
+"                    }\n"
+"                }\n"
+"            }\n"
+"            Err((url, error)) => {\n"
+"                bad_urls.push(url);\n"
+"                println!(\"Got crawling error: {:#}\", error);\n"
+"                continue;\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"    bad_urls\n"
+"}\n"
+"\n"
+"fn check_links(start_url: Url) -> Vec<Url> {\n"
+"    let (result_sender, result_receiver) = mpsc::channel::<CrawlResult>();\n"
+"    let (command_sender, command_receiver) = mpsc::channel::"
+"<CrawlCommand>();\n"
+"    spawn_crawler_threads(command_receiver, result_sender, 16);\n"
+"    control_crawl(start_url, command_sender, result_receiver)\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let start_url = reqwest::Url::parse(\"https://www.google.org\")."
+"unwrap();\n"
+"    let bad_urls = check_links(start_url);\n"
+"    println!(\"Bad URLs: {:#?}\", bad_urls);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
@@ -17189,54 +20247,381 @@ msgstr ""
 msgid "([back to exercise](dining-philosophers-async.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:32
+#: src/exercises/concurrency/solutions-afternoon.md:7
 msgid ""
-"// Add a delay before picking the second fork to allow the execution\n"
+"```rust,compile_fail\n"
+"use std::sync::Arc;\n"
+"use tokio::time;\n"
+"use tokio::sync::mpsc::{self, Sender};\n"
+"use tokio::sync::Mutex;\n"
+"\n"
+"struct Fork;\n"
+"\n"
+"struct Philosopher {\n"
+"    name: String,\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    thoughts: Sender<String>,\n"
+"}\n"
+"\n"
+"impl Philosopher {\n"
+"    async fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
+"            .unwrap();\n"
+"    }\n"
+"\n"
+"    async fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        let _first_lock = self.left_fork.lock().await;\n"
+"        // Add a delay before picking the second fork to allow the "
+"execution\n"
 "        // to transfer to another task\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:40
-msgid "// The locks are dropped here\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:60
-msgid ""
-"// To avoid a deadlock, we have to break the symmetry\n"
+"        time::sleep(time::Duration::from_millis(1)).await;\n"
+"        let _second_lock = self.right_fork.lock().await;\n"
+"\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        time::sleep(time::Duration::from_millis(5)).await;\n"
+"\n"
+"        // The locks are dropped here\n"
+"    }\n"
+"}\n"
+"\n"
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() {\n"
+"    // Create forks\n"
+"    let mut forks = vec![];\n"
+"    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::"
+"new(Fork))));\n"
+"\n"
+"    // Create philosophers\n"
+"    let (philosophers, mut rx) = {\n"
+"        let mut philosophers = vec![];\n"
+"        let (tx, rx) = mpsc::channel(10);\n"
+"        for (i, name) in PHILOSOPHERS.iter().enumerate() {\n"
+"            let left_fork = Arc::clone(&forks[i]);\n"
+"            let right_fork = Arc::clone(&forks[(i + 1) % PHILOSOPHERS."
+"len()]);\n"
+"            // To avoid a deadlock, we have to break the symmetry\n"
 "            // somewhere. This will swap the forks without deinitializing\n"
 "            // either of them.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:74
-msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:90
-msgid "\"Here is a thought: {thought}\""
+"            if i  == 0 {\n"
+"                std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"            }\n"
+"            philosophers.push(Philosopher {\n"
+"                name: name.to_string(),\n"
+"                left_fork,\n"
+"                right_fork,\n"
+"                thoughts: tx.clone(),\n"
+"            });\n"
+"        }\n"
+"        (philosophers, rx)\n"
+"        // tx is dropped here, so we don't need to explicitly drop it later\n"
+"    };\n"
+"\n"
+"    // Make them think and eat\n"
+"    for phil in philosophers {\n"
+"        tokio::spawn(async move {\n"
+"            for _ in 0..100 {\n"
+"                phil.think().await;\n"
+"                phil.eat().await;\n"
+"            }\n"
+"        });\n"
+"\n"
+"    }\n"
+"\n"
+"    // Output their thoughts\n"
+"    while let Some(thought) = rx.recv().await {\n"
+"        println!(\"Here is a thought: {thought}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:97
 msgid "([back to exercise](chat-app.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:117
-msgid "\"Welcome to chat! Type a message\""
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:121
+#: src/exercises/concurrency/solutions-afternoon.md:101
 msgid ""
-"// A continuous loop for concurrently performing two tasks: (1) receiving\n"
+"```rust,compile_fail\n"
+"use futures_util::sink::SinkExt;\n"
+"use futures_util::stream::StreamExt;\n"
+"use std::error::Error;\n"
+"use std::net::SocketAddr;\n"
+"use tokio::net::{TcpListener, TcpStream};\n"
+"use tokio::sync::broadcast::{channel, Sender};\n"
+"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
+"\n"
+"async fn handle_connection(\n"
+"    addr: SocketAddr,\n"
+"    mut ws_stream: WebsocketStream<TcpStream>,\n"
+"    bcast_tx: Sender<String>,\n"
+") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"\n"
+"    ws_stream\n"
+"        .send(Message::text(\"Welcome to chat! Type a message\".into()))\n"
+"        .await?;\n"
+"    let mut bcast_rx = bcast_tx.subscribe();\n"
+"\n"
+"    // A continuous loop for concurrently performing two tasks: (1) "
+"receiving\n"
 "    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
 "    // messages on `bcast_rx` and sending them to the client.\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            incoming = ws_stream.next() => {\n"
+"                match incoming {\n"
+"                    Some(Ok(msg)) => {\n"
+"                        if let Some(text) = msg.as_text() {\n"
+"                            println!(\"From client {addr:?} {text:?}\");\n"
+"                            bcast_tx.send(text.into())?;\n"
+"                        }\n"
+"                    }\n"
+"                    Some(Err(err)) => return Err(err.into()),\n"
+"                    None => return Ok(()),\n"
+"                }\n"
+"            }\n"
+"            msg = bcast_rx.recv() => {\n"
+"                ws_stream.send(Message::text(msg?)).await?;\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
+"    let (bcast_tx, _) = channel(16);\n"
+"\n"
+"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
+"    println!(\"listening on port 2000\");\n"
+"\n"
+"    loop {\n"
+"        let (socket, addr) = listener.accept().await?;\n"
+"        println!(\"New connection from {addr:?}\");\n"
+"        let bcast_tx = bcast_tx.clone();\n"
+"        tokio::spawn(async move {\n"
+"            // Wrap the raw TCP stream into a websocket.\n"
+"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
+"\n"
+"            handle_connection(addr, ws_stream, bcast_tx).await\n"
+"        });\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:130
-msgid "\"From client {addr:?} {text:?}\""
+#: src/exercises/concurrency/solutions-afternoon.md:168
+msgid ""
+"```rust,compile_fail\n"
+"use futures_util::stream::StreamExt;\n"
+"use futures_util::SinkExt;\n"
+"use http::Uri;\n"
+"use tokio::io::{AsyncBufReadExt, BufReader};\n"
+"use tokio_websockets::{ClientBuilder, Message};\n"
+"\n"
+"#[tokio::main]\n"
+"async fn main() -> Result<(), tokio_websockets::Error> {\n"
+"    let (mut ws_stream, _) =\n"
+"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
+"            .connect()\n"
+"            .await?;\n"
+"\n"
+"    let stdin = tokio::io::stdin();\n"
+"    let mut stdin = BufReader::new(stdin).lines();\n"
+"\n"
+"    // Continuous loop for concurrently sending and receiving messages.\n"
+"    loop {\n"
+"        tokio::select! {\n"
+"            incoming = ws_stream.next() => {\n"
+"                match incoming {\n"
+"                    Some(Ok(msg)) => {\n"
+"                        if let Some(text) = msg.as_text() {\n"
+"                            println!(\"From server: {}\", text);\n"
+"                        }\n"
+"                    },\n"
+"                    Some(Err(err)) => return Err(err.into()),\n"
+"                    None => return Ok(()),\n"
+"                }\n"
+"            }\n"
+"            res = stdin.next_line() => {\n"
+"                match res {\n"
+"                    Ok(None) => return Ok(()),\n"
+"                    Ok(Some(line)) => ws_stream.send(Message::text(line."
+"to_string())).await?,\n"
+"                    Err(err) => return Err(err.into()),\n"
+"                }\n"
+"            }\n"
+"\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:185
-msgid "// Continuous loop for concurrently sending and receiving messages.\n"
-msgstr ""
+#~ msgid ""
+#~ "```shell\n"
+#~ "$ cargo new exercise\n"
+#~ "     Created binary (application) `exercise` package\n"
+#~ "```"
+#~ msgstr ""
+#~ "```shell\n"
+#~ "$ cargo new exercise\n"
+#~ "     Created binary (application) `exercise` package\n"
+#~ "```"
 
-#: src/exercises/concurrency/solutions-afternoon.md:192
-msgid "\"From server: {}\""
-msgstr ""
+#~ msgid ""
+#~ "```shell\n"
+#~ "$ cd exercise\n"
+#~ "$ cargo run\n"
+#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+#~ "     Running `target/debug/exercise`\n"
+#~ "Hello, world!\n"
+#~ "```"
+#~ msgstr ""
+#~ "```shell\n"
+#~ "$ cd exercise\n"
+#~ "$ cargo run\n"
+#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+#~ "     Running `target/debug/exercise`\n"
+#~ "Hello, world!\n"
+#~ "```"
+
+#~ msgid ""
+#~ "```shell\n"
+#~ "$ cargo run\n"
+#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+#~ "     Running `target/debug/exercise`\n"
+#~ "Edit me!\n"
+#~ "```"
+#~ msgstr ""
+#~ "```shell\n"
+#~ "$ cargo run\n"
+#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+#~ "     Running `target/debug/exercise`\n"
+#~ "Edit me!\n"
+#~ "```"
+
+#, fuzzy
+#~ msgid ""
+#~ "```rust,editable\n"
+#~ "fn main() {\n"
+#~ "    let mut x = 10;\n"
+#~ "    while x != 1 {\n"
+#~ "        x = if x % 2 == 0 {\n"
+#~ "            x / 2\n"
+#~ "        } else {\n"
+#~ "            3 * x + 1\n"
+#~ "        };\n"
+#~ "    }\n"
+#~ "    println!(\"x: {x}\");\n"
+#~ "}\n"
+#~ "```"
+#~ msgstr ""
+#~ "```rust,editable\n"
+#~ "fn main() {              // プログラムのエントリーポイント\n"
+#~ "    let mut x: i32 = 6;  // 可変変数のバインディング\n"
+#~ "    print!(\"{x}\");       // printfのような、出力用マクロ\n"
+#~ "    while x != 1 {       // 式を囲む括弧は不要\n"
+#~ "        if x % 2 == 0 {  // 他の言語と同様の演算\n"
+#~ "            x = x / 2;\n"
+#~ "        } else {\n"
+#~ "            x = 3 * x + 1;\n"
+#~ "        }\n"
+#~ "        print!(\" -> {x}\");\n"
+#~ "    }\n"
+#~ "    println!();\n"
+#~ "}\n"
+#~ "```"
+
+#, fuzzy
+#~ msgid "Pattern Matching (TBD)"
+#~ msgstr "パターンマッチング"
+
+#~ msgid "Comparison"
+#~ msgstr "比較"
+
+#~ msgid "The course is fast paced and covers a lot of ground:"
+#~ msgstr "本講座はペースが早く、多くの内容をカバーします："
+
+#, fuzzy
+#~ msgid ""
+#~ "We suggest using [VS Code](https://code.visualstudio.com/) to edit the "
+#~ "code (but any LSP compatible editor works with rust-analyzer[3](https://"
+#~ "rust-analyzer.github.io/))."
+#~ msgstr ""
+#~ "これで\\[rust-analyzer\\]\\[1\\]を使って定義に飛べるようになります。コード"
+#~ "の編集には、[VS Code](https://code.visualstudio.com/)を推奨しています（た"
+#~ "だし、LSP互換エディタならどれでも大丈夫です）。"
+
+#~ msgid ""
+#~ "Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+#~ "clion/) family of IDEs, which do their own analysis but have their own "
+#~ "tradeoffs. If you prefer them, you can install the [Rust Plugin](https://"
+#~ "www.jetbrains.com/rust/). Please take note that as of January 2023 "
+#~ "debugging only works on the CLion version of the JetBrains IDEA suite."
+#~ msgstr ""
+#~ "[JetBrains](https://www.jetbrains.com/clion/)ファミリのIDEを使いたい人もい"
+#~ "るでしょう。これらは独自の分析を提供してくれますが、トレードオフもありま"
+#~ "す。もし使用したい場合、[Rust Plugin](https://www.jetbrains.com/rust/)のイ"
+#~ "ンストールが可能です。ただし、2023年1月時点では、デバッグがJetBrains IDEA "
+#~ "suiteのCLionバージョンでしか動作しない点に注意してください。"
+
+#, fuzzy
+#~ msgid "Extra Work in Modern C++"
+#~ msgstr "現代C++の二重解放"
+
+#~ msgid ""
+#~ "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+#~ "comprehensive-rust?style=flat-square)](https://github.com/google/"
+#~ "comprehensive-rust/graphs/contributors) [![GitHub stars](https://img."
+#~ "shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
+#~ "(https://github.com/google/comprehensive-rust/stargazers)"
+#~ msgstr ""
+#~ "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+#~ "comprehensive-rust?style=flat-square)](https://github.com/google/"
+#~ "comprehensive-rust/graphs/contributors) [![GitHub stars](https://img."
+#~ "shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
+#~ "(https://github.com/google/comprehensive-rust/stargazers)"
+
+#~ msgid ""
+#~ "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
+#~ "rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
+#~ "stargazers)"
+#~ msgstr ""
+#~ "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
+#~ "rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
+#~ "stargazers)"
+
+#~ msgid "Day 1: Basic Rust, ownership and the borrow checker."
+#~ msgstr "Day 1： Rustの基本、所有権と借用チェッカー"
+
+#~ msgid "Rustup (Recommended)"
+#~ msgstr "Rustup (推奨)"
+
+#~ msgid ""
+#~ "You can follow the instructions to install cargo and rust compiler, among "
+#~ "other standard ecosystem tools with the [rustup](https://rust-analyzer."
+#~ "github.io/) tool, which is maintained by the Rust Foundation."
+#~ msgstr ""
+#~ "[rustup](https://rust-analyzer.github.io/)ツールを使用して、cargoやrustコ"
+#~ "ンパイラなどの標準エコシステムツールをインストールします。RustupはRust "
+#~ "Foundationによってメンテナンスされています。"
+
+#~ msgid "Package Managers"
+#~ msgstr "パッケージマネージャ"
+
+#~ msgid ""
+#~ "Runtimes have the concept of a \"task\", similar to a thread but much "
+#~ "less resource-intensive."
+#~ msgstr ""
+#~ "ランタイムには「タスク」という概念があり、スレッドに似ているものの、スレッ"
+#~ "ドよりリソースの消費ははるかに小さいです。"

--- a/po/ja.po
+++ b/po/ja.po
@@ -5,12 +5,11 @@ msgstr ""
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
-"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.2\n"
 
 #: src/SUMMARY.md:4 src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
@@ -1838,21 +1837,16 @@ msgstr ""
 msgid "The code blocks in this course are fully interactive:"
 msgstr "講座のコードブロックはインタラクティブです："
 
-#: src/cargo/code-samples.md:13
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    println!(\"Edit me!\");\n"
-"}\n"
-"```"
-msgstr ""
+#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:45
+msgid "\"Edit me!\""
+msgstr "\"Edit me!\""
 
 #: src/cargo/code-samples.md:19
 msgid "You can use "
 msgstr "ボックス内にフォーカスがある状態で"
 
 #: src/cargo/code-samples.md:19
-msgid " to execute the code when focus is in the text box."
+msgid "to execute the code when focus is in the text box."
 msgstr "を押すと、コードが実行されます。"
 
 #: src/cargo/code-samples.md:24
@@ -1936,20 +1930,6 @@ msgid ""
 msgstr ""
 "`src/main.rs`のボイラープレートコードを、コピーしたコードで置き換えてくださ"
 "い。例えば、前のページの例を使った場合、`src/main.rs`は以下のようになります。"
-
-#: src/cargo/running-locally.md:43
-msgid ""
-"```rust\n"
-"fn main() {\n"
-"    println!(\"Edit me!\");\n"
-"}\n"
-"```"
-msgstr ""
-"```rust\n"
-"fn main() {\n"
-"    println!(\"Edit me!\");\n"
-"}\n"
-"```"
 
 #: src/cargo/running-locally.md:49
 msgid "Use `cargo run` to build and run your updated binary:"
@@ -2187,13 +2167,8 @@ msgid ""
 msgstr ""
 "さっそく一番シンプルなプログラムである定番のHello Worldからみてみましょう："
 
-#: src/hello-world.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    println!(\"Hello 🌍!\");\n"
-"}\n"
-"```"
+#: src/hello-world.md:8
+msgid "\"Hello 🌍!\""
 msgstr ""
 
 #: src/hello-world.md:12
@@ -2279,39 +2254,33 @@ msgstr ""
 msgid "Here is a small example program in Rust:"
 msgstr "ここでは、Rustによる小さなサンプルプログラムを紹介します："
 
-#: src/hello-world/small-example.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {              // Program entry point\n"
-"    let mut x: i32 = 6;  // Mutable variable binding\n"
-"    print!(\"{x}\");       // Macro for printing, like printf\n"
-"    while x != 1 {       // No parenthesis around expression\n"
-"        if x % 2 == 0 {  // Math like in other languages\n"
-"            x = x / 2;\n"
-"        } else {\n"
-"            x = 3 * x + 1;\n"
-"        }\n"
-"        print!(\" -> {x}\");\n"
-"    }\n"
-"    println!();\n"
-"}\n"
-"```"
-msgstr ""
-"```rust,editable\n"
-"fn main() {              // プログラムのエントリーポイント\n"
-"    let mut x: i32 = 6;  // 可変変数のバインディング\n"
-"    print!(\"{x}\");       // printfのような、出力用マクロ\n"
-"    while x != 1 {       // 式を囲む括弧は不要\n"
-"        if x % 2 == 0 {  // 他の言語と同様の演算\n"
-"            x = x / 2;\n"
-"        } else {\n"
-"            x = 3 * x + 1;\n"
-"        }\n"
-"        print!(\" -> {x}\");\n"
-"    }\n"
-"    println!();\n"
-"}\n"
-"```"
+#: src/hello-world/small-example.md:6
+msgid "// Program entry point\n"
+msgstr "// プログラムのエントリーポイント\n"
+
+#: src/hello-world/small-example.md:7
+msgid "// Mutable variable binding\n"
+msgstr "// 可変変数のバインディング\n"
+
+#: src/hello-world/small-example.md:8 src/traits/impl-trait.md:15
+msgid "\"{x}\""
+msgstr "\"{x}\""
+
+#: src/hello-world/small-example.md:8
+msgid "// Macro for printing, like printf\n"
+msgstr "// printfのような、出力用マクロ\n"
+
+#: src/hello-world/small-example.md:9
+msgid "// No parenthesis around expression\n"
+msgstr "// 式を囲む括弧は不要\n"
+
+#: src/hello-world/small-example.md:10
+msgid "// Math like in other languages\n"
+msgstr "// 他の言語と同様の演算\n"
+
+#: src/hello-world/small-example.md:15
+msgid "\" -> {x}\""
+msgstr "\" -> {x}\""
 
 #: src/hello-world/small-example.md:23
 msgid ""
@@ -2422,49 +2391,41 @@ msgstr ""
 msgid "Let's consider the following \"minimum wrong example\" program in C:"
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:6
-msgid ""
-"```c,editable\n"
-"#include <stdio.h>\n"
-"#include <stdlib.h>\n"
-"#include <sys/stat.h>\n"
-"\n"
-"int main(int argc, char* argv[]) {\n"
-"\tchar *buf, *filename;\n"
-"\tFILE *fp;\n"
-"\tsize_t bytes, len;\n"
-"\tstruct stat st;\n"
-"\n"
-"\tswitch (argc) {\n"
-"\t\tcase 1:\n"
-"\t\t\tprintf(\"Too few arguments!\\n\");\n"
-"\t\t\treturn 1;\n"
-"\n"
-"\t\tcase 2:\n"
-"\t\t\tfilename = argv[argc];\n"
-"\t\t\tstat(filename, &st);\n"
-"\t\t\tlen = st.st_size;\n"
-"\t\t\t\n"
-"\t\t\tbuf = (char*)malloc(len);\n"
-"\t\t\tif (!buf)\n"
-"\t\t\t\tprintf(\"malloc failed!\\n\", len);\n"
-"\t\t\t\treturn 1;\n"
-"\n"
-"\t\t\tfp = fopen(filename, \"rb\");\n"
-"\t\t\tbytes = fread(buf, 1, len, fp);\n"
-"\t\t\tif (bytes = st.st_size)\n"
-"\t\t\t\tprintf(\"%s\", buf);\n"
-"\t\t\telse\n"
-"\t\t\t\tprintf(\"fread failed!\\n\");\n"
-"\n"
-"\t\tcase 3:\n"
-"\t\t\tprintf(\"Too many arguments!\\n\");\n"
-"\t\t\treturn 1;\n"
-"\t}\n"
-"\n"
-"\treturn 0;\n"
-"}\n"
-"```"
+#: src/why-rust/an-example-in-c.md:7
+#: src/android/interoperability/with-c/bindgen.md:22
+msgid "<stdio.h>"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:8
+msgid "<stdlib.h>"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:9
+msgid "<sys/stat.h>"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:19
+msgid "\"Too few arguments!\\n\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:29
+msgid "\"malloc failed!\\n\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:32
+msgid "\"rb\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:35
+msgid "\"%s\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:37
+msgid "\"fread failed!\\n\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:40
+msgid "\"Too many arguments!\\n\""
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:48
@@ -2696,8 +2657,8 @@ msgid ""
 "For the purpose of this course, \"No memory leaks\" should be understood as "
 "\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"本講座での「メモリリークが起きない」は「_意図しない_メモリリークはほとんど起"
-"きない」と解釈すべきです。"
+"本講座での「メモリリークが起きない」は「\\_意図しない_メモリリークはほとんど"
+"起きない」と解釈すべきです。"
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
@@ -3240,22 +3201,27 @@ msgstr ""
 msgid "We can now understand the two string types in Rust:"
 msgstr ""
 
-#: src/basic-syntax/string-slices.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s1: &str = \"World\";\n"
-"    println!(\"s1: {s1}\");\n"
-"\n"
-"    let mut s2: String = String::from(\"Hello \");\n"
-"    println!(\"s2: {s2}\");\n"
-"    s2.push_str(s1);\n"
-"    println!(\"s2: {s2}\");\n"
-"    \n"
-"    let s3: &str = &s2[6..];\n"
-"    println!(\"s3: {s3}\");\n"
-"}\n"
-"```"
+#: src/basic-syntax/string-slices.md:7 src/traits/read-write.md:36
+#: src/testing/test-modules.md:12
+msgid "\"World\""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:8
+msgid "\"s1: {s1}\""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:10 src/memory-management/scope-based.md:16
+#: src/memory-management/garbage-collection.md:15
+msgid "\"Hello \""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:11 src/basic-syntax/string-slices.md:13
+#: src/ownership/move-semantics.md:9
+msgid "\"s2: {s2}\""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:16
+msgid "\"s3: {s3}\""
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:20
@@ -3351,9 +3317,8 @@ msgid ""
 "All language items in Rust can be documented using special `///` syntax."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:5
+#: src/basic-syntax/rustdoc.md:6
 msgid ""
-"```rust,editable\n"
 "/// Determine whether the first argument is divisible by the second "
 "argument.\n"
 "///\n"
@@ -3363,14 +3328,14 @@ msgid ""
 "/// ```\n"
 "/// assert!(is_divisible_by(42, 2));\n"
 "/// ```\n"
-"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
-"    if rhs == 0 {\n"
-"        return false;  // Corner case, early return\n"
-"    }\n"
-"    lhs % rhs == 0     // The last expression in a block is the return "
-"value\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/basic-syntax/rustdoc.md:16
+msgid "// Corner case, early return\n"
+msgstr ""
+
+#: src/basic-syntax/rustdoc.md:18
+msgid "// The last expression in a block is the return value\n"
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:22
@@ -3413,31 +3378,12 @@ msgid ""
 "method is an instance of the type it is associated with:"
 msgstr ""
 
-#: src/basic-syntax/methods.md:6
-msgid ""
-"```rust,editable\n"
-"struct Rectangle {\n"
-"    width: u32,\n"
-"    height: u32,\n"
-"}\n"
-"\n"
-"impl Rectangle {\n"
-"    fn area(&self) -> u32 {\n"
-"        self.width * self.height\n"
-"    }\n"
-"\n"
-"    fn inc_width(&mut self, delta: u32) {\n"
-"        self.width += delta;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut rect = Rectangle { width: 10, height: 5 };\n"
-"    println!(\"old area: {}\", rect.area());\n"
-"    rect.inc_width(5);\n"
-"    println!(\"new area: {}\", rect.area());\n"
-"}\n"
-"```"
+#: src/basic-syntax/methods.md:24
+msgid "\"old area: {}\""
+msgstr ""
+
+#: src/basic-syntax/methods.md:26
+msgid "\"new area: {}\""
 msgstr ""
 
 #: src/basic-syntax/methods.md:30
@@ -3500,18 +3446,20 @@ msgstr ""
 msgid "However, function parameters can be generic:"
 msgstr ""
 
-#: src/basic-syntax/functions-interlude.md:14
-msgid ""
-"```rust,editable\n"
-"fn pick_one<T>(a: T, b: T) -> T {\n"
-"    if std::process::id() % 2 == 0 { a } else { b }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
-"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
-"}\n"
-"```"
+#: src/basic-syntax/functions-interlude.md:20
+msgid "\"coin toss: {}\""
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:20
+msgid "\"heads\""
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:20
+msgid "\"tails\""
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:21
+msgid "\"cash prize: {}\""
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
@@ -3638,24 +3586,20 @@ msgid ""
 "keyword:"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:22
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let array = [10, 20, 30];\n"
-"    print!(\"Iterating over array:\");\n"
-"    for n in &array {\n"
-"        print!(\" {n}\");\n"
-"    }\n"
-"    println!();\n"
-"\n"
-"    print!(\"Iterating over range:\");\n"
-"    for i in 0..3 {\n"
-"        print!(\" {}\", array[i]);\n"
-"    }\n"
-"    println!();\n"
-"}\n"
-"```"
+#: src/exercises/day-1/for-loops.md:25
+msgid "\"Iterating over array:\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:27
+msgid "\" {n}\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:31
+msgid "\"Iterating over range:\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:33
+msgid "\" {}\""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:39
@@ -3675,35 +3619,28 @@ msgid ""
 "functions:"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:54
-msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];\n"
-"\n"
-"    println!(\"matrix:\");\n"
-"    pretty_print(&matrix);\n"
-"\n"
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
-"```"
+#: src/exercises/day-1/for-loops.md:55 src/exercises/day-1/luhn.md:26
+#: src/exercises/day-2/health-statistics.md:14
+#: src/exercises/day-2/strings-iterators.md:13
+#: src/exercises/day-3/simple-gui.md:20
+#: src/exercises/day-3/points-polygons.md:8
+#: src/exercises/day-3/safe-ffi-wrapper.md:49
+msgid "// TODO: remove this when you're done with your implementation.\n"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:68
+#: src/exercises/day-1/solutions-morning.md:44
+msgid "// <-- the comment makes rustfmt add a newline\n"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:73
+#: src/exercises/day-1/solutions-morning.md:49
+msgid "\"matrix:\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:77
+#: src/exercises/day-1/solutions-morning.md:53
+msgid "\"transposed:\""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:82
@@ -4058,15 +3995,12 @@ msgid ""
 "therefore will not move:"
 msgstr ""
 
-#: src/basic-syntax/static-and-const.md:38
-msgid ""
-"```rust,editable\n"
-"static BANNER: &str = \"Welcome to RustOS 3.14\";\n"
-"\n"
-"fn main() {\n"
-"    println!(\"{BANNER}\");\n"
-"}\n"
-"```"
+#: src/basic-syntax/static-and-const.md:39
+msgid "\"Welcome to RustOS 3.14\""
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:42
+msgid "\"{BANNER}\""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:46
@@ -4183,24 +4117,25 @@ msgid ""
 "the same scope:"
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let a = 10;\n"
-"    println!(\"before: {a}\");\n"
-"\n"
-"    {\n"
-"        let a = \"hello\";\n"
-"        println!(\"inner scope: {a}\");\n"
-"\n"
-"        let a = true;\n"
-"        println!(\"shadowed in inner scope: {a}\");\n"
-"    }\n"
-"\n"
-"    println!(\"after: {a}\");\n"
-"}\n"
-"```"
+#: src/basic-syntax/scopes-shadowing.md:9
+msgid "\"before: {a}\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:12 src/traits/from-into.md:7
+#: src/traits/from-into.md:19
+msgid "\"hello\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:13
+msgid "\"inner scope: {a}\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:16
+msgid "\"shadowed in inner scope: {a}\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:19
+msgid "\"after: {a}\""
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
@@ -4233,33 +4168,16 @@ msgid ""
 "variants:"
 msgstr ""
 
-#: src/enums.md:6
-msgid ""
-"```rust,editable\n"
-"fn generate_random_number() -> i32 {\n"
-"    // Implementation based on https://xkcd.com/221/\n"
-"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"enum CoinFlip {\n"
-"    Heads,\n"
-"    Tails,\n"
-"}\n"
-"\n"
-"fn flip_coin() -> CoinFlip {\n"
-"    let random_number = generate_random_number();\n"
-"    if random_number % 2 == 0 {\n"
-"        return CoinFlip::Heads;\n"
-"    } else {\n"
-"        return CoinFlip::Tails;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    println!(\"You got: {:?}\", flip_coin());\n"
-"}\n"
-"```"
+#: src/enums.md:8
+msgid "// Implementation based on https://xkcd.com/221/\n"
+msgstr ""
+
+#: src/enums.md:9
+msgid "// Chosen by fair dice roll. Guaranteed to be random.\n"
+msgstr ""
+
+#: src/enums.md:28
+msgid "\"You got: {:?}\""
 msgstr ""
 
 #: src/enums.md:36
@@ -4299,34 +4217,32 @@ msgid ""
 "the `match` statement to extract the data from each variant:"
 msgstr ""
 
-#: src/enums/variant-payloads.md:6
-msgid ""
-"```rust,editable\n"
-"enum WebEvent {\n"
-"    PageLoad,                 // Variant without payload\n"
-"    KeyPress(char),           // Tuple struct variant\n"
-"    Click { x: i64, y: i64 }, // Full struct variant\n"
-"}\n"
-"\n"
-"#[rustfmt::skip]\n"
-"fn inspect(event: WebEvent) {\n"
-"    match event {\n"
-"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
-"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
-"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let load = WebEvent::PageLoad;\n"
-"    let press = WebEvent::KeyPress('x');\n"
-"    let click = WebEvent::Click { x: 20, y: 80 };\n"
-"\n"
-"    inspect(load);\n"
-"    inspect(press);\n"
-"    inspect(click);\n"
-"}\n"
-"```"
+#: src/enums/variant-payloads.md:8
+msgid "// Variant without payload\n"
+msgstr ""
+
+#: src/enums/variant-payloads.md:9
+msgid "// Tuple struct variant\n"
+msgstr ""
+
+#: src/enums/variant-payloads.md:10
+msgid "// Full struct variant\n"
+msgstr ""
+
+#: src/enums/variant-payloads.md:16
+msgid "\"page loaded\""
+msgstr ""
+
+#: src/enums/variant-payloads.md:17
+msgid "\"pressed '{c}'\""
+msgstr ""
+
+#: src/enums/variant-payloads.md:18
+msgid "\"clicked at x={x}, y={y}\""
+msgstr ""
+
+#: src/enums/variant-payloads.md:24 src/pattern-matching.md:10
+msgid "'x'"
 msgstr ""
 
 #: src/enums/variant-payloads.md:35
@@ -4389,26 +4305,8 @@ msgid ""
 "account:"
 msgstr ""
 
-#: src/enums/sizes.md:5
-msgid ""
-"```rust,editable\n"
-"use std::any::type_name;\n"
-"use std::mem::{align_of, size_of};\n"
-"\n"
-"fn dbg_size<T>() {\n"
-"    println!(\"{}: size {} bytes, align: {} bytes\",\n"
-"        type_name::<T>(), size_of::<T>(), align_of::<T>());\n"
-"}\n"
-"\n"
-"enum Foo {\n"
-"    A,\n"
-"    B,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    dbg_size::<Foo>();\n"
-"}\n"
-"```"
+#: src/enums/sizes.md:10
+msgid "\"{}: size {} bytes, align: {} bytes\""
 msgstr ""
 
 #: src/enums/sizes.md:24
@@ -4510,18 +4408,12 @@ msgid ""
 "whether a value matches a pattern:"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:7
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let arg = std::env::args().next();\n"
-"    if let Some(value) = arg {\n"
-"        println!(\"Program name: {value}\");\n"
-"    } else {\n"
-"        println!(\"Missing name?\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/control-flow/if-let-expressions.md:11
+msgid "\"Program name: {value}\""
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:13
+msgid "\"Missing name?\""
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:18
@@ -4594,20 +4486,44 @@ msgid ""
 "sense, it works like a series of `if let` expressions:"
 msgstr ""
 
-#: src/control-flow/match-expressions.md:7
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    match std::env::args().next().as_deref() {\n"
-"        Some(\"cat\") => println!(\"Will do cat things\"),\n"
-"        Some(\"ls\")  => println!(\"Will ls some files\"),\n"
-"        Some(\"mv\")  => println!(\"Let's move some files\"),\n"
-"        Some(\"rm\")  => println!(\"Uh, dangerous!\"),\n"
-"        None        => println!(\"Hmm, no program name?\"),\n"
-"        _           => println!(\"Unknown program name!\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/control-flow/match-expressions.md:10
+msgid "\"cat\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:10
+msgid "\"Will do cat things\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:11
+msgid "\"ls\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:11
+msgid "\"Will ls some files\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:12
+msgid "\"mv\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:12
+msgid "\"Let's move some files\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:13
+msgid "\"rm\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:13
+msgid "\"Uh, dangerous!\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:14
+msgid "\"Hmm, no program name?\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:15
+msgid "\"Unknown program name!\""
 msgstr ""
 
 #: src/control-flow/match-expressions.md:20
@@ -4651,20 +4567,48 @@ msgstr ""
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
 msgstr ""
 
-#: src/pattern-matching.md:8
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let input = 'x';\n"
-"\n"
-"    match input {\n"
-"        'q'                   => println!(\"Quitting\"),\n"
-"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
-"        '0'..='9'             => println!(\"Number input\"),\n"
-"        _                     => println!(\"Something else\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching.md:13
+msgid "'q'"
+msgstr ""
+
+#: src/pattern-matching.md:13
+msgid "\"Quitting\""
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'a'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'s'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'w'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'d'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "\"Moving around\""
+msgstr ""
+
+#: src/pattern-matching.md:15
+msgid "'0'"
+msgstr ""
+
+#: src/pattern-matching.md:15
+msgid "'9'"
+msgstr ""
+
+#: src/pattern-matching.md:15
+msgid "\"Number input\""
+msgstr ""
+
+#: src/pattern-matching.md:16
+msgid "\"Something else\""
 msgstr ""
 
 #: src/pattern-matching.md:21
@@ -4716,30 +4660,16 @@ msgid ""
 "`enum` type:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:6
-msgid ""
-"```rust,editable\n"
-"enum Result {\n"
-"    Ok(i32),\n"
-"    Err(String),\n"
-"}\n"
-"\n"
-"fn divide_in_two(n: i32) -> Result {\n"
-"    if n % 2 == 0 {\n"
-"        Result::Ok(n / 2)\n"
-"    } else {\n"
-"        Result::Err(format!(\"cannot divide {n} into two equal parts\"))\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let n = 100;\n"
-"    match divide_in_two(n) {\n"
-"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
-"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-enums.md:16
+msgid "\"cannot divide {n} into two equal parts\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:23
+msgid "\"{n} divided in two is {half}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:24
+msgid "\"sorry, an error happened: {msg}\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
@@ -4766,25 +4696,16 @@ msgstr ""
 msgid "You can also destructure `structs`:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:5
-msgid ""
-"```rust,editable\n"
-"struct Foo {\n"
-"    x: (u32, u32),\n"
-"    y: u32,\n"
-"}\n"
-"\n"
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let foo = Foo { x: (1, 2), y: 3 };\n"
-"    match foo {\n"
-"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
-"        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
-"ignored\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-structs.md:15
+msgid "\"x.0 = 1, b = {b}, y = {y}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:16
+msgid "\"y = 2, x = {i:?}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:17
+msgid "\"y = {y}, other fields were ignored\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
@@ -4807,20 +4728,23 @@ msgid ""
 "You can destructure arrays, tuples, and slices by matching on their elements:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:5
-msgid ""
-"```rust,editable\n"
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let triple = [0, -2, 3];\n"
-"    println!(\"Tell me about {triple:?}\");\n"
-"    match triple {\n"
-"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"        _         => println!(\"All elements were ignored\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-arrays.md:9
+msgid "\"Tell me about {triple:?}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:11
+#: src/pattern-matching/destructuring-arrays.md:34
+msgid "\"First is 0, y = {y}, and z = {z}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:12
+#: src/pattern-matching/destructuring-arrays.md:35
+msgid "\"First is 1 and the rest were ignored\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:13
+#: src/pattern-matching/destructuring-arrays.md:36
+msgid "\"All elements were ignored\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
@@ -4829,24 +4753,8 @@ msgid ""
 "length."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:24
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    inspect(&[0, -2, 3]);\n"
-"    inspect(&[0, -2, 3, 4]);\n"
-"}\n"
-"\n"
-"#[rustfmt::skip]\n"
-"fn inspect(slice: &[i32]) {\n"
-"    println!(\"Tell me about {slice:?}\");\n"
-"    match slice {\n"
-"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"        _          => println!(\"All elements were ignored\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-arrays.md:32
+msgid "\"Tell me about {slice:?}\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:41
@@ -4873,21 +4781,24 @@ msgid ""
 "Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:6
-msgid ""
-"```rust,editable\n"
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let pair = (2, -2);\n"
-"    println!(\"Tell me about {pair:?}\");\n"
-"    match pair {\n"
-"        (x, y) if x == y     => println!(\"These are twins\"),\n"
-"        (x, y) if x + y == 0 => println!(\"Antimatter, kaboom!\"),\n"
-"        (x, _) if x % 2 == 1 => println!(\"The first one is odd\"),\n"
-"        _                    => println!(\"No correlation...\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/match-guards.md:10
+msgid "\"Tell me about {pair:?}\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:12
+msgid "\"These are twins\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:13
+msgid "\"Antimatter, kaboom!\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:14
+msgid "\"The first one is odd\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:15
+msgid "\"No correlation...\""
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
@@ -4984,57 +4895,72 @@ msgid ""
 "integers. Then, revisit the solution and try to implement it with iterators."
 msgstr ""
 
-#: src/exercises/day-1/luhn.md:25
-msgid ""
-"```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_non_digit_cc_number() {\n"
-"    assert!(!luhn(\"foo\"));\n"
-"    assert!(!luhn(\"foo 0 0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_empty_cc_number() {\n"
-"    assert!(!luhn(\"\"));\n"
-"    assert!(!luhn(\" \"));\n"
-"    assert!(!luhn(\"  \"));\n"
-"    assert!(!luhn(\"    \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_single_digit_cc_number() {\n"
-"    assert!(!luhn(\"0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_two_digit_cc_number() {\n"
-"    assert!(luhn(\" 0 0 \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_valid_cc_number() {\n"
-"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
-"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
-"    assert!(luhn(\"7992 7398 713\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
-"}\n"
-"\n"
-"#[allow(dead_code)]\n"
-"fn main() {}\n"
-"```"
+#: src/exercises/day-1/luhn.md:35
+#: src/exercises/day-2/iterators-and-ownership.md:75
+#: src/exercises/day-2/iterators-and-ownership.md:91
+#: src/traits/trait-bounds.md:22 src/traits/impl-trait.md:14
+#: src/exercises/day-3/simple-gui.md:148 src/exercises/day-3/simple-gui.md:149
+#: src/exercises/day-3/simple-gui.md:150 src/testing/test-modules.md:21
+#: src/exercises/day-1/solutions-afternoon.md:43
+msgid "\"foo\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:36 src/exercises/day-1/solutions-afternoon.md:44
+msgid "\"foo 0 0\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:41 src/testing/unit-tests.md:15
+#: src/exercises/day-1/solutions-afternoon.md:49
+#: src/exercises/day-3/solutions-morning.md:90
+#: src/exercises/day-3/solutions-morning.md:92
+#: src/exercises/day-3/solutions-morning.md:96
+#: src/exercises/day-3/solutions-morning.md:110
+#: src/exercises/day-3/solutions-morning.md:114
+msgid "\"\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:42 src/exercises/day-1/solutions-afternoon.md:50
+msgid "\" \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:43 src/exercises/day-1/solutions-afternoon.md:51
+msgid "\"  \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:44 src/exercises/day-1/solutions-afternoon.md:52
+msgid "\"    \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:49 src/exercises/day-1/solutions-afternoon.md:57
+msgid "\"0\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:54 src/exercises/day-1/solutions-afternoon.md:62
+msgid "\" 0 0 \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:59 src/exercises/day-1/solutions-afternoon.md:67
+msgid "\"4263 9826 4026 9299\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:60 src/exercises/day-1/solutions-afternoon.md:68
+msgid "\"4539 3195 0343 6467\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:61 src/exercises/day-1/solutions-afternoon.md:69
+msgid "\"7992 7398 713\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:66 src/exercises/day-1/solutions-afternoon.md:74
+msgid "\"4223 9826 4026 9299\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:67 src/exercises/day-1/solutions-afternoon.md:75
+msgid "\"4539 3195 0343 6476\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:68 src/exercises/day-1/solutions-afternoon.md:76
+msgid "\"8273 1232 7352 0569\""
 msgstr ""
 
 #: src/exercises/day-1/pattern-matching.md:1
@@ -5045,102 +4971,50 @@ msgstr ""
 msgid "Let's write a simple recursive evaluator for arithmetic expressions. "
 msgstr ""
 
-#: src/exercises/day-1/pattern-matching.md:5
-msgid ""
-"```rust\n"
-"/// An operation to perform on two subexpressions.\n"
-"#[derive(Debug)]\n"
-"enum Operation {\n"
-"    Add,\n"
-"    Sub,\n"
-"    Mul,\n"
-"    Div,\n"
-"}\n"
-"\n"
-"/// An expression, in tree form.\n"
-"#[derive(Debug)]\n"
-"enum Expression {\n"
-"    /// An operation on two subexpressions.\n"
-"    Op {\n"
-"        op: Operation,\n"
-"        left: Box<Expression>,\n"
-"        right: Box<Expression>,\n"
-"    },\n"
-"\n"
-"    /// A literal value\n"
-"    Value(i64),\n"
-"}\n"
-"\n"
-"/// The result of evaluating an expression.\n"
-"#[derive(Debug, PartialEq, Eq)]\n"
-"enum Res {\n"
-"    /// Evaluation was successful, with the given result.\n"
-"    Ok(i64),\n"
-"    /// Evaluation failed, with the given error message.\n"
-"    Err(String),\n"
-"}\n"
-"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
-"use Res::{Err, Ok};\n"
-"\n"
-"fn eval(e: Expression) -> Res {\n"
-"    todo!()\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_value() {\n"
-"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_sum() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(Expression::Value(10)),\n"
-"            right: Box::new(Expression::Value(20)),\n"
-"        }),\n"
-"        Ok(30)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_recursion() {\n"
-"    let term1 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Value(10)),\n"
-"        right: Box::new(Expression::Value(9)),\n"
-"    };\n"
-"    let term2 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Op {\n"
-"            op: Operation::Sub,\n"
-"            left: Box::new(Expression::Value(3)),\n"
-"            right: Box::new(Expression::Value(4)),\n"
-"        }),\n"
-"        right: Box::new(Expression::Value(5)),\n"
-"    };\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(term1),\n"
-"            right: Box::new(term2),\n"
-"        }),\n"
-"        Ok(85)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_error() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Div,\n"
-"            left: Box::new(Expression::Value(99)),\n"
-"            right: Box::new(Expression::Value(0)),\n"
-"        }),\n"
-"        Err(String::from(\"division by zero\"))\n"
-"    );\n"
-"}\n"
-"```"
+#: src/exercises/day-1/pattern-matching.md:6
+#: src/exercises/day-1/solutions-afternoon.md:83
+msgid "/// An operation to perform on two subexpressions.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:14
+#: src/exercises/day-1/solutions-afternoon.md:91
+msgid "/// An expression, in tree form.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:18
+#: src/exercises/day-1/solutions-afternoon.md:95
+msgid "/// An operation on two subexpressions.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:25
+#: src/exercises/day-1/solutions-afternoon.md:102
+msgid "/// A literal value\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:28
+#: src/exercises/day-1/solutions-afternoon.md:105
+msgid "/// The result of evaluating an expression.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:32
+#: src/exercises/day-1/solutions-afternoon.md:109
+msgid "/// Evaluation was successful, with the given result.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:34
+#: src/exercises/day-1/solutions-afternoon.md:111
+msgid "/// Evaluation failed, with the given error message.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:36
+#: src/exercises/day-1/solutions-afternoon.md:113
+msgid "// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:95
+#: src/exercises/day-1/solutions-afternoon.md:134
+#: src/exercises/day-1/solutions-afternoon.md:196
+msgid "\"division by zero\""
 msgstr ""
 
 #: src/exercises/day-1/pattern-matching.md:100
@@ -5290,13 +5164,11 @@ msgid ""
 "sized data, the actual string, on the heap:"
 msgstr ""
 
-#: src/memory-management/stack.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s1 = String::from(\"Hello\");\n"
-"}\n"
-"```"
+#: src/memory-management/stack.md:8 src/memory-management/stack.md:36
+#: src/std/string.md:8 src/traits/read-write.md:35 src/testing/unit-tests.md:20
+#: src/testing/unit-tests.md:25 src/testing/test-modules.md:12
+#: src/concurrency/scoped-threads.md:9 src/concurrency/scoped-threads.md:26
+msgid "\"Hello\""
 msgstr ""
 
 #: src/memory-management/stack.md:28
@@ -5319,24 +5191,25 @@ msgid ""
 "point out that this is rightfully unsafe!"
 msgstr ""
 
-#: src/memory-management/stack.md:34
+#: src/memory-management/stack.md:37 src/testing/unit-tests.md:7
+#: src/exercises/day-1/solutions-afternoon.md:11
+msgid "' '"
+msgstr ""
+
+#: src/memory-management/stack.md:38
+msgid "\"world\""
+msgstr ""
+
+#: src/memory-management/stack.md:39
 msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut s1 = String::from(\"Hello\");\n"
-"    s1.push(' ');\n"
-"    s1.push_str(\"world\");\n"
-"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"// DON'T DO THIS AT HOME! For educational purposes only.\n"
 "    // String provides no guarantees about its layout, so this could lead "
 "to\n"
 "    // undefined behavior.\n"
-"    unsafe {\n"
-"        let (ptr, capacity, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/memory-management/stack.md:44
+msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
 msgstr ""
 
 #: src/memory-management/manual.md:3
@@ -5357,17 +5230,11 @@ msgstr ""
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
 msgstr ""
 
-#: src/memory-management/manual.md:11
+#: src/memory-management/manual.md:14
 msgid ""
-"```c\n"
-"void foo(size_t n) {\n"
-"    int* int_array = malloc(n * sizeof(int));\n"
-"    //\n"
+"//\n"
 "    // ... lots of code\n"
 "    //\n"
-"    free(int_array);\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/memory-management/manual.md:21
@@ -5398,15 +5265,6 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:12
 msgid "C++ Example"
-msgstr ""
-
-#: src/memory-management/scope-based.md:14
-msgid ""
-"```c++\n"
-"void say_hello(std::unique_ptr<Person> person) {\n"
-"  std::cout << \"Hello \" << person->name << std::endl;\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/memory-management/scope-based.md:20
@@ -5454,15 +5312,6 @@ msgstr ""
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:13
-msgid ""
-"```java\n"
-"void sayHello(Person person) {\n"
-"  System.out.println(\"Hello \" + person.getName());\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/memory-management/rust.md:1
@@ -5531,16 +5380,12 @@ msgstr ""
 msgid "An assignment will transfer _ownership_ between variables:"
 msgstr ""
 
-#: src/ownership/move-semantics.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s1: String = String::from(\"Hello!\");\n"
-"    let s2: String = s1;\n"
-"    println!(\"s2: {s2}\");\n"
-"    // println!(\"s1: {s1}\");\n"
-"}\n"
-"```"
+#: src/ownership/move-semantics.md:7
+msgid "\"Hello!\""
+msgstr ""
+
+#: src/ownership/move-semantics.md:10
+msgid "// println!(\"s1: {s1}\");\n"
 msgstr ""
 
 #: src/ownership/move-semantics.md:14
@@ -5630,12 +5475,12 @@ msgstr "現代C++の二重解放"
 msgid "Modern C++ solves this differently:"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:5
-msgid ""
-"```c++\n"
-"std::string s1 = \"Cpp\";\n"
-"std::string s2 = s1;  // Duplicate the data in s1.\n"
-"```"
+#: src/ownership/double-free-modern-cpp.md:6
+msgid "\"Cpp\""
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:7
+msgid "// Duplicate the data in s1.\n"
 msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
@@ -5683,19 +5528,17 @@ msgid ""
 "parameter. This transfers ownership:"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:6
-msgid ""
-"```rust,editable\n"
-"fn say_hello(name: String) {\n"
-"    println!(\"Hello {name}\")\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let name = String::from(\"Alice\");\n"
-"    say_hello(name);\n"
-"    // say_hello(name);\n"
-"}\n"
-"```"
+#: src/ownership/moves-function-calls.md:8 src/traits/impl-trait.md:10
+msgid "\"Hello {name}\""
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:12
+#: src/android/interoperability/java.md:56
+msgid "\"Alice\""
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:14
+msgid "// say_hello(name);\n"
 msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
@@ -5972,26 +5815,24 @@ msgid ""
 "If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Highlight<'doc>(&'doc str);\n"
-"\n"
-"fn erase(text: String) {\n"
-"    println!(\"Bye {text}!\");\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
-"\");\n"
-"    let fox = Highlight(&text[4..19]);\n"
-"    let dog = Highlight(&text[35..43]);\n"
-"    // erase(text);\n"
-"    println!(\"{fox:?}\");\n"
-"    println!(\"{dog:?}\");\n"
-"}\n"
-"```"
+#: src/ownership/lifetimes-data-structures.md:10
+msgid "\"Bye {text}!\""
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:14
+msgid "\"The quick brown fox jumps over the lazy dog.\""
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:17
+msgid "// erase(text);\n"
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:18
+msgid "\"{fox:?}\""
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:19
+msgid "\"{dog:?}\""
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
@@ -6030,31 +5871,17 @@ msgstr ""
 msgid "Like C and C++, Rust has support for custom structs:"
 msgstr ""
 
-#: src/structs.md:5
-msgid ""
-"```rust,editable\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    peter.age = 28;\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    let jackie = Person {\n"
-"        name: String::from(\"Jackie\"),\n"
-"        ..peter\n"
-"    };\n"
-"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
-"}\n"
-"```"
+#: src/structs.md:13 src/structs/field-shorthand.md:20 src/methods.md:21
+#: src/android/interoperability/with-c/bindgen.md:87
+msgid "\"Peter\""
+msgstr ""
+
+#: src/structs.md:16 src/structs.md:19 src/structs.md:25
+msgid "\"{} is {} years old\""
+msgstr ""
+
+#: src/structs.md:22
+msgid "\"Jackie\""
 msgstr ""
 
 #: src/structs.md:33
@@ -6105,42 +5932,22 @@ msgstr ""
 msgid "If the field names are unimportant, you can use a tuple struct:"
 msgstr ""
 
-#: src/structs/tuple-structs.md:5
-msgid ""
-"```rust,editable\n"
-"struct Point(i32, i32);\n"
-"\n"
-"fn main() {\n"
-"    let p = Point(17, 23);\n"
-"    println!(\"({}, {})\", p.0, p.1);\n"
-"}\n"
-"```"
+#: src/structs/tuple-structs.md:10
+msgid "\"({}, {})\""
 msgstr ""
 
 #: src/structs/tuple-structs.md:14
 msgid "This is often used for single-field wrappers (called newtypes):"
 msgstr ""
 
-#: src/structs/tuple-structs.md:16
-msgid ""
-"```rust,editable,compile_fail\n"
-"struct PoundsOfForce(f64);\n"
-"struct Newtons(f64);\n"
-"\n"
-"fn compute_thruster_force() -> PoundsOfForce {\n"
-"    todo!(\"Ask a rocket scientist at NASA\")\n"
-"}\n"
-"\n"
-"fn set_thruster_force(force: Newtons) {\n"
-"    // ...\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let force = compute_thruster_force();\n"
-"    set_thruster_force(force);\n"
-"}\n"
-"\n"
-"```"
+#: src/structs/tuple-structs.md:21
+msgid "\"Ask a rocket scientist at NASA\""
+msgstr ""
+
+#: src/structs/tuple-structs.md:25
+#: src/bare-metal/microcontrollers/type-state.md:14
+#: src/async/pitfalls/cancellation.md:99
+msgid "// ...\n"
 msgstr ""
 
 #: src/structs/tuple-structs.md:37
@@ -6187,26 +5994,8 @@ msgid ""
 "struct using a shorthand:"
 msgstr ""
 
-#: src/structs/field-shorthand.md:6
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"\n"
-"impl Person {\n"
-"    fn new(name: String, age: u8) -> Person {\n"
-"        Person { name, age }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
-"    println!(\"{peter:?}\");\n"
-"}\n"
-"```"
+#: src/structs/field-shorthand.md:21
+msgid "\"{peter:?}\""
 msgstr ""
 
 #: src/structs/field-shorthand.md:27
@@ -6221,32 +6010,12 @@ msgid ""
 "default values for the other fields."
 msgstr ""
 
-#: src/structs/field-shorthand.md:43
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"impl Default for Person {\n"
-"    fn default() -> Person {\n"
-"        Person {\n"
-"            name: \"Bot\".to_string(),\n"
-"            age: 0,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"fn create_default() {\n"
-"    let tmp = Person {\n"
-"        ..Person::default()\n"
-"    };\n"
-"    let tmp = Person {\n"
-"        name: \"Sam\".to_string(),\n"
-"        ..Person::default()\n"
-"    };\n"
-"}\n"
-"```"
+#: src/structs/field-shorthand.md:52
+msgid "\"Bot\""
+msgstr ""
+
+#: src/structs/field-shorthand.md:62
+msgid "\"Sam\""
 msgstr ""
 
 #: src/structs/field-shorthand.md:68
@@ -6270,29 +6039,8 @@ msgid ""
 "an `impl` block:"
 msgstr ""
 
-#: src/methods.md:6
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"\n"
-"impl Person {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Hello, my name is {}\", self.name);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    peter.say_hello();\n"
-"}\n"
-"```"
+#: src/methods.md:15
+msgid "\"Hello, my name is {}\""
 msgstr ""
 
 #: src/methods.md:31
@@ -6395,50 +6143,40 @@ msgid ""
 "multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 
-#: src/methods/example.md:3
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Race {\n"
-"    name: String,\n"
-"    laps: Vec<i32>,\n"
-"}\n"
-"\n"
-"impl Race {\n"
-"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
-"        Race { name: String::from(name), laps: Vec::new() }\n"
-"    }\n"
-"\n"
-"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
-"access to self\n"
-"        self.laps.push(lap);\n"
-"    }\n"
-"\n"
-"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
-"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
-"        for (idx, lap) in self.laps.iter().enumerate() {\n"
-"            println!(\"Lap {idx}: {lap} sec\");\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn finish(self) {  // Exclusive ownership of self\n"
-"        let total = self.laps.iter().sum::<i32>();\n"
-"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
-"total);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
-"    race.add_lap(70);\n"
-"    race.add_lap(68);\n"
-"    race.print_laps();\n"
-"    race.add_lap(71);\n"
-"    race.print_laps();\n"
-"    race.finish();\n"
-"    // race.add_lap(42);\n"
-"}\n"
-"```"
+#: src/methods/example.md:11
+msgid "// No receiver, a static method\n"
+msgstr ""
+
+#: src/methods/example.md:15
+msgid "// Exclusive borrowed read-write access to self\n"
+msgstr ""
+
+#: src/methods/example.md:19
+msgid "// Shared and read-only borrowed access to self\n"
+msgstr ""
+
+#: src/methods/example.md:20
+msgid "\"Recorded {} laps for {}:\""
+msgstr ""
+
+#: src/methods/example.md:22
+msgid "\"Lap {idx}: {lap} sec\""
+msgstr ""
+
+#: src/methods/example.md:26
+msgid "// Exclusive ownership of self\n"
+msgstr ""
+
+#: src/methods/example.md:28
+msgid "\"Race {} is finished, total lap time: {}\""
+msgstr ""
+
+#: src/methods/example.md:33
+msgid "\"Monaco Grand Prix\""
+msgstr ""
+
+#: src/methods/example.md:40
+msgid "// race.add_lap(42);\n"
 msgstr ""
 
 #: src/methods/example.md:47
@@ -6492,19 +6230,12 @@ msgid ""
 "now, you just need to know part of its API:"
 msgstr ""
 
-#: src/exercises/day-2/book-library.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut vec = vec![10, 20];\n"
-"    vec.push(30);\n"
-"    let midpoint = vec.len() / 2;\n"
-"    println!(\"middle value: {}\", vec[midpoint]);\n"
-"    for item in &vec {\n"
-"        println!(\"item: {item}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/day-2/book-library.md:11
+msgid "\"middle value: {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:13
+msgid "\"item: {item}\""
 msgstr ""
 
 #: src/exercises/day-2/book-library.md:18
@@ -6513,28 +6244,14 @@ msgid ""
 "<https://play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 
-#: src/exercises/day-2/book-library.md:21
+#: src/exercises/day-2/book-library.md:32
+#: src/exercises/day-2/solutions-morning.md:18
+msgid "// This is a constructor, used below.\n"
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:40
+#: src/exercises/day-2/solutions-morning.md:26
 msgid ""
-"```rust,should_panic\n"
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}\n"
-"\n"
-"struct Book {\n"
-"    title: String,\n"
-"    year: u16,\n"
-"}\n"
-"\n"
-"impl Book {\n"
-"    // This is a constructor, used below.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
 "// Implement the methods below. Notice how the `self` parameter\n"
 "// changes type to indicate the method's required level of ownership\n"
 "// over the object:\n"
@@ -6542,61 +6259,74 @@ msgid ""
 "// - `&self` for shared read-only access,\n"
 "// - `&mut self` for unique and mutable access,\n"
 "// - `self` for unique access by value.\n"
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        todo!(\"Initialize and return a `Library` value\")\n"
-"    }\n"
-"\n"
-"    fn len(&self) -> usize {\n"
-"        todo!(\"Return the length of `self.books`\")\n"
-"    }\n"
-"\n"
-"    fn is_empty(&self) -> bool {\n"
-"        todo!(\"Return `true` if `self.books` is empty\")\n"
-"    }\n"
-"\n"
-"    fn add_book(&mut self, book: Book) {\n"
-"        todo!(\"Add a new book to `self.books`\")\n"
-"    }\n"
-"\n"
-"    fn print_books(&self) {\n"
-"        todo!(\"Iterate over `self.books` and print each book's title and "
-"year\")\n"
-"    }\n"
-"\n"
-"    fn oldest_book(&self) -> Option<&Book> {\n"
-"        todo!(\"Return a reference to the oldest book (if any)\")\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut library = Library::new();\n"
-"\n"
-"    println!(\n"
-"        \"The library is empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"\n"
-"    println!(\n"
-"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.print_books();\n"
-"\n"
-"    match library.oldest_book() {\n"
-"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
-"        None => println!(\"The library is empty!\"),\n"
-"    }\n"
-"\n"
-"    println!(\"The library has {} books\", library.len());\n"
-"    library.print_books();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:50
+msgid "\"Initialize and return a `Library` value\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:54
+msgid "\"Return the length of `self.books`\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:58
+msgid "\"Return `true` if `self.books` is empty\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:62
+msgid "\"Add a new book to `self.books`\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:66
+msgid "\"Iterate over `self.books` and print each book's title and year\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:70
+msgid "\"Return a reference to the oldest book (if any)\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:78
+#: src/exercises/day-2/solutions-morning.md:78
+msgid "\"The library is empty: library.is_empty() -> {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:82
+#: src/exercises/day-2/solutions-morning.md:82
+#: src/exercises/day-2/solutions-morning.md:107
+#: src/exercises/day-2/solutions-morning.md:118
+#: src/exercises/day-2/solutions-morning.md:125
+#: src/exercises/day-2/solutions-morning.md:137
+#: src/exercises/day-2/solutions-morning.md:140
+msgid "\"Lord of the Rings\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:83
+#: src/exercises/day-2/solutions-morning.md:83
+#: src/exercises/day-2/solutions-morning.md:108
+#: src/exercises/day-2/solutions-morning.md:126
+#: src/exercises/day-2/solutions-morning.md:143
+#: src/exercises/day-2/solutions-morning.md:146
+msgid "\"Alice's Adventures in Wonderland\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:86
+#: src/exercises/day-2/solutions-morning.md:86
+msgid "\"The library is no longer empty: library.is_empty() -> {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:93
+#: src/exercises/day-2/solutions-morning.md:93
+msgid "\"The oldest book is {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:94
+#: src/exercises/day-2/solutions-morning.md:94
+msgid "\"The library is empty!\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:97
+#: src/exercises/day-2/solutions-morning.md:97
+msgid "\"The library has {} books\""
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
@@ -6618,109 +6348,57 @@ msgid ""
 "methods:"
 msgstr ""
 
-#: src/exercises/day-2/health-statistics.md:13
+#: src/exercises/day-2/health-statistics.md:39
+msgid "\"Create a new User instance\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:43
+msgid "\"Return the user's name\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:47
+msgid "\"Return the user's age\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:51
+msgid "\"Return the user's height\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:55
+msgid "\"Return the number of time the user has visited the doctor\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:59
+msgid "\"Set the user's age\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:63
+msgid "\"Set the user's height\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:67
 msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub struct User {\n"
-"    name: String,\n"
-"    age: u32,\n"
-"    height: f32,\n"
-"    visit_count: usize,\n"
-"    last_blood_pressure: Option<(u32, u32)>,\n"
-"}\n"
-"\n"
-"pub struct Measurements {\n"
-"    height: f32,\n"
-"    blood_pressure: (u32, u32),\n"
-"}\n"
-"\n"
-"pub struct HealthReport<'a> {\n"
-"    patient_name: &'a str,\n"
-"    visit_count: u32,\n"
-"    height_change: f32,\n"
-"    blood_pressure_change: Option<(i32, i32)>,\n"
-"}\n"
-"\n"
-"impl User {\n"
-"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
-"        todo!(\"Create a new User instance\")\n"
-"    }\n"
-"\n"
-"    pub fn name(&self) -> &str {\n"
-"        todo!(\"Return the user's name\")\n"
-"    }\n"
-"\n"
-"    pub fn age(&self) -> u32 {\n"
-"        todo!(\"Return the user's age\")\n"
-"    }\n"
-"\n"
-"    pub fn height(&self) -> f32 {\n"
-"        todo!(\"Return the user's height\")\n"
-"    }\n"
-"\n"
-"    pub fn doctor_visits(&self) -> u32 {\n"
-"        todo!(\"Return the number of time the user has visited the "
-"doctor\")\n"
-"    }\n"
-"\n"
-"    pub fn set_age(&mut self, new_age: u32) {\n"
-"        todo!(\"Set the user's age\")\n"
-"    }\n"
-"\n"
-"    pub fn set_height(&mut self, new_height: f32) {\n"
-"        todo!(\"Set the user's height\")\n"
-"    }\n"
-"\n"
-"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
-"HealthReport {\n"
-"        todo!(\"Update a user's statistics based on measurements from a "
-"visit to the doctor\")\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_height() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.height(), 155.2);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_set_age() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.age(), 32);\n"
-"    bob.set_age(33);\n"
-"    assert_eq!(bob.age(), 33);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_visit() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.doctor_visits(), 0);\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (120, 80),\n"
-"    });\n"
-"    assert_eq!(report.patient_name, \"Bob\");\n"
-"    assert_eq!(report.visit_count, 1);\n"
-"    assert_eq!(report.blood_pressure_change, None);\n"
-"\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (115, 76),\n"
-"    });\n"
-"\n"
-"    assert_eq!(report.visit_count, 2);\n"
-"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
-"}\n"
-"```"
+"\"Update a user's statistics based on measurements from a visit to the "
+"doctor\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:72
+#: src/exercises/day-2/health-statistics.md:78
+#: src/exercises/day-2/health-statistics.md:84
+#: src/exercises/day-2/health-statistics.md:92
+#: src/exercises/day-2/health-statistics.md:98
+#: src/android/build-rules/library.md:44 src/android/aidl/client.md:23
+#: src/exercises/day-2/solutions-morning.md:233
+#: src/exercises/day-2/solutions-morning.md:239
+#: src/exercises/day-2/solutions-morning.md:245
+#: src/exercises/day-2/solutions-morning.md:253
+#: src/exercises/day-2/solutions-morning.md:259
+msgid "\"Bob\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:73
+#: src/exercises/day-2/solutions-morning.md:234
+msgid "\"I'm {} and my age is {}\""
 msgstr ""
 
 #: src/std.md:3
@@ -6795,18 +6473,12 @@ msgstr ""
 msgid "The types represent optional data:"
 msgstr ""
 
-#: src/std/option-result.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let numbers = vec![10, 20, 30];\n"
-"    let first: Option<&i8> = numbers.first();\n"
-"    println!(\"first: {first:?}\");\n"
-"\n"
-"    let arr: Result<[i8; 3], Vec<i8>> = numbers.try_into();\n"
-"    println!(\"arr: {arr:?}\");\n"
-"}\n"
-"```"
+#: src/std/option-result.md:9
+msgid "\"first: {first:?}\""
+msgstr ""
+
+#: src/std/option-result.md:12
+msgid "\"arr: {arr:?}\""
 msgstr ""
 
 #: src/std/option-result.md:18
@@ -6844,24 +6516,24 @@ msgid ""
 "standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
 
-#: src/std/string.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut s1 = String::new();\n"
-"    s1.push_str(\"Hello\");\n"
-"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());\n"
-"\n"
-"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
-"    s2.push_str(&s1);\n"
-"    s2.push('!');\n"
-"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());\n"
-"\n"
-"    let s3 = String::from(\"🇨🇭\");\n"
-"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
-"             s3.chars().count());\n"
-"}\n"
-"```"
+#: src/std/string.md:9
+msgid "\"s1: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/string.md:13
+msgid "'!'"
+msgstr ""
+
+#: src/std/string.md:14
+msgid "\"s2: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/string.md:16
+msgid "\"🇨🇭\""
+msgstr ""
+
+#: src/std/string.md:17
+msgid "\"s3: len = {}, number of chars = {}\""
 msgstr ""
 
 #: src/std/string.md:22
@@ -6946,31 +6618,28 @@ msgid ""
 "resizable heap-allocated buffer:"
 msgstr ""
 
-#: src/std/vec.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut v1 = Vec::new();\n"
-"    v1.push(42);\n"
-"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());\n"
-"\n"
-"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
-"    v2.extend(v1.iter());\n"
-"    v2.push(9999);\n"
-"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
-"\n"
-"    // Canonical macro to initialize a vector with elements.\n"
-"    let mut v3 = vec![0, 0, 1, 2, 3, 4];\n"
-"\n"
-"    // Retain only the even elements.\n"
-"    v3.retain(|x| x % 2 == 0);\n"
-"    println!(\"{v3:?}\");\n"
-"\n"
-"    // Remove consecutive duplicates.\n"
-"    v3.dedup();\n"
-"    println!(\"{v3:?}\");\n"
-"}\n"
-"```"
+#: src/std/vec.md:9
+msgid "\"v1: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/vec.md:14
+msgid "\"v2: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/vec.md:16
+msgid "// Canonical macro to initialize a vector with elements.\n"
+msgstr ""
+
+#: src/std/vec.md:19
+msgid "// Retain only the even elements.\n"
+msgstr ""
+
+#: src/std/vec.md:21 src/std/vec.md:25
+msgid "\"{v3:?}\""
+msgstr ""
+
+#: src/std/vec.md:23
+msgid "// Remove consecutive duplicates.\n"
 msgstr ""
 
 #: src/std/vec.md:29
@@ -7021,42 +6690,44 @@ msgstr ""
 msgid "Standard hash map with protection against HashDoS attacks:"
 msgstr ""
 
-#: src/std/hashmap.md:5
-msgid ""
-"```rust,editable\n"
-"use std::collections::HashMap;\n"
-"\n"
-"fn main() {\n"
-"    let mut page_counts = HashMap::new();\n"
-"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
-"207);\n"
-"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
-"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);\n"
-"\n"
-"    if !page_counts.contains_key(\"Les Misérables\") {\n"
-"        println!(\"We know about {} books, but not Les Misérables.\",\n"
-"                 page_counts.len());\n"
-"    }\n"
-"\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
-"Wonderland\"] {\n"
-"        match page_counts.get(book) {\n"
-"            Some(count) => println!(\"{book}: {count} pages\"),\n"
-"            None => println!(\"{book} is unknown.\")\n"
-"        }\n"
-"    }\n"
-"\n"
-"    // Use the .entry() method to insert a value if nothing is found.\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
-"Wonderland\"] {\n"
-"        let page_count: &mut i32 = page_counts.entry(book.to_string())."
-"or_insert(0);\n"
-"        *page_count += 1;\n"
-"    }\n"
-"\n"
-"    println!(\"{page_counts:#?}\");\n"
-"}\n"
-"```"
+#: src/std/hashmap.md:10
+msgid "\"Adventures of Huckleberry Finn\""
+msgstr ""
+
+#: src/std/hashmap.md:11
+msgid "\"Grimms' Fairy Tales\""
+msgstr ""
+
+#: src/std/hashmap.md:12 src/std/hashmap.md:19 src/std/hashmap.md:27
+msgid "\"Pride and Prejudice\""
+msgstr ""
+
+#: src/std/hashmap.md:14
+msgid "\"Les Misérables\""
+msgstr ""
+
+#: src/std/hashmap.md:15
+msgid "\"We know about {} books, but not Les Misérables.\""
+msgstr ""
+
+#: src/std/hashmap.md:19 src/std/hashmap.md:27
+msgid "\"Alice's Adventure in Wonderland\""
+msgstr ""
+
+#: src/std/hashmap.md:21
+msgid "\"{book}: {count} pages\""
+msgstr ""
+
+#: src/std/hashmap.md:22
+msgid "\"{book} is unknown.\""
+msgstr ""
+
+#: src/std/hashmap.md:26
+msgid "// Use the .entry() method to insert a value if nothing is found.\n"
+msgstr ""
+
+#: src/std/hashmap.md:32
+msgid "\"{page_counts:#?}\""
 msgstr ""
 
 #: src/std/hashmap.md:38
@@ -7071,16 +6742,12 @@ msgid ""
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
 
-#: src/std/hashmap.md:41
-msgid ""
-"```rust,ignore\n"
-"  let pc1 = page_counts\n"
-"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"      .unwrap_or(&336);\n"
-"  let pc2 = page_counts\n"
-"      .entry(\"The Hunger Games\".to_string())\n"
-"      .or_insert(374);\n"
-"```"
+#: src/std/hashmap.md:43
+msgid "\"Harry Potter and the Sorcerer's Stone \""
+msgstr ""
+
+#: src/std/hashmap.md:46 src/std/hashmap.md:55
+msgid "\"The Hunger Games\""
 msgstr ""
 
 #: src/std/hashmap.md:49
@@ -7095,14 +6762,8 @@ msgid ""
 "us to easily initialize a hash map from a literal array:"
 msgstr ""
 
-#: src/std/hashmap.md:52
-msgid ""
-"```rust,ignore\n"
-"  let page_counts = HashMap::from([\n"
-"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"    (\"The Hunger Games\".to_string(), 374),\n"
-"  ]);\n"
-"```"
+#: src/std/hashmap.md:54
+msgid "\"Harry Potter and the Sorcerer's Stone\""
 msgstr ""
 
 #: src/std/hashmap.md:59
@@ -7142,14 +6803,8 @@ msgid ""
 "pointer to data on the heap:"
 msgstr ""
 
-#: src/std/box.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let five = Box::new(5);\n"
-"    println!(\"five: {}\", *five);\n"
-"}\n"
-"```"
+#: src/std/box.md:8
+msgid "\"five: {}\""
 msgstr ""
 
 #: src/std/box.md:26
@@ -7197,21 +6852,8 @@ msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
-#: src/std/box-recursive.md:5 src/std/box-niche.md:3
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"enum List<T> {\n"
-"    Cons(T, Box<List<T>>),\n"
-"    Nil,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::"
-"new(List::Nil))));\n"
-"    println!(\"{list:?}\");\n"
-"}\n"
-"```"
+#: src/std/box-recursive.md:14 src/std/box-niche.md:12
+msgid "\"{list:?}\""
 msgstr ""
 
 #: src/std/box-recursive.md:18
@@ -7295,19 +6937,12 @@ msgid ""
 "from multiple places:"
 msgstr ""
 
-#: src/std/rc.md:6
-msgid ""
-"```rust,editable\n"
-"use std::rc::Rc;\n"
-"\n"
-"fn main() {\n"
-"    let mut a = Rc::new(10);\n"
-"    let mut b = Rc::clone(&a);\n"
-"\n"
-"    println!(\"a: {a}\");\n"
-"    println!(\"b: {b}\");\n"
-"}\n"
-"```"
+#: src/std/rc.md:13
+msgid "\"a: {a}\""
+msgstr ""
+
+#: src/std/rc.md:14
+msgid "\"b: {b}\""
 msgstr ""
 
 #: src/std/rc.md:18
@@ -7375,41 +7010,12 @@ msgid ""
 "shared and exclusive references at runtime and panics if they are misused."
 msgstr ""
 
-#: src/std/cell.md:12
-msgid ""
-"```rust,editable\n"
-"use std::cell::RefCell;\n"
-"use std::rc::Rc;\n"
-"\n"
-"#[derive(Debug, Default)]\n"
-"struct Node {\n"
-"    value: i64,\n"
-"    children: Vec<Rc<RefCell<Node>>>,\n"
-"}\n"
-"\n"
-"impl Node {\n"
-"    fn new(value: i64) -> Rc<RefCell<Node>> {\n"
-"        Rc::new(RefCell::new(Node { value, ..Node::default() }))\n"
-"    }\n"
-"\n"
-"    fn sum(&self) -> i64 {\n"
-"        self.value + self.children.iter().map(|c| c.borrow().sum()).sum::"
-"<i64>()\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let root = Node::new(1);\n"
-"    root.borrow_mut().children.push(Node::new(5));\n"
-"    let subtree = Node::new(10);\n"
-"    subtree.borrow_mut().children.push(Node::new(11));\n"
-"    subtree.borrow_mut().children.push(Node::new(12));\n"
-"    root.borrow_mut().children.push(subtree);\n"
-"\n"
-"    println!(\"graph: {root:#?}\");\n"
-"    println!(\"graph sum: {}\", root.borrow().sum());\n"
-"}\n"
-"```"
+#: src/std/cell.md:40
+msgid "\"graph: {root:#?}\""
+msgstr ""
+
+#: src/std/cell.md:41
+msgid "\"graph sum: {}\""
 msgstr ""
 
 #: src/std/cell.md:47
@@ -7448,26 +7054,12 @@ msgstr ""
 msgid "Similarly, `mod` lets us namespace types and functions:"
 msgstr ""
 
-#: src/modules.md:7
-msgid ""
-"```rust,editable\n"
-"mod foo {\n"
-"    pub fn do_something() {\n"
-"        println!(\"In the foo module\");\n"
-"    }\n"
-"}\n"
-"\n"
-"mod bar {\n"
-"    pub fn do_something() {\n"
-"        println!(\"In the bar module\");\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    foo::do_something();\n"
-"    bar::do_something();\n"
-"}\n"
-"```"
+#: src/modules.md:10
+msgid "\"In the foo module\""
+msgstr ""
+
+#: src/modules.md:16
+msgid "\"In the bar module\""
 msgstr ""
 
 #: src/modules.md:28
@@ -7504,34 +7096,20 @@ msgid ""
 "the descendants of `foo`."
 msgstr ""
 
-#: src/modules/visibility.md:10
-msgid ""
-"```rust,editable\n"
-"mod outer {\n"
-"    fn private() {\n"
-"        println!(\"outer::private\");\n"
-"    }\n"
-"\n"
-"    pub fn public() {\n"
-"        println!(\"outer::public\");\n"
-"    }\n"
-"\n"
-"    mod inner {\n"
-"        fn private() {\n"
-"            println!(\"outer::inner::private\");\n"
-"        }\n"
-"\n"
-"        pub fn public() {\n"
-"            println!(\"outer::inner::public\");\n"
-"            super::private();\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    outer::public();\n"
-"}\n"
-"```"
+#: src/modules/visibility.md:13
+msgid "\"outer::private\""
+msgstr ""
+
+#: src/modules/visibility.md:17
+msgid "\"outer::public\""
+msgstr ""
+
+#: src/modules/visibility.md:22
+msgid "\"outer::inner::private\""
+msgstr ""
+
+#: src/modules/visibility.md:26
+msgid "\"outer::inner::public\""
 msgstr ""
 
 #: src/modules/visibility.md:39
@@ -7629,23 +7207,23 @@ msgid ""
 "module."
 msgstr ""
 
-#: src/modules/filesystem.md:20
+#: src/modules/filesystem.md:21
 msgid ""
-"```rust,editable,compile_fail\n"
 "//! This module implements the garden, including a highly performant "
 "germination\n"
 "//! implementation.\n"
-"\n"
-"// Re-export types from this module.\n"
-"pub use seeds::SeedPacket;\n"
-"pub use garden::Garden;\n"
-"\n"
-"/// Sow the given seed packets.\n"
-"pub fn sow(seeds: Vec<SeedPacket>) { todo!() }\n"
-"\n"
-"/// Harvest the produce in the garden that is ready.\n"
-"pub fn harvest(garden: &mut Garden) { todo!() }\n"
-"```"
+msgstr ""
+
+#: src/modules/filesystem.md:23
+msgid "// Re-export types from this module.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:27
+msgid "/// Sow the given seed packets.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:30
+msgid "/// Harvest the produce in the garden that is ready.\n"
 msgstr ""
 
 #: src/modules/filesystem.md:37
@@ -7670,12 +7248,8 @@ msgid ""
 "directive:"
 msgstr ""
 
-#: src/modules/filesystem.md:54
-msgid ""
-"```rust,ignore\n"
-"#[path = \"some/path.rs\"]\n"
-"mod some_module;\n"
-"```"
+#: src/modules/filesystem.md:55
+msgid "\"some/path.rs\""
 msgstr ""
 
 #: src/modules/filesystem.md:59
@@ -7715,36 +7289,29 @@ msgstr ""
 msgid "You use this trait like this:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:22
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();\n"
-"\n"
-"    println!(\"v[0]: {:?}\", iter.next());\n"
-"    println!(\"v[1]: {:?}\", iter.next());\n"
-"    println!(\"v[2]: {:?}\", iter.next());\n"
-"    println!(\"No more items: {:?}\", iter.next());\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:27
+msgid "\"v[0]: {:?}\""
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:28
+msgid "\"v[1]: {:?}\""
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:29
+msgid "\"v[2]: {:?}\""
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:30
+msgid "\"No more items: {:?}\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:34
 msgid "What is the type returned by the iterator? Test your answer here:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:36
-msgid ""
-"```rust,editable,compile_fail\n"
-"fn main() {\n"
-"    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();\n"
-"\n"
-"    let v0: Option<..> = iter.next();\n"
-"    println!(\"v0: {v0:?}\");\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:42
+#: src/exercises/day-2/iterators-and-ownership.md:79
+msgid "\"v0: {v0:?}\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:46
@@ -7786,18 +7353,10 @@ msgstr ""
 msgid "Like before, what  is the type returned by the iterator?"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:73
-msgid ""
-"```rust,editable,compile_fail\n"
-"fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
-"from(\"bar\")];\n"
-"    let mut iter = v.into_iter();\n"
-"\n"
-"    let v0: Option<..> = iter.next();\n"
-"    println!(\"v0: {v0:?}\");\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:75
+#: src/exercises/day-2/iterators-and-ownership.md:91
+#: src/testing/test-modules.md:21
+msgid "\"bar\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:83
@@ -7811,22 +7370,9 @@ msgid ""
 "resulting iterator:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:89
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
-"from(\"bar\")];\n"
-"\n"
-"    for word in &v {\n"
-"        println!(\"word: {word}\");\n"
-"    }\n"
-"\n"
-"    for word in v {\n"
-"        println!(\"word: {word}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:94
+#: src/exercises/day-2/iterators-and-ownership.md:98
+msgid "\"word: {word}\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:103
@@ -7856,53 +7402,79 @@ msgid ""
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:12
-msgid ""
-"```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
-"abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
-"books\"));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
-"publishers\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_with_wildcard() {\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/bar/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books/book1\"\n"
-"    ));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
-"publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
-"```"
+#: src/exercises/day-2/strings-iterators.md:22
+#: src/exercises/day-2/strings-iterators.md:23
+#: src/exercises/day-2/strings-iterators.md:24
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/strings-iterators.md:27
+#: src/exercises/day-2/strings-iterators.md:28
+#: src/exercises/day-2/strings-iterators.md:46
+#: src/exercises/day-2/solutions-afternoon.md:32
+#: src/exercises/day-2/solutions-afternoon.md:33
+#: src/exercises/day-2/solutions-afternoon.md:34
+#: src/exercises/day-2/solutions-afternoon.md:36
+#: src/exercises/day-2/solutions-afternoon.md:37
+#: src/exercises/day-2/solutions-afternoon.md:38
+#: src/exercises/day-2/solutions-afternoon.md:56
+msgid "\"/v1/publishers\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:23
+#: src/exercises/day-2/solutions-afternoon.md:33
+msgid "\"/v1/publishers/abc-123\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:24
+#: src/exercises/day-2/solutions-afternoon.md:34
+msgid "\"/v1/publishers/abc/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/solutions-afternoon.md:36
+msgid "\"/v1\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:27
+#: src/exercises/day-2/solutions-afternoon.md:37
+msgid "\"/v1/publishersBooks\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:28
+#: src/exercises/day-2/solutions-afternoon.md:38
+msgid "\"/v1/parent/publishers\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:34
+#: src/exercises/day-2/strings-iterators.md:38
+#: src/exercises/day-2/strings-iterators.md:42
+#: src/exercises/day-2/strings-iterators.md:46
+#: src/exercises/day-2/strings-iterators.md:48
+#: src/exercises/day-2/solutions-afternoon.md:44
+#: src/exercises/day-2/solutions-afternoon.md:48
+#: src/exercises/day-2/solutions-afternoon.md:52
+#: src/exercises/day-2/solutions-afternoon.md:56
+#: src/exercises/day-2/solutions-afternoon.md:58
+msgid "\"/v1/publishers/*/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:35
+#: src/exercises/day-2/solutions-afternoon.md:45
+msgid "\"/v1/publishers/foo/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:39
+#: src/exercises/day-2/solutions-afternoon.md:49
+msgid "\"/v1/publishers/bar/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:43
+#: src/exercises/day-2/solutions-afternoon.md:53
+msgid "\"/v1/publishers/foo/books/book1\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:49
+#: src/exercises/day-2/solutions-afternoon.md:59
+msgid "\"/v1/publishers/foo/booksByAuthor\""
 msgstr ""
 
 #: src/welcome-day-3.md:1
@@ -7953,21 +7525,8 @@ msgid "You can use generics to abstract over the concrete field type:"
 msgstr ""
 "ジェネリクスを使って、具体的なフィールドの型を抽象化することができます："
 
-#: src/generics/data-types.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Point<T> {\n"
-"    x: T,\n"
-"    y: T,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let integer = Point { x: 5, y: 10 };\n"
-"    let float = Point { x: 1.0, y: 4.0 };\n"
-"    println!(\"{integer:?} and {float:?}\");\n"
-"}\n"
-"```"
+#: src/generics/data-types.md:15
+msgid "\"{integer:?} and {float:?}\""
 msgstr ""
 
 #: src/generics/data-types.md:21
@@ -7984,25 +7543,16 @@ msgstr "異なる型の要素を持つ点を許容するように、コードを
 msgid "You can declare a generic type on your `impl` block:"
 msgstr "`impl`に対して、ジェネリックな型を宣言することもできます："
 
-#: src/generics/methods.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Point<T>(T, T);\n"
-"\n"
-"impl<T> Point<T> {\n"
-"    fn x(&self) -> &T {\n"
-"        &self.0  // + 10\n"
-"    }\n"
-"\n"
-"    // fn set_x(&mut self, x: T)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let p = Point(5, 10);\n"
-"    println!(\"p.x = {}\", p.x());\n"
-"}\n"
-"```"
+#: src/generics/methods.md:11
+msgid "// + 10\n"
+msgstr ""
+
+#: src/generics/methods.md:14
+msgid "// fn set_x(&mut self, x: T)\n"
+msgstr ""
+
+#: src/generics/methods.md:19
+msgid "\"p.x = {}\""
 msgstr ""
 
 #: src/generics/methods.md:25
@@ -8062,37 +7612,24 @@ msgid ""
 "Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
-#: src/traits.md:5
-msgid ""
-"```rust,editable\n"
-"struct Dog { name: String, age: i8 }\n"
-"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
-"\n"
-"trait Pet {\n"
-"    fn talk(&self) -> String;\n"
-"}\n"
-"\n"
-"impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
-"name) }\n"
-"}\n"
-"\n"
-"impl Pet for Cat {\n"
-"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
-"}\n"
-"\n"
-"fn greet<P: Pet>(pet: &P) {\n"
-"    println!(\"Oh you're a cutie! What's your name? {}\", pet.talk());\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let captain_floof = Cat { lives: 9 };\n"
-"    let fido = Dog { name: String::from(\"Fido\"), age: 5 };\n"
-"\n"
-"    greet(&captain_floof);\n"
-"    greet(&fido);\n"
-"}\n"
-"```"
+#: src/traits.md:7 src/traits/trait-objects.md:7
+msgid "// No name needed, cats won't respond anyway.\n"
+msgstr ""
+
+#: src/traits.md:14 src/traits/trait-objects.md:14
+msgid "\"Woof, my name is {}!\""
+msgstr ""
+
+#: src/traits.md:18 src/traits/trait-objects.md:18
+msgid "\"Miau!\""
+msgstr ""
+
+#: src/traits.md:22
+msgid "\"Oh you're a cutie! What's your name? {}\""
+msgstr ""
+
+#: src/traits.md:27 src/traits/trait-objects.md:24
+msgid "\"Fido\""
 msgstr ""
 
 #: src/traits/trait-objects.md:3
@@ -8101,35 +7638,8 @@ msgid ""
 "collection:"
 msgstr ""
 
-#: src/traits/trait-objects.md:5
-msgid ""
-"```rust,editable\n"
-"struct Dog { name: String, age: i8 }\n"
-"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
-"\n"
-"trait Pet {\n"
-"    fn talk(&self) -> String;\n"
-"}\n"
-"\n"
-"impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
-"name) }\n"
-"}\n"
-"\n"
-"impl Pet for Cat {\n"
-"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let pets: Vec<Box<dyn Pet>> = vec![\n"
-"        Box::new(Cat { lives: 9 }),\n"
-"        Box::new(Dog { name: String::from(\"Fido\"), age: 5 }),\n"
-"    ];\n"
-"    for pet in pets {\n"
-"        println!(\"Hello, who are you? {}\", pet.talk());\n"
-"    }\n"
-"}\n"
-"```"
+#: src/traits/trait-objects.md:27
+msgid "\"Hello, who are you? {}\""
 msgstr ""
 
 #: src/traits/trait-objects.md:32
@@ -8233,16 +7743,16 @@ msgstr ""
 msgid "Compare these outputs in the above example:"
 msgstr ""
 
-#: src/traits/trait-objects.md:80
-msgid ""
-"```rust,ignore\n"
-"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"```"
+#: src/traits/trait-objects.md:81 src/traits/trait-objects.md:82
+#: src/traits/closures.md:54
+msgid "\"{} {}\""
+msgstr ""
+
+#: src/traits/trait-objects.md:83 src/traits/trait-objects.md:84
+#: src/testing/test-modules.md:12 src/android/build-rules/library.md:44
+#: src/async/pitfalls/cancellation.md:59
+#: src/exercises/day-3/solutions-morning.md:128
+msgid "\"{}\""
 msgstr ""
 
 #: src/traits/deriving-traits.md:3
@@ -8255,55 +7765,30 @@ msgstr ""
 msgid "You can let the compiler derive a number of traits as follows:"
 msgstr ""
 
-#: src/traits/deriving-traits.md:7
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug, Clone, PartialEq, Eq, Default)]\n"
-"struct Player {\n"
-"    name: String,\n"
-"    strength: u8,\n"
-"    hit_points: u8,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let p1 = Player::default();\n"
-"    let p2 = p1.clone();\n"
-"    println!(\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2,\n"
-"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
-"}\n"
-"```"
+#: src/traits/deriving-traits.md:18
+msgid "\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\""
+msgstr ""
+
+#: src/traits/deriving-traits.md:19
+#: src/exercises/day-1/solutions-afternoon.md:37
+msgid "\"yes\""
+msgstr ""
+
+#: src/traits/deriving-traits.md:19
+#: src/exercises/day-1/solutions-afternoon.md:37
+msgid "\"no\""
 msgstr ""
 
 #: src/traits/default-methods.md:3
 msgid "Traits can implement behavior in terms of other trait methods:"
 msgstr ""
 
-#: src/traits/default-methods.md:5
-msgid ""
-"```rust,editable\n"
-"trait Equals {\n"
-"    fn equals(&self, other: &Self) -> bool;\n"
-"    fn not_equals(&self, other: &Self) -> bool {\n"
-"        !self.equals(other)\n"
-"    }\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct Centimeter(i16);\n"
-"\n"
-"impl Equals for Centimeter {\n"
-"    fn equals(&self, other: &Centimeter) -> bool {\n"
-"        self.0 == other.0\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let a = Centimeter(10);\n"
-"    let b = Centimeter(20);\n"
-"    println!(\"{a:?} equals {b:?}: {}\", a.equals(&b));\n"
-"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equals(&b));\n"
-"}\n"
-"```"
+#: src/traits/default-methods.md:25
+msgid "\"{a:?} equals {b:?}: {}\""
+msgstr ""
+
+#: src/traits/default-methods.md:26
+msgid "\"{a:?} not_equals {b:?}: {}\""
 msgstr ""
 
 #: src/traits/default-methods.md:32
@@ -8341,32 +7826,26 @@ msgstr ""
 msgid "You can do this with `T: Trait` or `impl Trait`:"
 msgstr ""
 
-#: src/traits/trait-bounds.md:8
+#: src/traits/trait-bounds.md:12
 msgid ""
-"```rust,editable\n"
-"fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
-"    (a.clone(), a.clone())\n"
-"}\n"
-"\n"
 "// Syntactic sugar for:\n"
 "//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
-"fn add_42_millions(x: impl Into<i32>) -> i32 {\n"
-"    x.into() + 42_000_000\n"
-"}\n"
-"\n"
-"// struct NotClonable;\n"
-"\n"
-"fn main() {\n"
-"    let foo = String::from(\"foo\");\n"
-"    let pair = duplicate(foo);\n"
-"    println!(\"{pair:?}\");\n"
-"\n"
-"    let many = add_42_millions(42_i8);\n"
-"    println!(\"{many}\");\n"
-"    let many_more = add_42_millions(10_000_000);\n"
-"    println!(\"{many_more}\");\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/traits/trait-bounds.md:18
+msgid "// struct NotClonable;\n"
+msgstr ""
+
+#: src/traits/trait-bounds.md:24
+msgid "\"{pair:?}\""
+msgstr ""
+
+#: src/traits/trait-bounds.md:27
+msgid "\"{many}\""
+msgstr ""
+
+#: src/traits/trait-bounds.md:29
+msgid "\"{many_more}\""
 msgstr ""
 
 #: src/traits/trait-bounds.md:35
@@ -8395,22 +7874,6 @@ msgstr ""
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
-msgstr ""
-
-#: src/traits/impl-trait.md:6
-msgid ""
-"```rust,editable\n"
-"use std::fmt::Display;\n"
-"\n"
-"fn get_x(name: impl Display) -> impl Display {\n"
-"    format!(\"Hello {name}\")\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let x = get_x(\"foo\");\n"
-"    println!(\"{x}\");\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/traits/impl-trait.md:19
@@ -8511,32 +7974,8 @@ msgid ""
 "Iterator.html) trait on your own types:"
 msgstr ""
 
-#: src/traits/iterator.md:5
-msgid ""
-"```rust,editable\n"
-"struct Fibonacci {\n"
-"    curr: u32,\n"
-"    next: u32,\n"
-"}\n"
-"\n"
-"impl Iterator for Fibonacci {\n"
-"    type Item = u32;\n"
-"\n"
-"    fn next(&mut self) -> Option<Self::Item> {\n"
-"        let new_next = self.curr + self.next;\n"
-"        self.curr = self.next;\n"
-"        self.next = new_next;\n"
-"        Some(self.curr)\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let fib = Fibonacci { curr: 0, next: 1 };\n"
-"    for (i, n) in fib.enumerate().take(5) {\n"
-"        println!(\"fib({i}): {n}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/traits/iterator.md:25
+msgid "\"fib({i}): {n}\""
 msgstr ""
 
 #: src/traits/iterator.md:32
@@ -8563,18 +8002,8 @@ msgid ""
 "std/iter/trait.Iterator.html)."
 msgstr ""
 
-#: src/traits/from-iterator.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let primes = vec![2, 3, 5, 7];\n"
-"    let prime_squares = primes\n"
-"        .into_iter()\n"
-"        .map(|prime| prime * prime)\n"
-"        .collect::<Vec<_>>();\n"
-"    println!(\"prime_squares: {prime_squares:?}\");\n"
-"}\n"
-"```"
+#: src/traits/from-iterator.md:12
+msgid "\"prime_squares: {prime_squares:?}\""
 msgstr ""
 
 #: src/traits/from-iterator.md:18
@@ -8600,17 +8029,8 @@ msgid ""
 "facilitate type conversions:"
 msgstr ""
 
-#: src/traits/from-into.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s = String::from(\"hello\");\n"
-"    let addr = std::net::Ipv4Addr::from([127, 0, 0, 1]);\n"
-"    let one = i16::from(true);\n"
-"    let bigger = i32::from(123i16);\n"
-"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
-"}\n"
-"```"
+#: src/traits/from-into.md:11 src/traits/from-into.md:23
+msgid "\"{s}, {addr}, {one}, {bigger}\""
 msgstr ""
 
 #: src/traits/from-into.md:15
@@ -8618,19 +8038,6 @@ msgid ""
 "[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
 "automatically implemented when [`From`](https://doc.rust-lang.org/std/"
 "convert/trait.From.html) is implemented:"
-msgstr ""
-
-#: src/traits/from-into.md:17
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s: String = \"hello\".into();\n"
-"    let addr: std::net::Ipv4Addr = [127, 0, 0, 1].into();\n"
-"    let one: i16 = true.into();\n"
-"    let bigger: i32 = 123i16.into();\n"
-"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/traits/from-into.md:29
@@ -8658,25 +8065,16 @@ msgid ""
 "abstract over `u8` sources:"
 msgstr ""
 
-#: src/traits/read-write.md:5
-msgid ""
-"```rust,editable\n"
-"use std::io::{BufRead, BufReader, Read, Result};\n"
-"\n"
-"fn count_lines<R: Read>(reader: R) -> usize {\n"
-"    let buf_reader = BufReader::new(reader);\n"
-"    buf_reader.lines().count()\n"
-"}\n"
-"\n"
-"fn main() -> Result<()> {\n"
-"    let slice: &[u8] = b\"foo\\nbar\\nbaz\\n\";\n"
-"    println!(\"lines in slice: {}\", count_lines(slice));\n"
-"\n"
-"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
-"    println!(\"lines in file: {}\", count_lines(file));\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/traits/read-write.md:14
+msgid "b\"foo\\nbar\\nbaz\\n\""
+msgstr ""
+
+#: src/traits/read-write.md:15
+msgid "\"lines in slice: {}\""
+msgstr ""
+
+#: src/traits/read-write.md:18
+msgid "\"lines in file: {}\""
 msgstr ""
 
 #: src/traits/read-write.md:23
@@ -8685,24 +8083,12 @@ msgid ""
 "you abstract over `u8` sinks:"
 msgstr ""
 
-#: src/traits/read-write.md:25
-msgid ""
-"```rust,editable\n"
-"use std::io::{Result, Write};\n"
-"\n"
-"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
-"    writer.write_all(msg.as_bytes())?;\n"
-"    writer.write_all(\"\\n\".as_bytes())\n"
-"}\n"
-"\n"
-"fn main() -> Result<()> {\n"
-"    let mut buffer = Vec::new();\n"
-"    log(&mut buffer, \"Hello\")?;\n"
-"    log(&mut buffer, \"World\")?;\n"
-"    println!(\"Logged: {:?}\", buffer);\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/traits/read-write.md:30
+msgid "\"\\n\""
+msgstr ""
+
+#: src/traits/read-write.md:37
+msgid "\"Logged: {:?}\""
 msgstr ""
 
 #: src/traits/drop.md:1
@@ -8715,34 +8101,38 @@ msgid ""
 "html) can specify code to run when they go out of scope:"
 msgstr ""
 
-#: src/traits/drop.md:5
-msgid ""
-"```rust,editable\n"
-"struct Droppable {\n"
-"    name: &'static str,\n"
-"}\n"
-"\n"
-"impl Drop for Droppable {\n"
-"    fn drop(&mut self) {\n"
-"        println!(\"Dropping {}\", self.name);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let a = Droppable { name: \"a\" };\n"
-"    {\n"
-"        let b = Droppable { name: \"b\" };\n"
-"        {\n"
-"            let c = Droppable { name: \"c\" };\n"
-"            let d = Droppable { name: \"d\" };\n"
-"            println!(\"Exiting block B\");\n"
-"        }\n"
-"        println!(\"Exiting block A\");\n"
-"    }\n"
-"    drop(a);\n"
-"    println!(\"Exiting main\");\n"
-"}\n"
-"```"
+#: src/traits/drop.md:12
+msgid "\"Dropping {}\""
+msgstr ""
+
+#: src/traits/drop.md:17 src/exercises/concurrency/link-checker.md:92
+#: src/exercises/day-1/solutions-morning.md:86
+#: src/exercises/concurrency/solutions-morning.md:123
+msgid "\"a\""
+msgstr ""
+
+#: src/traits/drop.md:19 src/exercises/day-1/solutions-morning.md:86
+msgid "\"b\""
+msgstr ""
+
+#: src/traits/drop.md:21 src/exercises/day-1/solutions-morning.md:86
+msgid "\"c\""
+msgstr ""
+
+#: src/traits/drop.md:22 src/exercises/day-1/solutions-morning.md:86
+msgid "\"d\""
+msgstr ""
+
+#: src/traits/drop.md:23
+msgid "\"Exiting block B\""
+msgstr ""
+
+#: src/traits/drop.md:25
+msgid "\"Exiting block A\""
+msgstr ""
+
+#: src/traits/drop.md:28
+msgid "\"Exiting main\""
 msgstr ""
 
 #: src/traits/drop.md:34
@@ -8806,40 +8196,24 @@ msgid ""
 "produces a default value for a type."
 msgstr ""
 
-#: src/traits/default.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug, Default)]\n"
-"struct Derived {\n"
-"    x: u32,\n"
-"    y: String,\n"
-"    z: Implemented,\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct Implemented(String);\n"
-"\n"
-"impl Default for Implemented {\n"
-"    fn default() -> Self {\n"
-"        Self(\"John Smith\".into())\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let default_struct = Derived::default();\n"
-"    println!(\"{default_struct:#?}\");\n"
-"\n"
-"    let almost_default_struct = Derived {\n"
-"        y: \"Y is set!\".into(),\n"
-"        ..Derived::default()\n"
-"    };\n"
-"    println!(\"{almost_default_struct:#?}\");\n"
-"\n"
-"    let nothing: Option<Derived> = None;\n"
-"    println!(\"{:#?}\", nothing.unwrap_or_default());\n"
-"}\n"
-"\n"
-"```"
+#: src/traits/default.md:18
+msgid "\"John Smith\""
+msgstr ""
+
+#: src/traits/default.md:24
+msgid "\"{default_struct:#?}\""
+msgstr ""
+
+#: src/traits/default.md:27
+msgid "\"Y is set!\""
+msgstr ""
+
+#: src/traits/default.md:30
+msgid "\"{almost_default_struct:#?}\""
+msgstr ""
+
+#: src/traits/default.md:33
+msgid "\"{:#?}\""
 msgstr ""
 
 #: src/traits/default.md:40
@@ -8890,26 +8264,8 @@ msgid ""
 "rust-lang.org/std/ops/index.html):"
 msgstr ""
 
-#: src/traits/operators.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug, Copy, Clone)]\n"
-"struct Point { x: i32, y: i32 }\n"
-"\n"
-"impl std::ops::Add for Point {\n"
-"    type Output = Self;\n"
-"\n"
-"    fn add(self, other: Self) -> Self {\n"
-"        Self {x: self.x + other.x, y: self.y + other.y}\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let p1 = Point { x: 10, y: 20 };\n"
-"    let p2 = Point { x: 100, y: 200 };\n"
-"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
-"}\n"
-"```"
+#: src/traits/operators.md:20
+msgid "\"{:?} + {:?} = {:?}\""
 msgstr ""
 
 #: src/traits/operators.md:28
@@ -8955,31 +8311,20 @@ msgid ""
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
-#: src/traits/closures.md:8
-msgid ""
-"```rust,editable\n"
-"fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
-"    println!(\"Calling function on {input}\");\n"
-"    func(input)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let add_3 = |x| x + 3;\n"
-"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
-"    println!(\"add_3: {}\", apply_with_log(add_3, 20));\n"
-"\n"
-"    let mut v = Vec::new();\n"
-"    let mut accumulate = |x: i32| {\n"
-"        v.push(x);\n"
-"        v.iter().sum::<i32>()\n"
-"    };\n"
-"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 4));\n"
-"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 5));\n"
-"\n"
-"    let multiply_sum = |x| x * v.into_iter().sum::<i32>();\n"
-"    println!(\"multiply_sum: {}\", apply_with_log(multiply_sum, 3));\n"
-"}\n"
-"```"
+#: src/traits/closures.md:10
+msgid "\"Calling function on {input}\""
+msgstr ""
+
+#: src/traits/closures.md:16 src/traits/closures.md:17
+msgid "\"add_3: {}\""
+msgstr ""
+
+#: src/traits/closures.md:24 src/traits/closures.md:25
+msgid "\"accumulate: {}\""
+msgstr ""
+
+#: src/traits/closures.md:28
+msgid "\"multiply_sum: {}\""
 msgstr ""
 
 #: src/traits/closures.md:34
@@ -9020,18 +8365,12 @@ msgid ""
 "keyword makes them capture by value."
 msgstr ""
 
-#: src/traits/closures.md:52
-msgid ""
-"```rust,editable\n"
-"fn make_greeter(prefix: String) -> impl Fn(&str) {\n"
-"    return move |name| println!(\"{} {}\", prefix, name)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let hi = make_greeter(\"Hi\".to_string());\n"
-"    hi(\"there\");\n"
-"}\n"
-"```"
+#: src/traits/closures.md:58
+msgid "\"Hi\""
+msgstr ""
+
+#: src/traits/closures.md:59
+msgid "\"there\""
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
@@ -9090,117 +8429,39 @@ msgid ""
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:19
-msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]\n"
-"\n"
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;\n"
-"\n"
-"    /// Draw the widget into a buffer.\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
-"\n"
-"    /// Draw the widget on standard output.\n"
-"    fn draw(&self) {\n"
-"        let mut buffer = String::new();\n"
-"        self.draw_into(&mut buffer);\n"
-"        println!(\"{buffer}\");\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Label {\n"
-"    label: String,\n"
-"}\n"
-"\n"
-"impl Label {\n"
-"    fn new(label: &str) -> Label {\n"
-"        Label {\n"
-"            label: label.to_owned(),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Button {\n"
-"    label: Label,\n"
-"}\n"
-"\n"
-"impl Button {\n"
-"    fn new(label: &str) -> Button {\n"
-"        Button {\n"
-"            label: Label::new(label),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Window {\n"
-"    title: String,\n"
-"    widgets: Vec<Box<dyn Widget>>,\n"
-"}\n"
-"\n"
-"impl Window {\n"
-"    fn new(title: &str) -> Window {\n"
-"        Window {\n"
-"            title: title.to_owned(),\n"
-"            widgets: Vec::new(),\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
-"        self.widgets.push(widget);\n"
-"    }\n"
-"\n"
-"    fn inner_width(&self) -> usize {\n"
-"        std::cmp::max(\n"
-"            self.title.chars().count(),\n"
-"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-"        )\n"
-"    }\n"
-"}\n"
-"\n"
-"\n"
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
-"\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\"\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"```"
+#: src/exercises/day-3/simple-gui.md:24
+#: src/exercises/day-3/solutions-morning.md:9
+msgid "/// Natural width of `self`.\n"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:27
+#: src/exercises/day-3/solutions-morning.md:12
+msgid "/// Draw the widget into a buffer.\n"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:30
+#: src/exercises/day-3/solutions-morning.md:15
+msgid "/// Draw the widget on standard output.\n"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:34
+#: src/exercises/day-3/solutions-morning.md:19
+msgid "\"{buffer}\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:119
+#: src/exercises/day-3/solutions-morning.md:133
+msgid "\"Rust GUI Demo 1.23\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:120
+#: src/exercises/day-3/solutions-morning.md:134
+msgid "\"This is a small text GUI demo.\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:122
+#: src/exercises/day-3/solutions-morning.md:136
+msgid "\"Click me!\""
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:128
@@ -9215,16 +8476,16 @@ msgid ""
 "and how you can control alignment:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:145
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let width = 10;\n"
-"    println!(\"left aligned:  |{:/<width$}|\", \"foo\");\n"
-"    println!(\"centered:      |{:/^width$}|\", \"foo\");\n"
-"    println!(\"right aligned: |{:/>width$}|\", \"foo\");\n"
-"}\n"
-"```"
+#: src/exercises/day-3/simple-gui.md:148
+msgid "\"left aligned:  |{:/<width$}|\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:149
+msgid "\"centered:      |{:/^width$}|\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:150
+msgid "\"right aligned: |{:/>width$}|\""
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:154
@@ -9243,115 +8504,16 @@ msgid ""
 "make the tests pass:"
 msgstr ""
 
-#: src/exercises/day-3/points-polygons.md:7
-msgid ""
-"```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub struct Point {\n"
-"    // add fields\n"
-"}\n"
-"\n"
-"impl Point {\n"
-"    // add methods\n"
-"}\n"
-"\n"
-"pub struct Polygon {\n"
-"    // add fields\n"
-"}\n"
-"\n"
-"impl Polygon {\n"
-"    // add methods\n"
-"}\n"
-"\n"
-"pub struct Circle {\n"
-"    // add fields\n"
-"}\n"
-"\n"
-"impl Circle {\n"
-"    // add methods\n"
-"}\n"
-"\n"
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"\n"
-"    fn round_two_digits(x: f64) -> f64 {\n"
-"        (x * 100.0).round() / 100.0\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_magnitude() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_dist() {\n"
-"        let p1 = Point::new(10, 10);\n"
-"        let p2 = Point::new(14, 13);\n"
-"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_add() {\n"
-"        let p1 = Point::new(16, 16);\n"
-"        let p2 = p1 + Point::new(-4, 3);\n"
-"        assert_eq!(p2, Point::new(12, 19));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_left_most_point() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"        assert_eq!(poly.left_most_point(), Some(p1));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_iter() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"\n"
-"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
-"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}\n"
-"\n"
-"#[allow(dead_code)]\n"
-"fn main() {}\n"
-"```"
+#: src/exercises/day-3/points-polygons.md:12
+#: src/exercises/day-3/points-polygons.md:20
+#: src/exercises/day-3/points-polygons.md:28
+msgid "// add fields\n"
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:16
+#: src/exercises/day-3/points-polygons.md:24
+#: src/exercises/day-3/points-polygons.md:32
+msgid "// add methods\n"
 msgstr ""
 
 #: src/exercises/day-3/points-polygons.md:117
@@ -9393,14 +8555,8 @@ msgstr ""
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
 msgstr ""
 
-#: src/error-handling/panics.md:5
-msgid ""
-"```rust,editable,should_panic\n"
-"fn main() {\n"
-"    let v = vec![10, 20, 30];\n"
-"    println!(\"v[100]: {}\", v[100]);\n"
-"}\n"
-"```"
+#: src/error-handling/panics.md:8
+msgid "\"v[100]: {}\""
 msgstr ""
 
 #: src/error-handling/panics.md:12
@@ -9426,23 +8582,16 @@ msgid ""
 "caught:"
 msgstr ""
 
-#: src/error-handling/panic-unwind.md:5
-msgid ""
-"```rust,editable\n"
-"use std::panic;\n"
-"\n"
-"fn main() {\n"
-"    let result = panic::catch_unwind(|| {\n"
-"        \"No problem here!\"\n"
-"    });\n"
-"    println!(\"{result:?}\");\n"
-"\n"
-"    let result = panic::catch_unwind(|| {\n"
-"        panic!(\"oh no!\");\n"
-"    });\n"
-"    println!(\"{result:?}\");\n"
-"}\n"
-"```"
+#: src/error-handling/panic-unwind.md:10
+msgid "\"No problem here!\""
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:12 src/error-handling/panic-unwind.md:17
+msgid "\"{result:?}\""
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:15
+msgid "\"oh no!\""
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:21
@@ -9465,26 +8614,16 @@ msgid ""
 "are expected as part of normal operation:"
 msgstr ""
 
-#: src/error-handling/result.md:6
-msgid ""
-"```rust,editable\n"
-"use std::fs;\n"
-"use std::io::Read;\n"
-"\n"
-"fn main() {\n"
-"    let file = fs::File::open(\"diary.txt\");\n"
-"    match file {\n"
-"        Ok(mut file) => {\n"
-"            let mut contents = String::new();\n"
-"            file.read_to_string(&mut contents);\n"
-"            println!(\"Dear diary: {contents}\");\n"
-"        },\n"
-"        Err(err) => {\n"
-"            println!(\"The diary could not be opened: {err}\");\n"
-"        }\n"
-"    }\n"
-"}\n"
-"```"
+#: src/error-handling/result.md:11
+msgid "\"diary.txt\""
+msgstr ""
+
+#: src/error-handling/result.md:16
+msgid "\"Dear diary: {contents}\""
+msgstr ""
+
+#: src/error-handling/result.md:19
+msgid "\"The diary could not be opened: {err}\""
 msgstr ""
 
 #: src/error-handling/result.md:27
@@ -9520,32 +8659,21 @@ msgstr ""
 msgid "We can use this to simplify our error handling code:"
 msgstr ""
 
-#: src/error-handling/try-operator.md:21
-msgid ""
-"```rust,editable\n"
-"use std::{fs, io};\n"
-"use std::io::Read;\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, io::Error> {\n"
-"    let username_file_result = fs::File::open(path);\n"
-"    let mut username_file = match username_file_result {\n"
-"        Ok(file) => file,\n"
-"        Err(err) => return Err(err),\n"
-"    };\n"
-"\n"
-"    let mut username = String::new();\n"
-"    match username_file.read_to_string(&mut username) {\n"
-"        Ok(_) => Ok(username),\n"
-"        Err(err) => Err(err),\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
-"}\n"
-"```"
+#: src/error-handling/try-operator.md:40
+msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
+msgstr ""
+
+#: src/error-handling/try-operator.md:41
+#: src/error-handling/converting-error-types-example.md:43
+#: src/error-handling/deriving-error-enums.md:30
+#: src/error-handling/dynamic-errors.md:27
+#: src/error-handling/error-contexts.md:26
+msgid "\"config.dat\""
+msgstr ""
+
+#: src/error-handling/try-operator.md:42
+#: src/error-handling/converting-error-types-example.md:44
+msgid "\"username or error: {username:?}\""
 msgstr ""
 
 #: src/error-handling/try-operator.md:50
@@ -9594,53 +8722,19 @@ msgid ""
 "type returned by the function:"
 msgstr ""
 
-#: src/error-handling/converting-error-types-example.md:3
-msgid ""
-"```rust,editable\n"
-"use std::error::Error;\n"
-"use std::fmt::{self, Display, Formatter};\n"
-"use std::fs::{self, File};\n"
-"use std::io::{self, Read};\n"
-"\n"
-"#[derive(Debug)]\n"
-"enum ReadUsernameError {\n"
-"    IoError(io::Error),\n"
-"    EmptyUsername(String),\n"
-"}\n"
-"\n"
-"impl Error for ReadUsernameError {}\n"
-"\n"
-"impl Display for ReadUsernameError {\n"
-"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-"        match self {\n"
-"            Self::IoError(e) => write!(f, \"IO error: {e}\"),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
-"in {filename}\"),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"impl From<io::Error> for ReadUsernameError {\n"
-"    fn from(err: io::Error) -> ReadUsernameError {\n"
-"        ReadUsernameError::IoError(err)\n"
-"    }\n"
-"}\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
-"}\n"
-"```"
+#: src/error-handling/converting-error-types-example.md:20
+msgid "\"IO error: {e}\""
+msgstr ""
+
+#: src/error-handling/converting-error-types-example.md:21
+msgid "\"Found no username in {filename}\""
+msgstr ""
+
+#: src/error-handling/converting-error-types-example.md:42
+#: src/error-handling/deriving-error-enums.md:29
+#: src/error-handling/dynamic-errors.md:26
+#: src/error-handling/error-contexts.md:25
+msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:55
@@ -9664,38 +8758,24 @@ msgid ""
 "an error enum like we did on the previous page:"
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::{fs, io};\n"
-"use std::io::Read;\n"
-"use thiserror::Error;\n"
-"\n"
-"#[derive(Debug, Error)]\n"
-"enum ReadUsernameError {\n"
-"    #[error(\"Could not read: {0}\")]\n"
-"    IoError(#[from] io::Error),\n"
-"    #[error(\"Found no username in {0}\")]\n"
-"    EmptyUsername(String),\n"
-"}\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::new();\n"
-"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/error-handling/deriving-error-enums.md:13
+msgid "\"Could not read: {0}\""
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:15
+#: src/error-handling/dynamic-errors.md:13
+msgid "\"Found no username in {0}\""
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:31
+#: src/error-handling/dynamic-errors.md:28
+#: src/error-handling/error-contexts.md:27
+msgid "\"Username: {username}\""
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:32
+#: src/error-handling/dynamic-errors.md:29
+msgid "\"Error: {err}\""
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:39
@@ -9716,37 +8796,6 @@ msgid ""
 "makes this easy."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::fs;\n"
-"use std::io::Read;\n"
-"use thiserror::Error;\n"
-"use std::error::Error;\n"
-"\n"
-"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
-"#[error(\"Found no username in {0}\")]\n"
-"struct EmptyUsernameError(String);\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
-"    let mut username = String::new();\n"
-"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(EmptyUsernameError(String::from(path)).into());\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err}\"),\n"
-"    }\n"
-"}\n"
-"```"
-msgstr ""
-
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
@@ -9763,33 +8812,20 @@ msgid ""
 "error types:"
 msgstr ""
 
-#: src/error-handling/error-contexts.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::{fs, io};\n"
-"use std::io::Read;\n"
-"use anyhow::{Context, Result, bail};\n"
-"\n"
-"fn read_username(path: &str) -> Result<String> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    fs::File::open(path)\n"
-"        .with_context(|| format!(\"Failed to open {path}\"))?\n"
-"        .read_to_string(&mut username)\n"
-"        .context(\"Failed to read\")?;\n"
-"    if username.is_empty() {\n"
-"        bail!(\"Found no username in {path}\");\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err:?}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/error-handling/error-contexts.md:15
+msgid "\"Failed to open {path}\""
+msgstr ""
+
+#: src/error-handling/error-contexts.md:17
+msgid "\"Failed to read\""
+msgstr ""
+
+#: src/error-handling/error-contexts.md:19
+msgid "\"Found no username in {path}\""
+msgstr ""
+
+#: src/error-handling/error-contexts.md:28
+msgid "\"Error: {err:?}\""
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
@@ -9831,31 +8867,8 @@ msgstr ""
 msgid "Mark unit tests with `#[test]`:"
 msgstr ""
 
-#: src/testing/unit-tests.md:5
-msgid ""
-"```rust,editable,ignore\n"
-"fn first_word(text: &str) -> &str {\n"
-"    match text.find(' ') {\n"
-"        Some(idx) => &text[..idx],\n"
-"        None => &text,\n"
-"    }\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_empty() {\n"
-"    assert_eq!(first_word(\"\"), \"\");\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_single_word() {\n"
-"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_multiple_words() {\n"
-"    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
-"}\n"
-"```"
+#: src/testing/unit-tests.md:25
+msgid "\"Hello World\""
 msgstr ""
 
 #: src/testing/unit-tests.md:29
@@ -9868,27 +8881,12 @@ msgid ""
 "(https://play.rust-lang.org/)):"
 msgstr ""
 
-#: src/testing/test-modules.md:6
-msgid ""
-"```rust,editable\n"
-"fn helper(a: &str, b: &str) -> String {\n"
-"    format!(\"{a} {b}\")\n"
-"}\n"
-"\n"
-"pub fn main() {\n"
-"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"\n"
-"    #[test]\n"
-"    fn test_helper() {\n"
-"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/testing/test-modules.md:8
+msgid "\"{a} {b}\""
+msgstr ""
+
+#: src/testing/test-modules.md:21
+msgid "\"foo bar\""
 msgstr ""
 
 #: src/testing/test-modules.md:26
@@ -9903,9 +8901,8 @@ msgstr ""
 msgid "Rust has built-in support for documentation tests:"
 msgstr ""
 
-#: src/testing/doc-tests.md:5
+#: src/testing/doc-tests.md:6
 msgid ""
-"```rust\n"
 "/// Shortens a string to the given length.\n"
 "///\n"
 "/// ```\n"
@@ -9913,10 +8910,6 @@ msgid ""
 "/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
 "/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
 "/// ```\n"
-"pub fn shorten_string(s: &str, length: usize) -> &str {\n"
-"    &s[..std::cmp::min(length, s.len())]\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/testing/doc-tests.md:18
@@ -10048,28 +9041,22 @@ msgstr ""
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:5
+#: src/unsafe/raw-pointers.md:12
 msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut num = 5;\n"
-"\n"
-"    let r1 = &mut num as *mut i32;\n"
-"    let r2 = r1 as *const i32;\n"
-"\n"
-"    // Safe because r1 and r2 were obtained from references and so are\n"
+"// Safe because r1 and r2 were obtained from references and so are\n"
 "    // guaranteed to be non-null and properly aligned, the objects "
 "underlying\n"
 "    // the references from which they were obtained are live throughout the\n"
 "    // whole unsafe block, and they are not accessed either through the\n"
 "    // references or concurrently through any other pointers.\n"
-"    unsafe {\n"
-"        println!(\"r1 is: {}\", *r1);\n"
-"        *r1 = 10;\n"
-"        println!(\"r2 is: {}\", *r2);\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:18
+msgid "\"r1 is: {}\""
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:20
+msgid "\"r2 is: {}\""
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:27
@@ -10117,15 +9104,12 @@ msgstr ""
 msgid "It is safe to read an immutable static variable:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:5
-msgid ""
-"```rust,editable\n"
-"static HELLO_WORLD: &str = \"Hello, world!\";\n"
-"\n"
-"fn main() {\n"
-"    println!(\"HELLO_WORLD: {HELLO_WORLD}\");\n"
-"}\n"
-"```"
+#: src/unsafe/mutable-static-variables.md:6
+msgid "\"Hello, world!\""
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:9
+msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
@@ -10134,21 +9118,13 @@ msgid ""
 "static variables:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:16
-msgid ""
-"```rust,editable\n"
-"static mut COUNTER: u32 = 0;\n"
-"\n"
-"fn add_to_counter(inc: u32) {\n"
-"    unsafe { COUNTER += inc; }  // Potential data race!\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    add_to_counter(42);\n"
-"\n"
-"    unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
-"}\n"
-"```"
+#: src/unsafe/mutable-static-variables.md:20
+#: src/unsafe/mutable-static-variables.md:26
+msgid "// Potential data race!\n"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:26
+msgid "\"COUNTER: {COUNTER}\""
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:32
@@ -10170,21 +9146,16 @@ msgstr ""
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
 
-#: src/unsafe/unions.md:5
-msgid ""
-"```rust,editable\n"
-"#[repr(C)]\n"
-"union MyUnion {\n"
-"    i: u8,\n"
-"    b: bool,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let u = MyUnion { i: 42 };\n"
-"    println!(\"int: {}\", unsafe { u.i });\n"
-"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
-"}\n"
-"```"
+#: src/unsafe/unions.md:14
+msgid "\"int: {}\""
+msgstr ""
+
+#: src/unsafe/unions.md:15
+msgid "\"bool: {}\""
+msgstr ""
+
+#: src/unsafe/unions.md:15
+msgid "// Undefined behavior!\n"
 msgstr ""
 
 #: src/unsafe/unions.md:21
@@ -10207,34 +9178,32 @@ msgid ""
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:6
+#: src/unsafe/calling-unsafe-functions.md:8
+msgid "\"🗻∈🌏\""
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:10
 msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let emojis = \"🗻∈🌏\";\n"
-"\n"
-"    // Safe because the indices are in the correct order, within the bounds "
-"of\n"
+"// Safe because the indices are in the correct order, within the bounds of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
-"    unsafe {\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
-"    }\n"
-"\n"
-"    println!(\"char count: {}\", count_chars(unsafe { emojis."
-"get_unchecked(0..7) }));\n"
-"\n"
-"    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:13
+#: src/unsafe/calling-unsafe-functions.md:14
+#: src/unsafe/calling-unsafe-functions.md:15
+msgid "\"emoji: {}\""
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:18
+msgid "\"char count: {}\""
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:20
+msgid ""
+"// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
 "    // println!(\"char count: {}\", count_chars(unsafe { emojis."
 "get_unchecked(0..3) }));\n"
-"}\n"
-"\n"
-"fn count_chars(s: &str) -> usize {\n"
-"    s.chars().map(|_| 1).sum()\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:3
@@ -10243,32 +9212,21 @@ msgid ""
 "conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:6
+#: src/unsafe/writing-unsafe-functions.md:7
 msgid ""
-"```rust,editable\n"
 "/// Swaps the values pointed to by the given pointers.\n"
 "///\n"
 "/// # Safety\n"
 "///\n"
 "/// The pointers must be valid and properly aligned.\n"
-"unsafe fn swap(a: *mut u8, b: *mut u8) {\n"
-"    let temp = *a;\n"
-"    *a = *b;\n"
-"    *b = temp;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut a = 42;\n"
-"    let mut b = 66;\n"
-"\n"
-"    // Safe because ...\n"
-"    unsafe {\n"
-"        swap(&mut a, &mut b);\n"
-"    }\n"
-"\n"
-"    println!(\"a = {}, b = {}\", a, b);\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:22
+msgid "// Safe because ...\n"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:27
+msgid "\"a = {}, b = {}\""
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:33
@@ -10294,20 +9252,28 @@ msgid ""
 "them is thus unsafe:"
 msgstr ""
 
-#: src/unsafe/extern-functions.md:6
-msgid ""
-"```rust,editable\n"
-"extern \"C\" {\n"
-"    fn abs(input: i32) -> i32;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    unsafe {\n"
-"        // Undefined behavior if abs misbehaves.\n"
-"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
-"    }\n"
-"}\n"
-"```"
+#: src/unsafe/extern-functions.md:7 src/exercises/day-3/safe-ffi-wrapper.md:89
+#: src/android/interoperability/with-c.md:9
+#: src/android/interoperability/with-c/rust.md:15
+#: src/android/interoperability/with-c/rust.md:30
+#: src/bare-metal/aps/inline-assembly.md:18
+#: src/bare-metal/aps/better-uart/using.md:24
+#: src/bare-metal/aps/logging/using.md:23 src/exercises/bare-metal/rtc.md:46
+#: src/exercises/bare-metal/rtc.md:100 src/exercises/bare-metal/rtc.md:106
+#: src/exercises/bare-metal/rtc.md:113 src/exercises/bare-metal/rtc.md:119
+#: src/exercises/bare-metal/rtc.md:125 src/exercises/bare-metal/rtc.md:131
+#: src/exercises/bare-metal/rtc.md:137 src/exercises/bare-metal/rtc.md:143
+#: src/exercises/day-3/solutions-afternoon.md:45
+#: src/exercises/bare-metal/solutions-afternoon.md:43
+msgid "\"C\""
+msgstr ""
+
+#: src/unsafe/extern-functions.md:13
+msgid "// Undefined behavior if abs misbehaves.\n"
+msgstr ""
+
+#: src/unsafe/extern-functions.md:14
+msgid "\"Absolute value of -3 according to C: {}\""
 msgstr ""
 
 #: src/unsafe/extern-functions.md:21
@@ -10335,27 +9301,15 @@ msgid ""
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:9
+#: src/unsafe/unsafe-traits.md:12
 msgid ""
-"```rust,editable\n"
-"use std::mem::size_of_val;\n"
-"use std::slice;\n"
-"\n"
 "/// ...\n"
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
-"pub unsafe trait AsBytes {\n"
-"    fn as_bytes(&self) -> &[u8] {\n"
-"        unsafe {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, "
-"size_of_val(self))\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"// Safe because u32 has a defined representation and no padding.\n"
-"unsafe impl AsBytes for u32 {}\n"
-"```"
+msgstr ""
+
+#: src/unsafe/unsafe-traits.md:23
+msgid "// Safe because u32 has a defined representation and no padding.\n"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:30
@@ -10530,111 +9484,88 @@ msgid ""
 "functions and methods:"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:48
+#: src/exercises/day-3/safe-ffi-wrapper.md:54
+#: src/exercises/day-3/safe-ffi-wrapper.md:67
+#: src/exercises/day-3/safe-ffi-wrapper.md:78
+#: src/exercises/day-3/safe-ffi-wrapper.md:92
+#: src/exercises/day-3/safe-ffi-wrapper.md:100
+#: src/exercises/day-3/solutions-afternoon.md:10
+#: src/exercises/day-3/solutions-afternoon.md:23
+#: src/exercises/day-3/solutions-afternoon.md:34
+#: src/exercises/day-3/solutions-afternoon.md:48
+#: src/exercises/day-3/solutions-afternoon.md:56
+msgid "\"macos\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:57
+#: src/exercises/day-3/solutions-afternoon.md:13
+msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:64
+#: src/exercises/day-3/solutions-afternoon.md:20
 msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]\n"
-"\n"
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int};\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
-"\n"
-"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-"    #[repr(C)]\n"
-"    pub struct DIR {\n"
-"        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
-"PhantomPinned)>,\n"
-"    }\n"
-"\n"
-"    // Layout according to the Linux man page for readdir(3), where ino_t "
-"and\n"
+"// Layout according to the Linux man page for readdir(3), where ino_t and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_ino: c_ulong,\n"
-"        pub d_off: c_long,\n"
-"        pub d_reclen: c_ushort,\n"
-"        pub d_type: c_uchar,\n"
-"        pub d_name: [c_char; 256],\n"
-"    }\n"
-"\n"
-"    // Layout according to the macOS man page for dir(5).\n"
-"    #[cfg(all(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_fileno: u64,\n"
-"        pub d_seekoff: u64,\n"
-"        pub d_reclen: u16,\n"
-"        pub d_namlen: u16,\n"
-"        pub d_type: u8,\n"
-"        pub d_name: [c_char; 1024],\n"
-"    }\n"
-"\n"
-"    extern \"C\" {\n"
-"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
-"\n"
-"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        // See https://github.com/rust-lang/libc/issues/414 and the section "
-"on\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:77
+#: src/exercises/day-3/solutions-afternoon.md:33
+msgid "// Layout according to the macOS man page for dir(5).\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:92
+#: src/exercises/day-3/safe-ffi-wrapper.md:100
+#: src/exercises/day-3/solutions-afternoon.md:48
+#: src/exercises/day-3/solutions-afternoon.md:56
+msgid "\"x86_64\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:95
+#: src/exercises/day-3/solutions-afternoon.md:51
+msgid ""
+"// See https://github.com/rust-lang/libc/issues/414 and the section on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
 "        //\n"
 "        // \"Platforms that existed before these updates were available\" "
 "refers\n"
 "        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
 "PowerPC.\n"
-"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
-"        #[link_name = \"readdir$INODE64\"]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        pub fn closedir(s: *mut DIR) -> c_int;\n"
-"    }\n"
-"}\n"
-"\n"
-"use std::ffi::{CStr, CString, OsStr, OsString};\n"
-"use std::os::unix::ffi::OsStrExt;\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}\n"
-"\n"
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:101
+#: src/exercises/day-3/solutions-afternoon.md:57
+msgid "\"readdir$INODE64\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:119
+#: src/exercises/day-3/solutions-afternoon.md:75
+msgid ""
+"// Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:128
+msgid "// Keep calling readdir until we get a NULL pointer back.\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:135
+#: src/exercises/day-3/solutions-afternoon.md:108
+msgid "// Call closedir as needed.\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:141
+#: src/android/interoperability/with-c/rust.md:44
+#: src/exercises/day-3/solutions-afternoon.md:119
+#: src/exercises/day-3/solutions-afternoon.md:143
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\".\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:142
+#: src/exercises/day-3/solutions-afternoon.md:120
+msgid "\"files: {:#?}\""
 msgstr ""
 
 #: src/android.md:1
@@ -10770,31 +9701,29 @@ msgstr ""
 msgid "_hello_rust/Android.bp_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:8
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"hello_rust\",\n"
-"    crate_name: \"hello_rust\",\n"
-"    srcs: [\"src/main.rs\"],\n"
-"}\n"
-"```"
+#: src/android/build-rules/binary.md:10 src/android/build-rules/binary.md:11
+msgid "\"hello_rust\""
+msgstr ""
+
+#: src/android/build-rules/binary.md:12 src/android/build-rules/library.md:19
+#: src/android/logging.md:12
+msgid "\"src/main.rs\""
 msgstr ""
 
 #: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
 msgid "_hello_rust/src/main.rs_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:18
-msgid ""
-"```rust\n"
-"//! Rust demo.\n"
-"\n"
-"/// Prints a greeting to standard output.\n"
-"fn main() {\n"
-"    println!(\"Hello from Rust!\");\n"
-"}\n"
-"```"
+#: src/android/build-rules/binary.md:19 src/android/build-rules/library.md:37
+msgid "//! Rust demo.\n"
+msgstr ""
+
+#: src/android/build-rules/binary.md:20 src/android/build-rules/library.md:41
+msgid "/// Prints a greeting to standard output.\n"
+msgstr ""
+
+#: src/android/build-rules/binary.md:23
+msgid "\"Hello from Rust!\""
 msgstr ""
 
 #: src/android/build-rules/binary.md:27
@@ -10833,57 +9762,41 @@ msgid ""
 "crates/)."
 msgstr ""
 
-#: src/android/build-rules/library.md:15
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"hello_rust_with_dep\",\n"
-"    crate_name: \"hello_rust_with_dep\",\n"
-"    srcs: [\"src/main.rs\"],\n"
-"    rustlibs: [\n"
-"        \"libgreetings\",\n"
-"        \"libtextwrap\",\n"
-"    ],\n"
-"    prefer_rlib: true,\n"
-"}\n"
-"\n"
-"rust_library {\n"
-"    name: \"libgreetings\",\n"
-"    crate_name: \"greetings\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
-"}\n"
-"```"
+#: src/android/build-rules/library.md:17 src/android/build-rules/library.md:18
+msgid "\"hello_rust_with_dep\""
 msgstr ""
 
-#: src/android/build-rules/library.md:36
-msgid ""
-"```rust,ignore\n"
-"//! Rust demo.\n"
-"\n"
-"use greetings::greeting;\n"
-"use textwrap::fill;\n"
-"\n"
-"/// Prints a greeting to standard output.\n"
-"fn main() {\n"
-"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
-"}\n"
-"```"
+#: src/android/build-rules/library.md:21 src/android/build-rules/library.md:28
+msgid "\"libgreetings\""
+msgstr ""
+
+#: src/android/build-rules/library.md:22
+msgid "\"libtextwrap\""
+msgstr ""
+
+#: src/android/build-rules/library.md:29
+msgid "\"greetings\""
+msgstr ""
+
+#: src/android/build-rules/library.md:30 src/android/aidl/implementation.md:31
+#: src/android/interoperability/java.md:38
+msgid "\"src/lib.rs\""
 msgstr ""
 
 #: src/android/build-rules/library.md:48
 msgid "_hello_rust/src/lib.rs_:"
 msgstr ""
 
-#: src/android/build-rules/library.md:50
-msgid ""
-"```rust,ignore\n"
-"//! Greeting library.\n"
-"\n"
-"/// Greet `name`.\n"
-"pub fn greeting(name: &str) -> String {\n"
-"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
-"}\n"
-"```"
+#: src/android/build-rules/library.md:51
+msgid "//! Greeting library.\n"
+msgstr ""
+
+#: src/android/build-rules/library.md:52
+msgid "/// Greet `name`.\n"
+msgstr ""
+
+#: src/android/build-rules/library.md:55
+msgid "\"Hello {name}, it is very nice to meet you!\""
 msgstr ""
 
 #: src/android/build-rules/library.md:59
@@ -10931,20 +9844,16 @@ msgstr ""
 msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/interface.md:19
-msgid ""
-"```javascript\n"
-"aidl_interface {\n"
-"    name: \"com.example.birthdayservice\",\n"
-"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
-"    unstable: true,\n"
-"    backend: {\n"
-"        rust: { // Rust is not enabled by default\n"
-"            enabled: true,\n"
-"        },\n"
-"    },\n"
-"}\n"
-"```"
+#: src/android/aidl/interface.md:21
+msgid "\"com.example.birthdayservice\""
+msgstr ""
+
+#: src/android/aidl/interface.md:22
+msgid "\"com/example/birthdayservice/*.aidl\""
+msgstr ""
+
+#: src/android/aidl/interface.md:25
+msgid "// Rust is not enabled by default\n"
 msgstr ""
 
 #: src/android/aidl/interface.md:32
@@ -10965,29 +9874,16 @@ msgstr ""
 msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md:7
-msgid ""
-"```rust,ignore\n"
-"//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
-"IBirthdayService::IBirthdayService;\n"
-"use com_example_birthdayservice::binder;\n"
-"\n"
-"/// The `IBirthdayService` implementation.\n"
-"pub struct BirthdayService;\n"
-"\n"
-"impl binder::Interface for BirthdayService {}\n"
-"\n"
-"impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
-"Result<String> {\n"
-"        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} years!"
-"\"\n"
-"        ))\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/aidl/implementation.md:8
+msgid "//! Implementation of the `IBirthdayService` AIDL interface.\n"
+msgstr ""
+
+#: src/android/aidl/implementation.md:11
+msgid "/// The `IBirthdayService` implementation.\n"
+msgstr ""
+
+#: src/android/aidl/implementation.md:20
+msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
 msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
@@ -10995,19 +9891,23 @@ msgstr ""
 msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md:28
-msgid ""
-"```javascript\n"
-"rust_library {\n"
-"    name: \"libbirthdayservice\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
-"    crate_name: \"birthdayservice\",\n"
-"    rustlibs: [\n"
-"        \"com.example.birthdayservice-rust\",\n"
-"        \"libbinder_rs\",\n"
-"    ],\n"
-"}\n"
-"```"
+#: src/android/aidl/implementation.md:30 src/android/aidl/server.md:38
+msgid "\"libbirthdayservice\""
+msgstr ""
+
+#: src/android/aidl/implementation.md:32 src/android/aidl/server.md:13
+#: src/android/aidl/client.md:12
+msgid "\"birthdayservice\""
+msgstr ""
+
+#: src/android/aidl/implementation.md:34 src/android/aidl/server.md:36
+#: src/android/aidl/client.md:45
+msgid "\"com.example.birthdayservice-rust\""
+msgstr ""
+
+#: src/android/aidl/implementation.md:35 src/android/aidl/server.md:37
+#: src/android/aidl/client.md:46
+msgid "\"libbinder_rs\""
 msgstr ""
 
 #: src/android/aidl/server.md:1
@@ -11022,47 +9922,24 @@ msgstr ""
 msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
-#: src/android/aidl/server.md:7
-msgid ""
-"```rust,ignore\n"
-"//! Birthday service.\n"
-"use birthdayservice::BirthdayService;\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
-"IBirthdayService::BnBirthdayService;\n"
-"use com_example_birthdayservice::binder;\n"
-"\n"
-"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
-"\n"
-"/// Entry point for birthday service.\n"
-"fn main() {\n"
-"    let birthday_service = BirthdayService;\n"
-"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
-"        birthday_service,\n"
-"        binder::BinderFeatures::default(),\n"
-"    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
-"as_binder())\n"
-"        .expect(\"Failed to register service\");\n"
-"    binder::ProcessState::join_thread_pool()\n"
-"}\n"
-"```"
+#: src/android/aidl/server.md:8 src/android/aidl/client.md:8
+msgid "//! Birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/server.md:30
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"birthday_server\",\n"
-"    crate_name: \"birthday_server\",\n"
-"    srcs: [\"src/server.rs\"],\n"
-"    rustlibs: [\n"
-"        \"com.example.birthdayservice-rust\",\n"
-"        \"libbinder_rs\",\n"
-"        \"libbirthdayservice\",\n"
-"    ],\n"
-"    prefer_rlib: true,\n"
-"}\n"
-"```"
+#: src/android/aidl/server.md:14
+msgid "/// Entry point for birthday service.\n"
+msgstr ""
+
+#: src/android/aidl/server.md:23
+msgid "\"Failed to register service\""
+msgstr ""
+
+#: src/android/aidl/server.md:32 src/android/aidl/server.md:33
+msgid "\"birthday_server\""
+msgstr ""
+
+#: src/android/aidl/server.md:34
+msgid "\"src/server.rs\""
 msgstr ""
 
 #: src/android/aidl/deploy.md:3
@@ -11099,56 +9976,28 @@ msgstr ""
 msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
-#: src/android/aidl/client.md:7
-msgid ""
-"```rust,ignore\n"
-"//! Birthday service.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
-"IBirthdayService::IBirthdayService;\n"
-"use com_example_birthdayservice::binder;\n"
-"\n"
-"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
-"\n"
-"/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
-"StatusCode> {\n"
-"    binder::get_interface(SERVICE_IDENTIFIER)\n"
-"}\n"
-"\n"
-"/// Call the birthday service.\n"
-"fn main() -> Result<(), binder::Status> {\n"
-"    let name = std::env::args()\n"
-"        .nth(1)\n"
-"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
-"    let years = std::env::args()\n"
-"        .nth(2)\n"
-"        .and_then(|arg| arg.parse::<i32>().ok())\n"
-"        .unwrap_or(42);\n"
-"\n"
-"    binder::ProcessState::start_thread_pool();\n"
-"    let service = connect().expect(\"Failed to connect to "
-"BirthdayService\");\n"
-"    let msg = service.wishHappyBirthday(&name, years)?;\n"
-"    println!(\"{msg}\");\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/android/aidl/client.md:13
+msgid "/// Connect to the BirthdayService.\n"
 msgstr ""
 
-#: src/android/aidl/client.md:39
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"birthday_client\",\n"
-"    crate_name: \"birthday_client\",\n"
-"    srcs: [\"src/client.rs\"],\n"
-"    rustlibs: [\n"
-"        \"com.example.birthdayservice-rust\",\n"
-"        \"libbinder_rs\",\n"
-"    ],\n"
-"    prefer_rlib: true,\n"
-"}\n"
-"```"
+#: src/android/aidl/client.md:18
+msgid "/// Call the birthday service.\n"
+msgstr ""
+
+#: src/android/aidl/client.md:30
+msgid "\"Failed to connect to BirthdayService\""
+msgstr ""
+
+#: src/android/aidl/client.md:32
+msgid "\"{msg}\""
+msgstr ""
+
+#: src/android/aidl/client.md:41 src/android/aidl/client.md:42
+msgid "\"birthday_client\""
+msgstr ""
+
+#: src/android/aidl/client.md:43
+msgid "\"src/client.rs\""
 msgstr ""
 
 #: src/android/aidl/client.md:52
@@ -11185,46 +10034,44 @@ msgstr ""
 msgid "_hello_rust_logs/Android.bp_:"
 msgstr ""
 
-#: src/android/logging.md:8
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"hello_rust_logs\",\n"
-"    crate_name: \"hello_rust_logs\",\n"
-"    srcs: [\"src/main.rs\"],\n"
-"    rustlibs: [\n"
-"        \"liblog_rust\",\n"
-"        \"liblogger\",\n"
-"    ],\n"
-"    prefer_rlib: true,\n"
-"    host_supported: true,\n"
-"}\n"
-"```"
+#: src/android/logging.md:10 src/android/logging.md:11
+msgid "\"hello_rust_logs\""
+msgstr ""
+
+#: src/android/logging.md:14
+msgid "\"liblog_rust\""
+msgstr ""
+
+#: src/android/logging.md:15
+msgid "\"liblogger\""
 msgstr ""
 
 #: src/android/logging.md:22
 msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
-#: src/android/logging.md:24
-msgid ""
-"```rust,ignore\n"
-"//! Rust logging demo.\n"
-"\n"
-"use log::{debug, error, info};\n"
-"\n"
-"/// Logs a greeting.\n"
-"fn main() {\n"
-"    logger::init(\n"
-"        logger::Config::default()\n"
-"            .with_tag_on_device(\"rust\")\n"
-"            .with_min_level(log::Level::Trace),\n"
-"    );\n"
-"    debug!(\"Starting program.\");\n"
-"    info!(\"Things are going fine.\");\n"
-"    error!(\"Something went wrong!\");\n"
-"}\n"
-"```"
+#: src/android/logging.md:25
+msgid "//! Rust logging demo.\n"
+msgstr ""
+
+#: src/android/logging.md:28
+msgid "/// Logs a greeting.\n"
+msgstr ""
+
+#: src/android/logging.md:33
+msgid "\"rust\""
+msgstr ""
+
+#: src/android/logging.md:36
+msgid "\"Starting program.\""
+msgstr ""
+
+#: src/android/logging.md:37
+msgid "\"Things are going fine.\""
+msgstr ""
+
+#: src/android/logging.md:38
+msgid "\"Something went wrong!\""
 msgstr ""
 
 #: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
@@ -11280,19 +10127,8 @@ msgstr ""
 msgid "You can do it by hand if you want:"
 msgstr ""
 
-#: src/android/interoperability/with-c.md:8
-msgid ""
-"```rust\n"
-"extern \"C\" {\n"
-"    fn abs(x: i32) -> i32;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let x = -42;\n"
-"    let abs_x = unsafe { abs(x) };\n"
-"    println!(\"{x}, {abs_x}\");\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c.md:16
+msgid "\"{x}, {abs_x}\""
 msgstr ""
 
 #: src/android/interoperability/with-c.md:20
@@ -11333,19 +10169,22 @@ msgstr ""
 msgid "_interoperability/bindgen/libbirthday.c_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:21
-msgid ""
-"```c\n"
-"#include <stdio.h>\n"
-"#include \"libbirthday.h\"\n"
-"\n"
-"void print_card(const card* card) {\n"
-"  printf(\"+--------------\\n\");\n"
-"  printf(\"| Happy Birthday %s!\\n\", card->name);\n"
-"  printf(\"| Congratulations with the %i years!\\n\", card->years);\n"
-"  printf(\"+--------------\\n\");\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:23
+#: src/android/interoperability/with-c/bindgen.md:50
+msgid "\"libbirthday.h\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:26
+#: src/android/interoperability/with-c/bindgen.md:29
+msgid "\"+--------------\\n\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:27
+msgid "\"| Happy Birthday %s!\\n\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:28
+msgid "\"| Congratulations with the %i years!\\n\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:33
@@ -11359,14 +10198,13 @@ msgstr ""
 msgid "_interoperability/bindgen/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:37
-msgid ""
-"```javascript\n"
-"cc_library {\n"
-"    name: \"libbirthday\",\n"
-"    srcs: [\"libbirthday.c\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:39
+#: src/android/interoperability/with-c/bindgen.md:63
+msgid "\"libbirthday\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:40
+msgid "\"libbirthday.c\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
@@ -11379,67 +10217,45 @@ msgstr ""
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:49
-msgid ""
-"```c\n"
-"#include \"libbirthday.h\"\n"
-"```"
-msgstr ""
-
 #: src/android/interoperability/with-c/bindgen.md:53
 msgid "You can now auto-generate the bindings:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:57
-msgid ""
-"```javascript\n"
-"rust_bindgen {\n"
-"    name: \"libbirthday_bindgen\",\n"
-"    crate_name: \"birthday_bindgen\",\n"
-"    wrapper_src: \"libbirthday_wrapper.h\",\n"
-"    source_stem: \"bindings\",\n"
-"    static_libs: [\"libbirthday\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:59
+#: src/android/interoperability/with-c/bindgen.md:75
+msgid "\"libbirthday_bindgen\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:60
+msgid "\"birthday_bindgen\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:61
+msgid "\"libbirthday_wrapper.h\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:62
+msgid "\"bindings\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:67
 msgid "Finally, we can use the bindings in our Rust program:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:71
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"print_birthday_card\",\n"
-"    srcs: [\"main.rs\"],\n"
-"    rustlibs: [\"libbirthday_bindgen\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:73
+msgid "\"print_birthday_card\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:74
+msgid "\"main.rs\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:79
 msgid "_interoperability/bindgen/main.rs_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:81
-msgid ""
-"```rust,compile_fail\n"
-"//! Bindgen demo.\n"
-"\n"
-"use birthday_bindgen::{card, print_card};\n"
-"\n"
-"fn main() {\n"
-"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
-"    let card = card {\n"
-"        name: name.as_ptr(),\n"
-"        years: 42,\n"
-"    };\n"
-"    unsafe {\n"
-"        print_card(&card as *const card);\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:82
+msgid "//! Bindgen demo.\n"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:100
@@ -11456,19 +10272,26 @@ msgstr ""
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:110
-msgid ""
-"```javascript\n"
-"rust_test {\n"
-"    name: \"libbirthday_bindgen_test\",\n"
-"    srcs: [\":libbirthday_bindgen\"],\n"
-"    crate_name: \"libbirthday_bindgen_test\",\n"
-"    test_suites: [\"general-tests\"],\n"
-"    auto_gen_config: true,\n"
-"    clippy_lints: \"none\", // Generated file, skip linting\n"
-"    lints: \"none\",\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:112
+#: src/android/interoperability/with-c/bindgen.md:114
+msgid "\"libbirthday_bindgen_test\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:113
+msgid "\":libbirthday_bindgen\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:115
+msgid "\"general-tests\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:117
+#: src/android/interoperability/with-c/bindgen.md:118
+msgid "\"none\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:117
+msgid "// Generated file, skip linting\n"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
@@ -11483,58 +10306,41 @@ msgstr ""
 msgid "_interoperability/rust/libanalyze/analyze.rs_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:7
-msgid ""
-"```rust,editable\n"
-"//! Rust FFI demo.\n"
-"#![deny(improper_ctypes_definitions)]\n"
-"\n"
-"use std::os::raw::c_int;\n"
-"\n"
-"/// Analyze the numbers.\n"
-"#[no_mangle]\n"
-"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
-"    if x < y {\n"
-"        println!(\"x ({x}) is smallest!\");\n"
-"    } else {\n"
-"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:8
+msgid "//! Rust FFI demo.\n"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:12
+msgid "/// Analyze the numbers.\n"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:17
+msgid "\"x ({x}) is smallest!\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:19
+msgid "\"y ({y}) is probably larger than x ({x})\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:24
 msgid "_interoperability/rust/libanalyze/analyze.h_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:26
-msgid ""
-"```c\n"
-"#ifndef ANALYSE_H\n"
-"#define ANALYSE_H\n"
-"\n"
-"extern \"C\" {\n"
-"void analyze_numbers(int x, int y);\n"
-"}\n"
-"\n"
-"#endif\n"
-"```"
-msgstr ""
-
 #: src/android/interoperability/with-c/rust.md:37
 msgid "_interoperability/rust/libanalyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:39
-msgid ""
-"```javascript\n"
-"rust_ffi {\n"
-"    name: \"libanalyze_ffi\",\n"
-"    crate_name: \"analyze_ffi\",\n"
-"    srcs: [\"analyze.rs\"],\n"
-"    include_dirs: [\".\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:41
+#: src/android/interoperability/with-c/rust.md:68
+msgid "\"libanalyze_ffi\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:42
+msgid "\"analyze_ffi\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:43
+msgid "\"analyze.rs\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:48
@@ -11545,32 +10351,20 @@ msgstr ""
 msgid "_interoperability/rust/analyze/main.c_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:52
-msgid ""
-"```c\n"
-"#include \"analyze.h\"\n"
-"\n"
-"int main() {\n"
-"  analyze_numbers(10, 20);\n"
-"  analyze_numbers(123, 123);\n"
-"  return 0;\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:53
+msgid "\"analyze.h\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:62
 msgid "_interoperability/rust/analyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:64
-msgid ""
-"```javascript\n"
-"cc_binary {\n"
-"    name: \"analyze_numbers\",\n"
-"    srcs: [\"main.c\"],\n"
-"    static_libs: [\"libanalyze_ffi\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:66
+msgid "\"analyze_numbers\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:67
+msgid "\"main.c\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:75
@@ -11661,28 +10455,20 @@ msgstr ""
 msgid "_interoperability/java/src/lib.rs_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:11
-msgid ""
-"```rust,compile_fail\n"
-"//! Rust <-> Java FFI demo.\n"
-"\n"
-"use jni::objects::{JClass, JString};\n"
-"use jni::sys::jstring;\n"
-"use jni::JNIEnv;\n"
-"\n"
-"/// HelloWorld::hello method implementation.\n"
-"#[no_mangle]\n"
-"pub extern \"system\" fn Java_HelloWorld_hello(\n"
-"    env: JNIEnv,\n"
-"    _class: JClass,\n"
-"    name: JString,\n"
-") -> jstring {\n"
-"    let input: String = env.get_string(name).unwrap().into();\n"
-"    let greeting = format!(\"Hello, {input}!\");\n"
-"    let output = env.new_string(greeting).unwrap();\n"
-"    output.into_inner()\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:12
+msgid "//! Rust <-> Java FFI demo.\n"
+msgstr ""
+
+#: src/android/interoperability/java.md:17
+msgid "/// HelloWorld::hello method implementation.\n"
+msgstr ""
+
+#: src/android/interoperability/java.md:20
+msgid "\"system\""
+msgstr ""
+
+#: src/android/interoperability/java.md:26
+msgid "\"Hello, {input}!\""
 msgstr ""
 
 #: src/android/interoperability/java.md:32
@@ -11690,16 +10476,18 @@ msgstr ""
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:34
-msgid ""
-"```javascript\n"
-"rust_ffi_shared {\n"
-"    name: \"libhello_jni\",\n"
-"    crate_name: \"hello_jni\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
-"    rustlibs: [\"libjni\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:36
+#: src/android/interoperability/java.md:69
+msgid "\"libhello_jni\""
+msgstr ""
+
+#: src/android/interoperability/java.md:37
+#: src/android/interoperability/java.md:52
+msgid "\"hello_jni\""
+msgstr ""
+
+#: src/android/interoperability/java.md:39
+msgid "\"libjni\""
 msgstr ""
 
 #: src/android/interoperability/java.md:43
@@ -11710,34 +10498,16 @@ msgstr ""
 msgid "_interoperability/java/HelloWorld.java_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:47
-msgid ""
-"```java\n"
-"class HelloWorld {\n"
-"    private static native String hello(String name);\n"
-"\n"
-"    static {\n"
-"        System.loadLibrary(\"hello_jni\");\n"
-"    }\n"
-"\n"
-"    public static void main(String[] args) {\n"
-"        String output = HelloWorld.hello(\"Alice\");\n"
-"        System.out.println(output);\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:66
+msgid "\"helloworld_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:64
-msgid ""
-"```javascript\n"
-"java_binary {\n"
-"    name: \"helloworld_jni\",\n"
-"    srcs: [\"HelloWorld.java\"],\n"
-"    main_class: \"HelloWorld\",\n"
-"    required: [\"libhello_jni\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:67
+msgid "\"HelloWorld.java\""
+msgstr ""
+
+#: src/android/interoperability/java.md:68
+msgid "\"HelloWorld\""
 msgstr ""
 
 #: src/android/interoperability/java.md:73
@@ -11988,39 +10758,21 @@ msgstr ""
 "`alloc`を使うためには、[グローバル（ヒープ）アロケータ](https://doc.rust-"
 "lang.org/stable/std/alloc/trait.GlobalAlloc.html)を実装しなければなりません。"
 
-#: src/bare-metal/alloc.md:6
+#: src/bare-metal/alloc.md:23
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate alloc;\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use alloc::string::ToString;\n"
-"use alloc::vec::Vec;\n"
-"use buddy_system_allocator::LockedHeap;\n"
-"\n"
-"#[global_allocator]\n"
-"static HEAP_ALLOCATOR: LockedHeap<32> = LockedHeap::<32>::new();\n"
-"\n"
-"static mut HEAP: [u8; 65536] = [0; 65536];\n"
-"\n"
-"pub fn entry() {\n"
-"    // Safe because `HEAP` is only used here and `entry` is only called "
-"once.\n"
-"    unsafe {\n"
-"        // Give the allocator some memory to allocate.\n"
-"        HEAP_ALLOCATOR\n"
-"            .lock()\n"
-"            .init(HEAP.as_mut_ptr() as usize, HEAP.len());\n"
-"    }\n"
-"\n"
-"    // Now we can do things that require heap allocation.\n"
-"    let mut v = Vec::new();\n"
-"    v.push(\"A string\".to_string());\n"
-"}\n"
-"```"
+"// Safe because `HEAP` is only used here and `entry` is only called once.\n"
+msgstr ""
+
+#: src/bare-metal/alloc.md:25
+msgid "// Give the allocator some memory to allocate.\n"
+msgstr ""
+
+#: src/bare-metal/alloc.md:31
+msgid "// Now we can do things that require heap allocation.\n"
+msgstr ""
+
+#: src/bare-metal/alloc.md:33
+msgid "\"A string\""
 msgstr ""
 
 #: src/bare-metal/alloc.md:39
@@ -12101,69 +10853,35 @@ msgstr ""
 "大半のマイクロコントローラはメモリマップドRIO空間を通して周辺I/Oにアクセスし"
 "ます。micro:bitのLEDを光らせてみましょう:"
 
-#: src/bare-metal/microcontrollers/mmio.md:6
+#: src/bare-metal/microcontrollers/mmio.md:16
+msgid "/// GPIO port 0 peripheral address\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:19
+msgid "// GPIO peripheral offsets\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:24
+msgid "// PIN_CNF fields\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:34
+#: src/bare-metal/microcontrollers/pacs.md:21
+#: src/bare-metal/microcontrollers/hals.md:25
+msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:37
+#: src/bare-metal/microcontrollers/mmio.md:51
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"mod interrupts;\n"
-"\n"
-"use core::mem::size_of;\n"
-"use cortex_m_rt::entry;\n"
-"\n"
-"/// GPIO port 0 peripheral address\n"
-"const GPIO_P0: usize = 0x5000_0000;\n"
-"\n"
-"// GPIO peripheral offsets\n"
-"const PIN_CNF: usize = 0x700;\n"
-"const OUTSET: usize = 0x508;\n"
-"const OUTCLR: usize = 0x50c;\n"
-"\n"
-"// PIN_CNF fields\n"
-"const DIR_OUTPUT: u32 = 0x1;\n"
-"const INPUT_DISCONNECT: u32 = 0x1 << 1;\n"
-"const PULL_DISABLED: u32 = 0x0 << 2;\n"
-"const DRIVE_S0S1: u32 = 0x0 << 8;\n"
-"const SENSE_DISABLED: u32 = 0x0 << 16;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-"    let pin_cnf_21 = (GPIO_P0 + PIN_CNF + 21 * size_of::<u32>()) as *mut "
-"u32;\n"
-"    let pin_cnf_28 = (GPIO_P0 + PIN_CNF + 28 * size_of::<u32>()) as *mut "
-"u32;\n"
-"    // Safe because the pointers are to valid peripheral control registers, "
-"and\n"
+"// Safe because the pointers are to valid peripheral control registers, and\n"
 "    // no aliases exist.\n"
-"    unsafe {\n"
-"        pin_cnf_21.write_volatile(\n"
-"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
-"SENSE_DISABLED,\n"
-"        );\n"
-"        pin_cnf_28.write_volatile(\n"
-"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
-"SENSE_DISABLED,\n"
-"        );\n"
-"    }\n"
-"\n"
-"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
-"    let gpio0_outset = (GPIO_P0 + OUTSET) as *mut u32;\n"
-"    let gpio0_outclr = (GPIO_P0 + OUTCLR) as *mut u32;\n"
-"    // Safe because the pointers are to valid peripheral control registers, "
-"and\n"
-"    // no aliases exist.\n"
-"    unsafe {\n"
-"        gpio0_outclr.write_volatile(1 << 28);\n"
-"        gpio0_outset.write_volatile(1 << 21);\n"
-"    }\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:48
+#: src/bare-metal/microcontrollers/pacs.md:39
+#: src/bare-metal/microcontrollers/hals.md:29
+msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
@@ -12194,49 +10912,6 @@ msgstr ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) は[CMSIS-SVD](https://www."
 "keil.com/pack/doc/CMSIS/SVD/html/index.html) ファイルから、メモリマップされた"
 "周辺I/Oに対するほぼ安全（mostly-safe）なRustラッパーを生成します。"
-
-#: src/bare-metal/microcontrollers/pacs.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use cortex_m_rt::entry;\n"
-"use nrf52833_pac::Peripherals;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let p = Peripherals::take().unwrap();\n"
-"    let gpio0 = p.P0;\n"
-"\n"
-"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-"    gpio0.pin_cnf[21].write(|w| {\n"
-"        w.dir().output();\n"
-"        w.input().disconnect();\n"
-"        w.pull().disabled();\n"
-"        w.drive().s0s1();\n"
-"        w.sense().disabled();\n"
-"        w\n"
-"    });\n"
-"    gpio0.pin_cnf[28].write(|w| {\n"
-"        w.dir().output();\n"
-"        w.input().disconnect();\n"
-"        w.pull().disabled();\n"
-"        w.drive().s0s1();\n"
-"        w.sense().disabled();\n"
-"        w\n"
-"    });\n"
-"\n"
-"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
-"    gpio0.outclr.write(|w| w.pin28().clear());\n"
-"    gpio0.outset.write(|w| w.pin21().set());\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
-msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
@@ -12292,37 +10967,8 @@ msgstr ""
 "するラッパーを提供しています。これらのクレートの多くは[`embedded-hal`]"
 "(https://crates.io/crates/embedded-hal)が定義するトレイトを実装しています。"
 
-#: src/bare-metal/microcontrollers/hals.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use cortex_m_rt::entry;\n"
-"use nrf52833_hal::gpio::{p0, Level};\n"
-"use nrf52833_hal::pac::Peripherals;\n"
-"use nrf52833_hal::prelude::*;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let p = Peripherals::take().unwrap();\n"
-"\n"
-"    // Create HAL wrapper for GPIO port 0.\n"
-"    let gpio0 = p0::Parts::new(p.P0);\n"
-"\n"
-"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-"    let mut col1 = gpio0.p0_28.into_push_pull_output(Level::High);\n"
-"    let mut row1 = gpio0.p0_21.into_push_pull_output(Level::Low);\n"
-"\n"
-"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
-"    col1.set_low().unwrap();\n"
-"    row1.set_high().unwrap();\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+#: src/bare-metal/microcontrollers/hals.md:22
+msgid "// Create HAL wrapper for GPIO port 0.\n"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
@@ -12376,37 +11022,12 @@ msgstr "`microbit-v2`はマトリクスLEDに対する簡単なドライバを�
 msgid "The type state pattern"
 msgstr "タイプステートパターン"
 
-#: src/bare-metal/microcontrollers/type-state.md:3
-msgid ""
-"```rust,editable,compile_fail\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let p = Peripherals::take().unwrap();\n"
-"    let gpio0 = p0::Parts::new(p.P0);\n"
-"\n"
-"    let pin: P0_01<Disconnected> = gpio0.p0_01;\n"
-"\n"
-"    // let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
-"    let pin_input: P0_01<Input<Floating>> = pin.into_floating_input();\n"
-"    if pin_input.is_high().unwrap() {\n"
-"        // ...\n"
-"    }\n"
-"    let mut pin_output: P0_01<Output<OpenDrain>> = pin_input\n"
-"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
-"Level::Low);\n"
-"    pin_output.set_high().unwrap();\n"
-"    // pin_input.is_high(); // Error, moved.\n"
-"\n"
-"    let _pin2: P0_02<Output<OpenDrain>> = gpio0\n"
-"        .p0_02\n"
-"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
-"Level::Low);\n"
-"    let _pin3: P0_03<Output<PushPull>> = gpio0.p0_03."
-"into_push_pull_output(Level::Low);\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+#: src/bare-metal/microcontrollers/type-state.md:11
+msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:19
+msgid "// pin_input.is_high(); // Error, moved.\n"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
@@ -12813,41 +11434,26 @@ msgstr ""
 msgid "_src/main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:30
+#: src/exercises/bare-metal/compass.md:44
+#: src/exercises/bare-metal/solutions-morning.md:32
+msgid "// Configure serial port.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:52
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use core::fmt::Write;\n"
-"use cortex_m_rt::entry;\n"
-"use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let board = Board::take().unwrap();\n"
-"\n"
-"    // Configure serial port.\n"
-"    let mut serial = Uarte::new(\n"
-"        board.UARTE0,\n"
-"        board.uart.into(),\n"
-"        Parity::EXCLUDED,\n"
-"        Baudrate::BAUD115200,\n"
-"    );\n"
-"\n"
-"    // Set up the I2C controller and Inertial Measurement Unit.\n"
+"// Set up the I2C controller and Inertial Measurement Unit.\n"
 "    // TODO\n"
-"\n"
-"    writeln!(serial, \"Ready.\").unwrap();\n"
-"\n"
-"    loop {\n"
-"        // Read compass data and log it to the serial port.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:55
+#: src/exercises/bare-metal/solutions-morning.md:56
+msgid "\"Ready.\""
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:58
+msgid ""
+"// Read compass data and log it to the serial port.\n"
 "        // TODO\n"
-"    }\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:64 src/exercises/bare-metal/rtc.md:385
@@ -13060,40 +11666,46 @@ msgid ""
 "firmware to power off the system:"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:6
+#: src/bare-metal/aps/inline-assembly.md:19
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"use core::arch::asm;\n"
-"use core::panic::PanicInfo;\n"
-"\n"
-"mod exceptions;\n"
-"\n"
-"const PSCI_SYSTEM_OFF: u32 = 0x84000008;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(_x0: u64, _x1: u64, _x2: u64, _x3: u64) {\n"
-"    // Safe because this only uses the declared registers and doesn't do\n"
+"// Safe because this only uses the declared registers and doesn't do\n"
 "    // anything with memory.\n"
-"    unsafe {\n"
-"        asm!(\"hvc #0\",\n"
-"            inout(\"w0\") PSCI_SYSTEM_OFF => _,\n"
-"            inout(\"w1\") 0 => _,\n"
-"            inout(\"w2\") 0 => _,\n"
-"            inout(\"w3\") 0 => _,\n"
-"            inout(\"w4\") 0 => _,\n"
-"            inout(\"w5\") 0 => _,\n"
-"            inout(\"w6\") 0 => _,\n"
-"            inout(\"w7\") 0 => _,\n"
-"            options(nomem, nostack)\n"
-"        );\n"
-"    }\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:22
+msgid "\"hvc #0\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:23
+msgid "\"w0\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:24
+msgid "\"w1\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:25
+msgid "\"w2\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:26
+msgid "\"w3\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:27
+msgid "\"w4\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:28
+msgid "\"w5\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:29
+msgid "\"w6\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:30
+msgid "\"w7\""
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
@@ -13193,22 +11805,13 @@ msgid ""
 "documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:5
+#: src/bare-metal/aps/uart.md:9
+msgid "/// Minimal driver for a PL011 UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:17 src/bare-metal/aps/better-uart/driver.md:13
 msgid ""
-"```rust,editable\n"
-"const FLAG_REGISTER_OFFSET: usize = 0x18;\n"
-"const FR_BUSY: u8 = 1 << 3;\n"
-"const FR_TXFF: u8 = 1 << 5;\n"
-"\n"
-"/// Minimal driver for a PL011 UART.\n"
-"#[derive(Debug)]\n"
-"pub struct Uart {\n"
-"    base_address: *mut u8,\n"
-"}\n"
-"\n"
-"impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at "
-"the\n"
+"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -13218,34 +11821,32 @@ msgid ""
 "    /// PL011 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u8) -> Self {\n"
-"        Self { base_address }\n"
-"    }\n"
-"\n"
-"    /// Writes a single byte to the UART.\n"
-"    pub fn write_byte(&self, byte: u8) {\n"
-"        // Wait until there is room in the TX buffer.\n"
-"        while self.read_flag_register() & FR_TXFF != 0 {}\n"
-"\n"
-"        // Safe because we know that the base address points to the control\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:27
+#: src/exercises/bare-metal/rtc.md:336
+msgid "/// Writes a single byte to the UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:29
+#: src/exercises/bare-metal/rtc.md:338
+msgid "// Wait until there is room in the TX buffer.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:34 src/bare-metal/aps/uart.md:46
+msgid ""
+"// Safe because we know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe {\n"
-"            // Write to the TX buffer.\n"
-"            self.base_address.write_volatile(byte);\n"
-"        }\n"
-"\n"
-"        // Wait until the UART is no longer busy.\n"
-"        while self.read_flag_register() & FR_BUSY != 0 {}\n"
-"    }\n"
-"\n"
-"    fn read_flag_register(&self) -> u8 {\n"
-"        // Safe because we know that the base address points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET)."
-"read_volatile() }\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:35
+#: src/exercises/bare-metal/rtc.md:344
+msgid "// Write to the TX buffer.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:39
+#: src/exercises/bare-metal/rtc.md:348
+msgid "// Wait until the UART is no longer busy.\n"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
@@ -13282,24 +11883,11 @@ msgid ""
 "traits too."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:5
+#: src/bare-metal/aps/uart/traits.md:16 src/exercises/bare-metal/rtc.md:379
+#: src/exercises/bare-metal/solutions-afternoon.md:231
 msgid ""
-"```rust,editable,compile_fail\n"
-"use core::fmt::{self, Write};\n"
-"\n"
-"impl Write for Uart {\n"
-"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
-"        for c in s.as_bytes() {\n"
-"            self.write_byte(*c);\n"
-"        }\n"
-"        Ok(())\n"
-"    }\n"
-"}\n"
-"\n"
 "// Safe because it just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
-"unsafe impl Send for Uart {}\n"
-"```"
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
@@ -13494,37 +12082,54 @@ msgid ""
 "working with bitflags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use bitflags::bitflags;\n"
-"\n"
-"bitflags! {\n"
-"    /// Flags from the UART flag register.\n"
-"    #[repr(transparent)]\n"
-"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"    struct Flags: u16 {\n"
-"        /// Clear to send.\n"
-"        const CTS = 1 << 0;\n"
-"        /// Data set ready.\n"
-"        const DSR = 1 << 1;\n"
-"        /// Data carrier detect.\n"
-"        const DCD = 1 << 2;\n"
-"        /// UART busy transmitting data.\n"
-"        const BUSY = 1 << 3;\n"
-"        /// Receive FIFO is empty.\n"
-"        const RXFE = 1 << 4;\n"
-"        /// Transmit FIFO is full.\n"
-"        const TXFF = 1 << 5;\n"
-"        /// Receive FIFO is full.\n"
-"        const RXFF = 1 << 6;\n"
-"        /// Transmit FIFO is empty.\n"
-"        const TXFE = 1 << 7;\n"
-"        /// Ring indicator.\n"
-"        const RI = 1 << 8;\n"
-"    }\n"
-"}\n"
-"```"
+#: src/bare-metal/aps/better-uart/bitflags.md:9
+#: src/exercises/bare-metal/rtc.md:238
+msgid "/// Flags from the UART flag register.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:13
+#: src/exercises/bare-metal/rtc.md:242
+msgid "/// Clear to send.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:15
+#: src/exercises/bare-metal/rtc.md:244
+msgid "/// Data set ready.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:17
+#: src/exercises/bare-metal/rtc.md:246
+msgid "/// Data carrier detect.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:19
+#: src/exercises/bare-metal/rtc.md:248
+msgid "/// UART busy transmitting data.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:21
+#: src/exercises/bare-metal/rtc.md:250
+msgid "/// Receive FIFO is empty.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:23
+#: src/exercises/bare-metal/rtc.md:252
+msgid "/// Transmit FIFO is full.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:25
+#: src/exercises/bare-metal/rtc.md:254
+msgid "/// Receive FIFO is full.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:27
+#: src/exercises/bare-metal/rtc.md:256
+msgid "/// Transmit FIFO is empty.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:29
+#: src/exercises/bare-metal/rtc.md:258
+msgid "/// Ring indicator.\n"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
@@ -13555,69 +12160,28 @@ msgstr ""
 msgid "Now let's use the new `Registers` struct in our driver."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:5
+#: src/bare-metal/aps/better-uart/driver.md:6
+msgid "/// Driver for a PL011 UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:32
+#: src/bare-metal/aps/better-uart/driver.md:55
+#: src/exercises/bare-metal/rtc.md:341 src/exercises/bare-metal/rtc.md:364
 msgid ""
-"```rust,editable,compile_fail\n"
-"/// Driver for a PL011 UART.\n"
-"#[derive(Debug)]\n"
-"pub struct Uart {\n"
-"    registers: *mut Registers,\n"
-"}\n"
-"\n"
-"impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at "
-"the\n"
-"    /// given base address.\n"
-"    ///\n"
-"    /// # Safety\n"
-"    ///\n"
-"    /// The given base address must point to the 8 MMIO control registers of "
-"a\n"
-"    /// PL011 device, which must be mapped into the address space of the "
-"process\n"
-"    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
-"        Self {\n"
-"            registers: base_address as *mut Registers,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Writes a single byte to the UART.\n"
-"    pub fn write_byte(&self, byte: u8) {\n"
-"        // Wait until there is room in the TX buffer.\n"
-"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
-"\n"
-"        // Safe because we know that self.registers points to the control\n"
+"// Safe because we know that self.registers points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe {\n"
-"            // Write to the TX buffer.\n"
-"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
-"        }\n"
-"\n"
-"        // Wait until the UART is no longer busy.\n"
-"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
-"    }\n"
-"\n"
-"    /// Reads and returns a pending byte, or `None` if nothing has been "
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:43
+#: src/exercises/bare-metal/rtc.md:352
+msgid ""
+"/// Reads and returns a pending byte, or `None` if nothing has been "
 "received.\n"
-"    pub fn read_byte(&self) -> Option<u8> {\n"
-"        if self.read_flag_register().contains(Flags::RXFE) {\n"
-"            None\n"
-"        } else {\n"
-"            let data = unsafe { addr_of!((*self.registers).dr)."
-"read_volatile() };\n"
-"            // TODO: Check for error conditions in bits 8-11.\n"
-"            Some(data as u8)\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn read_flag_register(&self) -> Flags {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:49
+#: src/exercises/bare-metal/rtc.md:358
+msgid "// TODO: Check for error conditions in bits 8-11.\n"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
@@ -13637,51 +12201,40 @@ msgid ""
 "and echo incoming bytes."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:6
+#: src/bare-metal/aps/better-uart/using.md:19
+#: src/bare-metal/aps/logging/using.md:18 src/exercises/bare-metal/rtc.md:41
+#: src/exercises/bare-metal/solutions-afternoon.md:33
+msgid "/// Base address of the primary PL011 UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:25
+#: src/bare-metal/aps/logging/using.md:24 src/exercises/bare-metal/rtc.md:47
+#: src/exercises/bare-metal/solutions-afternoon.md:44
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod pl011;\n"
-"\n"
-"use crate::pl011::Uart;\n"
-"use core::fmt::Write;\n"
-"use core::panic::PanicInfo;\n"
-"use log::error;\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
+"// Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
 "    // and nothing else accesses that address range.\n"
-"    let mut uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"\n"
-"    writeln!(uart, \"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\").unwrap();\n"
-"\n"
-"    loop {\n"
-"        if let Some(byte) = uart.read_byte() {\n"
-"            uart.write_byte(byte);\n"
-"            match byte {\n"
-"                b'\\r' => {\n"
-"                    uart.write_byte(b'\\n');\n"
-"                }\n"
-"                b'q' => break,\n"
-"                _ => {}\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"\n"
-"    writeln!(uart, \"Bye!\").unwrap();\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:29
+#: src/bare-metal/aps/logging/using.md:29
+msgid "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:35
+msgid "b'\\r'"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:36
+#: src/async/pitfalls/cancellation.md:27
+msgid "b'\\n'"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:38
+msgid "b'q'"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:44
+msgid "\"Bye!\""
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
@@ -13703,50 +12256,12 @@ msgid ""
 "`Log` trait."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use crate::pl011::Uart;\n"
-"use core::fmt::Write;\n"
-"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
-"use spin::mutex::SpinMutex;\n"
-"\n"
-"static LOGGER: Logger = Logger {\n"
-"    uart: SpinMutex::new(None),\n"
-"};\n"
-"\n"
-"struct Logger {\n"
-"    uart: SpinMutex<Option<Uart>>,\n"
-"}\n"
-"\n"
-"impl Log for Logger {\n"
-"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
-"        true\n"
-"    }\n"
-"\n"
-"    fn log(&self, record: &Record) {\n"
-"        writeln!(\n"
-"            self.uart.lock().as_mut().unwrap(),\n"
-"            \"[{}] {}\",\n"
-"            record.level(),\n"
-"            record.args()\n"
-"        )\n"
-"        .unwrap();\n"
-"    }\n"
-"\n"
-"    fn flush(&self) {}\n"
-"}\n"
-"\n"
-"/// Initialises UART logger.\n"
-"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
-"SetLoggerError> {\n"
-"    LOGGER.uart.lock().replace(uart);\n"
-"\n"
-"    log::set_logger(&LOGGER)?;\n"
-"    log::set_max_level(max_level);\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/bare-metal/aps/logging.md:28 src/exercises/bare-metal/rtc.md:190
+msgid "\"[{}] {}\""
+msgstr ""
+
+#: src/bare-metal/aps/logging.md:37 src/exercises/bare-metal/rtc.md:199
+msgid "/// Initialises UART logger.\n"
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
@@ -13759,47 +12274,9 @@ msgstr ""
 msgid "We need to initialise the logger before we use it."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod logger;\n"
-"mod pl011;\n"
-"\n"
-"use crate::pl011::Uart;\n"
-"use core::panic::PanicInfo;\n"
-"use log::{error, info, LevelFilter};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
-"    // and nothing else accesses that address range.\n"
-"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
-"\n"
-"    info!(\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\");\n"
-"\n"
-"    assert_eq!(x1, 42);\n"
-"\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[panic_handler]\n"
-"fn panic(info: &PanicInfo) -> ! {\n"
-"    error!(\"{info}\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"    loop {}\n"
-"}\n"
-"```"
+#: src/bare-metal/aps/logging/using.md:38 src/exercises/bare-metal/rtc.md:69
+#: src/exercises/bare-metal/solutions-afternoon.md:121
+msgid "\"{info}\""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
@@ -13974,27 +12451,16 @@ msgid ""
 "Architecture."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use aarch64_paging::{\n"
-"    idmap::IdMap,\n"
-"    paging::{Attributes, MemoryRegion},\n"
-"};\n"
-"\n"
-"const ASID: usize = 1;\n"
-"const ROOT_LEVEL: usize = 1;\n"
-"\n"
-"// Create a new page table with identity mapping.\n"
-"let mut idmap = IdMap::new(ASID, ROOT_LEVEL);\n"
-"// Map a 2 MiB region of memory as read-only.\n"
-"idmap.map_range(\n"
-"    &MemoryRegion::new(0x80200000, 0x80400000),\n"
-"    Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,\n"
-").unwrap();\n"
-"// Set `TTBR0_EL1` to activate the page table.\n"
-"idmap.activate();\n"
-"```"
+#: src/bare-metal/useful-crates/aarch64-paging.md:14
+msgid "// Create a new page table with identity mapping.\n"
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:16
+msgid "// Map a 2 MiB region of memory as read-only.\n"
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:21
+msgid "// Set `TTBR0_EL1` to activate the page table.\n"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
@@ -14186,62 +12652,30 @@ msgid ""
 "look in the `rtc` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:23
+#: src/exercises/bare-metal/rtc.md:37
+#: src/exercises/bare-metal/solutions-afternoon.md:29
+msgid "/// Base addresses of the GICv3.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:52
+#: src/exercises/bare-metal/solutions-afternoon.md:49
+msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:54
+#: src/exercises/bare-metal/solutions-afternoon.md:51
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod logger;\n"
-"mod pl011;\n"
-"\n"
-"use crate::pl011::Uart;\n"
-"use arm_gic::gicv3::GicV3;\n"
-"use core::panic::PanicInfo;\n"
-"use log::{error, info, trace, LevelFilter};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base addresses of the GICv3.\n"
-"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
-"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
-"    // and nothing else accesses that address range.\n"
-"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
-"\n"
-"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
-"\n"
-"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
-"base\n"
+"// Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
-"GICR_BASE_ADDRESS) };\n"
-"    gic.setup();\n"
-"\n"
-"    // TODO: Create instance of RTC driver and print current time.\n"
-"\n"
-"    // TODO: Wait for 3 seconds.\n"
-"\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[panic_handler]\n"
-"fn panic(info: &PanicInfo) -> ! {\n"
-"    error!(\"{info}\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:60
+msgid "// TODO: Create instance of RTC driver and print current time.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:62
+msgid "// TODO: Wait for 3 seconds.\n"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:75
@@ -14250,9 +12684,9 @@ msgid ""
 "the exercise):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:79
+#: src/exercises/bare-metal/rtc.md:80 src/exercises/bare-metal/rtc.md:154
+#: src/exercises/bare-metal/rtc.md:215 src/exercises/bare-metal/rtc.md:415
 msgid ""
-"```rust,compile_fail\n"
 "// Copyright 2023 Google LLC\n"
 "//\n"
 "// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
@@ -14266,245 +12700,106 @@ msgid ""
 "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
 "// See the License for the specific language governing permissions and\n"
 "// limitations under the License.\n"
-"\n"
-"use arm_gic::gicv3::GicV3;\n"
-"use log::{error, info, trace};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn sync_exception_current(_elr: u64, _spsr: u64) {\n"
-"    error!(\"sync_exception_current\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn irq_current(_elr: u64, _spsr: u64) {\n"
-"    trace!(\"irq_current\");\n"
-"    let intid = GicV3::get_and_acknowledge_interrupt().expect(\"No pending "
-"interrupt\");\n"
-"    info!(\"IRQ {intid:?}\");\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn fiq_current(_elr: u64, _spsr: u64) {\n"
-"    error!(\"fiq_current\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn serr_current(_elr: u64, _spsr: u64) {\n"
-"    error!(\"serr_current\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn sync_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"sync_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn irq_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"irq_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn fiq_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"fiq_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn serr_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"serr_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:101
+msgid "\"sync_exception_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:107
+msgid "\"irq_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:108
+msgid "\"No pending interrupt\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:109
+msgid "\"IRQ {intid:?}\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:114
+msgid "\"fiq_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:120
+msgid "\"serr_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:126
+msgid "\"sync_lower\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:132
+msgid "\"irq_lower\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:138
+msgid "\"fiq_lower\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:144
+msgid "\"serr_lower\""
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:149
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:153
-msgid ""
-"```rust,compile_fail\n"
-"// Copyright 2023 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License.\n"
-"\n"
-"// ANCHOR: main\n"
-"use crate::pl011::Uart;\n"
-"use core::fmt::Write;\n"
-"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
-"use spin::mutex::SpinMutex;\n"
-"\n"
-"static LOGGER: Logger = Logger {\n"
-"    uart: SpinMutex::new(None),\n"
-"};\n"
-"\n"
-"struct Logger {\n"
-"    uart: SpinMutex<Option<Uart>>,\n"
-"}\n"
-"\n"
-"impl Log for Logger {\n"
-"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
-"        true\n"
-"    }\n"
-"\n"
-"    fn log(&self, record: &Record) {\n"
-"        writeln!(\n"
-"            self.uart.lock().as_mut().unwrap(),\n"
-"            \"[{}] {}\",\n"
-"            record.level(),\n"
-"            record.args()\n"
-"        )\n"
-"        .unwrap();\n"
-"    }\n"
-"\n"
-"    fn flush(&self) {}\n"
-"}\n"
-"\n"
-"/// Initialises UART logger.\n"
-"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
-"SetLoggerError> {\n"
-"    LOGGER.uart.lock().replace(uart);\n"
-"\n"
-"    log::set_logger(&LOGGER)?;\n"
-"    log::set_max_level(max_level);\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/exercises/bare-metal/rtc.md:167
+msgid "// ANCHOR: main\n"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:214
+#: src/exercises/bare-metal/rtc.md:233
+msgid "// ANCHOR: Flags\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:261
+msgid "// ANCHOR_END: Flags\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:265
 msgid ""
-"```rust,compile_fail\n"
-"// Copyright 2023 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License.\n"
-"\n"
-"#![allow(unused)]\n"
-"\n"
-"use core::fmt::{self, Write};\n"
-"use core::ptr::{addr_of, addr_of_mut};\n"
-"\n"
-"// ANCHOR: Flags\n"
-"use bitflags::bitflags;\n"
-"\n"
-"bitflags! {\n"
-"    /// Flags from the UART flag register.\n"
-"    #[repr(transparent)]\n"
-"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"    struct Flags: u16 {\n"
-"        /// Clear to send.\n"
-"        const CTS = 1 << 0;\n"
-"        /// Data set ready.\n"
-"        const DSR = 1 << 1;\n"
-"        /// Data carrier detect.\n"
-"        const DCD = 1 << 2;\n"
-"        /// UART busy transmitting data.\n"
-"        const BUSY = 1 << 3;\n"
-"        /// Receive FIFO is empty.\n"
-"        const RXFE = 1 << 4;\n"
-"        /// Transmit FIFO is full.\n"
-"        const TXFF = 1 << 5;\n"
-"        /// Receive FIFO is full.\n"
-"        const RXFF = 1 << 6;\n"
-"        /// Transmit FIFO is empty.\n"
-"        const TXFE = 1 << 7;\n"
-"        /// Ring indicator.\n"
-"        const RI = 1 << 8;\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: Flags\n"
-"\n"
-"bitflags! {\n"
-"    /// Flags from the UART Receive Status Register / Error Clear Register.\n"
-"    #[repr(transparent)]\n"
-"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"    struct ReceiveStatus: u16 {\n"
-"        /// Framing error.\n"
-"        const FE = 1 << 0;\n"
-"        /// Parity error.\n"
-"        const PE = 1 << 1;\n"
-"        /// Break error.\n"
-"        const BE = 1 << 2;\n"
-"        /// Overrun error.\n"
-"        const OE = 1 << 3;\n"
-"    }\n"
-"}\n"
-"\n"
-"// ANCHOR: Registers\n"
-"#[repr(C, align(4))]\n"
-"struct Registers {\n"
-"    dr: u16,\n"
-"    _reserved0: [u8; 2],\n"
-"    rsr: ReceiveStatus,\n"
-"    _reserved1: [u8; 19],\n"
-"    fr: Flags,\n"
-"    _reserved2: [u8; 6],\n"
-"    ilpr: u8,\n"
-"    _reserved3: [u8; 3],\n"
-"    ibrd: u16,\n"
-"    _reserved4: [u8; 2],\n"
-"    fbrd: u8,\n"
-"    _reserved5: [u8; 3],\n"
-"    lcr_h: u8,\n"
-"    _reserved6: [u8; 3],\n"
-"    cr: u16,\n"
-"    _reserved7: [u8; 3],\n"
-"    ifls: u8,\n"
-"    _reserved8: [u8; 3],\n"
-"    imsc: u16,\n"
-"    _reserved9: [u8; 2],\n"
-"    ris: u16,\n"
-"    _reserved10: [u8; 2],\n"
-"    mis: u16,\n"
-"    _reserved11: [u8; 2],\n"
-"    icr: u16,\n"
-"    _reserved12: [u8; 2],\n"
-"    dmacr: u8,\n"
-"    _reserved13: [u8; 3],\n"
-"}\n"
-"// ANCHOR_END: Registers\n"
-"\n"
+"/// Flags from the UART Receive Status Register / Error Clear Register.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:269
+msgid "/// Framing error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:271
+msgid "/// Parity error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:273
+msgid "/// Break error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:275
+msgid "/// Overrun error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:279
+msgid "// ANCHOR: Registers\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:311
+msgid "// ANCHOR_END: Registers\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:313
+msgid ""
 "// ANCHOR: Uart\n"
 "/// Driver for a PL011 UART.\n"
-"#[derive(Debug)]\n"
-"pub struct Uart {\n"
-"    registers: *mut Registers,\n"
-"}\n"
-"\n"
-"impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at "
-"the\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:322
+msgid ""
+"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -14514,101 +12809,46 @@ msgid ""
 "    /// PL011 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
-"        Self {\n"
-"            registers: base_address as *mut Registers,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Writes a single byte to the UART.\n"
-"    pub fn write_byte(&self, byte: u8) {\n"
-"        // Wait until there is room in the TX buffer.\n"
-"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
-"\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe {\n"
-"            // Write to the TX buffer.\n"
-"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
-"        }\n"
-"\n"
-"        // Wait until the UART is no longer busy.\n"
-"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
-"    }\n"
-"\n"
-"    /// Reads and returns a pending byte, or `None` if nothing has been "
-"received.\n"
-"    pub fn read_byte(&self) -> Option<u8> {\n"
-"        if self.read_flag_register().contains(Flags::RXFE) {\n"
-"            None\n"
-"        } else {\n"
-"            let data = unsafe { addr_of!((*self.registers).dr)."
-"read_volatile() };\n"
-"            // TODO: Check for error conditions in bits 8-11.\n"
-"            Some(data as u8)\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn read_flag_register(&self) -> Flags {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: Uart\n"
-"\n"
-"impl Write for Uart {\n"
-"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
-"        for c in s.as_bytes() {\n"
-"            self.write_byte(*c);\n"
-"        }\n"
-"        Ok(())\n"
-"    }\n"
-"}\n"
-"\n"
-"// Safe because it just contains a pointer to device memory, which can be\n"
-"// accessed from any context.\n"
-"unsafe impl Send for Uart {}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:368
+msgid "// ANCHOR_END: Uart\n"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:410
 msgid "_build.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:414
-msgid ""
-"```rust,compile_fail\n"
-"// Copyright 2023 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License.\n"
-"\n"
-"use cc::Build;\n"
-"use std::env;\n"
-"\n"
-"fn main() {\n"
-"    #[cfg(target_os = \"linux\")]\n"
-"    env::set_var(\"CROSS_COMPILE\", \"aarch64-linux-gnu\");\n"
-"    #[cfg(not(target_os = \"linux\"))]\n"
-"    env::set_var(\"CROSS_COMPILE\", \"aarch64-none-elf\");\n"
-"\n"
-"    Build::new()\n"
-"        .file(\"entry.S\")\n"
-"        .file(\"exceptions.S\")\n"
-"        .file(\"idmap.S\")\n"
-"        .compile(\"empty\")\n"
-"}\n"
-"```"
+#: src/exercises/bare-metal/rtc.md:433 src/exercises/bare-metal/rtc.md:435
+msgid "\"linux\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:434 src/exercises/bare-metal/rtc.md:436
+msgid "\"CROSS_COMPILE\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:434
+msgid "\"aarch64-linux-gnu\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:436
+msgid "\"aarch64-none-elf\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:439
+msgid "\"entry.S\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:440
+msgid "\"exceptions.S\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:441
+msgid "\"idmap.S\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:442
+msgid "\"empty\""
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
@@ -15147,49 +13387,24 @@ msgstr ""
 msgid "_Makefile_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:944
-msgid ""
-"```makefile\n"
-"# Copyright 2023 Google LLC\n"
-"#\n"
-"# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"# you may not use this file except in compliance with the License.\n"
-"# You may obtain a copy of the License at\n"
-"#\n"
-"#      http://www.apache.org/licenses/LICENSE-2.0\n"
-"#\n"
-"# Unless required by applicable law or agreed to in writing, software\n"
-"# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"# See the License for the specific language governing permissions and\n"
-"# limitations under the License.\n"
-"\n"
-"UNAME := $(shell uname -s)\n"
-"ifeq ($(UNAME),Linux)\n"
-"\tTARGET = aarch64-linux-gnu\n"
-"else\n"
-"\tTARGET = aarch64-none-elf\n"
-"endif\n"
-"OBJCOPY = $(TARGET)-objcopy\n"
-"\n"
-".PHONY: build qemu_minimal qemu qemu_logger\n"
-"\n"
-"all: rtc.bin\n"
-"\n"
-"build:\n"
-"\tcargo build\n"
-"\n"
-"rtc.bin: build\n"
-"\t$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@\n"
-"\n"
-"qemu: rtc.bin\n"
-"\tqemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio "
-"-display none -kernel $< -s\n"
-"\n"
-"clean:\n"
-"\tcargo clean\n"
-"\trm -f *.bin\n"
-"```"
+#: src/exercises/bare-metal/rtc.md:945
+msgid "# Copyright 2023 Google LLC"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:959
+msgid "$(shell uname -s)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:961
+msgid "aarch64-linux-gnu"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:978
+msgid "stdio -display none -kernel $< -s"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:981
+msgid "cargo clean"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:995
@@ -15223,26 +13438,12 @@ msgstr ""
 msgid "Rust threads work similarly to threads in other languages:"
 msgstr "Rustのスレッドは他の言語のスレッドと似た挙動をします:"
 
-#: src/concurrency/threads.md:5
-msgid ""
-"```rust,editable\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"fn main() {\n"
-"    thread::spawn(|| {\n"
-"        for i in 1..10 {\n"
-"            println!(\"Count in thread: {i}!\");\n"
-"            thread::sleep(Duration::from_millis(5));\n"
-"        }\n"
-"    });\n"
-"\n"
-"    for i in 1..5 {\n"
-"        println!(\"Main thread: {i}\");\n"
-"        thread::sleep(Duration::from_millis(5));\n"
-"    }\n"
-"}\n"
-"```"
+#: src/concurrency/threads.md:12
+msgid "\"Count in thread: {i}!\""
+msgstr ""
+
+#: src/concurrency/threads.md:18
+msgid "\"Main thread: {i}\""
 msgstr ""
 
 #: src/concurrency/threads.md:24
@@ -15296,22 +13497,8 @@ msgstr ""
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "通常のスレッドはそれらの環境から借用することはできません:"
 
-#: src/concurrency/scoped-threads.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::thread;\n"
-"\n"
-"fn foo() {\n"
-"    let s = String::from(\"Hello\");\n"
-"    thread::spawn(|| {\n"
-"        println!(\"Length: {}\", s.len());\n"
-"    });\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    foo();\n"
-"}\n"
-"```"
+#: src/concurrency/scoped-threads.md:11 src/concurrency/scoped-threads.md:30
+msgid "\"Length: {}\""
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:20
@@ -15321,23 +13508,6 @@ msgid ""
 msgstr ""
 "しかし、そのために[スコープ付きスレッド](https://doc.rust-lang.org/std/"
 "thread/fn.scope.html)を使うことができます:"
-
-#: src/concurrency/scoped-threads.md:22
-msgid ""
-"```rust,editable\n"
-"use std::thread;\n"
-"\n"
-"fn main() {\n"
-"    let s = String::from(\"Hello\");\n"
-"\n"
-"    thread::scope(|scope| {\n"
-"        scope.spawn(|| {\n"
-"            println!(\"Length: {}\", s.len());\n"
-"        });\n"
-"    });\n"
-"}\n"
-"```"
-msgstr ""
 
 #: src/concurrency/scoped-threads.md:40
 msgid ""
@@ -15364,25 +13534,9 @@ msgstr ""
 "の２つの部品はチャネルによって繋がっていますが、見ることができるのはエンドポ"
 "イントだけです。"
 
-#: src/concurrency/channels.md:6
-msgid ""
-"```rust,editable\n"
-"use std::sync::mpsc;\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::channel();\n"
-"\n"
-"    tx.send(10).unwrap();\n"
-"    tx.send(20).unwrap();\n"
-"\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"\n"
-"    let tx2 = tx.clone();\n"
-"    tx2.send(30).unwrap();\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"}\n"
-"```"
+#: src/concurrency/channels.md:15 src/concurrency/channels.md:16
+#: src/concurrency/channels.md:20
+msgid "\"Received: {:?}\""
 msgstr ""
 
 #: src/concurrency/channels.md:26
@@ -15408,31 +13562,24 @@ msgstr ""
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr "Unboundedで非同期的なチャネルは`mpsc::channel()`によって得られます："
 
-#: src/concurrency/channels/unbounded.md:5
-msgid ""
-"```rust,editable\n"
-"use std::sync::mpsc;\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::channel();\n"
-"\n"
-"    thread::spawn(move || {\n"
-"        let thread_id = thread::current().id();\n"
-"        for i in 1..10 {\n"
-"            tx.send(format!(\"Message {i}\")).unwrap();\n"
-"            println!(\"{thread_id:?}: sent Message {i}\");\n"
-"        }\n"
-"        println!(\"{thread_id:?}: done\");\n"
-"    });\n"
-"    thread::sleep(Duration::from_millis(100));\n"
-"\n"
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {msg}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/concurrency/channels/unbounded.md:16
+#: src/concurrency/channels/bounded.md:16
+msgid "\"Message {i}\""
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:17
+#: src/concurrency/channels/bounded.md:17
+msgid "\"{thread_id:?}: sent Message {i}\""
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:19
+#: src/concurrency/channels/bounded.md:19
+msgid "\"{thread_id:?}: done\""
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:24
+#: src/concurrency/channels/bounded.md:24
+msgid "\"Main: got {msg}\""
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:3
@@ -15441,33 +13588,6 @@ msgid ""
 msgstr ""
 "Bounded（かつ同期的）なチャネルを用いたとき、`send`は現在のスレッドをブロック"
 "することがあります："
-
-#: src/concurrency/channels/bounded.md:5
-msgid ""
-"```rust,editable\n"
-"use std::sync::mpsc;\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::sync_channel(3);\n"
-"\n"
-"    thread::spawn(move || {\n"
-"        let thread_id = thread::current().id();\n"
-"        for i in 1..10 {\n"
-"            tx.send(format!(\"Message {i}\")).unwrap();\n"
-"            println!(\"{thread_id:?}: sent Message {i}\");\n"
-"        }\n"
-"        println!(\"{thread_id:?}: done\");\n"
-"    });\n"
-"    thread::sleep(Duration::from_millis(100));\n"
-"\n"
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {msg}\");\n"
-"    }\n"
-"}\n"
-"```"
-msgstr ""
 
 #: src/concurrency/channels/bounded.md:31
 msgid ""
@@ -15767,27 +13887,14 @@ msgid ""
 "read-only access via `Arc::clone`:"
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md:5
-msgid ""
-"```rust,editable\n"
-"use std::thread;\n"
-"use std::sync::Arc;\n"
-"\n"
-"fn main() {\n"
-"    let v = Arc::new(vec![10, 20, 30]);\n"
-"    let mut handles = Vec::new();\n"
-"    for _ in 1..5 {\n"
-"        let v = Arc::clone(&v);\n"
-"        handles.push(thread::spawn(move || {\n"
-"            let thread_id = thread::current().id();\n"
-"            println!(\"{thread_id:?}: {v:?}\");\n"
-"        }));\n"
-"    }\n"
-"\n"
-"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
-"```"
+#: src/concurrency/shared_state/arc.md:16
+msgid "\"{thread_id:?}: {v:?}\""
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:21
+#: src/concurrency/shared_state/example.md:17
+#: src/concurrency/shared_state/example.md:45
+msgid "\"v: {v:?}\""
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
@@ -15829,23 +13936,9 @@ msgid ""
 "interface:"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:6
-msgid ""
-"```rust,editable\n"
-"use std::sync::Mutex;\n"
-"\n"
-"fn main() {\n"
-"    let v = Mutex::new(vec![10, 20, 30]);\n"
-"    println!(\"v: {:?}\", v.lock().unwrap());\n"
-"\n"
-"    {\n"
-"        let mut guard = v.lock().unwrap();\n"
-"        guard.push(40);\n"
-"    }\n"
-"\n"
-"    println!(\"v: {:?}\", v.lock().unwrap());\n"
-"}\n"
-"```"
+#: src/concurrency/shared_state/mutex.md:11
+#: src/concurrency/shared_state/mutex.md:18
+msgid "\"v: {:?}\""
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
@@ -15900,54 +13993,12 @@ msgstr ""
 msgid "Let us see `Arc` and `Mutex` in action:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::thread;\n"
-"// use std::sync::{Arc, Mutex};\n"
-"\n"
-"fn main() {\n"
-"    let v = vec![10, 20, 30];\n"
-"    let handle = thread::spawn(|| {\n"
-"        v.push(10);\n"
-"    });\n"
-"    v.push(1000);\n"
-"\n"
-"    handle.join().unwrap();\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
-"```"
+#: src/concurrency/shared_state/example.md:6
+msgid "// use std::sync::{Arc, Mutex};\n"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:23
 msgid "Possible solution:"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:25
-msgid ""
-"```rust,editable\n"
-"use std::sync::{Arc, Mutex};\n"
-"use std::thread;\n"
-"\n"
-"fn main() {\n"
-"    let v = Arc::new(Mutex::new(vec![10, 20, 30]));\n"
-"\n"
-"    let v2 = Arc::clone(&v);\n"
-"    let handle = thread::spawn(move || {\n"
-"        let mut v2 = v2.lock().unwrap();\n"
-"        v2.push(10);\n"
-"    });\n"
-"\n"
-"    {\n"
-"        let mut v = v.lock().unwrap();\n"
-"        v.push(1000);\n"
-"    }\n"
-"\n"
-"    handle.join().unwrap();\n"
-"\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:49
@@ -16015,49 +14066,89 @@ msgid ""
 "out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md:19
+#: src/exercises/concurrency/dining-philosophers.md:28
+#: src/exercises/concurrency/dining-philosophers-async.md:23
 msgid ""
-"```rust,compile_fail\n"
-"use std::sync::{mpsc, Arc, Mutex};\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // left_fork: ...\n"
+"// left_fork: ...\n"
 "    // right_fork: ...\n"
 "    // thoughts: ...\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"fn main() {\n"
-"    // Create forks\n"
-"\n"
-"    // Create philosophers\n"
-"\n"
-"    // Make each of them think and eat 100 times\n"
-"\n"
-"    // Output their thoughts\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:36
+#: src/exercises/concurrency/dining-philosophers-async.md:31
+#: src/exercises/concurrency/solutions-morning.md:24
+#: src/exercises/concurrency/solutions-afternoon.md:25
+msgid "\"Eureka! {} has a new idea!\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:41
+#: src/exercises/concurrency/dining-philosophers-async.md:36
+#: src/exercises/concurrency/solutions-afternoon.md:30
+msgid "// Pick up forks...\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:42
+#: src/exercises/concurrency/dining-philosophers-async.md:37
+#: src/exercises/concurrency/solutions-morning.md:33
+#: src/exercises/concurrency/solutions-afternoon.md:37
+msgid "\"{} is eating...\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Socrates\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Hypatia\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Plato\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Aristotle\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Pythagoras\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:51
+#: src/exercises/concurrency/dining-philosophers-async.md:47
+#: src/exercises/concurrency/solutions-afternoon.md:49
+msgid "// Create forks\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:53
+#: src/exercises/concurrency/dining-philosophers-async.md:49
+#: src/exercises/concurrency/solutions-afternoon.md:53
+msgid "// Create philosophers\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:55
+msgid "// Make each of them think and eat 100 times\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:57
+#: src/exercises/concurrency/dining-philosophers-async.md:53
+#: src/exercises/concurrency/solutions-afternoon.md:88
+msgid "// Output their thoughts\n"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:61
@@ -16138,73 +14229,42 @@ msgstr ""
 msgid "Your `src/main.rs` file should look something like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:57
-msgid ""
-"```rust,compile_fail\n"
-"use reqwest::{blocking::Client, Url};\n"
-"use scraper::{Html, Selector};\n"
-"use thiserror::Error;\n"
-"\n"
-"#[derive(Error, Debug)]\n"
-"enum Error {\n"
-"    #[error(\"request error: {0}\")]\n"
-"    ReqwestError(#[from] reqwest::Error),\n"
-"    #[error(\"bad http response: {0}\")]\n"
-"    BadResponse(String),\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct CrawlCommand {\n"
-"    url: Url,\n"
-"    extract_links: bool,\n"
-"}\n"
-"\n"
-"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
-"Error> {\n"
-"    println!(\"Checking {:#}\", command.url);\n"
-"    let response = client.get(command.url.clone()).send()?;\n"
-"    if !response.status().is_success() {\n"
-"        return Err(Error::BadResponse(response.status().to_string()));\n"
-"    }\n"
-"\n"
-"    let mut link_urls = Vec::new();\n"
-"    if !command.extract_links {\n"
-"        return Ok(link_urls);\n"
-"    }\n"
-"\n"
-"    let base_url = response.url().to_owned();\n"
-"    let body_text = response.text()?;\n"
-"    let document = Html::parse_document(&body_text);\n"
-"\n"
-"    let selector = Selector::parse(\"a\").unwrap();\n"
-"    let href_values = document\n"
-"        .select(&selector)\n"
-"        .filter_map(|element| element.value().attr(\"href\"));\n"
-"    for href in href_values {\n"
-"        match base_url.join(href) {\n"
-"            Ok(link_url) => {\n"
-"                link_urls.push(link_url);\n"
-"            }\n"
-"            Err(err) => {\n"
-"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
-"{err}\");\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"    Ok(link_urls)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let client = Client::new();\n"
-"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
-"    let crawl_command = CrawlCommand{ url: start_url, extract_links: "
-"true };\n"
-"    match visit_page(&client, &crawl_command) {\n"
-"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
-"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/link-checker.md:64
+#: src/exercises/concurrency/solutions-morning.md:95
+msgid "\"request error: {0}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:66
+#: src/exercises/concurrency/solutions-morning.md:97
+msgid "\"bad http response: {0}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:77
+#: src/exercises/concurrency/solutions-morning.md:108
+msgid "\"Checking {:#}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:95
+#: src/exercises/concurrency/solutions-morning.md:126
+msgid "\"href\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:102
+#: src/exercises/concurrency/solutions-morning.md:133
+msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:111
+#: src/exercises/concurrency/solutions-morning.md:246
+msgid "\"https://www.google.org\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:114
+msgid "\"Links: {links:#?}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:115
+msgid "\"Could not extract links: {err:#}\""
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:120
@@ -16299,25 +14359,8 @@ msgstr ""
 "おおまかには、Rustの非同期コードはほとんど「通常の」逐次的なコードのように見"
 "えます:"
 
-#: src/async/async-await.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use futures::executor::block_on;\n"
-"\n"
-"async fn count_to(count: i32) {\n"
-"    for i in 1..=count {\n"
-"        println!(\"Count is: {i}!\");\n"
-"    }\n"
-"}\n"
-"\n"
-"async fn async_main(count: i32) {\n"
-"    count_to(count).await;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    block_on(async_main(10));\n"
-"}\n"
-"```"
+#: src/async/async-await.md:10
+msgid "\"Count is: {i}!\""
 msgstr ""
 
 #: src/async/async-await.md:27
@@ -16450,9 +14493,9 @@ msgid ""
 "_reactor_) and is responsible for executing futures (an _executor_). Rust "
 "does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
-"_runtime_は非同期な演算（_reactor_）のサポートを提供し、また、futureを実行す"
-"ること（_executor_）を担当しています。Rustには「ビルトイン」のランタイムはあ"
-"りませんが、いくつかのランタイムの選択肢があります: "
+"\\_runtime_は非同期な演算（_reactor_）のサポートを提供し、また、futureを実行"
+"すること（_executor_）を担当しています。Rustには「ビルトイン」のランタイムは"
+"ありませんが、いくつかのランタイムの選択肢があります: "
 
 #: src/async/runtimes.md:7
 #, fuzzy
@@ -16527,28 +14570,12 @@ msgstr "標準ライブラリの非同期バージョン。"
 msgid "A large ecosystem of libraries."
 msgstr "大きなライブラリのエコシステム。"
 
-#: src/async/runtimes/tokio.md:10
-msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::time;\n"
-"\n"
-"async fn count_to(count: i32) {\n"
-"    for i in 1..=count {\n"
-"        println!(\"Count in task: {i}!\");\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    tokio::spawn(count_to(10));\n"
-"\n"
-"    for i in 1..5 {\n"
-"        println!(\"Main task: {i}\");\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"    }\n"
-"}\n"
-"```"
+#: src/async/runtimes/tokio.md:15
+msgid "\"Count in task: {i}!\""
+msgstr ""
+
+#: src/async/runtimes/tokio.md:25
+msgid "\"Main task: {i}\""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
@@ -16607,48 +14634,28 @@ msgstr ""
 "行処理は、例えば競合タイマーや入出力操作など、複数の子のfutureをポーリングす"
 "ることにより可能になります。"
 
-#: src/async/tasks.md:10
-msgid ""
-"```rust,compile_fail\n"
-"use tokio::io::{self, AsyncReadExt, AsyncWriteExt};\n"
-"use tokio::net::TcpListener;\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> io::Result<()> {\n"
-"    let listener = TcpListener::bind(\"127.0.0.1:6142\").await?;\n"
-"\tprintln!(\"listening on port 6142\");\n"
-"\n"
-"    loop {\n"
-"        let (mut socket, addr) = listener.accept().await?;\n"
-"\n"
-"        println!(\"connection from {addr:?}\");\n"
-"\n"
-"        tokio::spawn(async move {\n"
-"            if let Err(e) = socket.write_all(b\"Who are you?\\n\").await {\n"
-"                println!(\"socket error: {e:?}\");\n"
-"                return;\n"
-"            }\n"
-"\n"
-"            let mut buf = vec![0; 1024];\n"
-"            let reply = match socket.read(&mut buf).await {\n"
-"                Ok(n) => {\n"
-"                    let name = std::str::from_utf8(&buf[..n]).unwrap()."
-"trim();\n"
-"                    format!(\"Thanks for dialing in, {name}!\\n\")\n"
-"                }\n"
-"                Err(e) => {\n"
-"                    println!(\"socket error: {e:?}\");\n"
-"                    return;\n"
-"                }\n"
-"            };\n"
-"\n"
-"            if let Err(e) = socket.write_all(reply.as_bytes()).await {\n"
-"                println!(\"socket error: {e:?}\");\n"
-"            }\n"
-"        });\n"
-"    }\n"
-"}\n"
-"```"
+#: src/async/tasks.md:16
+msgid "\"127.0.0.1:6142\""
+msgstr ""
+
+#: src/async/tasks.md:17
+msgid "\"listening on port 6142\""
+msgstr ""
+
+#: src/async/tasks.md:22
+msgid "\"connection from {addr:?}\""
+msgstr ""
+
+#: src/async/tasks.md:25
+msgid "b\"Who are you?\\n\""
+msgstr ""
+
+#: src/async/tasks.md:26 src/async/tasks.md:37 src/async/tasks.md:43
+msgid "\"socket error: {e:?}\""
+msgstr ""
+
+#: src/async/tasks.md:34
+msgid "\"Thanks for dialing in, {name}!\\n\""
 msgstr ""
 
 #: src/async/tasks.md:52 src/async/control-flow/join.md:36
@@ -16692,36 +14699,24 @@ msgstr ""
 "いくつかのクレートは`async`/`await`をサポートしています。例えば、`tokio`チャ"
 "ネルは:"
 
-#: src/async/channels.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::sync::mpsc::{self, Receiver};\n"
-"\n"
-"async fn ping_handler(mut input: Receiver<()>) {\n"
-"    let mut count: usize = 0;\n"
-"\n"
-"    while let Some(_) = input.recv().await {\n"
-"        count += 1;\n"
-"        println!(\"Received {count} pings so far.\");\n"
-"    }\n"
-"\n"
-"    println!(\"ping_handler complete\");\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let (sender, receiver) = mpsc::channel(32);\n"
-"    let ping_handler_task = tokio::spawn(ping_handler(receiver));\n"
-"    for i in 0..10 {\n"
-"        sender.send(()).await.expect(\"Failed to send ping.\");\n"
-"        println!(\"Sent {} pings so far.\", i + 1);\n"
-"    }\n"
-"\n"
-"    drop(sender);\n"
-"    ping_handler_task.await.expect(\"Something went wrong in ping handler "
-"task.\");\n"
-"}\n"
-"```"
+#: src/async/channels.md:13
+msgid "\"Received {count} pings so far.\""
+msgstr ""
+
+#: src/async/channels.md:16
+msgid "\"ping_handler complete\""
+msgstr ""
+
+#: src/async/channels.md:24
+msgid "\"Failed to send ping.\""
+msgstr ""
+
+#: src/async/channels.md:25
+msgid "\"Sent {} pings so far.\""
+msgstr ""
+
+#: src/async/channels.md:29
+msgid "\"Something went wrong in ping handler task.\""
 msgstr ""
 
 #: src/async/channels.md:35
@@ -16794,34 +14789,25 @@ msgstr ""
 "て返します。これはJavaScriptにおける `Promise.all` やPythonにおける`asyncio."
 "gather`に似ています。"
 
-#: src/async/control-flow/join.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use anyhow::Result;\n"
-"use futures::future;\n"
-"use reqwest;\n"
-"use std::collections::HashMap;\n"
-"\n"
-"async fn size_of_page(url: &str) -> Result<usize> {\n"
-"    let resp = reqwest::get(url).await?;\n"
-"    Ok(resp.text().await?.len())\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let urls: [&str; 4] = [\n"
-"        \"https://google.com\",\n"
-"        \"https://httpbin.org/ip\",\n"
-"        \"https://play.rust-lang.org/\",\n"
-"        \"BAD_URL\",\n"
-"    ];\n"
-"    let futures_iter = urls.into_iter().map(size_of_page);\n"
-"    let results = future::join_all(futures_iter).await;\n"
-"    let page_sizes_dict: HashMap<&str, Result<usize>> =\n"
-"        urls.into_iter().zip(results.into_iter()).collect();\n"
-"    println!(\"{:?}\", page_sizes_dict);\n"
-"}\n"
-"```"
+#: src/async/control-flow/join.md:21
+msgid "\"https://google.com\""
+msgstr ""
+
+#: src/async/control-flow/join.md:22
+msgid "\"https://httpbin.org/ip\""
+msgstr ""
+
+#: src/async/control-flow/join.md:23
+msgid "\"https://play.rust-lang.org/\""
+msgstr ""
+
+#: src/async/control-flow/join.md:24
+msgid "\"BAD_URL\""
+msgstr ""
+
+#: src/async/control-flow/join.md:30
+#: src/exercises/day-1/solutions-morning.md:78
+msgid "\"{:?}\""
 msgstr ""
 
 #: src/async/control-flow/join.md:38
@@ -16881,54 +14867,28 @@ msgstr ""
 "整った時、その`statement`は`future`の結果に紐づく`pattern`の変数を用いて実行"
 "されます。"
 
-#: src/async/control-flow/select.md:13
-msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::sync::mpsc::{self, Receiver};\n"
-"use tokio::time::{sleep, Duration};\n"
-"\n"
-"#[derive(Debug, PartialEq)]\n"
-"enum Animal {\n"
-"    Cat { name: String },\n"
-"    Dog { name: String },\n"
-"}\n"
-"\n"
-"async fn first_animal_to_finish_race(\n"
-"    mut cat_rcv: Receiver<String>,\n"
-"    mut dog_rcv: Receiver<String>,\n"
-") -> Option<Animal> {\n"
-"    tokio::select! {\n"
-"        cat_name = cat_rcv.recv() => Some(Animal::Cat { name: cat_name? }),\n"
-"        dog_name = dog_rcv.recv() => Some(Animal::Dog { name: dog_name? })\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let (cat_sender, cat_receiver) = mpsc::channel(32);\n"
-"    let (dog_sender, dog_receiver) = mpsc::channel(32);\n"
-"    tokio::spawn(async move {\n"
-"        sleep(Duration::from_millis(500)).await;\n"
-"        cat_sender\n"
-"            .send(String::from(\"Felix\"))\n"
-"            .await\n"
-"            .expect(\"Failed to send cat.\");\n"
-"    });\n"
-"    tokio::spawn(async move {\n"
-"        sleep(Duration::from_millis(50)).await;\n"
-"        dog_sender\n"
-"            .send(String::from(\"Rex\"))\n"
-"            .await\n"
-"            .expect(\"Failed to send dog.\");\n"
-"    });\n"
-"\n"
-"    let winner = first_animal_to_finish_race(cat_receiver, dog_receiver)\n"
-"        .await\n"
-"        .expect(\"Failed to receive winner\");\n"
-"\n"
-"    println!(\"Winner is {winner:?}\");\n"
-"}\n"
-"```"
+#: src/async/control-flow/select.md:40
+msgid "\"Felix\""
+msgstr ""
+
+#: src/async/control-flow/select.md:42
+msgid "\"Failed to send cat.\""
+msgstr ""
+
+#: src/async/control-flow/select.md:47
+msgid "\"Rex\""
+msgstr ""
+
+#: src/async/control-flow/select.md:49
+msgid "\"Failed to send dog.\""
+msgstr ""
+
+#: src/async/control-flow/select.md:54
+msgid "\"Failed to receive winner\""
+msgstr ""
+
+#: src/async/control-flow/select.md:56
+msgid "\"Winner is {winner:?}\""
 msgstr ""
 
 #: src/async/control-flow/select.md:62
@@ -17018,27 +14978,12 @@ msgid ""
 "possible."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use futures::future::join_all;\n"
-"use std::time::Instant;\n"
-"\n"
-"async fn sleep_ms(start: &Instant, id: u64, duration_ms: u64) {\n"
-"    std::thread::sleep(std::time::Duration::from_millis(duration_ms));\n"
-"    println!(\n"
-"        \"future {id} slept for {duration_ms}ms, finished after {}ms\",\n"
-"        start.elapsed().as_millis()\n"
-"    );\n"
-"}\n"
-"\n"
-"#[tokio::main(flavor = \"current_thread\")]\n"
-"async fn main() {\n"
-"    let start = Instant::now();\n"
-"    let sleep_futures = (1..=10).map(|t| sleep_ms(&start, t, t * 10));\n"
-"    join_all(sleep_futures).await;\n"
-"}\n"
-"```"
+#: src/async/pitfalls/blocking-executor.md:14
+msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:19
+msgid "\"current_thread\""
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
@@ -17096,61 +15041,42 @@ msgid ""
 "repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:12
+#: src/async/pitfalls/pin.md:16
 msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::sync::{mpsc, oneshot};\n"
-"use tokio::task::spawn;\n"
-"use tokio::time::{sleep, Duration};\n"
-"\n"
 "// A work item. In this case, just sleep for the given time and respond\n"
 "// with a message on the `respond_on` channel.\n"
-"#[derive(Debug)]\n"
-"struct Work {\n"
-"    input: u32,\n"
-"    respond_on: oneshot::Sender<u32>,\n"
-"}\n"
-"\n"
-"// A worker which listens for work on a queue and performs it.\n"
-"async fn worker(mut work_queue: mpsc::Receiver<Work>) {\n"
-"    let mut iterations = 0;\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            Some(work) = work_queue.recv() => {\n"
-"                sleep(Duration::from_millis(10)).await; // Pretend to work.\n"
-"                work.respond_on\n"
-"                    .send(work.input * 1000)\n"
-"                    .expect(\"failed to send response\");\n"
-"                iterations += 1;\n"
-"            }\n"
-"            // TODO: report number of iterations every 100ms\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"// A requester which requests work and waits for it to complete.\n"
-"async fn do_work(work_queue: &mpsc::Sender<Work>, input: u32) -> u32 {\n"
-"    let (tx, rx) = oneshot::channel();\n"
-"    work_queue\n"
-"        .send(Work {\n"
-"            input,\n"
-"            respond_on: tx,\n"
-"        })\n"
-"        .await\n"
-"        .expect(\"failed to send on work queue\");\n"
-"    rx.await.expect(\"failed waiting for response\")\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let (tx, rx) = mpsc::channel(10);\n"
-"    spawn(worker(rx));\n"
-"    for i in 0..100 {\n"
-"        let resp = do_work(&tx, i).await;\n"
-"        println!(\"work result for iteration {i}: {resp}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:24
+msgid "// A worker which listens for work on a queue and performs it.\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:31
+msgid "// Pretend to work.\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:34
+msgid "\"failed to send response\""
+msgstr ""
+
+#: src/async/pitfalls/pin.md:37
+msgid "// TODO: report number of iterations every 100ms\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:41
+msgid "// A requester which requests work and waits for it to complete.\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:51
+msgid "\"failed to send on work queue\""
+msgstr ""
+
+#: src/async/pitfalls/pin.md:52
+msgid "\"failed waiting for response\""
+msgstr ""
+
+#: src/async/pitfalls/pin.md:61
+msgid "\"work result for iteration {i}: {resp}\""
 msgstr ""
 
 #: src/async/pitfalls/pin.md:68
@@ -17217,50 +15143,12 @@ msgid ""
 "provides a workaround through a macro:"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use async_trait::async_trait;\n"
-"use std::time::Instant;\n"
-"use tokio::time::{sleep, Duration};\n"
-"\n"
-"#[async_trait]\n"
-"trait Sleeper {\n"
-"    async fn sleep(&self);\n"
-"}\n"
-"\n"
-"struct FixedSleeper {\n"
-"    sleep_ms: u64,\n"
-"}\n"
-"\n"
-"#[async_trait]\n"
-"impl Sleeper for FixedSleeper {\n"
-"    async fn sleep(&self) {\n"
-"        sleep(Duration::from_millis(self.sleep_ms)).await;\n"
-"    }\n"
-"}\n"
-"\n"
-"async fn run_all_sleepers_multiple_times(sleepers: Vec<Box<dyn Sleeper>>, "
-"n_times: usize) {\n"
-"    for _ in 0..n_times {\n"
-"        println!(\"running all sleepers..\");\n"
-"        for sleeper in &sleepers {\n"
-"            let start = Instant::now();\n"
-"            sleeper.sleep().await;\n"
-"            println!(\"slept for {}ms\", start.elapsed().as_millis());\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let sleepers: Vec<Box<dyn Sleeper>> = vec![\n"
-"        Box::new(FixedSleeper { sleep_ms: 50 }),\n"
-"        Box::new(FixedSleeper { sleep_ms: 100 }),\n"
-"    ];\n"
-"    run_all_sleepers_multiple_times(sleepers, 5).await;\n"
-"}\n"
-"```"
+#: src/async/pitfalls/async-traits.md:30
+msgid "\"running all sleepers..\""
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:34
+msgid "\"slept for {}ms\""
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:51
@@ -17292,72 +15180,16 @@ msgid ""
 "example, it shouldn't deadlock or lose data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:8
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::io::{self, ErrorKind};\n"
-"use std::time::Duration;\n"
-"use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};\n"
-"\n"
-"struct LinesReader {\n"
-"    stream: DuplexStream,\n"
-"}\n"
-"\n"
-"impl LinesReader {\n"
-"    fn new(stream: DuplexStream) -> Self {\n"
-"        Self { stream }\n"
-"    }\n"
-"\n"
-"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
-"        let mut bytes = Vec::new();\n"
-"        let mut buf = [0];\n"
-"        while self.stream.read(&mut buf[..]).await? != 0 {\n"
-"            bytes.push(buf[0]);\n"
-"            if buf[0] == b'\\n' {\n"
-"                break;\n"
-"            }\n"
-"        }\n"
-"        if bytes.is_empty() {\n"
-"            return Ok(None)\n"
-"        }\n"
-"        let s = String::from_utf8(bytes)\n"
-"            .map_err(|_| io::Error::new(ErrorKind::InvalidData, \"not "
-"UTF-8\"))?;\n"
-"        Ok(Some(s))\n"
-"    }\n"
-"}\n"
-"\n"
-"async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::"
-"Result<()> {\n"
-"    for b in source.bytes() {\n"
-"        dest.write_u8(b).await?;\n"
-"        tokio::time::sleep(Duration::from_millis(10)).await\n"
-"    }\n"
-"    Ok(())\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> std::io::Result<()> {\n"
-"    let (client, server) = tokio::io::duplex(5);\n"
-"    let handle = tokio::spawn(slow_copy(\"hi\\nthere\\n\".to_owned(), "
-"client));\n"
-"\n"
-"    let mut lines = LinesReader::new(server);\n"
-"    let mut interval = tokio::time::interval(Duration::from_millis(60));\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            _ = interval.tick() => println!(\"tick!\"),\n"
-"            line = lines.next() => if let Some(l) = line? {\n"
-"                print!(\"{}\", l)\n"
-"            } else {\n"
-"                break\n"
-"            },\n"
-"        }\n"
-"    }\n"
-"    handle.await.unwrap()?;\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/async/pitfalls/cancellation.md:35
+msgid "\"not UTF-8\""
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:51
+msgid "\"hi\\nthere\\n\""
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:57
+msgid "\"tick!\""
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:72
@@ -17388,28 +15220,10 @@ msgid ""
 "struct:"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:83
+#: src/async/pitfalls/cancellation.md:95
 msgid ""
-"```rust,compile_fail\n"
-"struct LinesReader {\n"
-"    stream: DuplexStream,\n"
-"    bytes: Vec<u8>,\n"
-"    buf: [u8; 1],\n"
-"}\n"
-"\n"
-"impl LinesReader {\n"
-"    fn new(stream: DuplexStream) -> Self {\n"
-"        Self { stream, bytes: Vec::new(), buf: [0] }\n"
-"    }\n"
-"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
-"        // prefix buf and bytes with self.\n"
+"// prefix buf and bytes with self.\n"
 "        // ...\n"
-"        let raw = std::mem::take(&mut self.bytes);\n"
-"        let s = String::from_utf8(raw)\n"
-"        // ...\n"
-"    }\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:104
@@ -17468,52 +15282,9 @@ msgid ""
 "main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:13
-msgid ""
-"```rust,compile_fail\n"
-"use std::sync::Arc;\n"
-"use tokio::time;\n"
-"use tokio::sync::mpsc::{self, Sender};\n"
-"use tokio::sync::Mutex;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // left_fork: ...\n"
-"    // right_fork: ...\n"
-"    // thoughts: ...\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    async fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
-"await\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    async fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    // Create forks\n"
-"\n"
-"    // Create philosophers\n"
-"\n"
-"    // Make them think and eat\n"
-"\n"
-"    // Output their thoughts\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/dining-philosophers-async.md:51
+#: src/exercises/concurrency/solutions-afternoon.md:77
+msgid "// Make them think and eat\n"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
@@ -17654,47 +15425,29 @@ msgstr ""
 msgid "_src/bin/server.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:63
-msgid ""
-"```rust,compile_fail\n"
-"use futures_util::sink::SinkExt;\n"
-"use futures_util::stream::StreamExt;\n"
-"use std::error::Error;\n"
-"use std::net::SocketAddr;\n"
-"use tokio::net::{TcpListener, TcpStream};\n"
-"use tokio::sync::broadcast::{channel, Sender};\n"
-"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
-"\n"
-"async fn handle_connection(\n"
-"    addr: SocketAddr,\n"
-"    mut ws_stream: WebsocketStream<TcpStream>,\n"
-"    bcast_tx: Sender<String>,\n"
-") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"\n"
-"    // TODO: For a hint, see the description of the task below.\n"
-"\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"    let (bcast_tx, _) = channel(16);\n"
-"\n"
-"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
-"    println!(\"listening on port 2000\");\n"
-"\n"
-"    loop {\n"
-"        let (socket, addr) = listener.accept().await?;\n"
-"        println!(\"New connection from {addr:?}\");\n"
-"        let bcast_tx = bcast_tx.clone();\n"
-"        tokio::spawn(async move {\n"
-"            // Wrap the raw TCP stream into a websocket.\n"
-"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
-"\n"
-"            handle_connection(addr, ws_stream, bcast_tx).await\n"
-"        });\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/chat-app.md:78
+#: src/exercises/concurrency/chat-app.md:125
+msgid "// TODO: For a hint, see the description of the task below.\n"
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:86
+#: src/exercises/concurrency/solutions-afternoon.md:149
+msgid "\"127.0.0.1:2000\""
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:87
+#: src/exercises/concurrency/solutions-afternoon.md:150
+msgid "\"listening on port 2000\""
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:91
+#: src/exercises/concurrency/solutions-afternoon.md:154
+msgid "\"New connection from {addr:?}\""
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:94
+#: src/exercises/concurrency/solutions-afternoon.md:157
+msgid "// Wrap the raw TCP stream into a websocket.\n"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:103
@@ -17702,30 +15455,9 @@ msgstr ""
 msgid "_src/bin/client.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:107
-msgid ""
-"```rust,compile_fail\n"
-"use futures_util::stream::StreamExt;\n"
-"use futures_util::SinkExt;\n"
-"use http::Uri;\n"
-"use tokio::io::{AsyncBufReadExt, BufReader};\n"
-"use tokio_websockets::{ClientBuilder, Message};\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), tokio_websockets::Error> {\n"
-"    let (mut ws_stream, _) =\n"
-"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
-"            .connect()\n"
-"            .await?;\n"
-"\n"
-"    let stdin = tokio::io::stdin();\n"
-"    let mut stdin = BufReader::new(stdin).lines();\n"
-"\n"
-"\n"
-"    // TODO: For a hint, see the description of the task below.\n"
-"\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/chat-app.md:117
+#: src/exercises/concurrency/solutions-afternoon.md:178
+msgid "\"ws://127.0.0.1:2000\""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:130
@@ -18310,58 +16042,13 @@ msgstr ""
 msgid "([back to exercise](for-loops.md))"
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:7
-msgid ""
-"```rust\n"
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    let mut result = [[0; 3]; 3];\n"
-"    for i in 0..3 {\n"
-"        for j in 0..3 {\n"
-"            result[j][i] = matrix[i][j];\n"
-"        }\n"
-"    }\n"
-"    return result;\n"
-"}\n"
-"\n"
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    for row in matrix {\n"
-"        println!(\"{row:?}\");\n"
-"    }\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_transpose() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], //\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];\n"
-"    let transposed = transpose(matrix);\n"
-"    assert_eq!(\n"
-"        transposed,\n"
-"        [\n"
-"            [101, 201, 301], //\n"
-"            [102, 202, 302],\n"
-"            [103, 203, 303],\n"
-"        ]\n"
-"    );\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];\n"
-"\n"
-"    println!(\"matrix:\");\n"
-"    pretty_print(&matrix);\n"
-"\n"
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-morning.md:20
+msgid "\"{row:?}\""
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:27
+#: src/exercises/day-1/solutions-morning.md:35
+msgid "//\n"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:57
@@ -18390,34 +16077,24 @@ msgid ""
 "abstract over anything that can be referenced as a slice."
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:65
-msgid ""
-"```rust\n"
-"use std::convert::AsRef;\n"
-"use std::fmt::Debug;\n"
-"\n"
-"fn pretty_print<T, Line, Matrix>(matrix: Matrix)\n"
-"where\n"
-"    T: Debug,\n"
-"    // A line references a slice of items\n"
-"    Line: AsRef<[T]>,\n"
-"    // A matrix references a slice of lines\n"
-"    Matrix: AsRef<[Line]>\n"
-"{\n"
-"    for row in matrix.as_ref() {\n"
-"        println!(\"{:?}\", row.as_ref());\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    // &[&[i32]]\n"
-"    pretty_print(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);\n"
-"    // [[&str; 2]; 2]\n"
-"    pretty_print([[\"a\", \"b\"], [\"c\", \"d\"]]);\n"
-"    // Vec<Vec<i32>>\n"
-"    pretty_print(vec![vec![1, 2], vec![3, 4]]);\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-morning.md:72
+msgid "// A line references a slice of items\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:74
+msgid "// A matrix references a slice of lines\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:83
+msgid "// &[&[i32]]\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:85
+msgid "// [[&str; 2]; 2]\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:87
+msgid "// Vec<Vec<i32>>\n"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:92
@@ -18434,81 +16111,12 @@ msgstr ""
 msgid "([back to exercise](luhn.md))"
 msgstr ""
 
-#: src/exercises/day-1/solutions-afternoon.md:7
-msgid ""
-"```rust\n"
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    let mut digits_seen = 0;\n"
-"    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
-"enumerate() {\n"
-"        match ch.to_digit(10) {\n"
-"            Some(d) => {\n"
-"                sum += if i % 2 == 1 {\n"
-"                    let dd = d * 2;\n"
-"                    dd / 10 + dd % 10\n"
-"                } else {\n"
-"                    d\n"
-"                };\n"
-"                digits_seen += 1;\n"
-"            }\n"
-"            None => return false,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    if digits_seen < 2 {\n"
-"        return false;\n"
-"    }\n"
-"\n"
-"    sum % 10 == 0\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let cc_number = \"1234 5678 1234 5670\";\n"
-"    println!(\n"
-"        \"Is {cc_number} a valid credit card number? {}\",\n"
-"        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_non_digit_cc_number() {\n"
-"    assert!(!luhn(\"foo\"));\n"
-"    assert!(!luhn(\"foo 0 0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_empty_cc_number() {\n"
-"    assert!(!luhn(\"\"));\n"
-"    assert!(!luhn(\" \"));\n"
-"    assert!(!luhn(\"  \"));\n"
-"    assert!(!luhn(\"    \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_single_digit_cc_number() {\n"
-"    assert!(!luhn(\"0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_two_digit_cc_number() {\n"
-"    assert!(luhn(\" 0 0 \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_valid_cc_number() {\n"
-"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
-"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
-"    assert!(luhn(\"7992 7398 713\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-afternoon.md:34
+msgid "\"1234 5678 1234 5670\""
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:36
+msgid "\"Is {cc_number} a valid credit card number? {}\""
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:80
@@ -18516,135 +16124,12 @@ msgstr ""
 msgid "Pattern matching"
 msgstr "パターンマッチング"
 
-#: src/exercises/day-1/solutions-afternoon.md:82
-msgid ""
-"```rust\n"
-"/// An operation to perform on two subexpressions.\n"
-"#[derive(Debug)]\n"
-"enum Operation {\n"
-"    Add,\n"
-"    Sub,\n"
-"    Mul,\n"
-"    Div,\n"
-"}\n"
-"\n"
-"/// An expression, in tree form.\n"
-"#[derive(Debug)]\n"
-"enum Expression {\n"
-"    /// An operation on two subexpressions.\n"
-"    Op {\n"
-"        op: Operation,\n"
-"        left: Box<Expression>,\n"
-"        right: Box<Expression>,\n"
-"    },\n"
-"\n"
-"    /// A literal value\n"
-"    Value(i64),\n"
-"}\n"
-"\n"
-"/// The result of evaluating an expression.\n"
-"#[derive(Debug, PartialEq, Eq)]\n"
-"enum Res {\n"
-"    /// Evaluation was successful, with the given result.\n"
-"    Ok(i64),\n"
-"    /// Evaluation failed, with the given error message.\n"
-"    Err(String),\n"
-"}\n"
-"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
-"use Res::{Err, Ok};\n"
-"\n"
-"fn eval(e: Expression) -> Res {\n"
-"    match e {\n"
-"        Expression::Op { op, left, right } => {\n"
-"            let left = match eval(*left) {\n"
-"                Ok(v) => v,\n"
-"                Err(msg) => return Err(msg),\n"
-"            };\n"
-"            let right = match eval(*right) {\n"
-"                Ok(v) => v,\n"
-"                Err(msg) => return Err(msg),\n"
-"            };\n"
-"            Ok(match op {\n"
-"                Operation::Add => left + right,\n"
-"                Operation::Sub => left - right,\n"
-"                Operation::Mul => left * right,\n"
-"                Operation::Div => {\n"
-"                    if right == 0 {\n"
-"                        return Err(String::from(\"division by zero\"));\n"
-"                    } else {\n"
-"                        left / right\n"
-"                    }\n"
-"                }\n"
-"            })\n"
-"        }\n"
-"        Expression::Value(v) => Ok(v),\n"
-"    }\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_value() {\n"
-"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_sum() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(Expression::Value(10)),\n"
-"            right: Box::new(Expression::Value(20)),\n"
-"        }),\n"
-"        Ok(30)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_recursion() {\n"
-"    let term1 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Value(10)),\n"
-"        right: Box::new(Expression::Value(9)),\n"
-"    };\n"
-"    let term2 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Op {\n"
-"            op: Operation::Sub,\n"
-"            left: Box::new(Expression::Value(3)),\n"
-"            right: Box::new(Expression::Value(4)),\n"
-"        }),\n"
-"        right: Box::new(Expression::Value(5)),\n"
-"    };\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(term1),\n"
-"            right: Box::new(term2),\n"
-"        }),\n"
-"        Ok(85)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_error() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Div,\n"
-"            left: Box::new(Expression::Value(99)),\n"
-"            right: Box::new(Expression::Value(0)),\n"
-"        }),\n"
-"        Err(String::from(\"division by zero\"))\n"
-"    );\n"
-"}\n"
-"fn main() {\n"
-"    let expr = Expression::Op {\n"
-"        op: Operation::Sub,\n"
-"        left: Box::new(Expression::Value(20)),\n"
-"        right: Box::new(Expression::Value(10)),\n"
-"    };\n"
-"    println!(\"expr: {:?}\", expr);\n"
-"    println!(\"result: {:?}\", eval(expr));\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-afternoon.md:205
+msgid "\"expr: {:?}\""
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:206
+msgid "\"result: {:?}\""
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
@@ -18659,281 +16144,28 @@ msgstr "ライブラリをデザイン"
 msgid "([back to exercise](book-library.md))"
 msgstr ""
 
-#: src/exercises/day-2/solutions-morning.md:7
+#: src/exercises/day-2/solutions-morning.md:54
+msgid "\"{}, published in {}\""
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:59
 msgid ""
-"```rust\n"
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}\n"
-"\n"
-"struct Book {\n"
-"    title: String,\n"
-"    year: u16,\n"
-"}\n"
-"\n"
-"impl Book {\n"
-"    // This is a constructor, used below.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"// Implement the methods below. Notice how the `self` parameter\n"
-"// changes type to indicate the method's required level of ownership\n"
-"// over the object:\n"
-"//\n"
-"// - `&self` for shared read-only access,\n"
-"// - `&mut self` for unique and mutable access,\n"
-"// - `self` for unique access by value.\n"
-"impl Library {\n"
-"\n"
-"    fn new() -> Library {\n"
-"        Library { books: Vec::new() }\n"
-"    }\n"
-"\n"
-"    fn len(&self) -> usize {\n"
-"        self.books.len()\n"
-"    }\n"
-"\n"
-"    fn is_empty(&self) -> bool {\n"
-"        self.books.is_empty()\n"
-"    }\n"
-"\n"
-"    fn add_book(&mut self, book: Book) {\n"
-"        self.books.push(book)\n"
-"    }\n"
-"\n"
-"    fn print_books(&self) {\n"
-"        for book in &self.books {\n"
-"            println!(\"{}, published in {}\", book.title, book.year);\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn oldest_book(&self) -> Option<&Book> {\n"
-"        // Using a closure and a built-in method:\n"
+"// Using a closure and a built-in method:\n"
 "        // self.books.iter().min_by_key(|book| book.year)\n"
-"\n"
-"        // Longer hand-written solution:\n"
-"        let mut oldest: Option<&Book> = None;\n"
-"        for book in self.books.iter() {\n"
-"            if oldest.is_none() || book.year < oldest.unwrap().year {\n"
-"                oldest = Some(book);\n"
-"            }\n"
-"        }\n"
-"\n"
-"        oldest\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut library = Library::new();\n"
-"\n"
-"    println!(\n"
-"        \"The library is empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"\n"
-"    println!(\n"
-"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.print_books();\n"
-"\n"
-"    match library.oldest_book() {\n"
-"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
-"        None => println!(\"The library is empty!\"),\n"
-"    }\n"
-"\n"
-"    println!(\"The library has {} books\", library.len());\n"
-"    library.print_books();\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_len() {\n"
-"    let mut library = Library::new();\n"
-"    assert_eq!(library.len(), 0);\n"
-"    assert!(library.is_empty());\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    assert_eq!(library.len(), 2);\n"
-"    assert!(!library.is_empty());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_is_empty() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.is_empty());\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert!(!library.is_empty());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_print_books() {\n"
-"    let mut library = Library::new();\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    // We could try and capture stdout, but let us just call the\n"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:62
+msgid "// Longer hand-written solution:\n"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:127
+msgid ""
+"// We could try and capture stdout, but let us just call the\n"
 "    // method to start with.\n"
-"    library.print_books();\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_oldest_book() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.oldest_book().is_none());\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Lord of the Rings\")\n"
-"    );\n"
-"\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Alice's Adventures in Wonderland\")\n"
-"    );\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:153
 msgid "([back to exercise](health-statistics.md))"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:155
-msgid ""
-"```rust\n"
-"pub struct User {\n"
-"    name: String,\n"
-"    age: u32,\n"
-"    height: f32,\n"
-"    visit_count: usize,\n"
-"    last_blood_pressure: Option<(u32, u32)>,\n"
-"}\n"
-"\n"
-"pub struct Measurements {\n"
-"    height: f32,\n"
-"    blood_pressure: (u32, u32),\n"
-"}\n"
-"\n"
-"pub struct HealthReport<'a> {\n"
-"    patient_name: &'a str,\n"
-"    visit_count: u32,\n"
-"    height_change: f32,\n"
-"    blood_pressure_change: Option<(i32, i32)>,\n"
-"}\n"
-"\n"
-"impl User {\n"
-"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
-"        Self {\n"
-"            name,\n"
-"            age,\n"
-"            height,\n"
-"            visit_count: 0,\n"
-"            last_blood_pressure: None,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    pub fn name(&self) -> &str {\n"
-"        &self.name\n"
-"    }\n"
-"\n"
-"    pub fn age(&self) -> u32 {\n"
-"        self.age\n"
-"    }\n"
-"\n"
-"    pub fn height(&self) -> f32 {\n"
-"        self.height\n"
-"    }\n"
-"\n"
-"    pub fn doctor_visits(&self) -> u32 {\n"
-"        self.visit_count as u32\n"
-"    }\n"
-"\n"
-"    pub fn set_age(&mut self, new_age: u32) {\n"
-"        self.age = new_age\n"
-"    }\n"
-"\n"
-"    pub fn set_height(&mut self, new_height: f32) {\n"
-"        self.height = new_height\n"
-"    }\n"
-"\n"
-"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
-"HealthReport {\n"
-"        self.visit_count += 1;\n"
-"        let bp = measurements.blood_pressure;\n"
-"        let report = HealthReport {\n"
-"            patient_name: &self.name,\n"
-"            visit_count: self.visit_count as u32,\n"
-"            height_change: measurements.height - self.height,\n"
-"            blood_pressure_change: match self.last_blood_pressure {\n"
-"                Some(lbp) => Some((\n"
-"                    bp.0 as i32 - lbp.0 as i32,\n"
-"                    bp.1 as i32 - lbp.1 as i32\n"
-"                )),\n"
-"                None => None,\n"
-"            }\n"
-"        };\n"
-"        self.height = measurements.height;\n"
-"        self.last_blood_pressure = Some(bp);\n"
-"        report\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_height() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.height(), 155.2);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_set_age() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.age(), 32);\n"
-"    bob.set_age(33);\n"
-"    assert_eq!(bob.age(), 33);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_visit() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.doctor_visits(), 0);\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (120, 80),\n"
-"    });\n"
-"    assert_eq!(report.patient_name, \"Bob\");\n"
-"    assert_eq!(report.visit_count, 1);\n"
-"    assert_eq!(report.blood_pressure_change, None);\n"
-"\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (115, 76),\n"
-"    });\n"
-"\n"
-"    assert_eq!(report.visit_count, 2);\n"
-"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
@@ -18944,24 +16176,18 @@ msgstr ""
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-afternoon.md:10
+#: src/exercises/day-2/solutions-afternoon.md:12
+msgid "'/'"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:16
+msgid "\"*\""
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:22
 msgid ""
-"```rust\n"
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"\n"
-"    let mut request_segments = request_path.split('/');\n"
-"\n"
-"    for prefix_segment in prefix.split('/') {\n"
-"        let Some(request_segment) = request_segments.next() else {\n"
-"            return false;\n"
-"        };\n"
-"        if request_segment != prefix_segment && prefix_segment != \"*\" {\n"
-"            return false;\n"
-"        }\n"
-"    }\n"
-"    true\n"
-"\n"
-"    // Alternatively, Iterator::zip() lets us iterate simultaneously over "
+"// Alternatively, Iterator::zip() lets us iterate simultaneously over "
 "prefix\n"
 "    // and request segments. The zip() iterator is finished as soon as one "
 "of\n"
@@ -18972,47 +16198,6 @@ msgid ""
 "    // to produce an iterator that returns Some(str) for each pattern "
 "segments,\n"
 "    // and then returns None indefinitely.\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
-"abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
-"books\"));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
-"publishers\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_with_wildcard() {\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/bar/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books/book1\"\n"
-"    ));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
-"publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
-"\n"
-"fn main() {}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
@@ -19023,230 +16208,54 @@ msgstr ""
 msgid "([back to exercise](simple-gui.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-morning.md:7
+#: src/exercises/day-3/solutions-morning.md:75
+msgid "// Add 4 paddings for borders\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:87
 msgid ""
-"```rust\n"
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;\n"
-"\n"
-"    /// Draw the widget into a buffer.\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
-"\n"
-"    /// Draw the widget on standard output.\n"
-"    fn draw(&self) {\n"
-"        let mut buffer = String::new();\n"
-"        self.draw_into(&mut buffer);\n"
-"        println!(\"{buffer}\");\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Label {\n"
-"    label: String,\n"
-"}\n"
-"\n"
-"impl Label {\n"
-"    fn new(label: &str) -> Label {\n"
-"        Label {\n"
-"            label: label.to_owned(),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Button {\n"
-"    label: Label,\n"
-"}\n"
-"\n"
-"impl Button {\n"
-"    fn new(label: &str) -> Button {\n"
-"        Button {\n"
-"            label: Label::new(label),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Window {\n"
-"    title: String,\n"
-"    widgets: Vec<Box<dyn Widget>>,\n"
-"}\n"
-"\n"
-"impl Window {\n"
-"    fn new(title: &str) -> Window {\n"
-"        Window {\n"
-"            title: title.to_owned(),\n"
-"            widgets: Vec::new(),\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
-"        self.widgets.push(widget);\n"
-"    }\n"
-"\n"
-"    fn inner_width(&self) -> usize {\n"
-"        std::cmp::max(\n"
-"            self.title.chars().count(),\n"
-"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-"        )\n"
-"    }\n"
-"}\n"
-"\n"
-"\n"
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        // Add 4 paddings for borders\n"
-"        self.inner_width() + 4\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        let mut inner = String::new();\n"
-"        for widget in &self.widgets {\n"
-"            widget.draw_into(&mut inner);\n"
-"        }\n"
-"\n"
-"        let inner_width = self.inner_width();\n"
-"\n"
-"        // TODO: after learning about error handling, you can change\n"
+"// TODO: after learning about error handling, you can change\n"
 "        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
 "        // the ?-operator here instead of .unwrap().\n"
-"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
-"        writeln!(buffer, \"| {:^inner_width$} |\", &self.title).unwrap();\n"
-"        writeln!(buffer, \"+={:=<inner_width$}=+\", \"\").unwrap();\n"
-"        for line in inner.lines() {\n"
-"            writeln!(buffer, \"| {:inner_width$} |\", line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        self.label.width() + 8 // add a bit of padding\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        let width = self.width();\n"
-"        let mut label = String::new();\n"
-"        self.label.draw_into(&mut label);\n"
-"\n"
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
-"        for line in label.lines() {\n"
-"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        self.label\n"
-"            .lines()\n"
-"            .map(|line| line.chars().count())\n"
-"            .max()\n"
-"            .unwrap_or(0)\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
-"\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\"\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:90
+#: src/exercises/day-3/solutions-morning.md:96
+msgid "\"+-{:-<inner_width$}-+\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:91
+msgid "\"| {:^inner_width$} |\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:92
+msgid "\"+={:=<inner_width$}=+\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:94
+msgid "\"| {:inner_width$} |\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:102
+msgid "// add a bit of padding\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:110
+#: src/exercises/day-3/solutions-morning.md:114
+msgid "\"+{:-<width$}+\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:112
+msgid "\"|{:^width$}|\""
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:144
 msgid "([back to exercise](points-polygons.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-morning.md:146
+#: src/exercises/day-3/solutions-morning.md:223
 msgid ""
-"```rust\n"
-"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-"pub struct Point {\n"
-"    x: i32,\n"
-"    y: i32,\n"
-"}\n"
-"\n"
-"impl Point {\n"
-"    pub fn new(x: i32, y: i32) -> Point {\n"
-"        Point { x, y }\n"
-"    }\n"
-"\n"
-"    pub fn magnitude(self) -> f64 {\n"
-"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-"    }\n"
-"\n"
-"    pub fn dist(self, other: Point) -> f64 {\n"
-"        (self - other).magnitude()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl std::ops::Add for Point {\n"
-"    type Output = Self;\n"
-"\n"
-"    fn add(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x + other.x,\n"
-"            y: self.y + other.y,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"impl std::ops::Sub for Point {\n"
-"    type Output = Self;\n"
-"\n"
-"    fn sub(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x - other.x,\n"
-"            y: self.y - other.y,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Polygon {\n"
-"    points: Vec<Point>,\n"
-"}\n"
-"\n"
-"impl Polygon {\n"
-"    pub fn new() -> Polygon {\n"
-"        Polygon { points: Vec::new() }\n"
-"    }\n"
-"\n"
-"    pub fn add_point(&mut self, point: Point) {\n"
-"        self.points.push(point);\n"
-"    }\n"
-"\n"
-"    pub fn left_most_point(&self) -> Option<Point> {\n"
-"        self.points.iter().min_by_key(|p| p.x).copied()\n"
-"    }\n"
-"\n"
-"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-"        self.points.iter()\n"
-"    }\n"
-"\n"
-"    pub fn length(&self) -> f64 {\n"
-"        if self.points.is_empty() {\n"
-"            return 0.0;\n"
-"        }\n"
-"\n"
-"        let mut result = 0.0;\n"
-"        let mut last_point = self.points[0];\n"
-"        for point in &self.points[1..] {\n"
-"            result += last_point.dist(*point);\n"
-"            last_point = *point;\n"
-"        }\n"
-"        result += last_point.dist(self.points[0]);\n"
-"        result\n"
-"        // Alternatively, Iterator::zip() lets us iterate over the points as "
-"pairs\n"
+"// Alternatively, Iterator::zip() lets us iterate over the points as pairs\n"
 "        // but we need to pair each point with the next one, and the last "
 "point\n"
 "        // with the first point. The zip() iterator is finished as soon as "
@@ -19256,127 +16265,6 @@ msgid ""
 "        // with Iterator::skip to create the second iterator for the zip and "
 "using map \n"
 "        // and sum to calculate the total length.\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Circle {\n"
-"    center: Point,\n"
-"    radius: i32,\n"
-"}\n"
-"\n"
-"impl Circle {\n"
-"    pub fn new(center: Point, radius: i32) -> Circle {\n"
-"        Circle { center, radius }\n"
-"    }\n"
-"\n"
-"    pub fn circumference(&self) -> f64 {\n"
-"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-"    }\n"
-"\n"
-"    pub fn dist(&self, other: &Self) -> f64 {\n"
-"        self.center.dist(other.center)\n"
-"    }\n"
-"}\n"
-"\n"
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}\n"
-"\n"
-"impl From<Polygon> for Shape {\n"
-"    fn from(poly: Polygon) -> Self {\n"
-"        Shape::Polygon(poly)\n"
-"    }\n"
-"}\n"
-"\n"
-"impl From<Circle> for Shape {\n"
-"    fn from(circle: Circle) -> Self {\n"
-"        Shape::Circle(circle)\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Shape {\n"
-"    pub fn perimeter(&self) -> f64 {\n"
-"        match self {\n"
-"            Shape::Polygon(poly) => poly.length(),\n"
-"            Shape::Circle(circle) => circle.circumference(),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"\n"
-"    fn round_two_digits(x: f64) -> f64 {\n"
-"        (x * 100.0).round() / 100.0\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_magnitude() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_dist() {\n"
-"        let p1 = Point::new(10, 10);\n"
-"        let p2 = Point::new(14, 13);\n"
-"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_add() {\n"
-"        let p1 = Point::new(16, 16);\n"
-"        let p2 = p1 + Point::new(-4, 3);\n"
-"        assert_eq!(p2, Point::new(12, 19));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_left_most_point() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"        assert_eq!(poly.left_most_point(), Some(p1));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_iter() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"\n"
-"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
-"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
@@ -19387,172 +16275,81 @@ msgstr ""
 msgid "([back to exercise](safe-ffi-wrapper.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-afternoon.md:7
+#: src/exercises/day-3/solutions-afternoon.md:77
+msgid "\"Invalid path: {err}\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:78
+msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:81
+msgid "\"Could not open {:?}\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:91
 msgid ""
-"```rust\n"
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int};\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
-"\n"
-"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-"    #[repr(C)]\n"
-"    pub struct DIR {\n"
-"        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
-"PhantomPinned)>,\n"
-"    }\n"
-"\n"
-"    // Layout according to the Linux man page for readdir(3), where ino_t "
-"and\n"
-"    // off_t are resolved according to the definitions in\n"
-"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_ino: c_ulong,\n"
-"        pub d_off: c_long,\n"
-"        pub d_reclen: c_ushort,\n"
-"        pub d_type: c_uchar,\n"
-"        pub d_name: [c_char; 256],\n"
-"    }\n"
-"\n"
-"    // Layout according to the macOS man page for dir(5).\n"
-"    #[cfg(all(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_fileno: u64,\n"
-"        pub d_seekoff: u64,\n"
-"        pub d_reclen: u16,\n"
-"        pub d_namlen: u16,\n"
-"        pub d_type: u8,\n"
-"        pub d_name: [c_char; 1024],\n"
-"    }\n"
-"\n"
-"    extern \"C\" {\n"
-"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
-"\n"
-"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        // See https://github.com/rust-lang/libc/issues/414 and the section "
-"on\n"
-"        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
-"        //\n"
-"        // \"Platforms that existed before these updates were available\" "
-"refers\n"
-"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
-"PowerPC.\n"
-"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
-"        #[link_name = \"readdir$INODE64\"]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        pub fn closedir(s: *mut DIR) -> c_int;\n"
-"    }\n"
-"}\n"
-"\n"
-"use std::ffi::{CStr, CString, OsStr, OsString};\n"
-"use std::os::unix::ffi::OsStrExt;\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}\n"
-"\n"
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
-"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
-"{err}\"))?;\n"
-"        // SAFETY: path.as_ptr() cannot be NULL.\n"
-"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
-"        if dir.is_null() {\n"
-"            Err(format!(\"Could not open {:?}\", path))\n"
-"        } else {\n"
-"            Ok(DirectoryIterator { path, dir })\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
+"// Keep calling readdir until we get a NULL pointer back.\n"
 "        // SAFETY: self.dir is never NULL.\n"
-"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
-"        if dirent.is_null() {\n"
-"            // We have reached the end of the directory.\n"
-"            return None;\n"
-"        }\n"
-"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:95
+msgid "// We have reached the end of the directory.\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:98
+msgid ""
+"// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
 "        // terminated.\n"
-"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
-"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
-"        Some(os_str.to_owned())\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        if !self.dir.is_null() {\n"
-"            // SAFETY: self.dir is not NULL.\n"
-"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
-"                panic!(\"Could not close {:?}\", self.path);\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"    use std::error::Error;\n"
-"\n"
-"    #[test]\n"
-"    fn test_nonexisting_directory() {\n"
-"        let iter = DirectoryIterator::new(\"no-such-directory\");\n"
-"        assert!(iter.is_err());\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_empty_directory() -> Result<(), Box<dyn Error>> {\n"
-"        let tmp = tempfile::TempDir::new()?;\n"
-"        let iter = DirectoryIterator::new(\n"
-"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
-"        )?;\n"
-"        let mut entries = iter.collect::<Vec<_>>();\n"
-"        entries.sort();\n"
-"        assert_eq!(entries, &[\".\", \"..\"]);\n"
-"        Ok(())\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
-"        let tmp = tempfile::TempDir::new()?;\n"
-"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo "
-"Diaries\\n\")?;\n"
-"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n\")?;\n"
-"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n\")?;\n"
-"        let iter = DirectoryIterator::new(\n"
-"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
-"        )?;\n"
-"        let mut entries = iter.collect::<Vec<_>>();\n"
-"        entries.sort();\n"
-"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", \"foo."
-"txt\"]);\n"
-"        Ok(())\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:110
+msgid "// SAFETY: self.dir is not NULL.\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:112
+msgid "\"Could not close {:?}\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:131
+msgid "\"no-such-directory\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:139
+#: src/exercises/day-3/solutions-afternoon.md:154
+msgid "\"Non UTF-8 character in path\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:143
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"..\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:150
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"foo.txt\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:150
+msgid "\"The Foo Diaries\\n\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:151
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"bar.png\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:151
+msgid "\"<PNG>\\n\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:152
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"crab.rs\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:152
+msgid "\"//! Crab\\n\""
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
@@ -19563,151 +16360,30 @@ msgstr ""
 msgid "([back to exercise](compass.md))"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:7
+#: src/exercises/bare-metal/solutions-morning.md:40
+msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:41
+msgid "\"Setting up IMU...\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:49
+msgid "// Set up display and timer.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:59
+msgid "// Read compass data and log it to the serial port.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:67
+msgid "\"{},{},{}\\t{},{},{}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:103
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use core::fmt::Write;\n"
-"use cortex_m_rt::entry;\n"
-"use core::cmp::{max, min};\n"
-"use lsm303agr::{AccelOutputDataRate, Lsm303agr, MagOutputDataRate};\n"
-"use microbit::display::blocking::Display;\n"
-"use microbit::hal::prelude::*;\n"
-"use microbit::hal::twim::Twim;\n"
-"use microbit::hal::uarte::{Baudrate, Parity, Uarte};\n"
-"use microbit::hal::Timer;\n"
-"use microbit::pac::twim0::frequency::FREQUENCY_A;\n"
-"use microbit::Board;\n"
-"\n"
-"const COMPASS_SCALE: i32 = 30000;\n"
-"const ACCELEROMETER_SCALE: i32 = 700;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let board = Board::take().unwrap();\n"
-"\n"
-"    // Configure serial port.\n"
-"    let mut serial = Uarte::new(\n"
-"        board.UARTE0,\n"
-"        board.uart.into(),\n"
-"        Parity::EXCLUDED,\n"
-"        Baudrate::BAUD115200,\n"
-"    );\n"
-"\n"
-"    // Set up the I2C controller and Inertial Measurement Unit.\n"
-"    writeln!(serial, \"Setting up IMU...\").unwrap();\n"
-"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::"
-"K100);\n"
-"    let mut imu = Lsm303agr::new_with_i2c(i2c);\n"
-"    imu.init().unwrap();\n"
-"    imu.set_mag_odr(MagOutputDataRate::Hz50).unwrap();\n"
-"    imu.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();\n"
-"    let mut imu = imu.into_mag_continuous().ok().unwrap();\n"
-"\n"
-"    // Set up display and timer.\n"
-"    let mut timer = Timer::new(board.TIMER0);\n"
-"    let mut display = Display::new(board.display_pins);\n"
-"\n"
-"    let mut mode = Mode::Compass;\n"
-"    let mut button_pressed = false;\n"
-"\n"
-"    writeln!(serial, \"Ready.\").unwrap();\n"
-"\n"
-"    loop {\n"
-"        // Read compass data and log it to the serial port.\n"
-"        while !(imu.mag_status().unwrap().xyz_new_data\n"
-"            && imu.accel_status().unwrap().xyz_new_data)\n"
-"        {}\n"
-"        let compass_reading = imu.mag_data().unwrap();\n"
-"        let accelerometer_reading = imu.accel_data().unwrap();\n"
-"        writeln!(\n"
-"            serial,\n"
-"            \"{},{},{}\\t{},{},{}\",\n"
-"            compass_reading.x,\n"
-"            compass_reading.y,\n"
-"            compass_reading.z,\n"
-"            accelerometer_reading.x,\n"
-"            accelerometer_reading.y,\n"
-"            accelerometer_reading.z,\n"
-"        )\n"
-"        .unwrap();\n"
-"\n"
-"        let mut image = [[0; 5]; 5];\n"
-"        let (x, y) = match mode {\n"
-"            Mode::Compass => (\n"
-"                scale(-compass_reading.x, -COMPASS_SCALE, COMPASS_SCALE, 0, "
-"4) as usize,\n"
-"                scale(compass_reading.y, -COMPASS_SCALE, COMPASS_SCALE, 0, "
-"4) as usize,\n"
-"            ),\n"
-"            Mode::Accelerometer => (\n"
-"                scale(\n"
-"                    accelerometer_reading.x,\n"
-"                    -ACCELEROMETER_SCALE,\n"
-"                    ACCELEROMETER_SCALE,\n"
-"                    0,\n"
-"                    4,\n"
-"                ) as usize,\n"
-"                scale(\n"
-"                    -accelerometer_reading.y,\n"
-"                    -ACCELEROMETER_SCALE,\n"
-"                    ACCELEROMETER_SCALE,\n"
-"                    0,\n"
-"                    4,\n"
-"                ) as usize,\n"
-"            ),\n"
-"        };\n"
-"        image[y][x] = 255;\n"
-"        display.show(&mut timer, image, 100);\n"
-"\n"
-"        // If button A is pressed, switch to the next mode and briefly blink "
-"all LEDs on.\n"
-"        if board.buttons.button_a.is_low().unwrap() {\n"
-"            if !button_pressed {\n"
-"                mode = mode.next();\n"
-"                display.show(&mut timer, [[255; 5]; 5], 200);\n"
-"            }\n"
-"            button_pressed = true;\n"
-"        } else {\n"
-"            button_pressed = false;\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"enum Mode {\n"
-"    Compass,\n"
-"    Accelerometer,\n"
-"}\n"
-"\n"
-"impl Mode {\n"
-"    fn next(self) -> Self {\n"
-"        match self {\n"
-"            Self::Compass => Self::Accelerometer,\n"
-"            Self::Accelerometer => Self::Compass,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -"
-"> i32 {\n"
-"    let range_in = max_in - min_in;\n"
-"    let range_out = max_out - min_out;\n"
-"    cap(\n"
-"        min_out + range_out * (value - min_in) / range_in,\n"
-"        min_out,\n"
-"        max_out,\n"
-"    )\n"
-"}\n"
-"\n"
-"fn cap(value: i32, min_value: i32, max_value: i32) -> i32 {\n"
-"    max(min_value, min(value, max_value))\n"
-"}\n"
-"```"
+"// If button A is pressed, switch to the next mode and briefly blink all "
+"LEDs on.\n"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -19718,174 +16394,92 @@ msgstr ""
 msgid "_main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:9
+#: src/exercises/bare-metal/solutions-afternoon.md:36
+msgid "/// Base address of the PL031 RTC.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:38
+msgid "/// The IRQ used by the PL031 RTC.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:57
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod logger;\n"
-"mod pl011;\n"
-"mod pl031;\n"
-"\n"
-"use crate::pl031::Rtc;\n"
-"use arm_gic::gicv3::{IntId, Trigger};\n"
-"use arm_gic::{irq_enable, wfi};\n"
-"use chrono::{TimeZone, Utc};\n"
-"use core::hint::spin_loop;\n"
-"use crate::pl011::Uart;\n"
-"use arm_gic::gicv3::GicV3;\n"
-"use core::panic::PanicInfo;\n"
-"use log::{error, info, trace, LevelFilter};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base addresses of the GICv3.\n"
-"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
-"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"/// Base address of the PL031 RTC.\n"
-"const PL031_BASE_ADDRESS: *mut u32 = 0x901_0000 as _;\n"
-"/// The IRQ used by the PL031 RTC.\n"
-"const PL031_IRQ: IntId = IntId::spi(2);\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
+"// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
 "    // and nothing else accesses that address range.\n"
-"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
-"\n"
-"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
-"\n"
-"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
-"base\n"
-"    // addresses of a GICv3 distributor and redistributor respectively, and\n"
-"    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
-"GICR_BASE_ADDRESS) };\n"
-"    gic.setup();\n"
-"\n"
-"    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 "
-"device,\n"
-"    // and nothing else accesses that address range.\n"
-"    let mut rtc = unsafe { Rtc::new(PL031_BASE_ADDRESS) };\n"
-"    let timestamp = rtc.read();\n"
-"    let time = Utc.timestamp_opt(timestamp.into(), 0).unwrap();\n"
-"    info!(\"RTC: {time}\");\n"
-"\n"
-"    GicV3::set_priority_mask(0xff);\n"
-"    gic.set_interrupt_priority(PL031_IRQ, 0x80);\n"
-"    gic.set_trigger(PL031_IRQ, Trigger::Level);\n"
-"    irq_enable();\n"
-"    gic.enable_interrupt(PL031_IRQ, true);\n"
-"\n"
-"    // Wait for 3 seconds, without interrupts.\n"
-"    let target = timestamp + 3;\n"
-"    rtc.set_match(target);\n"
-"    info!(\n"
-"        \"Waiting for {}\",\n"
-"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
-"    );\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    while !rtc.matched() {\n"
-"        spin_loop();\n"
-"    }\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    info!(\"Finished waiting\");\n"
-"\n"
-"    // Wait another 3 seconds for an interrupt.\n"
-"    let target = timestamp + 6;\n"
-"    info!(\n"
-"        \"Waiting for {}\",\n"
-"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
-"    );\n"
-"    rtc.set_match(target);\n"
-"    rtc.clear_interrupt();\n"
-"    rtc.enable_interrupt(true);\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    while !rtc.interrupt_pending() {\n"
-"        wfi();\n"
-"    }\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    info!(\"Finished waiting\");\n"
-"\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[panic_handler]\n"
-"fn panic(info: &PanicInfo) -> ! {\n"
-"    error!(\"{info}\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:62
+msgid "\"RTC: {time}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:70
+msgid "// Wait for 3 seconds, without interrupts.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:74
+#: src/exercises/bare-metal/solutions-afternoon.md:95
+msgid "\"Waiting for {}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:78
+#: src/exercises/bare-metal/solutions-afternoon.md:86
+#: src/exercises/bare-metal/solutions-afternoon.md:102
+#: src/exercises/bare-metal/solutions-afternoon.md:110
+msgid "\"matched={}, interrupt_pending={}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:90
+#: src/exercises/bare-metal/solutions-afternoon.md:114
+msgid "\"Finished waiting\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:92
+msgid "// Wait another 3 seconds for an interrupt.\n"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:127
 msgid "_pl031.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:129
+#: src/exercises/bare-metal/solutions-afternoon.md:134
+msgid "/// Data register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:136
+msgid "/// Match register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:138
+msgid "/// Load register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:140
+msgid "/// Control register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:143
+msgid "/// Interrupt Mask Set or Clear register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:146
+msgid "/// Raw Interrupt Status\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:149
+msgid "/// Masked Interrupt Status\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:152
+msgid "/// Interrupt Clear Register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:156
+msgid "/// Driver for a PL031 real-time clock.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:164
 msgid ""
-"```rust\n"
-"use core::ptr::{addr_of, addr_of_mut};\n"
-"\n"
-"#[repr(C, align(4))]\n"
-"struct Registers {\n"
-"    /// Data register\n"
-"    dr: u32,\n"
-"    /// Match register\n"
-"    mr: u32,\n"
-"    /// Load register\n"
-"    lr: u32,\n"
-"    /// Control register\n"
-"    cr: u8,\n"
-"    _reserved0: [u8; 3],\n"
-"    /// Interrupt Mask Set or Clear register\n"
-"    imsc: u8,\n"
-"    _reserved1: [u8; 3],\n"
-"    /// Raw Interrupt Status\n"
-"    ris: u8,\n"
-"    _reserved2: [u8; 3],\n"
-"    /// Masked Interrupt Status\n"
-"    mis: u8,\n"
-"    _reserved3: [u8; 3],\n"
-"    /// Interrupt Clear Register\n"
-"    icr: u8,\n"
-"    _reserved4: [u8; 3],\n"
-"}\n"
-"\n"
-"/// Driver for a PL031 real-time clock.\n"
-"#[derive(Debug)]\n"
-"pub struct Rtc {\n"
-"    registers: *mut Registers,\n"
-"}\n"
-"\n"
-"impl Rtc {\n"
-"    /// Constructs a new instance of the RTC driver for a PL031 device at "
-"the\n"
+"/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -19895,76 +16489,55 @@ msgid ""
 "    /// PL031 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
-"        Self {\n"
-"            registers: base_address as *mut Registers,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Reads the current RTC value.\n"
-"    pub fn read(&self) -> u32 {\n"
-"        // Safe because we know that self.registers points to the control\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:178
+msgid "/// Reads the current RTC value.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:180
+#: src/exercises/bare-metal/solutions-afternoon.md:188
+#: src/exercises/bare-metal/solutions-afternoon.md:196
+#: src/exercises/bare-metal/solutions-afternoon.md:207
+#: src/exercises/bare-metal/solutions-afternoon.md:219
+#: src/exercises/bare-metal/solutions-afternoon.md:226
+msgid ""
+"// Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of!((*self.registers).dr).read_volatile() }\n"
-"    }\n"
-"\n"
-"    /// Writes a match value. When the RTC value matches this then an "
-"interrupt\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:185
+msgid ""
+"/// Writes a match value. When the RTC value matches this then an interrupt\n"
 "    /// will be generated (if it is enabled).\n"
-"    pub fn set_match(&mut self, value: u32) {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).mr).write_volatile(value) }\n"
-"    }\n"
-"\n"
-"    /// Returns whether the match register matches the RTC value, whether or "
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:193
+msgid ""
+"/// Returns whether the match register matches the RTC value, whether or "
 "not\n"
 "    /// the interrupt is enabled.\n"
-"    pub fn matched(&self) -> bool {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).ris)."
-"read_volatile() };\n"
-"        (ris & 0x01) != 0\n"
-"    }\n"
-"\n"
-"    /// Returns whether there is currently an interrupt pending.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:202
+msgid ""
+"/// Returns whether there is currently an interrupt pending.\n"
 "    ///\n"
 "    /// This should be true if and only if `matched` returns true and the\n"
 "    /// interrupt is masked.\n"
-"    pub fn interrupt_pending(&self) -> bool {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).mis)."
-"read_volatile() };\n"
-"        (ris & 0x01) != 0\n"
-"    }\n"
-"\n"
-"    /// Sets or clears the interrupt mask.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:213
+msgid ""
+"/// Sets or clears the interrupt mask.\n"
 "    ///\n"
 "    /// When the mask is true the interrupt is enabled; when it is false "
 "the\n"
 "    /// interrupt is disabled.\n"
-"    pub fn enable_interrupt(&mut self, mask: bool) {\n"
-"        let imsc = if mask { 0x01 } else { 0x00 };\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).imsc)."
-"write_volatile(imsc) }\n"
-"    }\n"
-"\n"
-"    /// Clears a pending interrupt, if any.\n"
-"    pub fn clear_interrupt(&mut self) {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).icr).write_volatile(0x01) }\n"
-"    }\n"
-"}\n"
-"\n"
-"// Safe because it just contains a pointer to device memory, which can be\n"
-"// accessed from any context.\n"
-"unsafe impl Send for Rtc {}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:224
+msgid "/// Clears a pending interrupt, if any.\n"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
@@ -19975,82 +16548,19 @@ msgstr ""
 msgid "([back to exercise](dining-philosophers.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md:7
+#: src/exercises/concurrency/solutions-morning.md:29
+msgid "\"{} is trying to eat\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:53
 msgid ""
-"```rust\n"
-"use std::sync::{mpsc, Arc, Mutex};\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    left_fork: Arc<Mutex<Fork>>,\n"
-"    right_fork: Arc<Mutex<Fork>>,\n"
-"    thoughts: mpsc::SyncSender<String>,\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    fn eat(&self) {\n"
-"        println!(\"{} is trying to eat\", &self.name);\n"
-"        let left = self.left_fork.lock().unwrap();\n"
-"        let right = self.right_fork.lock().unwrap();\n"
-"\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::sync_channel(10);\n"
-"\n"
-"    let forks = (0..PHILOSOPHERS.len())\n"
-"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
-"        .collect::<Vec<_>>();\n"
-"\n"
-"    for i in 0..forks.len() {\n"
-"        let tx = tx.clone();\n"
-"        let mut left_fork = Arc::clone(&forks[i]);\n"
-"        let mut right_fork = Arc::clone(&forks[(i + 1) % forks.len()]);\n"
-"\n"
-"        // To avoid a deadlock, we have to break the symmetry\n"
+"// To avoid a deadlock, we have to break the symmetry\n"
 "        // somewhere. This will swap the forks without deinitializing\n"
 "        // either of them.\n"
-"        if i == forks.len() - 1 {\n"
-"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
-"        }\n"
-"\n"
-"        let philosopher = Philosopher {\n"
-"            name: PHILOSOPHERS[i].to_string(),\n"
-"            thoughts: tx,\n"
-"            left_fork,\n"
-"            right_fork,\n"
-"        };\n"
-"\n"
-"        thread::spawn(move || {\n"
-"            for _ in 0..100 {\n"
-"                philosopher.eat();\n"
-"                philosopher.think();\n"
-"            }\n"
-"        });\n"
-"    }\n"
-"\n"
-"    drop(tx);\n"
-"    for thought in rx {\n"
-"        println!(\"{thought}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:77
+msgid "\"{thought}\""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:82
@@ -20062,181 +16572,27 @@ msgstr "マルチスレッド・リンクチェッカー"
 msgid "([back to exercise](link-checker.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md:86
+#: src/exercises/concurrency/solutions-morning.md:155
 msgid ""
-"```rust,compile_fail\n"
-"use std::{sync::Arc, sync::Mutex, sync::mpsc, thread};\n"
-"\n"
-"use reqwest::{blocking::Client, Url};\n"
-"use scraper::{Html, Selector};\n"
-"use thiserror::Error;\n"
-"\n"
-"#[derive(Error, Debug)]\n"
-"enum Error {\n"
-"    #[error(\"request error: {0}\")]\n"
-"    ReqwestError(#[from] reqwest::Error),\n"
-"    #[error(\"bad http response: {0}\")]\n"
-"    BadResponse(String),\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct CrawlCommand {\n"
-"    url: Url,\n"
-"    extract_links: bool,\n"
-"}\n"
-"\n"
-"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
-"Error> {\n"
-"    println!(\"Checking {:#}\", command.url);\n"
-"    let response = client.get(command.url.clone()).send()?;\n"
-"    if !response.status().is_success() {\n"
-"        return Err(Error::BadResponse(response.status().to_string()));\n"
-"    }\n"
-"\n"
-"    let mut link_urls = Vec::new();\n"
-"    if !command.extract_links {\n"
-"        return Ok(link_urls);\n"
-"    }\n"
-"\n"
-"    let base_url = response.url().to_owned();\n"
-"    let body_text = response.text()?;\n"
-"    let document = Html::parse_document(&body_text);\n"
-"\n"
-"    let selector = Selector::parse(\"a\").unwrap();\n"
-"    let href_values = document\n"
-"        .select(&selector)\n"
-"        .filter_map(|element| element.value().attr(\"href\"));\n"
-"    for href in href_values {\n"
-"        match base_url.join(href) {\n"
-"            Ok(link_url) => {\n"
-"                link_urls.push(link_url);\n"
-"            }\n"
-"            Err(err) => {\n"
-"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
-"{err}\");\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"    Ok(link_urls)\n"
-"}\n"
-"\n"
-"struct CrawlState {\n"
-"    domain: String,\n"
-"    visited_pages: std::collections::HashSet<String>,\n"
-"}\n"
-"\n"
-"impl CrawlState {\n"
-"    fn new(start_url: &Url) -> CrawlState {\n"
-"        let mut visited_pages = std::collections::HashSet::new();\n"
-"        visited_pages.insert(start_url.as_str().to_string());\n"
-"        CrawlState {\n"
-"            domain: start_url.domain().unwrap().to_string(),\n"
-"            visited_pages,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Determine whether links within the given page should be extracted.\n"
-"    fn should_extract_links(&self, url: &Url) -> bool {\n"
-"        let Some(url_domain) = url.domain() else {\n"
-"            return false;\n"
-"        };\n"
-"        url_domain == self.domain\n"
-"    }\n"
-"\n"
-"    /// Mark the given page as visited, returning false if it had already\n"
+"/// Determine whether links within the given page should be extracted.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:163
+msgid ""
+"/// Mark the given page as visited, returning false if it had already\n"
 "    /// been visited.\n"
-"    fn mark_visited(&mut self, url: &Url) -> bool {\n"
-"        self.visited_pages.insert(url.as_str().to_string())\n"
-"    }\n"
-"}\n"
-"\n"
-"type CrawlResult = Result<Vec<Url>, (Url, Error)>;\n"
-"fn spawn_crawler_threads(\n"
-"    command_receiver: mpsc::Receiver<CrawlCommand>,\n"
-"    result_sender: mpsc::Sender<CrawlResult>,\n"
-"    thread_count: u32,\n"
-") {\n"
-"    let command_receiver = Arc::new(Mutex::new(command_receiver));\n"
-"\n"
-"    for _ in 0..thread_count {\n"
-"        let result_sender = result_sender.clone();\n"
-"        let command_receiver = command_receiver.clone();\n"
-"        thread::spawn(move || {\n"
-"            let client = Client::new();\n"
-"            loop {\n"
-"                let command_result = {\n"
-"                    let receiver_guard = command_receiver.lock().unwrap();\n"
-"                    receiver_guard.recv()\n"
-"                };\n"
-"                let Ok(crawl_command) = command_result else {\n"
-"                    // The sender got dropped. No more commands coming in.\n"
-"                    break;\n"
-"                };\n"
-"                let crawl_result = match visit_page(&client, &crawl_command) "
-"{\n"
-"                    Ok(link_urls) => Ok(link_urls),\n"
-"                    Err(error) => Err((crawl_command.url, error)),\n"
-"                };\n"
-"                result_sender.send(crawl_result).unwrap();\n"
-"            }\n"
-"        });\n"
-"    }\n"
-"}\n"
-"\n"
-"fn control_crawl(\n"
-"    start_url: Url,\n"
-"    command_sender: mpsc::Sender<CrawlCommand>,\n"
-"    result_receiver: mpsc::Receiver<CrawlResult>,\n"
-") -> Vec<Url> {\n"
-"    let mut crawl_state = CrawlState::new(&start_url);\n"
-"    let start_command = CrawlCommand { url: start_url, extract_links: "
-"true };\n"
-"    command_sender.send(start_command).unwrap();\n"
-"    let mut pending_urls = 1;\n"
-"\n"
-"    let mut bad_urls = Vec::new();\n"
-"    while pending_urls > 0 {\n"
-"        let crawl_result = result_receiver.recv().unwrap();\n"
-"        pending_urls -= 1;\n"
-"\n"
-"        match crawl_result {\n"
-"            Ok(link_urls) => {\n"
-"                for url in link_urls {\n"
-"                    if crawl_state.mark_visited(&url) {\n"
-"                        let extract_links = crawl_state."
-"should_extract_links(&url);\n"
-"                        let crawl_command = CrawlCommand { url, "
-"extract_links };\n"
-"                        command_sender.send(crawl_command).unwrap();\n"
-"                        pending_urls += 1;\n"
-"                    }\n"
-"                }\n"
-"            }\n"
-"            Err((url, error)) => {\n"
-"                bad_urls.push(url);\n"
-"                println!(\"Got crawling error: {:#}\", error);\n"
-"                continue;\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"    bad_urls\n"
-"}\n"
-"\n"
-"fn check_links(start_url: Url) -> Vec<Url> {\n"
-"    let (result_sender, result_receiver) = mpsc::channel::<CrawlResult>();\n"
-"    let (command_sender, command_receiver) = mpsc::channel::"
-"<CrawlCommand>();\n"
-"    spawn_crawler_threads(command_receiver, result_sender, 16);\n"
-"    control_crawl(start_url, command_sender, result_receiver)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let start_url = reqwest::Url::parse(\"https://www.google.org\")."
-"unwrap();\n"
-"    let bad_urls = check_links(start_url);\n"
-"    println!(\"Bad URLs: {:#?}\", bad_urls);\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:189
+msgid "// The sender got dropped. No more commands coming in.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:230
+msgid "\"Got crawling error: {:#}\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:248
+msgid "\"Bad URLs: {:#?}\""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
@@ -20247,381 +16603,54 @@ msgstr ""
 msgid "([back to exercise](dining-philosophers-async.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:7
+#: src/exercises/concurrency/solutions-afternoon.md:32
 msgid ""
-"```rust,compile_fail\n"
-"use std::sync::Arc;\n"
-"use tokio::time;\n"
-"use tokio::sync::mpsc::{self, Sender};\n"
-"use tokio::sync::Mutex;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    left_fork: Arc<Mutex<Fork>>,\n"
-"    right_fork: Arc<Mutex<Fork>>,\n"
-"    thoughts: Sender<String>,\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    async fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
-"await\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    async fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        let _first_lock = self.left_fork.lock().await;\n"
-"        // Add a delay before picking the second fork to allow the "
-"execution\n"
+"// Add a delay before picking the second fork to allow the execution\n"
 "        // to transfer to another task\n"
-"        time::sleep(time::Duration::from_millis(1)).await;\n"
-"        let _second_lock = self.right_fork.lock().await;\n"
-"\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"\n"
-"        // The locks are dropped here\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    // Create forks\n"
-"    let mut forks = vec![];\n"
-"    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::"
-"new(Fork))));\n"
-"\n"
-"    // Create philosophers\n"
-"    let (philosophers, mut rx) = {\n"
-"        let mut philosophers = vec![];\n"
-"        let (tx, rx) = mpsc::channel(10);\n"
-"        for (i, name) in PHILOSOPHERS.iter().enumerate() {\n"
-"            let left_fork = Arc::clone(&forks[i]);\n"
-"            let right_fork = Arc::clone(&forks[(i + 1) % PHILOSOPHERS."
-"len()]);\n"
-"            // To avoid a deadlock, we have to break the symmetry\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:40
+msgid "// The locks are dropped here\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:60
+msgid ""
+"// To avoid a deadlock, we have to break the symmetry\n"
 "            // somewhere. This will swap the forks without deinitializing\n"
 "            // either of them.\n"
-"            if i  == 0 {\n"
-"                std::mem::swap(&mut left_fork, &mut right_fork);\n"
-"            }\n"
-"            philosophers.push(Philosopher {\n"
-"                name: name.to_string(),\n"
-"                left_fork,\n"
-"                right_fork,\n"
-"                thoughts: tx.clone(),\n"
-"            });\n"
-"        }\n"
-"        (philosophers, rx)\n"
-"        // tx is dropped here, so we don't need to explicitly drop it later\n"
-"    };\n"
-"\n"
-"    // Make them think and eat\n"
-"    for phil in philosophers {\n"
-"        tokio::spawn(async move {\n"
-"            for _ in 0..100 {\n"
-"                phil.think().await;\n"
-"                phil.eat().await;\n"
-"            }\n"
-"        });\n"
-"\n"
-"    }\n"
-"\n"
-"    // Output their thoughts\n"
-"    while let Some(thought) = rx.recv().await {\n"
-"        println!(\"Here is a thought: {thought}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:74
+msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:90
+msgid "\"Here is a thought: {thought}\""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:97
 msgid "([back to exercise](chat-app.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:101
+#: src/exercises/concurrency/solutions-afternoon.md:117
+msgid "\"Welcome to chat! Type a message\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:121
 msgid ""
-"```rust,compile_fail\n"
-"use futures_util::sink::SinkExt;\n"
-"use futures_util::stream::StreamExt;\n"
-"use std::error::Error;\n"
-"use std::net::SocketAddr;\n"
-"use tokio::net::{TcpListener, TcpStream};\n"
-"use tokio::sync::broadcast::{channel, Sender};\n"
-"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
-"\n"
-"async fn handle_connection(\n"
-"    addr: SocketAddr,\n"
-"    mut ws_stream: WebsocketStream<TcpStream>,\n"
-"    bcast_tx: Sender<String>,\n"
-") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"\n"
-"    ws_stream\n"
-"        .send(Message::text(\"Welcome to chat! Type a message\".into()))\n"
-"        .await?;\n"
-"    let mut bcast_rx = bcast_tx.subscribe();\n"
-"\n"
-"    // A continuous loop for concurrently performing two tasks: (1) "
-"receiving\n"
+"// A continuous loop for concurrently performing two tasks: (1) receiving\n"
 "    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
 "    // messages on `bcast_rx` and sending them to the client.\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            incoming = ws_stream.next() => {\n"
-"                match incoming {\n"
-"                    Some(Ok(msg)) => {\n"
-"                        if let Some(text) = msg.as_text() {\n"
-"                            println!(\"From client {addr:?} {text:?}\");\n"
-"                            bcast_tx.send(text.into())?;\n"
-"                        }\n"
-"                    }\n"
-"                    Some(Err(err)) => return Err(err.into()),\n"
-"                    None => return Ok(()),\n"
-"                }\n"
-"            }\n"
-"            msg = bcast_rx.recv() => {\n"
-"                ws_stream.send(Message::text(msg?)).await?;\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"    let (bcast_tx, _) = channel(16);\n"
-"\n"
-"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
-"    println!(\"listening on port 2000\");\n"
-"\n"
-"    loop {\n"
-"        let (socket, addr) = listener.accept().await?;\n"
-"        println!(\"New connection from {addr:?}\");\n"
-"        let bcast_tx = bcast_tx.clone();\n"
-"        tokio::spawn(async move {\n"
-"            // Wrap the raw TCP stream into a websocket.\n"
-"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
-"\n"
-"            handle_connection(addr, ws_stream, bcast_tx).await\n"
-"        });\n"
-"    }\n"
-"}\n"
-"```"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:168
-msgid ""
-"```rust,compile_fail\n"
-"use futures_util::stream::StreamExt;\n"
-"use futures_util::SinkExt;\n"
-"use http::Uri;\n"
-"use tokio::io::{AsyncBufReadExt, BufReader};\n"
-"use tokio_websockets::{ClientBuilder, Message};\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), tokio_websockets::Error> {\n"
-"    let (mut ws_stream, _) =\n"
-"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
-"            .connect()\n"
-"            .await?;\n"
-"\n"
-"    let stdin = tokio::io::stdin();\n"
-"    let mut stdin = BufReader::new(stdin).lines();\n"
-"\n"
-"    // Continuous loop for concurrently sending and receiving messages.\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            incoming = ws_stream.next() => {\n"
-"                match incoming {\n"
-"                    Some(Ok(msg)) => {\n"
-"                        if let Some(text) = msg.as_text() {\n"
-"                            println!(\"From server: {}\", text);\n"
-"                        }\n"
-"                    },\n"
-"                    Some(Err(err)) => return Err(err.into()),\n"
-"                    None => return Ok(()),\n"
-"                }\n"
-"            }\n"
-"            res = stdin.next_line() => {\n"
-"                match res {\n"
-"                    Ok(None) => return Ok(()),\n"
-"                    Ok(Some(line)) => ws_stream.send(Message::text(line."
-"to_string())).await?,\n"
-"                    Err(err) => return Err(err.into()),\n"
-"                }\n"
-"            }\n"
-"\n"
-"        }\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/solutions-afternoon.md:130
+msgid "\"From client {addr:?} {text:?}\""
 msgstr ""
 
-#~ msgid ""
-#~ "```shell\n"
-#~ "$ cargo new exercise\n"
-#~ "     Created binary (application) `exercise` package\n"
-#~ "```"
-#~ msgstr ""
-#~ "```shell\n"
-#~ "$ cargo new exercise\n"
-#~ "     Created binary (application) `exercise` package\n"
-#~ "```"
+#: src/exercises/concurrency/solutions-afternoon.md:185
+msgid "// Continuous loop for concurrently sending and receiving messages.\n"
+msgstr ""
 
-#~ msgid ""
-#~ "```shell\n"
-#~ "$ cd exercise\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Hello, world!\n"
-#~ "```"
-#~ msgstr ""
-#~ "```shell\n"
-#~ "$ cd exercise\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Hello, world!\n"
-#~ "```"
-
-#~ msgid ""
-#~ "```shell\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Edit me!\n"
-#~ "```"
-#~ msgstr ""
-#~ "```shell\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Edit me!\n"
-#~ "```"
-
-#, fuzzy
-#~ msgid ""
-#~ "```rust,editable\n"
-#~ "fn main() {\n"
-#~ "    let mut x = 10;\n"
-#~ "    while x != 1 {\n"
-#~ "        x = if x % 2 == 0 {\n"
-#~ "            x / 2\n"
-#~ "        } else {\n"
-#~ "            3 * x + 1\n"
-#~ "        };\n"
-#~ "    }\n"
-#~ "    println!(\"x: {x}\");\n"
-#~ "}\n"
-#~ "```"
-#~ msgstr ""
-#~ "```rust,editable\n"
-#~ "fn main() {              // プログラムのエントリーポイント\n"
-#~ "    let mut x: i32 = 6;  // 可変変数のバインディング\n"
-#~ "    print!(\"{x}\");       // printfのような、出力用マクロ\n"
-#~ "    while x != 1 {       // 式を囲む括弧は不要\n"
-#~ "        if x % 2 == 0 {  // 他の言語と同様の演算\n"
-#~ "            x = x / 2;\n"
-#~ "        } else {\n"
-#~ "            x = 3 * x + 1;\n"
-#~ "        }\n"
-#~ "        print!(\" -> {x}\");\n"
-#~ "    }\n"
-#~ "    println!();\n"
-#~ "}\n"
-#~ "```"
-
-#, fuzzy
-#~ msgid "Pattern Matching (TBD)"
-#~ msgstr "パターンマッチング"
-
-#~ msgid "Comparison"
-#~ msgstr "比較"
-
-#~ msgid "The course is fast paced and covers a lot of ground:"
-#~ msgstr "本講座はペースが早く、多くの内容をカバーします："
-
-#, fuzzy
-#~ msgid ""
-#~ "We suggest using [VS Code](https://code.visualstudio.com/) to edit the "
-#~ "code (but any LSP compatible editor works with rust-analyzer[3](https://"
-#~ "rust-analyzer.github.io/))."
-#~ msgstr ""
-#~ "これで\\[rust-analyzer\\]\\[1\\]を使って定義に飛べるようになります。コード"
-#~ "の編集には、[VS Code](https://code.visualstudio.com/)を推奨しています（た"
-#~ "だし、LSP互換エディタならどれでも大丈夫です）。"
-
-#~ msgid ""
-#~ "Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
-#~ "clion/) family of IDEs, which do their own analysis but have their own "
-#~ "tradeoffs. If you prefer them, you can install the [Rust Plugin](https://"
-#~ "www.jetbrains.com/rust/). Please take note that as of January 2023 "
-#~ "debugging only works on the CLion version of the JetBrains IDEA suite."
-#~ msgstr ""
-#~ "[JetBrains](https://www.jetbrains.com/clion/)ファミリのIDEを使いたい人もい"
-#~ "るでしょう。これらは独自の分析を提供してくれますが、トレードオフもありま"
-#~ "す。もし使用したい場合、[Rust Plugin](https://www.jetbrains.com/rust/)のイ"
-#~ "ンストールが可能です。ただし、2023年1月時点では、デバッグがJetBrains IDEA "
-#~ "suiteのCLionバージョンでしか動作しない点に注意してください。"
-
-#, fuzzy
-#~ msgid "Extra Work in Modern C++"
-#~ msgstr "現代C++の二重解放"
-
-#~ msgid ""
-#~ "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
-#~ "comprehensive-rust?style=flat-square)](https://github.com/google/"
-#~ "comprehensive-rust/graphs/contributors) [![GitHub stars](https://img."
-#~ "shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
-#~ "(https://github.com/google/comprehensive-rust/stargazers)"
-#~ msgstr ""
-#~ "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
-#~ "comprehensive-rust?style=flat-square)](https://github.com/google/"
-#~ "comprehensive-rust/graphs/contributors) [![GitHub stars](https://img."
-#~ "shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
-#~ "(https://github.com/google/comprehensive-rust/stargazers)"
-
-#~ msgid ""
-#~ "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-#~ "rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-#~ "stargazers)"
-#~ msgstr ""
-#~ "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-#~ "rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-#~ "stargazers)"
-
-#~ msgid "Day 1: Basic Rust, ownership and the borrow checker."
-#~ msgstr "Day 1： Rustの基本、所有権と借用チェッカー"
-
-#~ msgid "Rustup (Recommended)"
-#~ msgstr "Rustup (推奨)"
-
-#~ msgid ""
-#~ "You can follow the instructions to install cargo and rust compiler, among "
-#~ "other standard ecosystem tools with the [rustup](https://rust-analyzer."
-#~ "github.io/) tool, which is maintained by the Rust Foundation."
-#~ msgstr ""
-#~ "[rustup](https://rust-analyzer.github.io/)ツールを使用して、cargoやrustコ"
-#~ "ンパイラなどの標準エコシステムツールをインストールします。RustupはRust "
-#~ "Foundationによってメンテナンスされています。"
-
-#~ msgid "Package Managers"
-#~ msgstr "パッケージマネージャ"
-
-#~ msgid ""
-#~ "Runtimes have the concept of a \"task\", similar to a thread but much "
-#~ "less resource-intensive."
-#~ msgstr ""
-#~ "ランタイムには「タスク」という概念があり、スレッドに似ているものの、スレッ"
-#~ "ドよりリソースの消費ははるかに小さいです。"
+#: src/exercises/concurrency/solutions-afternoon.md:192
+msgid "\"From server: {}\""
+msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -5,12 +5,11 @@ msgstr ""
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
-"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.2\n"
 
 #: src/SUMMARY.md:4 src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
@@ -1893,21 +1892,16 @@ msgstr ""
 msgid "The code blocks in this course are fully interactive:"
 msgstr "講座のコードブロックはインタラクティブです："
 
-#: src/cargo/code-samples.md:13
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    println!(\"Edit me!\");\n"
-"}\n"
-"```"
-msgstr ""
+#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:45
+msgid "\"Edit me!\""
+msgstr "\"Edit me!\""
 
 #: src/cargo/code-samples.md:19
 msgid "You can use "
 msgstr "ボックス内にフォーカスがある状態で"
 
 #: src/cargo/code-samples.md:19
-msgid " to execute the code when focus is in the text box."
+msgid "to execute the code when focus is in the text box."
 msgstr "を押すと、コードが実行されます。"
 
 #: src/cargo/code-samples.md:24
@@ -1991,20 +1985,6 @@ msgid ""
 msgstr ""
 "`src/main.rs`のボイラープレートコードを、コピーしたコードで置き換えてくださ"
 "い。例えば、前のページの例を使った場合、`src/main.rs`は以下のようになります。"
-
-#: src/cargo/running-locally.md:43
-msgid ""
-"```rust\n"
-"fn main() {\n"
-"    println!(\"Edit me!\");\n"
-"}\n"
-"```"
-msgstr ""
-"```rust\n"
-"fn main() {\n"
-"    println!(\"Edit me!\");\n"
-"}\n"
-"```"
 
 #: src/cargo/running-locally.md:49
 msgid "Use `cargo run` to build and run your updated binary:"
@@ -2242,13 +2222,8 @@ msgid ""
 msgstr ""
 "さっそく一番シンプルなプログラムである定番のHello Worldからみてみましょう："
 
-#: src/hello-world.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    println!(\"Hello 🌍!\");\n"
-"}\n"
-"```"
+#: src/hello-world.md:8
+msgid "\"Hello 🌍!\""
 msgstr ""
 
 #: src/hello-world.md:12
@@ -2334,39 +2309,33 @@ msgstr ""
 msgid "Here is a small example program in Rust:"
 msgstr "ここでは、Rustによる小さなサンプルプログラムを紹介します："
 
-#: src/hello-world/small-example.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {              // Program entry point\n"
-"    let mut x: i32 = 6;  // Mutable variable binding\n"
-"    print!(\"{x}\");       // Macro for printing, like printf\n"
-"    while x != 1 {       // No parenthesis around expression\n"
-"        if x % 2 == 0 {  // Math like in other languages\n"
-"            x = x / 2;\n"
-"        } else {\n"
-"            x = 3 * x + 1;\n"
-"        }\n"
-"        print!(\" -> {x}\");\n"
-"    }\n"
-"    println!();\n"
-"}\n"
-"```"
-msgstr ""
-"```rust,editable\n"
-"fn main() {              // プログラムのエントリーポイント\n"
-"    let mut x: i32 = 6;  // 可変変数のバインディング\n"
-"    print!(\"{x}\");       // printfのような、出力用マクロ\n"
-"    while x != 1 {       // 式を囲む括弧は不要\n"
-"        if x % 2 == 0 {  // 他の言語と同様の演算\n"
-"            x = x / 2;\n"
-"        } else {\n"
-"            x = 3 * x + 1;\n"
-"        }\n"
-"        print!(\" -> {x}\");\n"
-"    }\n"
-"    println!();\n"
-"}\n"
-"```"
+#: src/hello-world/small-example.md:6
+msgid "// Program entry point\n"
+msgstr "// プログラムのエントリーポイント\n"
+
+#: src/hello-world/small-example.md:7
+msgid "// Mutable variable binding\n"
+msgstr "// 可変変数のバインディング\n"
+
+#: src/hello-world/small-example.md:8 src/traits/impl-trait.md:15
+msgid "\"{x}\""
+msgstr "\"{x}\""
+
+#: src/hello-world/small-example.md:8
+msgid "// Macro for printing, like printf\n"
+msgstr "// printfのような、出力用マクロ\n"
+
+#: src/hello-world/small-example.md:9
+msgid "// No parenthesis around expression\n"
+msgstr "// 式を囲む括弧は不要\n"
+
+#: src/hello-world/small-example.md:10
+msgid "// Math like in other languages\n"
+msgstr "// 他の言語と同様の演算\n"
+
+#: src/hello-world/small-example.md:15
+msgid "\" -> {x}\""
+msgstr "\" -> {x}\""
 
 #: src/hello-world/small-example.md:23
 msgid ""
@@ -2477,49 +2446,41 @@ msgstr ""
 msgid "Let's consider the following \"minimum wrong example\" program in C:"
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:6
-msgid ""
-"```c,editable\n"
-"#include <stdio.h>\n"
-"#include <stdlib.h>\n"
-"#include <sys/stat.h>\n"
-"\n"
-"int main(int argc, char* argv[]) {\n"
-"\tchar *buf, *filename;\n"
-"\tFILE *fp;\n"
-"\tsize_t bytes, len;\n"
-"\tstruct stat st;\n"
-"\n"
-"\tswitch (argc) {\n"
-"\t\tcase 1:\n"
-"\t\t\tprintf(\"Too few arguments!\\n\");\n"
-"\t\t\treturn 1;\n"
-"\n"
-"\t\tcase 2:\n"
-"\t\t\tfilename = argv[argc];\n"
-"\t\t\tstat(filename, &st);\n"
-"\t\t\tlen = st.st_size;\n"
-"\t\t\t\n"
-"\t\t\tbuf = (char*)malloc(len);\n"
-"\t\t\tif (!buf)\n"
-"\t\t\t\tprintf(\"malloc failed!\\n\", len);\n"
-"\t\t\t\treturn 1;\n"
-"\n"
-"\t\t\tfp = fopen(filename, \"rb\");\n"
-"\t\t\tbytes = fread(buf, 1, len, fp);\n"
-"\t\t\tif (bytes = st.st_size)\n"
-"\t\t\t\tprintf(\"%s\", buf);\n"
-"\t\t\telse\n"
-"\t\t\t\tprintf(\"fread failed!\\n\");\n"
-"\n"
-"\t\tcase 3:\n"
-"\t\t\tprintf(\"Too many arguments!\\n\");\n"
-"\t\t\treturn 1;\n"
-"\t}\n"
-"\n"
-"\treturn 0;\n"
-"}\n"
-"```"
+#: src/why-rust/an-example-in-c.md:7
+#: src/android/interoperability/with-c/bindgen.md:22
+msgid "<stdio.h>"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:8
+msgid "<stdlib.h>"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:9
+msgid "<sys/stat.h>"
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:19
+msgid "\"Too few arguments!\\n\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:29
+msgid "\"malloc failed!\\n\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:32
+msgid "\"rb\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:35
+msgid "\"%s\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:37
+msgid "\"fread failed!\\n\""
+msgstr ""
+
+#: src/why-rust/an-example-in-c.md:40
+msgid "\"Too many arguments!\\n\""
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:48
@@ -2751,8 +2712,8 @@ msgid ""
 "For the purpose of this course, \"No memory leaks\" should be understood as "
 "\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"本講座での「メモリリークが起きない」は「_意図しない_メモリリークはほとんど起"
-"きない」と解釈すべきです。"
+"本講座での「メモリリークが起きない」は「\\_意図しない_メモリリークはほとんど"
+"起きない」と解釈すべきです。"
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
@@ -3297,22 +3258,27 @@ msgstr ""
 msgid "We can now understand the two string types in Rust:"
 msgstr ""
 
-#: src/basic-syntax/string-slices.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s1: &str = \"World\";\n"
-"    println!(\"s1: {s1}\");\n"
-"\n"
-"    let mut s2: String = String::from(\"Hello \");\n"
-"    println!(\"s2: {s2}\");\n"
-"    s2.push_str(s1);\n"
-"    println!(\"s2: {s2}\");\n"
-"    \n"
-"    let s3: &str = &s2[6..];\n"
-"    println!(\"s3: {s3}\");\n"
-"}\n"
-"```"
+#: src/basic-syntax/string-slices.md:7 src/traits/read-write.md:36
+#: src/testing/test-modules.md:12
+msgid "\"World\""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:8
+msgid "\"s1: {s1}\""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:10 src/memory-management/scope-based.md:16
+#: src/memory-management/garbage-collection.md:15
+msgid "\"Hello \""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:11 src/basic-syntax/string-slices.md:13
+#: src/ownership/move-semantics.md:9
+msgid "\"s2: {s2}\""
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:16
+msgid "\"s3: {s3}\""
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:20
@@ -3408,9 +3374,8 @@ msgid ""
 "All language items in Rust can be documented using special `///` syntax."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:5
+#: src/basic-syntax/rustdoc.md:6
 msgid ""
-"```rust,editable\n"
 "/// Determine whether the first argument is divisible by the second "
 "argument.\n"
 "///\n"
@@ -3420,14 +3385,14 @@ msgid ""
 "/// ```\n"
 "/// assert!(is_divisible_by(42, 2));\n"
 "/// ```\n"
-"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
-"    if rhs == 0 {\n"
-"        return false;  // Corner case, early return\n"
-"    }\n"
-"    lhs % rhs == 0     // The last expression in a block is the return "
-"value\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/basic-syntax/rustdoc.md:16
+msgid "// Corner case, early return\n"
+msgstr ""
+
+#: src/basic-syntax/rustdoc.md:18
+msgid "// The last expression in a block is the return value\n"
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:22
@@ -3470,31 +3435,12 @@ msgid ""
 "method is an instance of the type it is associated with:"
 msgstr ""
 
-#: src/basic-syntax/methods.md:6
-msgid ""
-"```rust,editable\n"
-"struct Rectangle {\n"
-"    width: u32,\n"
-"    height: u32,\n"
-"}\n"
-"\n"
-"impl Rectangle {\n"
-"    fn area(&self) -> u32 {\n"
-"        self.width * self.height\n"
-"    }\n"
-"\n"
-"    fn inc_width(&mut self, delta: u32) {\n"
-"        self.width += delta;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut rect = Rectangle { width: 10, height: 5 };\n"
-"    println!(\"old area: {}\", rect.area());\n"
-"    rect.inc_width(5);\n"
-"    println!(\"new area: {}\", rect.area());\n"
-"}\n"
-"```"
+#: src/basic-syntax/methods.md:24
+msgid "\"old area: {}\""
+msgstr ""
+
+#: src/basic-syntax/methods.md:26
+msgid "\"new area: {}\""
 msgstr ""
 
 #: src/basic-syntax/methods.md:30
@@ -3557,18 +3503,20 @@ msgstr ""
 msgid "However, function parameters can be generic:"
 msgstr ""
 
-#: src/basic-syntax/functions-interlude.md:14
-msgid ""
-"```rust,editable\n"
-"fn pick_one<T>(a: T, b: T) -> T {\n"
-"    if std::process::id() % 2 == 0 { a } else { b }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
-"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
-"}\n"
-"```"
+#: src/basic-syntax/functions-interlude.md:20
+msgid "\"coin toss: {}\""
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:20
+msgid "\"heads\""
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:20
+msgid "\"tails\""
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:21
+msgid "\"cash prize: {}\""
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
@@ -3695,24 +3643,20 @@ msgid ""
 "keyword:"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:22
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let array = [10, 20, 30];\n"
-"    print!(\"Iterating over array:\");\n"
-"    for n in &array {\n"
-"        print!(\" {n}\");\n"
-"    }\n"
-"    println!();\n"
-"\n"
-"    print!(\"Iterating over range:\");\n"
-"    for i in 0..3 {\n"
-"        print!(\" {}\", array[i]);\n"
-"    }\n"
-"    println!();\n"
-"}\n"
-"```"
+#: src/exercises/day-1/for-loops.md:25
+msgid "\"Iterating over array:\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:27
+msgid "\" {n}\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:31
+msgid "\"Iterating over range:\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:33
+msgid "\" {}\""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:39
@@ -3732,35 +3676,28 @@ msgid ""
 "functions:"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:54
-msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];\n"
-"\n"
-"    println!(\"matrix:\");\n"
-"    pretty_print(&matrix);\n"
-"\n"
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
-"```"
+#: src/exercises/day-1/for-loops.md:55 src/exercises/day-1/luhn.md:26
+#: src/exercises/day-2/health-statistics.md:14
+#: src/exercises/day-2/strings-iterators.md:13
+#: src/exercises/day-3/simple-gui.md:20
+#: src/exercises/day-3/points-polygons.md:8
+#: src/exercises/day-3/safe-ffi-wrapper.md:49
+msgid "// TODO: remove this when you're done with your implementation.\n"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:68
+#: src/exercises/day-1/solutions-morning.md:44
+msgid "// <-- the comment makes rustfmt add a newline\n"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:73
+#: src/exercises/day-1/solutions-morning.md:49
+msgid "\"matrix:\""
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:77
+#: src/exercises/day-1/solutions-morning.md:53
+msgid "\"transposed:\""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:82
@@ -4115,15 +4052,12 @@ msgid ""
 "therefore will not move:"
 msgstr ""
 
-#: src/basic-syntax/static-and-const.md:38
-msgid ""
-"```rust,editable\n"
-"static BANNER: &str = \"Welcome to RustOS 3.14\";\n"
-"\n"
-"fn main() {\n"
-"    println!(\"{BANNER}\");\n"
-"}\n"
-"```"
+#: src/basic-syntax/static-and-const.md:39
+msgid "\"Welcome to RustOS 3.14\""
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:42
+msgid "\"{BANNER}\""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:46
@@ -4240,24 +4174,25 @@ msgid ""
 "the same scope:"
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let a = 10;\n"
-"    println!(\"before: {a}\");\n"
-"\n"
-"    {\n"
-"        let a = \"hello\";\n"
-"        println!(\"inner scope: {a}\");\n"
-"\n"
-"        let a = true;\n"
-"        println!(\"shadowed in inner scope: {a}\");\n"
-"    }\n"
-"\n"
-"    println!(\"after: {a}\");\n"
-"}\n"
-"```"
+#: src/basic-syntax/scopes-shadowing.md:9
+msgid "\"before: {a}\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:12 src/traits/from-into.md:7
+#: src/traits/from-into.md:19
+msgid "\"hello\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:13
+msgid "\"inner scope: {a}\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:16
+msgid "\"shadowed in inner scope: {a}\""
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:19
+msgid "\"after: {a}\""
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
@@ -4290,33 +4225,16 @@ msgid ""
 "variants:"
 msgstr ""
 
-#: src/enums.md:6
-msgid ""
-"```rust,editable\n"
-"fn generate_random_number() -> i32 {\n"
-"    // Implementation based on https://xkcd.com/221/\n"
-"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"enum CoinFlip {\n"
-"    Heads,\n"
-"    Tails,\n"
-"}\n"
-"\n"
-"fn flip_coin() -> CoinFlip {\n"
-"    let random_number = generate_random_number();\n"
-"    if random_number % 2 == 0 {\n"
-"        return CoinFlip::Heads;\n"
-"    } else {\n"
-"        return CoinFlip::Tails;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    println!(\"You got: {:?}\", flip_coin());\n"
-"}\n"
-"```"
+#: src/enums.md:8
+msgid "// Implementation based on https://xkcd.com/221/\n"
+msgstr ""
+
+#: src/enums.md:9
+msgid "// Chosen by fair dice roll. Guaranteed to be random.\n"
+msgstr ""
+
+#: src/enums.md:28
+msgid "\"You got: {:?}\""
 msgstr ""
 
 #: src/enums.md:36
@@ -4356,34 +4274,32 @@ msgid ""
 "the `match` statement to extract the data from each variant:"
 msgstr ""
 
-#: src/enums/variant-payloads.md:6
-msgid ""
-"```rust,editable\n"
-"enum WebEvent {\n"
-"    PageLoad,                 // Variant without payload\n"
-"    KeyPress(char),           // Tuple struct variant\n"
-"    Click { x: i64, y: i64 }, // Full struct variant\n"
-"}\n"
-"\n"
-"#[rustfmt::skip]\n"
-"fn inspect(event: WebEvent) {\n"
-"    match event {\n"
-"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
-"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
-"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let load = WebEvent::PageLoad;\n"
-"    let press = WebEvent::KeyPress('x');\n"
-"    let click = WebEvent::Click { x: 20, y: 80 };\n"
-"\n"
-"    inspect(load);\n"
-"    inspect(press);\n"
-"    inspect(click);\n"
-"}\n"
-"```"
+#: src/enums/variant-payloads.md:8
+msgid "// Variant without payload\n"
+msgstr ""
+
+#: src/enums/variant-payloads.md:9
+msgid "// Tuple struct variant\n"
+msgstr ""
+
+#: src/enums/variant-payloads.md:10
+msgid "// Full struct variant\n"
+msgstr ""
+
+#: src/enums/variant-payloads.md:16
+msgid "\"page loaded\""
+msgstr ""
+
+#: src/enums/variant-payloads.md:17
+msgid "\"pressed '{c}'\""
+msgstr ""
+
+#: src/enums/variant-payloads.md:18
+msgid "\"clicked at x={x}, y={y}\""
+msgstr ""
+
+#: src/enums/variant-payloads.md:24 src/pattern-matching.md:10
+msgid "'x'"
 msgstr ""
 
 #: src/enums/variant-payloads.md:35
@@ -4446,26 +4362,8 @@ msgid ""
 "account:"
 msgstr ""
 
-#: src/enums/sizes.md:5
-msgid ""
-"```rust,editable\n"
-"use std::any::type_name;\n"
-"use std::mem::{align_of, size_of};\n"
-"\n"
-"fn dbg_size<T>() {\n"
-"    println!(\"{}: size {} bytes, align: {} bytes\",\n"
-"        type_name::<T>(), size_of::<T>(), align_of::<T>());\n"
-"}\n"
-"\n"
-"enum Foo {\n"
-"    A,\n"
-"    B,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    dbg_size::<Foo>();\n"
-"}\n"
-"```"
+#: src/enums/sizes.md:10
+msgid "\"{}: size {} bytes, align: {} bytes\""
 msgstr ""
 
 #: src/enums/sizes.md:24
@@ -4577,18 +4475,12 @@ msgid ""
 "whether a value matches a pattern:"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:7
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let arg = std::env::args().next();\n"
-"    if let Some(value) = arg {\n"
-"        println!(\"Program name: {value}\");\n"
-"    } else {\n"
-"        println!(\"Missing name?\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/control-flow/if-let-expressions.md:11
+msgid "\"Program name: {value}\""
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:13
+msgid "\"Missing name?\""
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:18
@@ -4661,20 +4553,44 @@ msgid ""
 "sense, it works like a series of `if let` expressions:"
 msgstr ""
 
-#: src/control-flow/match-expressions.md:7
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    match std::env::args().next().as_deref() {\n"
-"        Some(\"cat\") => println!(\"Will do cat things\"),\n"
-"        Some(\"ls\")  => println!(\"Will ls some files\"),\n"
-"        Some(\"mv\")  => println!(\"Let's move some files\"),\n"
-"        Some(\"rm\")  => println!(\"Uh, dangerous!\"),\n"
-"        None        => println!(\"Hmm, no program name?\"),\n"
-"        _           => println!(\"Unknown program name!\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/control-flow/match-expressions.md:10
+msgid "\"cat\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:10
+msgid "\"Will do cat things\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:11
+msgid "\"ls\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:11
+msgid "\"Will ls some files\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:12
+msgid "\"mv\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:12
+msgid "\"Let's move some files\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:13
+msgid "\"rm\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:13
+msgid "\"Uh, dangerous!\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:14
+msgid "\"Hmm, no program name?\""
+msgstr ""
+
+#: src/control-flow/match-expressions.md:15
+msgid "\"Unknown program name!\""
 msgstr ""
 
 #: src/control-flow/match-expressions.md:20
@@ -4718,20 +4634,48 @@ msgstr ""
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
 msgstr ""
 
-#: src/pattern-matching.md:8
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let input = 'x';\n"
-"\n"
-"    match input {\n"
-"        'q'                   => println!(\"Quitting\"),\n"
-"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
-"        '0'..='9'             => println!(\"Number input\"),\n"
-"        _                     => println!(\"Something else\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching.md:13
+msgid "'q'"
+msgstr ""
+
+#: src/pattern-matching.md:13
+msgid "\"Quitting\""
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'a'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'s'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'w'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "'d'"
+msgstr ""
+
+#: src/pattern-matching.md:14
+msgid "\"Moving around\""
+msgstr ""
+
+#: src/pattern-matching.md:15
+msgid "'0'"
+msgstr ""
+
+#: src/pattern-matching.md:15
+msgid "'9'"
+msgstr ""
+
+#: src/pattern-matching.md:15
+msgid "\"Number input\""
+msgstr ""
+
+#: src/pattern-matching.md:16
+msgid "\"Something else\""
 msgstr ""
 
 #: src/pattern-matching.md:21
@@ -4783,30 +4727,16 @@ msgid ""
 "`enum` type:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:6
-msgid ""
-"```rust,editable\n"
-"enum Result {\n"
-"    Ok(i32),\n"
-"    Err(String),\n"
-"}\n"
-"\n"
-"fn divide_in_two(n: i32) -> Result {\n"
-"    if n % 2 == 0 {\n"
-"        Result::Ok(n / 2)\n"
-"    } else {\n"
-"        Result::Err(format!(\"cannot divide {n} into two equal parts\"))\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let n = 100;\n"
-"    match divide_in_two(n) {\n"
-"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
-"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-enums.md:16
+msgid "\"cannot divide {n} into two equal parts\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:23
+msgid "\"{n} divided in two is {half}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:24
+msgid "\"sorry, an error happened: {msg}\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
@@ -4833,25 +4763,16 @@ msgstr ""
 msgid "You can also destructure `structs`:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:5
-msgid ""
-"```rust,editable\n"
-"struct Foo {\n"
-"    x: (u32, u32),\n"
-"    y: u32,\n"
-"}\n"
-"\n"
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let foo = Foo { x: (1, 2), y: 3 };\n"
-"    match foo {\n"
-"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
-"        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
-"ignored\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-structs.md:15
+msgid "\"x.0 = 1, b = {b}, y = {y}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:16
+msgid "\"y = 2, x = {i:?}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:17
+msgid "\"y = {y}, other fields were ignored\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
@@ -4874,20 +4795,23 @@ msgid ""
 "You can destructure arrays, tuples, and slices by matching on their elements:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:5
-msgid ""
-"```rust,editable\n"
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let triple = [0, -2, 3];\n"
-"    println!(\"Tell me about {triple:?}\");\n"
-"    match triple {\n"
-"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"        _         => println!(\"All elements were ignored\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-arrays.md:9
+msgid "\"Tell me about {triple:?}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:11
+#: src/pattern-matching/destructuring-arrays.md:34
+msgid "\"First is 0, y = {y}, and z = {z}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:12
+#: src/pattern-matching/destructuring-arrays.md:35
+msgid "\"First is 1 and the rest were ignored\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:13
+#: src/pattern-matching/destructuring-arrays.md:36
+msgid "\"All elements were ignored\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
@@ -4896,24 +4820,8 @@ msgid ""
 "length."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:24
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    inspect(&[0, -2, 3]);\n"
-"    inspect(&[0, -2, 3, 4]);\n"
-"}\n"
-"\n"
-"#[rustfmt::skip]\n"
-"fn inspect(slice: &[i32]) {\n"
-"    println!(\"Tell me about {slice:?}\");\n"
-"    match slice {\n"
-"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"        _          => println!(\"All elements were ignored\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/destructuring-arrays.md:32
+msgid "\"Tell me about {slice:?}\""
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:41
@@ -4940,21 +4848,24 @@ msgid ""
 "Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:6
-msgid ""
-"```rust,editable\n"
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let pair = (2, -2);\n"
-"    println!(\"Tell me about {pair:?}\");\n"
-"    match pair {\n"
-"        (x, y) if x == y     => println!(\"These are twins\"),\n"
-"        (x, y) if x + y == 0 => println!(\"Antimatter, kaboom!\"),\n"
-"        (x, _) if x % 2 == 1 => println!(\"The first one is odd\"),\n"
-"        _                    => println!(\"No correlation...\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/pattern-matching/match-guards.md:10
+msgid "\"Tell me about {pair:?}\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:12
+msgid "\"These are twins\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:13
+msgid "\"Antimatter, kaboom!\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:14
+msgid "\"The first one is odd\""
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:15
+msgid "\"No correlation...\""
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
@@ -5051,57 +4962,72 @@ msgid ""
 "integers. Then, revisit the solution and try to implement it with iterators."
 msgstr ""
 
-#: src/exercises/day-1/luhn.md:25
-msgid ""
-"```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_non_digit_cc_number() {\n"
-"    assert!(!luhn(\"foo\"));\n"
-"    assert!(!luhn(\"foo 0 0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_empty_cc_number() {\n"
-"    assert!(!luhn(\"\"));\n"
-"    assert!(!luhn(\" \"));\n"
-"    assert!(!luhn(\"  \"));\n"
-"    assert!(!luhn(\"    \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_single_digit_cc_number() {\n"
-"    assert!(!luhn(\"0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_two_digit_cc_number() {\n"
-"    assert!(luhn(\" 0 0 \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_valid_cc_number() {\n"
-"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
-"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
-"    assert!(luhn(\"7992 7398 713\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
-"}\n"
-"\n"
-"#[allow(dead_code)]\n"
-"fn main() {}\n"
-"```"
+#: src/exercises/day-1/luhn.md:35
+#: src/exercises/day-2/iterators-and-ownership.md:75
+#: src/exercises/day-2/iterators-and-ownership.md:91
+#: src/traits/trait-bounds.md:22 src/traits/impl-trait.md:14
+#: src/exercises/day-3/simple-gui.md:148 src/exercises/day-3/simple-gui.md:149
+#: src/exercises/day-3/simple-gui.md:150 src/testing/test-modules.md:21
+#: src/exercises/day-1/solutions-afternoon.md:49
+msgid "\"foo\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:36 src/exercises/day-1/solutions-afternoon.md:50
+msgid "\"foo 0 0\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:41 src/testing/unit-tests.md:15
+#: src/exercises/day-1/solutions-afternoon.md:55
+#: src/exercises/day-3/solutions-morning.md:90
+#: src/exercises/day-3/solutions-morning.md:92
+#: src/exercises/day-3/solutions-morning.md:96
+#: src/exercises/day-3/solutions-morning.md:110
+#: src/exercises/day-3/solutions-morning.md:114
+msgid "\"\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:42 src/exercises/day-1/solutions-afternoon.md:56
+msgid "\" \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:43 src/exercises/day-1/solutions-afternoon.md:57
+msgid "\"  \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:44 src/exercises/day-1/solutions-afternoon.md:58
+msgid "\"    \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:49 src/exercises/day-1/solutions-afternoon.md:63
+msgid "\"0\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:54 src/exercises/day-1/solutions-afternoon.md:68
+msgid "\" 0 0 \""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:59 src/exercises/day-1/solutions-afternoon.md:73
+msgid "\"4263 9826 4026 9299\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:60 src/exercises/day-1/solutions-afternoon.md:74
+msgid "\"4539 3195 0343 6467\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:61 src/exercises/day-1/solutions-afternoon.md:75
+msgid "\"7992 7398 713\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:66 src/exercises/day-1/solutions-afternoon.md:80
+msgid "\"4223 9826 4026 9299\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:67 src/exercises/day-1/solutions-afternoon.md:81
+msgid "\"4539 3195 0343 6476\""
+msgstr ""
+
+#: src/exercises/day-1/luhn.md:68 src/exercises/day-1/solutions-afternoon.md:82
+msgid "\"8273 1232 7352 0569\""
 msgstr ""
 
 #: src/exercises/day-1/pattern-matching.md:1
@@ -5112,102 +5038,50 @@ msgstr ""
 msgid "Let's write a simple recursive evaluator for arithmetic expressions. "
 msgstr ""
 
-#: src/exercises/day-1/pattern-matching.md:5
-msgid ""
-"```rust\n"
-"/// An operation to perform on two subexpressions.\n"
-"#[derive(Debug)]\n"
-"enum Operation {\n"
-"    Add,\n"
-"    Sub,\n"
-"    Mul,\n"
-"    Div,\n"
-"}\n"
-"\n"
-"/// An expression, in tree form.\n"
-"#[derive(Debug)]\n"
-"enum Expression {\n"
-"    /// An operation on two subexpressions.\n"
-"    Op {\n"
-"        op: Operation,\n"
-"        left: Box<Expression>,\n"
-"        right: Box<Expression>,\n"
-"    },\n"
-"\n"
-"    /// A literal value\n"
-"    Value(i64),\n"
-"}\n"
-"\n"
-"/// The result of evaluating an expression.\n"
-"#[derive(Debug, PartialEq, Eq)]\n"
-"enum Res {\n"
-"    /// Evaluation was successful, with the given result.\n"
-"    Ok(i64),\n"
-"    /// Evaluation failed, with the given error message.\n"
-"    Err(String),\n"
-"}\n"
-"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
-"use Res::{Err, Ok};\n"
-"\n"
-"fn eval(e: Expression) -> Res {\n"
-"    todo!()\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_value() {\n"
-"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_sum() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(Expression::Value(10)),\n"
-"            right: Box::new(Expression::Value(20)),\n"
-"        }),\n"
-"        Ok(30)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_recursion() {\n"
-"    let term1 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Value(10)),\n"
-"        right: Box::new(Expression::Value(9)),\n"
-"    };\n"
-"    let term2 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Op {\n"
-"            op: Operation::Sub,\n"
-"            left: Box::new(Expression::Value(3)),\n"
-"            right: Box::new(Expression::Value(4)),\n"
-"        }),\n"
-"        right: Box::new(Expression::Value(5)),\n"
-"    };\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(term1),\n"
-"            right: Box::new(term2),\n"
-"        }),\n"
-"        Ok(85)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_error() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Div,\n"
-"            left: Box::new(Expression::Value(99)),\n"
-"            right: Box::new(Expression::Value(0)),\n"
-"        }),\n"
-"        Err(String::from(\"division by zero\"))\n"
-"    );\n"
-"}\n"
-"```"
+#: src/exercises/day-1/pattern-matching.md:6
+#: src/exercises/day-1/solutions-afternoon.md:89
+msgid "/// An operation to perform on two subexpressions.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:14
+#: src/exercises/day-1/solutions-afternoon.md:97
+msgid "/// An expression, in tree form.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:18
+#: src/exercises/day-1/solutions-afternoon.md:101
+msgid "/// An operation on two subexpressions.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:25
+#: src/exercises/day-1/solutions-afternoon.md:108
+msgid "/// A literal value\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:28
+#: src/exercises/day-1/solutions-afternoon.md:111
+msgid "/// The result of evaluating an expression.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:32
+#: src/exercises/day-1/solutions-afternoon.md:115
+msgid "/// Evaluation was successful, with the given result.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:34
+#: src/exercises/day-1/solutions-afternoon.md:117
+msgid "/// Evaluation failed, with the given error message.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:36
+#: src/exercises/day-1/solutions-afternoon.md:119
+msgid "// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
+msgstr ""
+
+#: src/exercises/day-1/pattern-matching.md:95
+#: src/exercises/day-1/solutions-afternoon.md:140
+#: src/exercises/day-1/solutions-afternoon.md:202
+msgid "\"division by zero\""
 msgstr ""
 
 #: src/exercises/day-1/pattern-matching.md:100
@@ -5357,13 +5231,11 @@ msgid ""
 "sized data, the actual string, on the heap:"
 msgstr ""
 
-#: src/memory-management/stack.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s1 = String::from(\"Hello\");\n"
-"}\n"
-"```"
+#: src/memory-management/stack.md:8 src/memory-management/stack.md:39
+#: src/std/string.md:8 src/traits/read-write.md:35 src/testing/unit-tests.md:20
+#: src/testing/unit-tests.md:25 src/testing/test-modules.md:12
+#: src/concurrency/scoped-threads.md:9 src/concurrency/scoped-threads.md:26
+msgid "\"Hello\""
 msgstr ""
 
 #: src/memory-management/stack.md:28
@@ -5386,24 +5258,25 @@ msgid ""
 "point out that this is rightfully unsafe!"
 msgstr ""
 
-#: src/memory-management/stack.md:37
+#: src/memory-management/stack.md:40 src/testing/unit-tests.md:7
+#: src/exercises/day-1/solutions-afternoon.md:13
+msgid "' '"
+msgstr ""
+
+#: src/memory-management/stack.md:41
+msgid "\"world\""
+msgstr ""
+
+#: src/memory-management/stack.md:42
 msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut s1 = String::from(\"Hello\");\n"
-"    s1.push(' ');\n"
-"    s1.push_str(\"world\");\n"
-"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"// DON'T DO THIS AT HOME! For educational purposes only.\n"
 "    // String provides no guarantees about its layout, so this could lead "
 "to\n"
 "    // undefined behavior.\n"
-"    unsafe {\n"
-"        let (ptr, capacity, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/memory-management/stack.md:47
+msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
 msgstr ""
 
 #: src/memory-management/manual.md:3
@@ -5424,17 +5297,11 @@ msgstr ""
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
 msgstr ""
 
-#: src/memory-management/manual.md:11
+#: src/memory-management/manual.md:14
 msgid ""
-"```c\n"
-"void foo(size_t n) {\n"
-"    int* int_array = malloc(n * sizeof(int));\n"
-"    //\n"
+"//\n"
 "    // ... lots of code\n"
 "    //\n"
-"    free(int_array);\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/memory-management/manual.md:21
@@ -5465,15 +5332,6 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:12
 msgid "C++ Example"
-msgstr ""
-
-#: src/memory-management/scope-based.md:14
-msgid ""
-"```c++\n"
-"void say_hello(std::unique_ptr<Person> person) {\n"
-"  std::cout << \"Hello \" << person->name << std::endl;\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/memory-management/scope-based.md:20
@@ -5521,15 +5379,6 @@ msgstr ""
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:13
-msgid ""
-"```java\n"
-"void sayHello(Person person) {\n"
-"  System.out.println(\"Hello \" + person.getName());\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/memory-management/rust.md:1
@@ -5598,16 +5447,12 @@ msgstr ""
 msgid "An assignment will transfer _ownership_ between variables:"
 msgstr ""
 
-#: src/ownership/move-semantics.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s1: String = String::from(\"Hello!\");\n"
-"    let s2: String = s1;\n"
-"    println!(\"s2: {s2}\");\n"
-"    // println!(\"s1: {s1}\");\n"
-"}\n"
-"```"
+#: src/ownership/move-semantics.md:7
+msgid "\"Hello!\""
+msgstr ""
+
+#: src/ownership/move-semantics.md:10
+msgid "// println!(\"s1: {s1}\");\n"
 msgstr ""
 
 #: src/ownership/move-semantics.md:14
@@ -5697,12 +5542,12 @@ msgstr "現代C++の二重解放"
 msgid "Modern C++ solves this differently:"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:5
-msgid ""
-"```c++\n"
-"std::string s1 = \"Cpp\";\n"
-"std::string s2 = s1;  // Duplicate the data in s1.\n"
-"```"
+#: src/ownership/double-free-modern-cpp.md:6
+msgid "\"Cpp\""
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:7
+msgid "// Duplicate the data in s1.\n"
 msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
@@ -5750,19 +5595,17 @@ msgid ""
 "parameter. This transfers ownership:"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:6
-msgid ""
-"```rust,editable\n"
-"fn say_hello(name: String) {\n"
-"    println!(\"Hello {name}\")\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let name = String::from(\"Alice\");\n"
-"    say_hello(name);\n"
-"    // say_hello(name);\n"
-"}\n"
-"```"
+#: src/ownership/moves-function-calls.md:8 src/traits/impl-trait.md:10
+msgid "\"Hello {name}\""
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:12
+#: src/android/interoperability/java.md:56
+msgid "\"Alice\""
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:14
+msgid "// say_hello(name);\n"
 msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
@@ -6039,26 +5882,24 @@ msgid ""
 "If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Highlight<'doc>(&'doc str);\n"
-"\n"
-"fn erase(text: String) {\n"
-"    println!(\"Bye {text}!\");\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
-"\");\n"
-"    let fox = Highlight(&text[4..19]);\n"
-"    let dog = Highlight(&text[35..43]);\n"
-"    // erase(text);\n"
-"    println!(\"{fox:?}\");\n"
-"    println!(\"{dog:?}\");\n"
-"}\n"
-"```"
+#: src/ownership/lifetimes-data-structures.md:10
+msgid "\"Bye {text}!\""
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:14
+msgid "\"The quick brown fox jumps over the lazy dog.\""
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:17
+msgid "// erase(text);\n"
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:18
+msgid "\"{fox:?}\""
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:19
+msgid "\"{dog:?}\""
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
@@ -6097,31 +5938,17 @@ msgstr ""
 msgid "Like C and C++, Rust has support for custom structs:"
 msgstr ""
 
-#: src/structs.md:5
-msgid ""
-"```rust,editable\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    peter.age = 28;\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    let jackie = Person {\n"
-"        name: String::from(\"Jackie\"),\n"
-"        ..peter\n"
-"    };\n"
-"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
-"}\n"
-"```"
+#: src/structs.md:13 src/structs/field-shorthand.md:20 src/methods.md:21
+#: src/android/interoperability/with-c/bindgen.md:87
+msgid "\"Peter\""
+msgstr ""
+
+#: src/structs.md:16 src/structs.md:19 src/structs.md:25
+msgid "\"{} is {} years old\""
+msgstr ""
+
+#: src/structs.md:22
+msgid "\"Jackie\""
 msgstr ""
 
 #: src/structs.md:33
@@ -6172,42 +5999,23 @@ msgstr ""
 msgid "If the field names are unimportant, you can use a tuple struct:"
 msgstr ""
 
-#: src/structs/tuple-structs.md:5
-msgid ""
-"```rust,editable\n"
-"struct Point(i32, i32);\n"
-"\n"
-"fn main() {\n"
-"    let p = Point(17, 23);\n"
-"    println!(\"({}, {})\", p.0, p.1);\n"
-"}\n"
-"```"
+#: src/structs/tuple-structs.md:10
+msgid "\"({}, {})\""
 msgstr ""
 
 #: src/structs/tuple-structs.md:14
 msgid "This is often used for single-field wrappers (called newtypes):"
 msgstr ""
 
-#: src/structs/tuple-structs.md:16
-msgid ""
-"```rust,editable,compile_fail\n"
-"struct PoundsOfForce(f64);\n"
-"struct Newtons(f64);\n"
-"\n"
-"fn compute_thruster_force() -> PoundsOfForce {\n"
-"    todo!(\"Ask a rocket scientist at NASA\")\n"
-"}\n"
-"\n"
-"fn set_thruster_force(force: Newtons) {\n"
-"    // ...\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let force = compute_thruster_force();\n"
-"    set_thruster_force(force);\n"
-"}\n"
-"\n"
-"```"
+#: src/structs/tuple-structs.md:21
+msgid "\"Ask a rocket scientist at NASA\""
+msgstr ""
+
+#: src/structs/tuple-structs.md:25
+#: src/android/interoperability/cpp/cpp-bridge.md:50
+#: src/bare-metal/microcontrollers/type-state.md:14
+#: src/async/pitfalls/cancellation.md:99
+msgid "// ...\n"
 msgstr ""
 
 #: src/structs/tuple-structs.md:37
@@ -6254,26 +6062,8 @@ msgid ""
 "struct using a shorthand:"
 msgstr ""
 
-#: src/structs/field-shorthand.md:6
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"\n"
-"impl Person {\n"
-"    fn new(name: String, age: u8) -> Person {\n"
-"        Person { name, age }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
-"    println!(\"{peter:?}\");\n"
-"}\n"
-"```"
+#: src/structs/field-shorthand.md:21
+msgid "\"{peter:?}\""
 msgstr ""
 
 #: src/structs/field-shorthand.md:27
@@ -6288,32 +6078,12 @@ msgid ""
 "default values for the other fields."
 msgstr ""
 
-#: src/structs/field-shorthand.md:43
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"impl Default for Person {\n"
-"    fn default() -> Person {\n"
-"        Person {\n"
-"            name: \"Bot\".to_string(),\n"
-"            age: 0,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"fn create_default() {\n"
-"    let tmp = Person {\n"
-"        ..Person::default()\n"
-"    };\n"
-"    let tmp = Person {\n"
-"        name: \"Sam\".to_string(),\n"
-"        ..Person::default()\n"
-"    };\n"
-"}\n"
-"```"
+#: src/structs/field-shorthand.md:52
+msgid "\"Bot\""
+msgstr ""
+
+#: src/structs/field-shorthand.md:62
+msgid "\"Sam\""
 msgstr ""
 
 #: src/structs/field-shorthand.md:68
@@ -6337,29 +6107,8 @@ msgid ""
 "an `impl` block:"
 msgstr ""
 
-#: src/methods.md:6
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Person {\n"
-"    name: String,\n"
-"    age: u8,\n"
-"}\n"
-"\n"
-"impl Person {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Hello, my name is {}\", self.name);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    peter.say_hello();\n"
-"}\n"
-"```"
+#: src/methods.md:15
+msgid "\"Hello, my name is {}\""
 msgstr ""
 
 #: src/methods.md:31
@@ -6462,50 +6211,40 @@ msgid ""
 "multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 
-#: src/methods/example.md:3
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Race {\n"
-"    name: String,\n"
-"    laps: Vec<i32>,\n"
-"}\n"
-"\n"
-"impl Race {\n"
-"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
-"        Race { name: String::from(name), laps: Vec::new() }\n"
-"    }\n"
-"\n"
-"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
-"access to self\n"
-"        self.laps.push(lap);\n"
-"    }\n"
-"\n"
-"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
-"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
-"        for (idx, lap) in self.laps.iter().enumerate() {\n"
-"            println!(\"Lap {idx}: {lap} sec\");\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn finish(self) {  // Exclusive ownership of self\n"
-"        let total = self.laps.iter().sum::<i32>();\n"
-"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
-"total);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
-"    race.add_lap(70);\n"
-"    race.add_lap(68);\n"
-"    race.print_laps();\n"
-"    race.add_lap(71);\n"
-"    race.print_laps();\n"
-"    race.finish();\n"
-"    // race.add_lap(42);\n"
-"}\n"
-"```"
+#: src/methods/example.md:11
+msgid "// No receiver, a static method\n"
+msgstr ""
+
+#: src/methods/example.md:15
+msgid "// Exclusive borrowed read-write access to self\n"
+msgstr ""
+
+#: src/methods/example.md:19
+msgid "// Shared and read-only borrowed access to self\n"
+msgstr ""
+
+#: src/methods/example.md:20
+msgid "\"Recorded {} laps for {}:\""
+msgstr ""
+
+#: src/methods/example.md:22
+msgid "\"Lap {idx}: {lap} sec\""
+msgstr ""
+
+#: src/methods/example.md:26
+msgid "// Exclusive ownership of self\n"
+msgstr ""
+
+#: src/methods/example.md:28
+msgid "\"Race {} is finished, total lap time: {}\""
+msgstr ""
+
+#: src/methods/example.md:33
+msgid "\"Monaco Grand Prix\""
+msgstr ""
+
+#: src/methods/example.md:40
+msgid "// race.add_lap(42);\n"
 msgstr ""
 
 #: src/methods/example.md:47
@@ -6559,19 +6298,12 @@ msgid ""
 "now, you just need to know part of its API:"
 msgstr ""
 
-#: src/exercises/day-2/book-library.md:6
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut vec = vec![10, 20];\n"
-"    vec.push(30);\n"
-"    let midpoint = vec.len() / 2;\n"
-"    println!(\"middle value: {}\", vec[midpoint]);\n"
-"    for item in &vec {\n"
-"        println!(\"item: {item}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/day-2/book-library.md:11
+msgid "\"middle value: {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:13
+msgid "\"item: {item}\""
 msgstr ""
 
 #: src/exercises/day-2/book-library.md:18
@@ -6580,28 +6312,14 @@ msgid ""
 "<https://play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 
-#: src/exercises/day-2/book-library.md:21
+#: src/exercises/day-2/book-library.md:32
+#: src/exercises/day-2/solutions-morning.md:18
+msgid "// This is a constructor, used below.\n"
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:40
+#: src/exercises/day-2/solutions-morning.md:26
 msgid ""
-"```rust,should_panic\n"
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}\n"
-"\n"
-"struct Book {\n"
-"    title: String,\n"
-"    year: u16,\n"
-"}\n"
-"\n"
-"impl Book {\n"
-"    // This is a constructor, used below.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
 "// Implement the methods below. Notice how the `self` parameter\n"
 "// changes type to indicate the method's required level of ownership\n"
 "// over the object:\n"
@@ -6609,61 +6327,74 @@ msgid ""
 "// - `&self` for shared read-only access,\n"
 "// - `&mut self` for unique and mutable access,\n"
 "// - `self` for unique access by value.\n"
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        todo!(\"Initialize and return a `Library` value\")\n"
-"    }\n"
-"\n"
-"    fn len(&self) -> usize {\n"
-"        todo!(\"Return the length of `self.books`\")\n"
-"    }\n"
-"\n"
-"    fn is_empty(&self) -> bool {\n"
-"        todo!(\"Return `true` if `self.books` is empty\")\n"
-"    }\n"
-"\n"
-"    fn add_book(&mut self, book: Book) {\n"
-"        todo!(\"Add a new book to `self.books`\")\n"
-"    }\n"
-"\n"
-"    fn print_books(&self) {\n"
-"        todo!(\"Iterate over `self.books` and print each book's title and "
-"year\")\n"
-"    }\n"
-"\n"
-"    fn oldest_book(&self) -> Option<&Book> {\n"
-"        todo!(\"Return a reference to the oldest book (if any)\")\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut library = Library::new();\n"
-"\n"
-"    println!(\n"
-"        \"The library is empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"\n"
-"    println!(\n"
-"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.print_books();\n"
-"\n"
-"    match library.oldest_book() {\n"
-"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
-"        None => println!(\"The library is empty!\"),\n"
-"    }\n"
-"\n"
-"    println!(\"The library has {} books\", library.len());\n"
-"    library.print_books();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:50
+msgid "\"Initialize and return a `Library` value\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:54
+msgid "\"Return the length of `self.books`\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:58
+msgid "\"Return `true` if `self.books` is empty\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:62
+msgid "\"Add a new book to `self.books`\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:66
+msgid "\"Iterate over `self.books` and print each book's title and year\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:70
+msgid "\"Return a reference to the oldest book (if any)\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:78
+#: src/exercises/day-2/solutions-morning.md:78
+msgid "\"The library is empty: library.is_empty() -> {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:82
+#: src/exercises/day-2/solutions-morning.md:82
+#: src/exercises/day-2/solutions-morning.md:107
+#: src/exercises/day-2/solutions-morning.md:118
+#: src/exercises/day-2/solutions-morning.md:125
+#: src/exercises/day-2/solutions-morning.md:137
+#: src/exercises/day-2/solutions-morning.md:140
+msgid "\"Lord of the Rings\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:83
+#: src/exercises/day-2/solutions-morning.md:83
+#: src/exercises/day-2/solutions-morning.md:108
+#: src/exercises/day-2/solutions-morning.md:126
+#: src/exercises/day-2/solutions-morning.md:143
+#: src/exercises/day-2/solutions-morning.md:146
+msgid "\"Alice's Adventures in Wonderland\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:86
+#: src/exercises/day-2/solutions-morning.md:86
+msgid "\"The library is no longer empty: library.is_empty() -> {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:93
+#: src/exercises/day-2/solutions-morning.md:93
+msgid "\"The oldest book is {}\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:94
+#: src/exercises/day-2/solutions-morning.md:94
+msgid "\"The library is empty!\""
+msgstr ""
+
+#: src/exercises/day-2/book-library.md:97
+#: src/exercises/day-2/solutions-morning.md:97
+msgid "\"The library has {} books\""
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
@@ -6685,109 +6416,57 @@ msgid ""
 "methods:"
 msgstr ""
 
-#: src/exercises/day-2/health-statistics.md:13
+#: src/exercises/day-2/health-statistics.md:39
+msgid "\"Create a new User instance\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:43
+msgid "\"Return the user's name\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:47
+msgid "\"Return the user's age\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:51
+msgid "\"Return the user's height\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:55
+msgid "\"Return the number of time the user has visited the doctor\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:59
+msgid "\"Set the user's age\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:63
+msgid "\"Set the user's height\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:67
 msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub struct User {\n"
-"    name: String,\n"
-"    age: u32,\n"
-"    height: f32,\n"
-"    visit_count: usize,\n"
-"    last_blood_pressure: Option<(u32, u32)>,\n"
-"}\n"
-"\n"
-"pub struct Measurements {\n"
-"    height: f32,\n"
-"    blood_pressure: (u32, u32),\n"
-"}\n"
-"\n"
-"pub struct HealthReport<'a> {\n"
-"    patient_name: &'a str,\n"
-"    visit_count: u32,\n"
-"    height_change: f32,\n"
-"    blood_pressure_change: Option<(i32, i32)>,\n"
-"}\n"
-"\n"
-"impl User {\n"
-"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
-"        todo!(\"Create a new User instance\")\n"
-"    }\n"
-"\n"
-"    pub fn name(&self) -> &str {\n"
-"        todo!(\"Return the user's name\")\n"
-"    }\n"
-"\n"
-"    pub fn age(&self) -> u32 {\n"
-"        todo!(\"Return the user's age\")\n"
-"    }\n"
-"\n"
-"    pub fn height(&self) -> f32 {\n"
-"        todo!(\"Return the user's height\")\n"
-"    }\n"
-"\n"
-"    pub fn doctor_visits(&self) -> u32 {\n"
-"        todo!(\"Return the number of time the user has visited the "
-"doctor\")\n"
-"    }\n"
-"\n"
-"    pub fn set_age(&mut self, new_age: u32) {\n"
-"        todo!(\"Set the user's age\")\n"
-"    }\n"
-"\n"
-"    pub fn set_height(&mut self, new_height: f32) {\n"
-"        todo!(\"Set the user's height\")\n"
-"    }\n"
-"\n"
-"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
-"HealthReport {\n"
-"        todo!(\"Update a user's statistics based on measurements from a "
-"visit to the doctor\")\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_height() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.height(), 155.2);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_set_age() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.age(), 32);\n"
-"    bob.set_age(33);\n"
-"    assert_eq!(bob.age(), 33);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_visit() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.doctor_visits(), 0);\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (120, 80),\n"
-"    });\n"
-"    assert_eq!(report.patient_name, \"Bob\");\n"
-"    assert_eq!(report.visit_count, 1);\n"
-"    assert_eq!(report.blood_pressure_change, None);\n"
-"\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (115, 76),\n"
-"    });\n"
-"\n"
-"    assert_eq!(report.visit_count, 2);\n"
-"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
-"}\n"
-"```"
+"\"Update a user's statistics based on measurements from a visit to the "
+"doctor\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:72
+#: src/exercises/day-2/health-statistics.md:78
+#: src/exercises/day-2/health-statistics.md:84
+#: src/exercises/day-2/health-statistics.md:92
+#: src/exercises/day-2/health-statistics.md:98
+#: src/android/build-rules/library.md:43 src/android/aidl/client.md:23
+#: src/exercises/day-2/solutions-morning.md:233
+#: src/exercises/day-2/solutions-morning.md:239
+#: src/exercises/day-2/solutions-morning.md:245
+#: src/exercises/day-2/solutions-morning.md:253
+#: src/exercises/day-2/solutions-morning.md:259
+msgid "\"Bob\""
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:73
+#: src/exercises/day-2/solutions-morning.md:234
+msgid "\"I'm {} and my age is {}\""
 msgstr ""
 
 #: src/std.md:3
@@ -6862,18 +6541,12 @@ msgstr ""
 msgid "The types represent optional data:"
 msgstr ""
 
-#: src/std/option-result.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let numbers = vec![10, 20, 30];\n"
-"    let first: Option<&i8> = numbers.first();\n"
-"    println!(\"first: {first:?}\");\n"
-"\n"
-"    let arr: Result<[i8; 3], Vec<i8>> = numbers.try_into();\n"
-"    println!(\"arr: {arr:?}\");\n"
-"}\n"
-"```"
+#: src/std/option-result.md:9
+msgid "\"first: {first:?}\""
+msgstr ""
+
+#: src/std/option-result.md:12
+msgid "\"arr: {arr:?}\""
 msgstr ""
 
 #: src/std/option-result.md:18
@@ -6911,24 +6584,24 @@ msgid ""
 "standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
 
-#: src/std/string.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut s1 = String::new();\n"
-"    s1.push_str(\"Hello\");\n"
-"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());\n"
-"\n"
-"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
-"    s2.push_str(&s1);\n"
-"    s2.push('!');\n"
-"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());\n"
-"\n"
-"    let s3 = String::from(\"🇨🇭\");\n"
-"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
-"             s3.chars().count());\n"
-"}\n"
-"```"
+#: src/std/string.md:9
+msgid "\"s1: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/string.md:13
+msgid "'!'"
+msgstr ""
+
+#: src/std/string.md:14
+msgid "\"s2: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/string.md:16
+msgid "\"🇨🇭\""
+msgstr ""
+
+#: src/std/string.md:17
+msgid "\"s3: len = {}, number of chars = {}\""
 msgstr ""
 
 #: src/std/string.md:22
@@ -7013,31 +6686,28 @@ msgid ""
 "resizable heap-allocated buffer:"
 msgstr ""
 
-#: src/std/vec.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut v1 = Vec::new();\n"
-"    v1.push(42);\n"
-"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());\n"
-"\n"
-"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
-"    v2.extend(v1.iter());\n"
-"    v2.push(9999);\n"
-"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
-"\n"
-"    // Canonical macro to initialize a vector with elements.\n"
-"    let mut v3 = vec![0, 0, 1, 2, 3, 4];\n"
-"\n"
-"    // Retain only the even elements.\n"
-"    v3.retain(|x| x % 2 == 0);\n"
-"    println!(\"{v3:?}\");\n"
-"\n"
-"    // Remove consecutive duplicates.\n"
-"    v3.dedup();\n"
-"    println!(\"{v3:?}\");\n"
-"}\n"
-"```"
+#: src/std/vec.md:9
+msgid "\"v1: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/vec.md:14
+msgid "\"v2: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std/vec.md:16
+msgid "// Canonical macro to initialize a vector with elements.\n"
+msgstr ""
+
+#: src/std/vec.md:19
+msgid "// Retain only the even elements.\n"
+msgstr ""
+
+#: src/std/vec.md:21 src/std/vec.md:25
+msgid "\"{v3:?}\""
+msgstr ""
+
+#: src/std/vec.md:23
+msgid "// Remove consecutive duplicates.\n"
 msgstr ""
 
 #: src/std/vec.md:29
@@ -7088,42 +6758,44 @@ msgstr ""
 msgid "Standard hash map with protection against HashDoS attacks:"
 msgstr ""
 
-#: src/std/hashmap.md:5
-msgid ""
-"```rust,editable\n"
-"use std::collections::HashMap;\n"
-"\n"
-"fn main() {\n"
-"    let mut page_counts = HashMap::new();\n"
-"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
-"207);\n"
-"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
-"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);\n"
-"\n"
-"    if !page_counts.contains_key(\"Les Misérables\") {\n"
-"        println!(\"We know about {} books, but not Les Misérables.\",\n"
-"                 page_counts.len());\n"
-"    }\n"
-"\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
-"Wonderland\"] {\n"
-"        match page_counts.get(book) {\n"
-"            Some(count) => println!(\"{book}: {count} pages\"),\n"
-"            None => println!(\"{book} is unknown.\")\n"
-"        }\n"
-"    }\n"
-"\n"
-"    // Use the .entry() method to insert a value if nothing is found.\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
-"Wonderland\"] {\n"
-"        let page_count: &mut i32 = page_counts.entry(book.to_string())."
-"or_insert(0);\n"
-"        *page_count += 1;\n"
-"    }\n"
-"\n"
-"    println!(\"{page_counts:#?}\");\n"
-"}\n"
-"```"
+#: src/std/hashmap.md:10
+msgid "\"Adventures of Huckleberry Finn\""
+msgstr ""
+
+#: src/std/hashmap.md:11
+msgid "\"Grimms' Fairy Tales\""
+msgstr ""
+
+#: src/std/hashmap.md:12 src/std/hashmap.md:19 src/std/hashmap.md:27
+msgid "\"Pride and Prejudice\""
+msgstr ""
+
+#: src/std/hashmap.md:14
+msgid "\"Les Misérables\""
+msgstr ""
+
+#: src/std/hashmap.md:15
+msgid "\"We know about {} books, but not Les Misérables.\""
+msgstr ""
+
+#: src/std/hashmap.md:19 src/std/hashmap.md:27
+msgid "\"Alice's Adventure in Wonderland\""
+msgstr ""
+
+#: src/std/hashmap.md:21
+msgid "\"{book}: {count} pages\""
+msgstr ""
+
+#: src/std/hashmap.md:22
+msgid "\"{book} is unknown.\""
+msgstr ""
+
+#: src/std/hashmap.md:26
+msgid "// Use the .entry() method to insert a value if nothing is found.\n"
+msgstr ""
+
+#: src/std/hashmap.md:32
+msgid "\"{page_counts:#?}\""
 msgstr ""
 
 #: src/std/hashmap.md:38
@@ -7138,16 +6810,12 @@ msgid ""
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
 
-#: src/std/hashmap.md:41
-msgid ""
-"```rust,ignore\n"
-"  let pc1 = page_counts\n"
-"      .get(\"Harry Potter and the Sorcerer's Stone\")\n"
-"      .unwrap_or(&336);\n"
-"  let pc2 = page_counts\n"
-"      .entry(\"The Hunger Games\".to_string())\n"
-"      .or_insert(374);\n"
-"```"
+#: src/std/hashmap.md:43 src/std/hashmap.md:54
+msgid "\"Harry Potter and the Sorcerer's Stone\""
+msgstr ""
+
+#: src/std/hashmap.md:46 src/std/hashmap.md:55
+msgid "\"The Hunger Games\""
 msgstr ""
 
 #: src/std/hashmap.md:49
@@ -7160,16 +6828,6 @@ msgid ""
 "doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
 "From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
 "us to easily initialize a hash map from a literal array:"
-msgstr ""
-
-#: src/std/hashmap.md:52
-msgid ""
-"```rust,ignore\n"
-"  let page_counts = HashMap::from([\n"
-"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"    (\"The Hunger Games\".to_string(), 374),\n"
-"  ]);\n"
-"```"
 msgstr ""
 
 #: src/std/hashmap.md:59
@@ -7209,14 +6867,8 @@ msgid ""
 "pointer to data on the heap:"
 msgstr ""
 
-#: src/std/box.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let five = Box::new(5);\n"
-"    println!(\"five: {}\", *five);\n"
-"}\n"
-"```"
+#: src/std/box.md:8
+msgid "\"five: {}\""
 msgstr ""
 
 #: src/std/box.md:26
@@ -7264,21 +6916,8 @@ msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
-#: src/std/box-recursive.md:5 src/std/box-niche.md:3
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"enum List<T> {\n"
-"    Cons(T, Box<List<T>>),\n"
-"    Nil,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::"
-"new(List::Nil))));\n"
-"    println!(\"{list:?}\");\n"
-"}\n"
-"```"
+#: src/std/box-recursive.md:14 src/std/box-niche.md:12
+msgid "\"{list:?}\""
 msgstr ""
 
 #: src/std/box-recursive.md:18
@@ -7362,19 +7001,12 @@ msgid ""
 "from multiple places:"
 msgstr ""
 
-#: src/std/rc.md:6
-msgid ""
-"```rust,editable\n"
-"use std::rc::Rc;\n"
-"\n"
-"fn main() {\n"
-"    let mut a = Rc::new(10);\n"
-"    let mut b = Rc::clone(&a);\n"
-"\n"
-"    println!(\"a: {a}\");\n"
-"    println!(\"b: {b}\");\n"
-"}\n"
-"```"
+#: src/std/rc.md:13
+msgid "\"a: {a}\""
+msgstr ""
+
+#: src/std/rc.md:14
+msgid "\"b: {b}\""
 msgstr ""
 
 #: src/std/rc.md:18
@@ -7442,41 +7074,12 @@ msgid ""
 "shared and exclusive references at runtime and panics if they are misused."
 msgstr ""
 
-#: src/std/cell.md:12
-msgid ""
-"```rust,editable\n"
-"use std::cell::RefCell;\n"
-"use std::rc::Rc;\n"
-"\n"
-"#[derive(Debug, Default)]\n"
-"struct Node {\n"
-"    value: i64,\n"
-"    children: Vec<Rc<RefCell<Node>>>,\n"
-"}\n"
-"\n"
-"impl Node {\n"
-"    fn new(value: i64) -> Rc<RefCell<Node>> {\n"
-"        Rc::new(RefCell::new(Node { value, ..Node::default() }))\n"
-"    }\n"
-"\n"
-"    fn sum(&self) -> i64 {\n"
-"        self.value + self.children.iter().map(|c| c.borrow().sum()).sum::"
-"<i64>()\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let root = Node::new(1);\n"
-"    root.borrow_mut().children.push(Node::new(5));\n"
-"    let subtree = Node::new(10);\n"
-"    subtree.borrow_mut().children.push(Node::new(11));\n"
-"    subtree.borrow_mut().children.push(Node::new(12));\n"
-"    root.borrow_mut().children.push(subtree);\n"
-"\n"
-"    println!(\"graph: {root:#?}\");\n"
-"    println!(\"graph sum: {}\", root.borrow().sum());\n"
-"}\n"
-"```"
+#: src/std/cell.md:40
+msgid "\"graph: {root:#?}\""
+msgstr ""
+
+#: src/std/cell.md:41
+msgid "\"graph sum: {}\""
 msgstr ""
 
 #: src/std/cell.md:47
@@ -7515,26 +7118,12 @@ msgstr ""
 msgid "Similarly, `mod` lets us namespace types and functions:"
 msgstr ""
 
-#: src/modules.md:7
-msgid ""
-"```rust,editable\n"
-"mod foo {\n"
-"    pub fn do_something() {\n"
-"        println!(\"In the foo module\");\n"
-"    }\n"
-"}\n"
-"\n"
-"mod bar {\n"
-"    pub fn do_something() {\n"
-"        println!(\"In the bar module\");\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    foo::do_something();\n"
-"    bar::do_something();\n"
-"}\n"
-"```"
+#: src/modules.md:10
+msgid "\"In the foo module\""
+msgstr ""
+
+#: src/modules.md:16
+msgid "\"In the bar module\""
 msgstr ""
 
 #: src/modules.md:28
@@ -7571,34 +7160,20 @@ msgid ""
 "the descendants of `foo`."
 msgstr ""
 
-#: src/modules/visibility.md:10
-msgid ""
-"```rust,editable\n"
-"mod outer {\n"
-"    fn private() {\n"
-"        println!(\"outer::private\");\n"
-"    }\n"
-"\n"
-"    pub fn public() {\n"
-"        println!(\"outer::public\");\n"
-"    }\n"
-"\n"
-"    mod inner {\n"
-"        fn private() {\n"
-"            println!(\"outer::inner::private\");\n"
-"        }\n"
-"\n"
-"        pub fn public() {\n"
-"            println!(\"outer::inner::public\");\n"
-"            super::private();\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    outer::public();\n"
-"}\n"
-"```"
+#: src/modules/visibility.md:13
+msgid "\"outer::private\""
+msgstr ""
+
+#: src/modules/visibility.md:17
+msgid "\"outer::public\""
+msgstr ""
+
+#: src/modules/visibility.md:22
+msgid "\"outer::inner::private\""
+msgstr ""
+
+#: src/modules/visibility.md:26
+msgid "\"outer::inner::public\""
 msgstr ""
 
 #: src/modules/visibility.md:39
@@ -7696,23 +7271,23 @@ msgid ""
 "module."
 msgstr ""
 
-#: src/modules/filesystem.md:20
+#: src/modules/filesystem.md:21
 msgid ""
-"```rust,editable,compile_fail\n"
 "//! This module implements the garden, including a highly performant "
 "germination\n"
 "//! implementation.\n"
-"\n"
-"// Re-export types from this module.\n"
-"pub use seeds::SeedPacket;\n"
-"pub use garden::Garden;\n"
-"\n"
-"/// Sow the given seed packets.\n"
-"pub fn sow(seeds: Vec<SeedPacket>) { todo!() }\n"
-"\n"
-"/// Harvest the produce in the garden that is ready.\n"
-"pub fn harvest(garden: &mut Garden) { todo!() }\n"
-"```"
+msgstr ""
+
+#: src/modules/filesystem.md:23
+msgid "// Re-export types from this module.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:27
+msgid "/// Sow the given seed packets.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:30
+msgid "/// Harvest the produce in the garden that is ready.\n"
 msgstr ""
 
 #: src/modules/filesystem.md:37
@@ -7737,12 +7312,8 @@ msgid ""
 "directive:"
 msgstr ""
 
-#: src/modules/filesystem.md:54
-msgid ""
-"```rust,ignore\n"
-"#[path = \"some/path.rs\"]\n"
-"mod some_module;\n"
-"```"
+#: src/modules/filesystem.md:55
+msgid "\"some/path.rs\""
 msgstr ""
 
 #: src/modules/filesystem.md:59
@@ -7782,36 +7353,29 @@ msgstr ""
 msgid "You use this trait like this:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:22
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();\n"
-"\n"
-"    println!(\"v[0]: {:?}\", iter.next());\n"
-"    println!(\"v[1]: {:?}\", iter.next());\n"
-"    println!(\"v[2]: {:?}\", iter.next());\n"
-"    println!(\"No more items: {:?}\", iter.next());\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:27
+msgid "\"v[0]: {:?}\""
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:28
+msgid "\"v[1]: {:?}\""
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:29
+msgid "\"v[2]: {:?}\""
+msgstr ""
+
+#: src/exercises/day-2/iterators-and-ownership.md:30
+msgid "\"No more items: {:?}\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:34
 msgid "What is the type returned by the iterator? Test your answer here:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:36
-msgid ""
-"```rust,editable,compile_fail\n"
-"fn main() {\n"
-"    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();\n"
-"\n"
-"    let v0: Option<..> = iter.next();\n"
-"    println!(\"v0: {v0:?}\");\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:42
+#: src/exercises/day-2/iterators-and-ownership.md:79
+msgid "\"v0: {v0:?}\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:46
@@ -7853,18 +7417,10 @@ msgstr ""
 msgid "Like before, what  is the type returned by the iterator?"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:73
-msgid ""
-"```rust,editable,compile_fail\n"
-"fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
-"from(\"bar\")];\n"
-"    let mut iter = v.into_iter();\n"
-"\n"
-"    let v0: Option<..> = iter.next();\n"
-"    println!(\"v0: {v0:?}\");\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:75
+#: src/exercises/day-2/iterators-and-ownership.md:91
+#: src/testing/test-modules.md:21
+msgid "\"bar\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:83
@@ -7878,22 +7434,9 @@ msgid ""
 "resulting iterator:"
 msgstr ""
 
-#: src/exercises/day-2/iterators-and-ownership.md:89
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
-"from(\"bar\")];\n"
-"\n"
-"    for word in &v {\n"
-"        println!(\"word: {word}\");\n"
-"    }\n"
-"\n"
-"    for word in v {\n"
-"        println!(\"word: {word}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/day-2/iterators-and-ownership.md:94
+#: src/exercises/day-2/iterators-and-ownership.md:98
+msgid "\"word: {word}\""
 msgstr ""
 
 #: src/exercises/day-2/iterators-and-ownership.md:103
@@ -7923,53 +7466,79 @@ msgid ""
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:12
-msgid ""
-"```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
-"abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
-"books\"));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
-"publishers\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_with_wildcard() {\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/bar/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books/book1\"\n"
-"    ));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
-"publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
-"```"
+#: src/exercises/day-2/strings-iterators.md:22
+#: src/exercises/day-2/strings-iterators.md:23
+#: src/exercises/day-2/strings-iterators.md:24
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/strings-iterators.md:27
+#: src/exercises/day-2/strings-iterators.md:28
+#: src/exercises/day-2/strings-iterators.md:46
+#: src/exercises/day-2/solutions-afternoon.md:32
+#: src/exercises/day-2/solutions-afternoon.md:33
+#: src/exercises/day-2/solutions-afternoon.md:34
+#: src/exercises/day-2/solutions-afternoon.md:36
+#: src/exercises/day-2/solutions-afternoon.md:37
+#: src/exercises/day-2/solutions-afternoon.md:38
+#: src/exercises/day-2/solutions-afternoon.md:56
+msgid "\"/v1/publishers\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:23
+#: src/exercises/day-2/solutions-afternoon.md:33
+msgid "\"/v1/publishers/abc-123\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:24
+#: src/exercises/day-2/solutions-afternoon.md:34
+msgid "\"/v1/publishers/abc/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/solutions-afternoon.md:36
+msgid "\"/v1\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:27
+#: src/exercises/day-2/solutions-afternoon.md:37
+msgid "\"/v1/publishersBooks\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:28
+#: src/exercises/day-2/solutions-afternoon.md:38
+msgid "\"/v1/parent/publishers\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:34
+#: src/exercises/day-2/strings-iterators.md:38
+#: src/exercises/day-2/strings-iterators.md:42
+#: src/exercises/day-2/strings-iterators.md:46
+#: src/exercises/day-2/strings-iterators.md:48
+#: src/exercises/day-2/solutions-afternoon.md:44
+#: src/exercises/day-2/solutions-afternoon.md:48
+#: src/exercises/day-2/solutions-afternoon.md:52
+#: src/exercises/day-2/solutions-afternoon.md:56
+#: src/exercises/day-2/solutions-afternoon.md:58
+msgid "\"/v1/publishers/*/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:35
+#: src/exercises/day-2/solutions-afternoon.md:45
+msgid "\"/v1/publishers/foo/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:39
+#: src/exercises/day-2/solutions-afternoon.md:49
+msgid "\"/v1/publishers/bar/books\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:43
+#: src/exercises/day-2/solutions-afternoon.md:53
+msgid "\"/v1/publishers/foo/books/book1\""
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:49
+#: src/exercises/day-2/solutions-afternoon.md:59
+msgid "\"/v1/publishers/foo/booksByAuthor\""
 msgstr ""
 
 #: src/welcome-day-3.md:1
@@ -8020,21 +7589,8 @@ msgid "You can use generics to abstract over the concrete field type:"
 msgstr ""
 "ジェネリクスを使って、具体的なフィールドの型を抽象化することができます："
 
-#: src/generics/data-types.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Point<T> {\n"
-"    x: T,\n"
-"    y: T,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let integer = Point { x: 5, y: 10 };\n"
-"    let float = Point { x: 1.0, y: 4.0 };\n"
-"    println!(\"{integer:?} and {float:?}\");\n"
-"}\n"
-"```"
+#: src/generics/data-types.md:15
+msgid "\"{integer:?} and {float:?}\""
 msgstr ""
 
 #: src/generics/data-types.md:21
@@ -8051,25 +7607,16 @@ msgstr "異なる型の要素を持つ点を許容するように、コードを
 msgid "You can declare a generic type on your `impl` block:"
 msgstr "`impl`に対して、ジェネリックな型を宣言することもできます："
 
-#: src/generics/methods.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug)]\n"
-"struct Point<T>(T, T);\n"
-"\n"
-"impl<T> Point<T> {\n"
-"    fn x(&self) -> &T {\n"
-"        &self.0  // + 10\n"
-"    }\n"
-"\n"
-"    // fn set_x(&mut self, x: T)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let p = Point(5, 10);\n"
-"    println!(\"p.x = {}\", p.x());\n"
-"}\n"
-"```"
+#: src/generics/methods.md:11
+msgid "// + 10\n"
+msgstr ""
+
+#: src/generics/methods.md:14
+msgid "// fn set_x(&mut self, x: T)\n"
+msgstr ""
+
+#: src/generics/methods.md:19
+msgid "\"p.x = {}\""
 msgstr ""
 
 #: src/generics/methods.md:25
@@ -8129,37 +7676,24 @@ msgid ""
 "Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
-#: src/traits.md:5
-msgid ""
-"```rust,editable\n"
-"struct Dog { name: String, age: i8 }\n"
-"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
-"\n"
-"trait Pet {\n"
-"    fn talk(&self) -> String;\n"
-"}\n"
-"\n"
-"impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
-"name) }\n"
-"}\n"
-"\n"
-"impl Pet for Cat {\n"
-"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
-"}\n"
-"\n"
-"fn greet<P: Pet>(pet: &P) {\n"
-"    println!(\"Oh you're a cutie! What's your name? {}\", pet.talk());\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let captain_floof = Cat { lives: 9 };\n"
-"    let fido = Dog { name: String::from(\"Fido\"), age: 5 };\n"
-"\n"
-"    greet(&captain_floof);\n"
-"    greet(&fido);\n"
-"}\n"
-"```"
+#: src/traits.md:7 src/traits/trait-objects.md:7
+msgid "// No name needed, cats won't respond anyway.\n"
+msgstr ""
+
+#: src/traits.md:14 src/traits/trait-objects.md:14
+msgid "\"Woof, my name is {}!\""
+msgstr ""
+
+#: src/traits.md:18 src/traits/trait-objects.md:18
+msgid "\"Miau!\""
+msgstr ""
+
+#: src/traits.md:22
+msgid "\"Oh you're a cutie! What's your name? {}\""
+msgstr ""
+
+#: src/traits.md:27 src/traits/trait-objects.md:24
+msgid "\"Fido\""
 msgstr ""
 
 #: src/traits/trait-objects.md:3
@@ -8168,35 +7702,8 @@ msgid ""
 "collection:"
 msgstr ""
 
-#: src/traits/trait-objects.md:5
-msgid ""
-"```rust,editable\n"
-"struct Dog { name: String, age: i8 }\n"
-"struct Cat { lives: i8 } // No name needed, cats won't respond anyway.\n"
-"\n"
-"trait Pet {\n"
-"    fn talk(&self) -> String;\n"
-"}\n"
-"\n"
-"impl Pet for Dog {\n"
-"    fn talk(&self) -> String { format!(\"Woof, my name is {}!\", self."
-"name) }\n"
-"}\n"
-"\n"
-"impl Pet for Cat {\n"
-"    fn talk(&self) -> String { String::from(\"Miau!\") }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let pets: Vec<Box<dyn Pet>> = vec![\n"
-"        Box::new(Cat { lives: 9 }),\n"
-"        Box::new(Dog { name: String::from(\"Fido\"), age: 5 }),\n"
-"    ];\n"
-"    for pet in pets {\n"
-"        println!(\"Hello, who are you? {}\", pet.talk());\n"
-"    }\n"
-"}\n"
-"```"
+#: src/traits/trait-objects.md:27
+msgid "\"Hello, who are you? {}\""
 msgstr ""
 
 #: src/traits/trait-objects.md:32
@@ -8300,16 +7807,17 @@ msgstr ""
 msgid "Compare these outputs in the above example:"
 msgstr ""
 
-#: src/traits/trait-objects.md:80
-msgid ""
-"```rust,ignore\n"
-"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"```"
+#: src/traits/trait-objects.md:81 src/traits/trait-objects.md:82
+#: src/traits/closures.md:54
+msgid "\"{} {}\""
+msgstr ""
+
+#: src/traits/trait-objects.md:83 src/traits/trait-objects.md:84
+#: src/testing/test-modules.md:12 src/android/build-rules/library.md:43
+#: src/android/interoperability/cpp/rust-bridge.md:17
+#: src/async/pitfalls/cancellation.md:59
+#: src/exercises/day-3/solutions-morning.md:128
+msgid "\"{}\""
 msgstr ""
 
 #: src/traits/deriving-traits.md:3
@@ -8322,55 +7830,30 @@ msgstr ""
 msgid "You can let the compiler derive a number of traits as follows:"
 msgstr ""
 
-#: src/traits/deriving-traits.md:7
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug, Clone, PartialEq, Eq, Default)]\n"
-"struct Player {\n"
-"    name: String,\n"
-"    strength: u8,\n"
-"    hit_points: u8,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let p1 = Player::default();\n"
-"    let p2 = p1.clone();\n"
-"    println!(\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2,\n"
-"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
-"}\n"
-"```"
+#: src/traits/deriving-traits.md:18
+msgid "\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\""
+msgstr ""
+
+#: src/traits/deriving-traits.md:19
+#: src/exercises/day-1/solutions-afternoon.md:43
+msgid "\"yes\""
+msgstr ""
+
+#: src/traits/deriving-traits.md:19
+#: src/exercises/day-1/solutions-afternoon.md:43
+msgid "\"no\""
 msgstr ""
 
 #: src/traits/default-methods.md:3
 msgid "Traits can implement behavior in terms of other trait methods:"
 msgstr ""
 
-#: src/traits/default-methods.md:5
-msgid ""
-"```rust,editable\n"
-"trait Equals {\n"
-"    fn equals(&self, other: &Self) -> bool;\n"
-"    fn not_equals(&self, other: &Self) -> bool {\n"
-"        !self.equals(other)\n"
-"    }\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct Centimeter(i16);\n"
-"\n"
-"impl Equals for Centimeter {\n"
-"    fn equals(&self, other: &Centimeter) -> bool {\n"
-"        self.0 == other.0\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let a = Centimeter(10);\n"
-"    let b = Centimeter(20);\n"
-"    println!(\"{a:?} equals {b:?}: {}\", a.equals(&b));\n"
-"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equals(&b));\n"
-"}\n"
-"```"
+#: src/traits/default-methods.md:25
+msgid "\"{a:?} equals {b:?}: {}\""
+msgstr ""
+
+#: src/traits/default-methods.md:26
+msgid "\"{a:?} not_equals {b:?}: {}\""
 msgstr ""
 
 #: src/traits/default-methods.md:32
@@ -8408,32 +7891,26 @@ msgstr ""
 msgid "You can do this with `T: Trait` or `impl Trait`:"
 msgstr ""
 
-#: src/traits/trait-bounds.md:8
+#: src/traits/trait-bounds.md:12
 msgid ""
-"```rust,editable\n"
-"fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
-"    (a.clone(), a.clone())\n"
-"}\n"
-"\n"
 "// Syntactic sugar for:\n"
 "//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
-"fn add_42_millions(x: impl Into<i32>) -> i32 {\n"
-"    x.into() + 42_000_000\n"
-"}\n"
-"\n"
-"// struct NotClonable;\n"
-"\n"
-"fn main() {\n"
-"    let foo = String::from(\"foo\");\n"
-"    let pair = duplicate(foo);\n"
-"    println!(\"{pair:?}\");\n"
-"\n"
-"    let many = add_42_millions(42_i8);\n"
-"    println!(\"{many}\");\n"
-"    let many_more = add_42_millions(10_000_000);\n"
-"    println!(\"{many_more}\");\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/traits/trait-bounds.md:18
+msgid "// struct NotClonable;\n"
+msgstr ""
+
+#: src/traits/trait-bounds.md:24
+msgid "\"{pair:?}\""
+msgstr ""
+
+#: src/traits/trait-bounds.md:27
+msgid "\"{many}\""
+msgstr ""
+
+#: src/traits/trait-bounds.md:29
+msgid "\"{many_more}\""
 msgstr ""
 
 #: src/traits/trait-bounds.md:35
@@ -8462,22 +7939,6 @@ msgstr ""
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
-msgstr ""
-
-#: src/traits/impl-trait.md:6
-msgid ""
-"```rust,editable\n"
-"use std::fmt::Display;\n"
-"\n"
-"fn get_x(name: impl Display) -> impl Display {\n"
-"    format!(\"Hello {name}\")\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let x = get_x(\"foo\");\n"
-"    println!(\"{x}\");\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/traits/impl-trait.md:19
@@ -8578,32 +8039,8 @@ msgid ""
 "Iterator.html) trait on your own types:"
 msgstr ""
 
-#: src/traits/iterator.md:5
-msgid ""
-"```rust,editable\n"
-"struct Fibonacci {\n"
-"    curr: u32,\n"
-"    next: u32,\n"
-"}\n"
-"\n"
-"impl Iterator for Fibonacci {\n"
-"    type Item = u32;\n"
-"\n"
-"    fn next(&mut self) -> Option<Self::Item> {\n"
-"        let new_next = self.curr + self.next;\n"
-"        self.curr = self.next;\n"
-"        self.next = new_next;\n"
-"        Some(self.curr)\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let fib = Fibonacci { curr: 0, next: 1 };\n"
-"    for (i, n) in fib.enumerate().take(5) {\n"
-"        println!(\"fib({i}): {n}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/traits/iterator.md:25
+msgid "\"fib({i}): {n}\""
 msgstr ""
 
 #: src/traits/iterator.md:32
@@ -8630,18 +8067,8 @@ msgid ""
 "std/iter/trait.Iterator.html)."
 msgstr ""
 
-#: src/traits/from-iterator.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let primes = vec![2, 3, 5, 7];\n"
-"    let prime_squares = primes\n"
-"        .into_iter()\n"
-"        .map(|prime| prime * prime)\n"
-"        .collect::<Vec<_>>();\n"
-"    println!(\"prime_squares: {prime_squares:?}\");\n"
-"}\n"
-"```"
+#: src/traits/from-iterator.md:12
+msgid "\"prime_squares: {prime_squares:?}\""
 msgstr ""
 
 #: src/traits/from-iterator.md:18
@@ -8667,17 +8094,8 @@ msgid ""
 "facilitate type conversions:"
 msgstr ""
 
-#: src/traits/from-into.md:5
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s = String::from(\"hello\");\n"
-"    let addr = std::net::Ipv4Addr::from([127, 0, 0, 1]);\n"
-"    let one = i16::from(true);\n"
-"    let bigger = i32::from(123i16);\n"
-"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
-"}\n"
-"```"
+#: src/traits/from-into.md:11 src/traits/from-into.md:23
+msgid "\"{s}, {addr}, {one}, {bigger}\""
 msgstr ""
 
 #: src/traits/from-into.md:15
@@ -8685,19 +8103,6 @@ msgid ""
 "[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
 "automatically implemented when [`From`](https://doc.rust-lang.org/std/"
 "convert/trait.From.html) is implemented:"
-msgstr ""
-
-#: src/traits/from-into.md:17
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let s: String = \"hello\".into();\n"
-"    let addr: std::net::Ipv4Addr = [127, 0, 0, 1].into();\n"
-"    let one: i16 = true.into();\n"
-"    let bigger: i32 = 123i16.into();\n"
-"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/traits/from-into.md:29
@@ -8725,25 +8130,16 @@ msgid ""
 "abstract over `u8` sources:"
 msgstr ""
 
-#: src/traits/read-write.md:5
-msgid ""
-"```rust,editable\n"
-"use std::io::{BufRead, BufReader, Read, Result};\n"
-"\n"
-"fn count_lines<R: Read>(reader: R) -> usize {\n"
-"    let buf_reader = BufReader::new(reader);\n"
-"    buf_reader.lines().count()\n"
-"}\n"
-"\n"
-"fn main() -> Result<()> {\n"
-"    let slice: &[u8] = b\"foo\\nbar\\nbaz\\n\";\n"
-"    println!(\"lines in slice: {}\", count_lines(slice));\n"
-"\n"
-"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
-"    println!(\"lines in file: {}\", count_lines(file));\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/traits/read-write.md:14
+msgid "b\"foo\\nbar\\nbaz\\n\""
+msgstr ""
+
+#: src/traits/read-write.md:15
+msgid "\"lines in slice: {}\""
+msgstr ""
+
+#: src/traits/read-write.md:18
+msgid "\"lines in file: {}\""
 msgstr ""
 
 #: src/traits/read-write.md:23
@@ -8752,24 +8148,12 @@ msgid ""
 "you abstract over `u8` sinks:"
 msgstr ""
 
-#: src/traits/read-write.md:25
-msgid ""
-"```rust,editable\n"
-"use std::io::{Result, Write};\n"
-"\n"
-"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
-"    writer.write_all(msg.as_bytes())?;\n"
-"    writer.write_all(\"\\n\".as_bytes())\n"
-"}\n"
-"\n"
-"fn main() -> Result<()> {\n"
-"    let mut buffer = Vec::new();\n"
-"    log(&mut buffer, \"Hello\")?;\n"
-"    log(&mut buffer, \"World\")?;\n"
-"    println!(\"Logged: {:?}\", buffer);\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/traits/read-write.md:30
+msgid "\"\\n\""
+msgstr ""
+
+#: src/traits/read-write.md:37
+msgid "\"Logged: {:?}\""
 msgstr ""
 
 #: src/traits/drop.md:1
@@ -8782,34 +8166,38 @@ msgid ""
 "html) can specify code to run when they go out of scope:"
 msgstr ""
 
-#: src/traits/drop.md:5
-msgid ""
-"```rust,editable\n"
-"struct Droppable {\n"
-"    name: &'static str,\n"
-"}\n"
-"\n"
-"impl Drop for Droppable {\n"
-"    fn drop(&mut self) {\n"
-"        println!(\"Dropping {}\", self.name);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let a = Droppable { name: \"a\" };\n"
-"    {\n"
-"        let b = Droppable { name: \"b\" };\n"
-"        {\n"
-"            let c = Droppable { name: \"c\" };\n"
-"            let d = Droppable { name: \"d\" };\n"
-"            println!(\"Exiting block B\");\n"
-"        }\n"
-"        println!(\"Exiting block A\");\n"
-"    }\n"
-"    drop(a);\n"
-"    println!(\"Exiting main\");\n"
-"}\n"
-"```"
+#: src/traits/drop.md:12
+msgid "\"Dropping {}\""
+msgstr ""
+
+#: src/traits/drop.md:17 src/exercises/concurrency/link-checker.md:92
+#: src/exercises/day-1/solutions-morning.md:86
+#: src/exercises/concurrency/solutions-morning.md:123
+msgid "\"a\""
+msgstr ""
+
+#: src/traits/drop.md:19 src/exercises/day-1/solutions-morning.md:86
+msgid "\"b\""
+msgstr ""
+
+#: src/traits/drop.md:21 src/exercises/day-1/solutions-morning.md:86
+msgid "\"c\""
+msgstr ""
+
+#: src/traits/drop.md:22 src/exercises/day-1/solutions-morning.md:86
+msgid "\"d\""
+msgstr ""
+
+#: src/traits/drop.md:23
+msgid "\"Exiting block B\""
+msgstr ""
+
+#: src/traits/drop.md:25
+msgid "\"Exiting block A\""
+msgstr ""
+
+#: src/traits/drop.md:28
+msgid "\"Exiting main\""
 msgstr ""
 
 #: src/traits/drop.md:34
@@ -8873,40 +8261,24 @@ msgid ""
 "produces a default value for a type."
 msgstr ""
 
-#: src/traits/default.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug, Default)]\n"
-"struct Derived {\n"
-"    x: u32,\n"
-"    y: String,\n"
-"    z: Implemented,\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct Implemented(String);\n"
-"\n"
-"impl Default for Implemented {\n"
-"    fn default() -> Self {\n"
-"        Self(\"John Smith\".into())\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let default_struct = Derived::default();\n"
-"    println!(\"{default_struct:#?}\");\n"
-"\n"
-"    let almost_default_struct = Derived {\n"
-"        y: \"Y is set!\".into(),\n"
-"        ..Derived::default()\n"
-"    };\n"
-"    println!(\"{almost_default_struct:#?}\");\n"
-"\n"
-"    let nothing: Option<Derived> = None;\n"
-"    println!(\"{:#?}\", nothing.unwrap_or_default());\n"
-"}\n"
-"\n"
-"```"
+#: src/traits/default.md:18
+msgid "\"John Smith\""
+msgstr ""
+
+#: src/traits/default.md:24
+msgid "\"{default_struct:#?}\""
+msgstr ""
+
+#: src/traits/default.md:27
+msgid "\"Y is set!\""
+msgstr ""
+
+#: src/traits/default.md:30
+msgid "\"{almost_default_struct:#?}\""
+msgstr ""
+
+#: src/traits/default.md:33
+msgid "\"{:#?}\""
 msgstr ""
 
 #: src/traits/default.md:40
@@ -8957,26 +8329,8 @@ msgid ""
 "rust-lang.org/std/ops/index.html):"
 msgstr ""
 
-#: src/traits/operators.md:5
-msgid ""
-"```rust,editable\n"
-"#[derive(Debug, Copy, Clone)]\n"
-"struct Point { x: i32, y: i32 }\n"
-"\n"
-"impl std::ops::Add for Point {\n"
-"    type Output = Self;\n"
-"\n"
-"    fn add(self, other: Self) -> Self {\n"
-"        Self {x: self.x + other.x, y: self.y + other.y}\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let p1 = Point { x: 10, y: 20 };\n"
-"    let p2 = Point { x: 100, y: 200 };\n"
-"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
-"}\n"
-"```"
+#: src/traits/operators.md:20
+msgid "\"{:?} + {:?} = {:?}\""
 msgstr ""
 
 #: src/traits/operators.md:28
@@ -9022,31 +8376,20 @@ msgid ""
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
-#: src/traits/closures.md:8
-msgid ""
-"```rust,editable\n"
-"fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
-"    println!(\"Calling function on {input}\");\n"
-"    func(input)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let add_3 = |x| x + 3;\n"
-"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
-"    println!(\"add_3: {}\", apply_with_log(add_3, 20));\n"
-"\n"
-"    let mut v = Vec::new();\n"
-"    let mut accumulate = |x: i32| {\n"
-"        v.push(x);\n"
-"        v.iter().sum::<i32>()\n"
-"    };\n"
-"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 4));\n"
-"    println!(\"accumulate: {}\", apply_with_log(&mut accumulate, 5));\n"
-"\n"
-"    let multiply_sum = |x| x * v.into_iter().sum::<i32>();\n"
-"    println!(\"multiply_sum: {}\", apply_with_log(multiply_sum, 3));\n"
-"}\n"
-"```"
+#: src/traits/closures.md:10
+msgid "\"Calling function on {input}\""
+msgstr ""
+
+#: src/traits/closures.md:16 src/traits/closures.md:17
+msgid "\"add_3: {}\""
+msgstr ""
+
+#: src/traits/closures.md:24 src/traits/closures.md:25
+msgid "\"accumulate: {}\""
+msgstr ""
+
+#: src/traits/closures.md:28
+msgid "\"multiply_sum: {}\""
 msgstr ""
 
 #: src/traits/closures.md:34
@@ -9087,18 +8430,12 @@ msgid ""
 "keyword makes them capture by value."
 msgstr ""
 
-#: src/traits/closures.md:52
-msgid ""
-"```rust,editable\n"
-"fn make_greeter(prefix: String) -> impl Fn(&str) {\n"
-"    return move |name| println!(\"{} {}\", prefix, name)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let hi = make_greeter(\"Hi\".to_string());\n"
-"    hi(\"there\");\n"
-"}\n"
-"```"
+#: src/traits/closures.md:58
+msgid "\"Hi\""
+msgstr ""
+
+#: src/traits/closures.md:59
+msgid "\"there\""
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
@@ -9157,117 +8494,39 @@ msgid ""
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:19
-msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]\n"
-"\n"
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;\n"
-"\n"
-"    /// Draw the widget into a buffer.\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
-"\n"
-"    /// Draw the widget on standard output.\n"
-"    fn draw(&self) {\n"
-"        let mut buffer = String::new();\n"
-"        self.draw_into(&mut buffer);\n"
-"        println!(\"{buffer}\");\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Label {\n"
-"    label: String,\n"
-"}\n"
-"\n"
-"impl Label {\n"
-"    fn new(label: &str) -> Label {\n"
-"        Label {\n"
-"            label: label.to_owned(),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Button {\n"
-"    label: Label,\n"
-"}\n"
-"\n"
-"impl Button {\n"
-"    fn new(label: &str) -> Button {\n"
-"        Button {\n"
-"            label: Label::new(label),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Window {\n"
-"    title: String,\n"
-"    widgets: Vec<Box<dyn Widget>>,\n"
-"}\n"
-"\n"
-"impl Window {\n"
-"    fn new(title: &str) -> Window {\n"
-"        Window {\n"
-"            title: title.to_owned(),\n"
-"            widgets: Vec::new(),\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
-"        self.widgets.push(widget);\n"
-"    }\n"
-"\n"
-"    fn inner_width(&self) -> usize {\n"
-"        std::cmp::max(\n"
-"            self.title.chars().count(),\n"
-"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-"        )\n"
-"    }\n"
-"}\n"
-"\n"
-"\n"
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
-"\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\"\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"```"
+#: src/exercises/day-3/simple-gui.md:24
+#: src/exercises/day-3/solutions-morning.md:9
+msgid "/// Natural width of `self`.\n"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:27
+#: src/exercises/day-3/solutions-morning.md:12
+msgid "/// Draw the widget into a buffer.\n"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:30
+#: src/exercises/day-3/solutions-morning.md:15
+msgid "/// Draw the widget on standard output.\n"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:34
+#: src/exercises/day-3/solutions-morning.md:19
+msgid "\"{buffer}\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:119
+#: src/exercises/day-3/solutions-morning.md:133
+msgid "\"Rust GUI Demo 1.23\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:120
+#: src/exercises/day-3/solutions-morning.md:134
+msgid "\"This is a small text GUI demo.\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:122
+#: src/exercises/day-3/solutions-morning.md:136
+msgid "\"Click me!\""
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:128
@@ -9282,16 +8541,16 @@ msgid ""
 "and how you can control alignment:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:145
-msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let width = 10;\n"
-"    println!(\"left aligned:  |{:/<width$}|\", \"foo\");\n"
-"    println!(\"centered:      |{:/^width$}|\", \"foo\");\n"
-"    println!(\"right aligned: |{:/>width$}|\", \"foo\");\n"
-"}\n"
-"```"
+#: src/exercises/day-3/simple-gui.md:148
+msgid "\"left aligned:  |{:/<width$}|\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:149
+msgid "\"centered:      |{:/^width$}|\""
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:150
+msgid "\"right aligned: |{:/>width$}|\""
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:154
@@ -9310,115 +8569,16 @@ msgid ""
 "make the tests pass:"
 msgstr ""
 
-#: src/exercises/day-3/points-polygons.md:7
-msgid ""
-"```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]\n"
-"\n"
-"pub struct Point {\n"
-"    // add fields\n"
-"}\n"
-"\n"
-"impl Point {\n"
-"    // add methods\n"
-"}\n"
-"\n"
-"pub struct Polygon {\n"
-"    // add fields\n"
-"}\n"
-"\n"
-"impl Polygon {\n"
-"    // add methods\n"
-"}\n"
-"\n"
-"pub struct Circle {\n"
-"    // add fields\n"
-"}\n"
-"\n"
-"impl Circle {\n"
-"    // add methods\n"
-"}\n"
-"\n"
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"\n"
-"    fn round_two_digits(x: f64) -> f64 {\n"
-"        (x * 100.0).round() / 100.0\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_magnitude() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_dist() {\n"
-"        let p1 = Point::new(10, 10);\n"
-"        let p2 = Point::new(14, 13);\n"
-"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_add() {\n"
-"        let p1 = Point::new(16, 16);\n"
-"        let p2 = p1 + Point::new(-4, 3);\n"
-"        assert_eq!(p2, Point::new(12, 19));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_left_most_point() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"        assert_eq!(poly.left_most_point(), Some(p1));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_iter() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"\n"
-"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
-"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}\n"
-"\n"
-"#[allow(dead_code)]\n"
-"fn main() {}\n"
-"```"
+#: src/exercises/day-3/points-polygons.md:12
+#: src/exercises/day-3/points-polygons.md:20
+#: src/exercises/day-3/points-polygons.md:28
+msgid "// add fields\n"
+msgstr ""
+
+#: src/exercises/day-3/points-polygons.md:16
+#: src/exercises/day-3/points-polygons.md:24
+#: src/exercises/day-3/points-polygons.md:32
+msgid "// add methods\n"
 msgstr ""
 
 #: src/exercises/day-3/points-polygons.md:117
@@ -9460,14 +8620,8 @@ msgstr ""
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
 msgstr ""
 
-#: src/error-handling/panics.md:5
-msgid ""
-"```rust,editable,should_panic\n"
-"fn main() {\n"
-"    let v = vec![10, 20, 30];\n"
-"    println!(\"v[100]: {}\", v[100]);\n"
-"}\n"
-"```"
+#: src/error-handling/panics.md:8
+msgid "\"v[100]: {}\""
 msgstr ""
 
 #: src/error-handling/panics.md:12
@@ -9493,23 +8647,16 @@ msgid ""
 "caught:"
 msgstr ""
 
-#: src/error-handling/panic-unwind.md:5
-msgid ""
-"```rust,editable\n"
-"use std::panic;\n"
-"\n"
-"fn main() {\n"
-"    let result = panic::catch_unwind(|| {\n"
-"        \"No problem here!\"\n"
-"    });\n"
-"    println!(\"{result:?}\");\n"
-"\n"
-"    let result = panic::catch_unwind(|| {\n"
-"        panic!(\"oh no!\");\n"
-"    });\n"
-"    println!(\"{result:?}\");\n"
-"}\n"
-"```"
+#: src/error-handling/panic-unwind.md:10
+msgid "\"No problem here!\""
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:12 src/error-handling/panic-unwind.md:17
+msgid "\"{result:?}\""
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:15
+msgid "\"oh no!\""
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:21
@@ -9532,26 +8679,16 @@ msgid ""
 "are expected as part of normal operation:"
 msgstr ""
 
-#: src/error-handling/result.md:6
-msgid ""
-"```rust,editable\n"
-"use std::fs;\n"
-"use std::io::Read;\n"
-"\n"
-"fn main() {\n"
-"    let file = fs::File::open(\"diary.txt\");\n"
-"    match file {\n"
-"        Ok(mut file) => {\n"
-"            let mut contents = String::new();\n"
-"            file.read_to_string(&mut contents);\n"
-"            println!(\"Dear diary: {contents}\");\n"
-"        },\n"
-"        Err(err) => {\n"
-"            println!(\"The diary could not be opened: {err}\");\n"
-"        }\n"
-"    }\n"
-"}\n"
-"```"
+#: src/error-handling/result.md:11
+msgid "\"diary.txt\""
+msgstr ""
+
+#: src/error-handling/result.md:16
+msgid "\"Dear diary: {contents}\""
+msgstr ""
+
+#: src/error-handling/result.md:19
+msgid "\"The diary could not be opened: {err}\""
 msgstr ""
 
 #: src/error-handling/result.md:27
@@ -9587,32 +8724,21 @@ msgstr ""
 msgid "We can use this to simplify our error handling code:"
 msgstr ""
 
-#: src/error-handling/try-operator.md:21
-msgid ""
-"```rust,editable\n"
-"use std::{fs, io};\n"
-"use std::io::Read;\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, io::Error> {\n"
-"    let username_file_result = fs::File::open(path);\n"
-"    let mut username_file = match username_file_result {\n"
-"        Ok(file) => file,\n"
-"        Err(err) => return Err(err),\n"
-"    };\n"
-"\n"
-"    let mut username = String::new();\n"
-"    match username_file.read_to_string(&mut username) {\n"
-"        Ok(_) => Ok(username),\n"
-"        Err(err) => Err(err),\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
-"}\n"
-"```"
+#: src/error-handling/try-operator.md:40
+msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
+msgstr ""
+
+#: src/error-handling/try-operator.md:41
+#: src/error-handling/converting-error-types-example.md:43
+#: src/error-handling/deriving-error-enums.md:30
+#: src/error-handling/dynamic-errors.md:27
+#: src/error-handling/error-contexts.md:26
+msgid "\"config.dat\""
+msgstr ""
+
+#: src/error-handling/try-operator.md:42
+#: src/error-handling/converting-error-types-example.md:44
+msgid "\"username or error: {username:?}\""
 msgstr ""
 
 #: src/error-handling/try-operator.md:50
@@ -9661,53 +8787,19 @@ msgid ""
 "type returned by the function."
 msgstr ""
 
-#: src/error-handling/converting-error-types-example.md:3
-msgid ""
-"```rust,editable\n"
-"use std::error::Error;\n"
-"use std::fmt::{self, Display, Formatter};\n"
-"use std::fs::{self, File};\n"
-"use std::io::{self, Read};\n"
-"\n"
-"#[derive(Debug)]\n"
-"enum ReadUsernameError {\n"
-"    IoError(io::Error),\n"
-"    EmptyUsername(String),\n"
-"}\n"
-"\n"
-"impl Error for ReadUsernameError {}\n"
-"\n"
-"impl Display for ReadUsernameError {\n"
-"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-"        match self {\n"
-"            Self::IoError(e) => write!(f, \"IO error: {e}\"),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
-"in {filename}\"),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"impl From<io::Error> for ReadUsernameError {\n"
-"    fn from(err: io::Error) -> ReadUsernameError {\n"
-"        ReadUsernameError::IoError(err)\n"
-"    }\n"
-"}\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
-"}\n"
-"```"
+#: src/error-handling/converting-error-types-example.md:20
+msgid "\"IO error: {e}\""
+msgstr ""
+
+#: src/error-handling/converting-error-types-example.md:21
+msgid "\"Found no username in {filename}\""
+msgstr ""
+
+#: src/error-handling/converting-error-types-example.md:42
+#: src/error-handling/deriving-error-enums.md:29
+#: src/error-handling/dynamic-errors.md:26
+#: src/error-handling/error-contexts.md:25
+msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:55
@@ -9731,38 +8823,24 @@ msgid ""
 "an error enum like we did on the previous page:"
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::{fs, io};\n"
-"use std::io::Read;\n"
-"use thiserror::Error;\n"
-"\n"
-"#[derive(Debug, Error)]\n"
-"enum ReadUsernameError {\n"
-"    #[error(\"Could not read: {0}\")]\n"
-"    IoError(#[from] io::Error),\n"
-"    #[error(\"Found no username in {0}\")]\n"
-"    EmptyUsername(String),\n"
-"}\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::new();\n"
-"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/error-handling/deriving-error-enums.md:13
+msgid "\"Could not read: {0}\""
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:15
+#: src/error-handling/dynamic-errors.md:13
+msgid "\"Found no username in {0}\""
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:31
+#: src/error-handling/dynamic-errors.md:28
+#: src/error-handling/error-contexts.md:27
+msgid "\"Username: {username}\""
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:32
+#: src/error-handling/dynamic-errors.md:29
+msgid "\"Error: {err}\""
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:39
@@ -9783,37 +8861,6 @@ msgid ""
 "makes this easy."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::fs;\n"
-"use std::io::Read;\n"
-"use thiserror::Error;\n"
-"use std::error::Error;\n"
-"\n"
-"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
-"#[error(\"Found no username in {0}\")]\n"
-"struct EmptyUsernameError(String);\n"
-"\n"
-"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
-"    let mut username = String::new();\n"
-"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(EmptyUsernameError(String::from(path)).into());\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err}\"),\n"
-"    }\n"
-"}\n"
-"```"
-msgstr ""
-
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
@@ -9830,33 +8877,20 @@ msgid ""
 "error types:"
 msgstr ""
 
-#: src/error-handling/error-contexts.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::{fs, io};\n"
-"use std::io::Read;\n"
-"use anyhow::{Context, Result, bail};\n"
-"\n"
-"fn read_username(path: &str) -> Result<String> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    fs::File::open(path)\n"
-"        .with_context(|| format!(\"Failed to open {path}\"))?\n"
-"        .read_to_string(&mut username)\n"
-"        .context(\"Failed to read\")?;\n"
-"    if username.is_empty() {\n"
-"        bail!(\"Found no username in {path}\");\n"
-"    }\n"
-"    Ok(username)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err:?}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/error-handling/error-contexts.md:15
+msgid "\"Failed to open {path}\""
+msgstr ""
+
+#: src/error-handling/error-contexts.md:17
+msgid "\"Failed to read\""
+msgstr ""
+
+#: src/error-handling/error-contexts.md:19
+msgid "\"Found no username in {path}\""
+msgstr ""
+
+#: src/error-handling/error-contexts.md:28
+msgid "\"Error: {err:?}\""
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
@@ -9898,31 +8932,8 @@ msgstr ""
 msgid "Mark unit tests with `#[test]`:"
 msgstr ""
 
-#: src/testing/unit-tests.md:5
-msgid ""
-"```rust,editable,ignore\n"
-"fn first_word(text: &str) -> &str {\n"
-"    match text.find(' ') {\n"
-"        Some(idx) => &text[..idx],\n"
-"        None => &text,\n"
-"    }\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_empty() {\n"
-"    assert_eq!(first_word(\"\"), \"\");\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_single_word() {\n"
-"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_multiple_words() {\n"
-"    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
-"}\n"
-"```"
+#: src/testing/unit-tests.md:25
+msgid "\"Hello World\""
 msgstr ""
 
 #: src/testing/unit-tests.md:29
@@ -9935,27 +8946,12 @@ msgid ""
 "(https://play.rust-lang.org/)):"
 msgstr ""
 
-#: src/testing/test-modules.md:6
-msgid ""
-"```rust,editable\n"
-"fn helper(a: &str, b: &str) -> String {\n"
-"    format!(\"{a} {b}\")\n"
-"}\n"
-"\n"
-"pub fn main() {\n"
-"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"\n"
-"    #[test]\n"
-"    fn test_helper() {\n"
-"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/testing/test-modules.md:8
+msgid "\"{a} {b}\""
+msgstr ""
+
+#: src/testing/test-modules.md:21
+msgid "\"foo bar\""
 msgstr ""
 
 #: src/testing/test-modules.md:26
@@ -9970,9 +8966,8 @@ msgstr ""
 msgid "Rust has built-in support for documentation tests:"
 msgstr ""
 
-#: src/testing/doc-tests.md:5
+#: src/testing/doc-tests.md:6
 msgid ""
-"```rust\n"
 "/// Shortens a string to the given length.\n"
 "///\n"
 "/// ```\n"
@@ -9980,10 +8975,6 @@ msgid ""
 "/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
 "/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
 "/// ```\n"
-"pub fn shorten_string(s: &str, length: usize) -> &str {\n"
-"    &s[..std::cmp::min(length, s.len())]\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/testing/doc-tests.md:18
@@ -10115,28 +9106,22 @@ msgstr ""
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:5
+#: src/unsafe/raw-pointers.md:12
 msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let mut num = 5;\n"
-"\n"
-"    let r1 = &mut num as *mut i32;\n"
-"    let r2 = r1 as *const i32;\n"
-"\n"
-"    // Safe because r1 and r2 were obtained from references and so are\n"
+"// Safe because r1 and r2 were obtained from references and so are\n"
 "    // guaranteed to be non-null and properly aligned, the objects "
 "underlying\n"
 "    // the references from which they were obtained are live throughout the\n"
 "    // whole unsafe block, and they are not accessed either through the\n"
 "    // references or concurrently through any other pointers.\n"
-"    unsafe {\n"
-"        println!(\"r1 is: {}\", *r1);\n"
-"        *r1 = 10;\n"
-"        println!(\"r2 is: {}\", *r2);\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:18
+msgid "\"r1 is: {}\""
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:20
+msgid "\"r2 is: {}\""
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:27
@@ -10184,15 +9169,12 @@ msgstr ""
 msgid "It is safe to read an immutable static variable:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:5
-msgid ""
-"```rust,editable\n"
-"static HELLO_WORLD: &str = \"Hello, world!\";\n"
-"\n"
-"fn main() {\n"
-"    println!(\"HELLO_WORLD: {HELLO_WORLD}\");\n"
-"}\n"
-"```"
+#: src/unsafe/mutable-static-variables.md:6
+msgid "\"Hello, world!\""
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:9
+msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
@@ -10201,21 +9183,13 @@ msgid ""
 "static variables:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:16
-msgid ""
-"```rust,editable\n"
-"static mut COUNTER: u32 = 0;\n"
-"\n"
-"fn add_to_counter(inc: u32) {\n"
-"    unsafe { COUNTER += inc; }  // Potential data race!\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    add_to_counter(42);\n"
-"\n"
-"    unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
-"}\n"
-"```"
+#: src/unsafe/mutable-static-variables.md:20
+#: src/unsafe/mutable-static-variables.md:26
+msgid "// Potential data race!\n"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:26
+msgid "\"COUNTER: {COUNTER}\""
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:32
@@ -10237,21 +9211,16 @@ msgstr ""
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
 
-#: src/unsafe/unions.md:5
-msgid ""
-"```rust,editable\n"
-"#[repr(C)]\n"
-"union MyUnion {\n"
-"    i: u8,\n"
-"    b: bool,\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let u = MyUnion { i: 42 };\n"
-"    println!(\"int: {}\", unsafe { u.i });\n"
-"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
-"}\n"
-"```"
+#: src/unsafe/unions.md:14
+msgid "\"int: {}\""
+msgstr ""
+
+#: src/unsafe/unions.md:15
+msgid "\"bool: {}\""
+msgstr ""
+
+#: src/unsafe/unions.md:15
+msgid "// Undefined behavior!\n"
 msgstr ""
 
 #: src/unsafe/unions.md:21
@@ -10274,34 +9243,32 @@ msgid ""
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:6
+#: src/unsafe/calling-unsafe-functions.md:8
+msgid "\"🗻∈🌏\""
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:10
 msgid ""
-"```rust,editable\n"
-"fn main() {\n"
-"    let emojis = \"🗻∈🌏\";\n"
-"\n"
-"    // Safe because the indices are in the correct order, within the bounds "
-"of\n"
+"// Safe because the indices are in the correct order, within the bounds of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
-"    unsafe {\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
-"    }\n"
-"\n"
-"    println!(\"char count: {}\", count_chars(unsafe { emojis."
-"get_unchecked(0..7) }));\n"
-"\n"
-"    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:13
+#: src/unsafe/calling-unsafe-functions.md:14
+#: src/unsafe/calling-unsafe-functions.md:15
+msgid "\"emoji: {}\""
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:18
+msgid "\"char count: {}\""
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:20
+msgid ""
+"// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
 "    // println!(\"char count: {}\", count_chars(unsafe { emojis."
 "get_unchecked(0..3) }));\n"
-"}\n"
-"\n"
-"fn count_chars(s: &str) -> usize {\n"
-"    s.chars().count()\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:3
@@ -10310,32 +9277,21 @@ msgid ""
 "conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:6
+#: src/unsafe/writing-unsafe-functions.md:7
 msgid ""
-"```rust,editable\n"
 "/// Swaps the values pointed to by the given pointers.\n"
 "///\n"
 "/// # Safety\n"
 "///\n"
 "/// The pointers must be valid and properly aligned.\n"
-"unsafe fn swap(a: *mut u8, b: *mut u8) {\n"
-"    let temp = *a;\n"
-"    *a = *b;\n"
-"    *b = temp;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut a = 42;\n"
-"    let mut b = 66;\n"
-"\n"
-"    // Safe because ...\n"
-"    unsafe {\n"
-"        swap(&mut a, &mut b);\n"
-"    }\n"
-"\n"
-"    println!(\"a = {}, b = {}\", a, b);\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:22
+msgid "// Safe because ...\n"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:27
+msgid "\"a = {}, b = {}\""
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:33
@@ -10361,20 +9317,30 @@ msgid ""
 "them is thus unsafe:"
 msgstr ""
 
-#: src/unsafe/extern-functions.md:6
-msgid ""
-"```rust,editable\n"
-"extern \"C\" {\n"
-"    fn abs(input: i32) -> i32;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    unsafe {\n"
-"        // Undefined behavior if abs misbehaves.\n"
-"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
-"    }\n"
-"}\n"
-"```"
+#: src/unsafe/extern-functions.md:7 src/exercises/day-3/safe-ffi-wrapper.md:89
+#: src/android/interoperability/with-c.md:9
+#: src/android/interoperability/with-c/rust.md:15
+#: src/android/interoperability/with-c/rust.md:30
+#: src/android/interoperability/cpp/cpp-bridge.md:29
+#: src/android/interoperability/cpp/cpp-bridge.md:38
+#: src/bare-metal/aps/inline-assembly.md:18
+#: src/bare-metal/aps/better-uart/using.md:24
+#: src/bare-metal/aps/logging/using.md:23 src/exercises/bare-metal/rtc.md:46
+#: src/exercises/bare-metal/rtc.md:100 src/exercises/bare-metal/rtc.md:106
+#: src/exercises/bare-metal/rtc.md:113 src/exercises/bare-metal/rtc.md:119
+#: src/exercises/bare-metal/rtc.md:125 src/exercises/bare-metal/rtc.md:131
+#: src/exercises/bare-metal/rtc.md:137 src/exercises/bare-metal/rtc.md:143
+#: src/exercises/day-3/solutions-afternoon.md:45
+#: src/exercises/bare-metal/solutions-afternoon.md:43
+msgid "\"C\""
+msgstr ""
+
+#: src/unsafe/extern-functions.md:13
+msgid "// Undefined behavior if abs misbehaves.\n"
+msgstr ""
+
+#: src/unsafe/extern-functions.md:14
+msgid "\"Absolute value of -3 according to C: {}\""
 msgstr ""
 
 #: src/unsafe/extern-functions.md:21
@@ -10402,27 +9368,15 @@ msgid ""
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:9
+#: src/unsafe/unsafe-traits.md:12
 msgid ""
-"```rust,editable\n"
-"use std::mem::size_of_val;\n"
-"use std::slice;\n"
-"\n"
 "/// ...\n"
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
-"pub unsafe trait AsBytes {\n"
-"    fn as_bytes(&self) -> &[u8] {\n"
-"        unsafe {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, "
-"size_of_val(self))\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"// Safe because u32 has a defined representation and no padding.\n"
-"unsafe impl AsBytes for u32 {}\n"
-"```"
+msgstr ""
+
+#: src/unsafe/unsafe-traits.md:23
+msgid "// Safe because u32 has a defined representation and no padding.\n"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:30
@@ -10597,111 +9551,88 @@ msgid ""
 "functions and methods:"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:48
+#: src/exercises/day-3/safe-ffi-wrapper.md:54
+#: src/exercises/day-3/safe-ffi-wrapper.md:67
+#: src/exercises/day-3/safe-ffi-wrapper.md:78
+#: src/exercises/day-3/safe-ffi-wrapper.md:92
+#: src/exercises/day-3/safe-ffi-wrapper.md:100
+#: src/exercises/day-3/solutions-afternoon.md:10
+#: src/exercises/day-3/solutions-afternoon.md:23
+#: src/exercises/day-3/solutions-afternoon.md:34
+#: src/exercises/day-3/solutions-afternoon.md:48
+#: src/exercises/day-3/solutions-afternoon.md:56
+msgid "\"macos\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:57
+#: src/exercises/day-3/solutions-afternoon.md:13
+msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:64
+#: src/exercises/day-3/solutions-afternoon.md:20
 msgid ""
-"```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]\n"
-"\n"
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int};\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
-"\n"
-"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-"    #[repr(C)]\n"
-"    pub struct DIR {\n"
-"        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
-"PhantomPinned)>,\n"
-"    }\n"
-"\n"
-"    // Layout according to the Linux man page for readdir(3), where ino_t "
-"and\n"
+"// Layout according to the Linux man page for readdir(3), where ino_t and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_ino: c_ulong,\n"
-"        pub d_off: c_long,\n"
-"        pub d_reclen: c_ushort,\n"
-"        pub d_type: c_uchar,\n"
-"        pub d_name: [c_char; 256],\n"
-"    }\n"
-"\n"
-"    // Layout according to the macOS man page for dir(5).\n"
-"    #[cfg(all(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_fileno: u64,\n"
-"        pub d_seekoff: u64,\n"
-"        pub d_reclen: u16,\n"
-"        pub d_namlen: u16,\n"
-"        pub d_type: u8,\n"
-"        pub d_name: [c_char; 1024],\n"
-"    }\n"
-"\n"
-"    extern \"C\" {\n"
-"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
-"\n"
-"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        // See https://github.com/rust-lang/libc/issues/414 and the section "
-"on\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:77
+#: src/exercises/day-3/solutions-afternoon.md:33
+msgid "// Layout according to the macOS man page for dir(5).\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:92
+#: src/exercises/day-3/safe-ffi-wrapper.md:100
+#: src/exercises/day-3/solutions-afternoon.md:48
+#: src/exercises/day-3/solutions-afternoon.md:56
+msgid "\"x86_64\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:95
+#: src/exercises/day-3/solutions-afternoon.md:51
+msgid ""
+"// See https://github.com/rust-lang/libc/issues/414 and the section on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
 "        //\n"
 "        // \"Platforms that existed before these updates were available\" "
 "refers\n"
 "        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
 "PowerPC.\n"
-"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
-"        #[link_name = \"readdir$INODE64\"]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        pub fn closedir(s: *mut DIR) -> c_int;\n"
-"    }\n"
-"}\n"
-"\n"
-"use std::ffi::{CStr, CString, OsStr, OsString};\n"
-"use std::os::unix::ffi::OsStrExt;\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}\n"
-"\n"
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:101
+#: src/exercises/day-3/solutions-afternoon.md:57
+msgid "\"readdir$INODE64\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:119
+#: src/exercises/day-3/solutions-afternoon.md:75
+msgid ""
+"// Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:128
+msgid "// Keep calling readdir until we get a NULL pointer back.\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:135
+#: src/exercises/day-3/solutions-afternoon.md:108
+msgid "// Call closedir as needed.\n"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:141
+#: src/android/interoperability/with-c/rust.md:44
+#: src/exercises/day-3/solutions-afternoon.md:119
+#: src/exercises/day-3/solutions-afternoon.md:143
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\".\""
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:142
+#: src/exercises/day-3/solutions-afternoon.md:120
+msgid "\"files: {:#?}\""
 msgstr ""
 
 #: src/android.md:1
@@ -10837,31 +9768,29 @@ msgstr ""
 msgid "_hello_rust/Android.bp_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:8
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"hello_rust\",\n"
-"    crate_name: \"hello_rust\",\n"
-"    srcs: [\"src/main.rs\"],\n"
-"}\n"
-"```"
+#: src/android/build-rules/binary.md:10 src/android/build-rules/binary.md:11
+msgid "\"hello_rust\""
+msgstr ""
+
+#: src/android/build-rules/binary.md:12 src/android/build-rules/library.md:19
+#: src/android/logging.md:12
+msgid "\"src/main.rs\""
 msgstr ""
 
 #: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:33
 msgid "_hello_rust/src/main.rs_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:18
-msgid ""
-"```rust\n"
-"//! Rust demo.\n"
-"\n"
-"/// Prints a greeting to standard output.\n"
-"fn main() {\n"
-"    println!(\"Hello from Rust!\");\n"
-"}\n"
-"```"
+#: src/android/build-rules/binary.md:19 src/android/build-rules/library.md:36
+msgid "//! Rust demo.\n"
+msgstr ""
+
+#: src/android/build-rules/binary.md:20 src/android/build-rules/library.md:40
+msgid "/// Prints a greeting to standard output.\n"
+msgstr ""
+
+#: src/android/build-rules/binary.md:23
+msgid "\"Hello from Rust!\""
 msgstr ""
 
 #: src/android/build-rules/binary.md:27
@@ -10900,56 +9829,41 @@ msgid ""
 "crates/)."
 msgstr ""
 
-#: src/android/build-rules/library.md:15
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"hello_rust_with_dep\",\n"
-"    crate_name: \"hello_rust_with_dep\",\n"
-"    srcs: [\"src/main.rs\"],\n"
-"    rustlibs: [\n"
-"        \"libgreetings\",\n"
-"        \"libtextwrap\",\n"
-"    ],\n"
-"}\n"
-"\n"
-"rust_library {\n"
-"    name: \"libgreetings\",\n"
-"    crate_name: \"greetings\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
-"}\n"
-"```"
+#: src/android/build-rules/library.md:17 src/android/build-rules/library.md:18
+msgid "\"hello_rust_with_dep\""
 msgstr ""
 
-#: src/android/build-rules/library.md:35
-msgid ""
-"```rust,ignore\n"
-"//! Rust demo.\n"
-"\n"
-"use greetings::greeting;\n"
-"use textwrap::fill;\n"
-"\n"
-"/// Prints a greeting to standard output.\n"
-"fn main() {\n"
-"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
-"}\n"
-"```"
+#: src/android/build-rules/library.md:21 src/android/build-rules/library.md:27
+msgid "\"libgreetings\""
+msgstr ""
+
+#: src/android/build-rules/library.md:22
+msgid "\"libtextwrap\""
+msgstr ""
+
+#: src/android/build-rules/library.md:28
+msgid "\"greetings\""
+msgstr ""
+
+#: src/android/build-rules/library.md:29 src/android/aidl/implementation.md:31
+#: src/android/interoperability/java.md:38
+msgid "\"src/lib.rs\""
 msgstr ""
 
 #: src/android/build-rules/library.md:47
 msgid "_hello_rust/src/lib.rs_:"
 msgstr ""
 
-#: src/android/build-rules/library.md:49
-msgid ""
-"```rust,ignore\n"
-"//! Greeting library.\n"
-"\n"
-"/// Greet `name`.\n"
-"pub fn greeting(name: &str) -> String {\n"
-"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
-"}\n"
-"```"
+#: src/android/build-rules/library.md:50
+msgid "//! Greeting library.\n"
+msgstr ""
+
+#: src/android/build-rules/library.md:51
+msgid "/// Greet `name`.\n"
+msgstr ""
+
+#: src/android/build-rules/library.md:54
+msgid "\"Hello {name}, it is very nice to meet you!\""
 msgstr ""
 
 #: src/android/build-rules/library.md:58
@@ -10997,20 +9911,16 @@ msgstr ""
 msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/interface.md:19
-msgid ""
-"```javascript\n"
-"aidl_interface {\n"
-"    name: \"com.example.birthdayservice\",\n"
-"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
-"    unstable: true,\n"
-"    backend: {\n"
-"        rust: { // Rust is not enabled by default\n"
-"            enabled: true,\n"
-"        },\n"
-"    },\n"
-"}\n"
-"```"
+#: src/android/aidl/interface.md:21
+msgid "\"com.example.birthdayservice\""
+msgstr ""
+
+#: src/android/aidl/interface.md:22
+msgid "\"com/example/birthdayservice/*.aidl\""
+msgstr ""
+
+#: src/android/aidl/interface.md:25
+msgid "// Rust is not enabled by default\n"
 msgstr ""
 
 #: src/android/aidl/interface.md:32
@@ -11031,29 +9941,16 @@ msgstr ""
 msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md:7
-msgid ""
-"```rust,ignore\n"
-"//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
-"IBirthdayService::IBirthdayService;\n"
-"use com_example_birthdayservice::binder;\n"
-"\n"
-"/// The `IBirthdayService` implementation.\n"
-"pub struct BirthdayService;\n"
-"\n"
-"impl binder::Interface for BirthdayService {}\n"
-"\n"
-"impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
-"Result<String> {\n"
-"        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} years!"
-"\"\n"
-"        ))\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/aidl/implementation.md:8
+msgid "//! Implementation of the `IBirthdayService` AIDL interface.\n"
+msgstr ""
+
+#: src/android/aidl/implementation.md:11
+msgid "/// The `IBirthdayService` implementation.\n"
+msgstr ""
+
+#: src/android/aidl/implementation.md:20
+msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
 msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
@@ -11061,19 +9958,23 @@ msgstr ""
 msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md:28
-msgid ""
-"```javascript\n"
-"rust_library {\n"
-"    name: \"libbirthdayservice\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
-"    crate_name: \"birthdayservice\",\n"
-"    rustlibs: [\n"
-"        \"com.example.birthdayservice-rust\",\n"
-"        \"libbinder_rs\",\n"
-"    ],\n"
-"}\n"
-"```"
+#: src/android/aidl/implementation.md:30 src/android/aidl/server.md:38
+msgid "\"libbirthdayservice\""
+msgstr ""
+
+#: src/android/aidl/implementation.md:32 src/android/aidl/server.md:13
+#: src/android/aidl/client.md:12
+msgid "\"birthdayservice\""
+msgstr ""
+
+#: src/android/aidl/implementation.md:34 src/android/aidl/server.md:36
+#: src/android/aidl/client.md:45
+msgid "\"com.example.birthdayservice-rust\""
+msgstr ""
+
+#: src/android/aidl/implementation.md:35 src/android/aidl/server.md:37
+#: src/android/aidl/client.md:46
+msgid "\"libbinder_rs\""
 msgstr ""
 
 #: src/android/aidl/server.md:1
@@ -11088,46 +9989,24 @@ msgstr ""
 msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
-#: src/android/aidl/server.md:7
-msgid ""
-"```rust,ignore\n"
-"//! Birthday service.\n"
-"use birthdayservice::BirthdayService;\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
-"IBirthdayService::BnBirthdayService;\n"
-"use com_example_birthdayservice::binder;\n"
-"\n"
-"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
-"\n"
-"/// Entry point for birthday service.\n"
-"fn main() {\n"
-"    let birthday_service = BirthdayService;\n"
-"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
-"        birthday_service,\n"
-"        binder::BinderFeatures::default(),\n"
-"    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
-"as_binder())\n"
-"        .expect(\"Failed to register service\");\n"
-"    binder::ProcessState::join_thread_pool()\n"
-"}\n"
-"```"
+#: src/android/aidl/server.md:8 src/android/aidl/client.md:8
+msgid "//! Birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/server.md:30
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"birthday_server\",\n"
-"    crate_name: \"birthday_server\",\n"
-"    srcs: [\"src/server.rs\"],\n"
-"    rustlibs: [\n"
-"        \"com.example.birthdayservice-rust\",\n"
-"        \"libbinder_rs\",\n"
-"        \"libbirthdayservice\",\n"
-"    ],\n"
-"}\n"
-"```"
+#: src/android/aidl/server.md:14
+msgid "/// Entry point for birthday service.\n"
+msgstr ""
+
+#: src/android/aidl/server.md:23
+msgid "\"Failed to register service\""
+msgstr ""
+
+#: src/android/aidl/server.md:32 src/android/aidl/server.md:33
+msgid "\"birthday_server\""
+msgstr ""
+
+#: src/android/aidl/server.md:34
+msgid "\"src/server.rs\""
 msgstr ""
 
 #: src/android/aidl/deploy.md:3
@@ -11164,55 +10043,28 @@ msgstr ""
 msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
-#: src/android/aidl/client.md:7
-msgid ""
-"```rust,ignore\n"
-"//! Birthday service.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
-"IBirthdayService::IBirthdayService;\n"
-"use com_example_birthdayservice::binder;\n"
-"\n"
-"const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
-"\n"
-"/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
-"StatusCode> {\n"
-"    binder::get_interface(SERVICE_IDENTIFIER)\n"
-"}\n"
-"\n"
-"/// Call the birthday service.\n"
-"fn main() -> Result<(), binder::Status> {\n"
-"    let name = std::env::args()\n"
-"        .nth(1)\n"
-"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
-"    let years = std::env::args()\n"
-"        .nth(2)\n"
-"        .and_then(|arg| arg.parse::<i32>().ok())\n"
-"        .unwrap_or(42);\n"
-"\n"
-"    binder::ProcessState::start_thread_pool();\n"
-"    let service = connect().expect(\"Failed to connect to "
-"BirthdayService\");\n"
-"    let msg = service.wishHappyBirthday(&name, years)?;\n"
-"    println!(\"{msg}\");\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/android/aidl/client.md:13
+msgid "/// Connect to the BirthdayService.\n"
 msgstr ""
 
-#: src/android/aidl/client.md:39
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"birthday_client\",\n"
-"    crate_name: \"birthday_client\",\n"
-"    srcs: [\"src/client.rs\"],\n"
-"    rustlibs: [\n"
-"        \"com.example.birthdayservice-rust\",\n"
-"        \"libbinder_rs\",\n"
-"    ],\n"
-"}\n"
-"```"
+#: src/android/aidl/client.md:18
+msgid "/// Call the birthday service.\n"
+msgstr ""
+
+#: src/android/aidl/client.md:30
+msgid "\"Failed to connect to BirthdayService\""
+msgstr ""
+
+#: src/android/aidl/client.md:32
+msgid "\"{msg}\""
+msgstr ""
+
+#: src/android/aidl/client.md:41 src/android/aidl/client.md:42
+msgid "\"birthday_client\""
+msgstr ""
+
+#: src/android/aidl/client.md:43
+msgid "\"src/client.rs\""
 msgstr ""
 
 #: src/android/aidl/client.md:51
@@ -11249,45 +10101,44 @@ msgstr ""
 msgid "_hello_rust_logs/Android.bp_:"
 msgstr ""
 
-#: src/android/logging.md:8
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"hello_rust_logs\",\n"
-"    crate_name: \"hello_rust_logs\",\n"
-"    srcs: [\"src/main.rs\"],\n"
-"    rustlibs: [\n"
-"        \"liblog_rust\",\n"
-"        \"liblogger\",\n"
-"    ],\n"
-"    host_supported: true,\n"
-"}\n"
-"```"
+#: src/android/logging.md:10 src/android/logging.md:11
+msgid "\"hello_rust_logs\""
+msgstr ""
+
+#: src/android/logging.md:14
+msgid "\"liblog_rust\""
+msgstr ""
+
+#: src/android/logging.md:15
+msgid "\"liblogger\""
 msgstr ""
 
 #: src/android/logging.md:21
 msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
-#: src/android/logging.md:23
-msgid ""
-"```rust,ignore\n"
-"//! Rust logging demo.\n"
-"\n"
-"use log::{debug, error, info};\n"
-"\n"
-"/// Logs a greeting.\n"
-"fn main() {\n"
-"    logger::init(\n"
-"        logger::Config::default()\n"
-"            .with_tag_on_device(\"rust\")\n"
-"            .with_min_level(log::Level::Trace),\n"
-"    );\n"
-"    debug!(\"Starting program.\");\n"
-"    info!(\"Things are going fine.\");\n"
-"    error!(\"Something went wrong!\");\n"
-"}\n"
-"```"
+#: src/android/logging.md:24
+msgid "//! Rust logging demo.\n"
+msgstr ""
+
+#: src/android/logging.md:27
+msgid "/// Logs a greeting.\n"
+msgstr ""
+
+#: src/android/logging.md:32
+msgid "\"rust\""
+msgstr ""
+
+#: src/android/logging.md:35
+msgid "\"Starting program.\""
+msgstr ""
+
+#: src/android/logging.md:36
+msgid "\"Things are going fine.\""
+msgstr ""
+
+#: src/android/logging.md:37
+msgid "\"Something went wrong!\""
 msgstr ""
 
 #: src/android/logging.md:41 src/android/interoperability/with-c/bindgen.md:98
@@ -11343,19 +10194,8 @@ msgstr ""
 msgid "You can do it by hand if you want:"
 msgstr ""
 
-#: src/android/interoperability/with-c.md:8
-msgid ""
-"```rust\n"
-"extern \"C\" {\n"
-"    fn abs(x: i32) -> i32;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let x = -42;\n"
-"    let abs_x = unsafe { abs(x) };\n"
-"    println!(\"{x}, {abs_x}\");\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c.md:16
+msgid "\"{x}, {abs_x}\""
 msgstr ""
 
 #: src/android/interoperability/with-c.md:20
@@ -11396,19 +10236,22 @@ msgstr ""
 msgid "_interoperability/bindgen/libbirthday.c_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:21
-msgid ""
-"```c\n"
-"#include <stdio.h>\n"
-"#include \"libbirthday.h\"\n"
-"\n"
-"void print_card(const card* card) {\n"
-"  printf(\"+--------------\\n\");\n"
-"  printf(\"| Happy Birthday %s!\\n\", card->name);\n"
-"  printf(\"| Congratulations with the %i years!\\n\", card->years);\n"
-"  printf(\"+--------------\\n\");\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:23
+#: src/android/interoperability/with-c/bindgen.md:50
+msgid "\"libbirthday.h\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:26
+#: src/android/interoperability/with-c/bindgen.md:29
+msgid "\"+--------------\\n\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:27
+msgid "\"| Happy Birthday %s!\\n\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:28
+msgid "\"| Congratulations with the %i years!\\n\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:33
@@ -11422,14 +10265,13 @@ msgstr ""
 msgid "_interoperability/bindgen/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:37
-msgid ""
-"```javascript\n"
-"cc_library {\n"
-"    name: \"libbirthday\",\n"
-"    srcs: [\"libbirthday.c\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:39
+#: src/android/interoperability/with-c/bindgen.md:63
+msgid "\"libbirthday\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:40
+msgid "\"libbirthday.c\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
@@ -11442,67 +10284,45 @@ msgstr ""
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:49
-msgid ""
-"```c\n"
-"#include \"libbirthday.h\"\n"
-"```"
-msgstr ""
-
 #: src/android/interoperability/with-c/bindgen.md:53
 msgid "You can now auto-generate the bindings:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:57
-msgid ""
-"```javascript\n"
-"rust_bindgen {\n"
-"    name: \"libbirthday_bindgen\",\n"
-"    crate_name: \"birthday_bindgen\",\n"
-"    wrapper_src: \"libbirthday_wrapper.h\",\n"
-"    source_stem: \"bindings\",\n"
-"    static_libs: [\"libbirthday\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:59
+#: src/android/interoperability/with-c/bindgen.md:75
+msgid "\"libbirthday_bindgen\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:60
+msgid "\"birthday_bindgen\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:61
+msgid "\"libbirthday_wrapper.h\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:62
+msgid "\"bindings\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:67
 msgid "Finally, we can use the bindings in our Rust program:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:71
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"print_birthday_card\",\n"
-"    srcs: [\"main.rs\"],\n"
-"    rustlibs: [\"libbirthday_bindgen\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:73
+msgid "\"print_birthday_card\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:74
+msgid "\"main.rs\""
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:79
 msgid "_interoperability/bindgen/main.rs_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:81
-msgid ""
-"```rust,compile_fail\n"
-"//! Bindgen demo.\n"
-"\n"
-"use birthday_bindgen::{card, print_card};\n"
-"\n"
-"fn main() {\n"
-"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
-"    let card = card {\n"
-"        name: name.as_ptr(),\n"
-"        years: 42,\n"
-"    };\n"
-"    unsafe {\n"
-"        print_card(&card as *const card);\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:82
+msgid "//! Bindgen demo.\n"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:100
@@ -11519,19 +10339,26 @@ msgstr ""
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:110
-msgid ""
-"```javascript\n"
-"rust_test {\n"
-"    name: \"libbirthday_bindgen_test\",\n"
-"    srcs: [\":libbirthday_bindgen\"],\n"
-"    crate_name: \"libbirthday_bindgen_test\",\n"
-"    test_suites: [\"general-tests\"],\n"
-"    auto_gen_config: true,\n"
-"    clippy_lints: \"none\", // Generated file, skip linting\n"
-"    lints: \"none\",\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/bindgen.md:112
+#: src/android/interoperability/with-c/bindgen.md:114
+msgid "\"libbirthday_bindgen_test\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:113
+msgid "\":libbirthday_bindgen\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:115
+msgid "\"general-tests\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:117
+#: src/android/interoperability/with-c/bindgen.md:118
+msgid "\"none\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:117
+msgid "// Generated file, skip linting\n"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
@@ -11546,58 +10373,41 @@ msgstr ""
 msgid "_interoperability/rust/libanalyze/analyze.rs_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:7
-msgid ""
-"```rust,editable\n"
-"//! Rust FFI demo.\n"
-"#![deny(improper_ctypes_definitions)]\n"
-"\n"
-"use std::os::raw::c_int;\n"
-"\n"
-"/// Analyze the numbers.\n"
-"#[no_mangle]\n"
-"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
-"    if x < y {\n"
-"        println!(\"x ({x}) is smallest!\");\n"
-"    } else {\n"
-"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:8
+msgid "//! Rust FFI demo.\n"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:12
+msgid "/// Analyze the numbers.\n"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:17
+msgid "\"x ({x}) is smallest!\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:19
+msgid "\"y ({y}) is probably larger than x ({x})\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:24
 msgid "_interoperability/rust/libanalyze/analyze.h_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:26
-msgid ""
-"```c\n"
-"#ifndef ANALYSE_H\n"
-"#define ANALYSE_H\n"
-"\n"
-"extern \"C\" {\n"
-"void analyze_numbers(int x, int y);\n"
-"}\n"
-"\n"
-"#endif\n"
-"```"
-msgstr ""
-
 #: src/android/interoperability/with-c/rust.md:37
 msgid "_interoperability/rust/libanalyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:39
-msgid ""
-"```javascript\n"
-"rust_ffi {\n"
-"    name: \"libanalyze_ffi\",\n"
-"    crate_name: \"analyze_ffi\",\n"
-"    srcs: [\"analyze.rs\"],\n"
-"    include_dirs: [\".\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:41
+#: src/android/interoperability/with-c/rust.md:68
+msgid "\"libanalyze_ffi\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:42
+msgid "\"analyze_ffi\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:43
+msgid "\"analyze.rs\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:48
@@ -11608,32 +10418,20 @@ msgstr ""
 msgid "_interoperability/rust/analyze/main.c_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:52
-msgid ""
-"```c\n"
-"#include \"analyze.h\"\n"
-"\n"
-"int main() {\n"
-"  analyze_numbers(10, 20);\n"
-"  analyze_numbers(123, 123);\n"
-"  return 0;\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:53
+msgid "\"analyze.h\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:62
 msgid "_interoperability/rust/analyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:64
-msgid ""
-"```javascript\n"
-"cc_binary {\n"
-"    name: \"analyze_numbers\",\n"
-"    srcs: [\"main.c\"],\n"
-"    static_libs: [\"libanalyze_ffi\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/with-c/rust.md:66
+msgid "\"analyze_numbers\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:67
+msgid "\"main.c\""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:75
@@ -11670,39 +10468,40 @@ msgid ""
 "blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:7
-msgid ""
-"```rust,ignore\n"
-"#[allow(unsafe_op_in_unsafe_fn)]\n"
-"#[cxx::bridge(namespace = \"org::blobstore\")]\n"
-"mod ffi {\n"
-"    // Shared structs with fields visible to both languages.\n"
-"    struct BlobMetadata {\n"
-"        size: usize,\n"
-"        tags: Vec<String>,\n"
-"    }\n"
-"\n"
-"    // Rust types and signatures exposed to C++.\n"
-"    extern \"Rust\" {\n"
-"        type MultiBuf;\n"
-"\n"
-"        fn next_chunk(buf: &mut MultiBuf) -> &[u8];\n"
-"    }\n"
-"\n"
-"    // C++ types and signatures exposed to Rust.\n"
-"    unsafe extern \"C++\" {\n"
-"        include!(\"include/blobstore.h\");\n"
-"\n"
-"        type BlobstoreClient;\n"
-"\n"
-"        fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;\n"
-"        fn put(self: Pin<&mut BlobstoreClient>, parts: &mut MultiBuf) -> "
-"u64;\n"
-"        fn tag(self: Pin<&mut BlobstoreClient>, blobid: u64, tag: &str);\n"
-"        fn metadata(&self, blobid: u64) -> BlobMetadata;\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/cpp/bridge.md:9
+msgid "\"org::blobstore\""
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:11
+msgid "// Shared structs with fields visible to both languages.\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:17
+#: src/android/interoperability/cpp/generated-cpp.md:6
+msgid "// Rust types and signatures exposed to C++.\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:18
+#: src/android/interoperability/cpp/rust-bridge.md:6
+#: src/android/interoperability/cpp/generated-cpp.md:7
+#: src/android/interoperability/cpp/rust-result.md:6
+msgid "\"Rust\""
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:24
+#: src/android/interoperability/cpp/cpp-bridge.md:6
+msgid "// C++ types and signatures exposed to Rust.\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:25
+#: src/android/interoperability/cpp/cpp-bridge.md:7
+#: src/android/interoperability/cpp/cpp-exception.md:6
+msgid "\"C++\""
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:26
+#: src/android/interoperability/cpp/cpp-bridge.md:8
+msgid "\"include/blobstore.h\""
 msgstr ""
 
 #: src/android/interoperability/cpp/bridge.md:40
@@ -11732,30 +10531,16 @@ msgstr ""
 msgid "Rust Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:3
-msgid ""
-"```rust,ignore\n"
-"#[cxx::bridge]\n"
-"mod ffi {\n"
-"    extern \"Rust\" {\n"
-"        type MyType; // Opaque type\n"
-"        fn foo(&self); // Method on `MyType`\n"
-"        fn bar() -> Box<MyType>; // Free function\n"
-"    }\n"
-"}\n"
-"\n"
-"struct MyType(i32);\n"
-"\n"
-"impl MyType {\n"
-"    fn foo(&self) {\n"
-"        println!(\"{}\", self.0);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn bar() -> Box<MyType> {\n"
-"    Box::new(MyType(123))\n"
-"}\n"
-"```"
+#: src/android/interoperability/cpp/rust-bridge.md:7
+msgid "// Opaque type\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:8
+msgid "// Method on `MyType`\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:9
+msgid "// Free function\n"
 msgstr ""
 
 #: src/android/interoperability/cpp/rust-bridge.md:28
@@ -11772,21 +10557,6 @@ msgid ""
 "except with a .rs.h file extension."
 msgstr ""
 
-#: src/android/interoperability/cpp/generated-cpp.md:3
-msgid ""
-"```rust,ignore\n"
-"#[cxx::bridge]\n"
-"mod ffi {\n"
-"    // Rust types and signatures exposed to C++.\n"
-"    extern \"Rust\" {\n"
-"        type MultiBuf;\n"
-"\n"
-"        fn next_chunk(buf: &mut MultiBuf) -> &[u8];\n"
-"    }\n"
-"}\n"
-"```"
-msgstr ""
-
 #: src/android/interoperability/cpp/generated-cpp.md:15
 msgid "Results in (roughly) the following C++:"
 msgstr ""
@@ -11795,65 +10565,16 @@ msgstr ""
 msgid "C++ Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:3
-msgid ""
-"```rust,ignore\n"
-"#[cxx::bridge]\n"
-"mod ffi {\n"
-"    // C++ types and signatures exposed to Rust.\n"
-"    unsafe extern \"C++\" {\n"
-"        include!(\"include/blobstore.h\");\n"
-"\n"
-"        type BlobstoreClient;\n"
-"\n"
-"        fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;\n"
-"        fn put(self: Pin<&mut BlobstoreClient>, parts: &mut MultiBuf) -> "
-"u64;\n"
-"        fn tag(self: Pin<&mut BlobstoreClient>, blobid: u64, tag: &str);\n"
-"        fn metadata(&self, blobid: u64) -> BlobMetadata;\n"
-"    }\n"
-"}\n"
-"```"
-msgstr ""
-
 #: src/android/interoperability/cpp/cpp-bridge.md:20
 msgid "Results in (roughly) the following Rust:"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:22
-msgid ""
-"```rust,ignore\n"
-"#[repr(C)]\n"
-"pub struct BlobstoreClient {\n"
-"    _private: ::cxx::private::Opaque,\n"
-"}\n"
-"\n"
-"pub fn new_blobstore_client() -> ::cxx::UniquePtr<BlobstoreClient> {\n"
-"    extern \"C\" {\n"
-"        #[link_name = \"org$blobstore$cxxbridge1$new_blobstore_client\"]\n"
-"        fn __new_blobstore_client() -> *mut BlobstoreClient;\n"
-"    }\n"
-"    unsafe { ::cxx::UniquePtr::from_raw(__new_blobstore_client()) }\n"
-"}\n"
-"\n"
-"impl BlobstoreClient {\n"
-"    pub fn put(&self, parts: &mut MultiBuf) -> u64 {\n"
-"        extern \"C\" {\n"
-"            #[link_name = \"org$blobstore$cxxbridge1$BlobstoreClient$put\"]\n"
-"            fn __put(\n"
-"                _: &BlobstoreClient,\n"
-"                parts: *mut ::cxx::core::ffi::c_void,\n"
-"            ) -> u64;\n"
-"        }\n"
-"        unsafe {\n"
-"            __put(self, parts as *mut MultiBuf as *mut ::cxx::core::ffi::"
-"c_void)\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"// ...\n"
-"```"
+#: src/android/interoperability/cpp/cpp-bridge.md:30
+msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:39
+msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
 msgstr ""
 
 #: src/android/interoperability/cpp/cpp-bridge.md:56
@@ -11869,25 +10590,8 @@ msgid ""
 "call from Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md:3
-msgid ""
-"```rust,ignore\n"
-"#[cxx::bridge]\n"
-"mod ffi {\n"
-"    #[derive(Clone, Debug, Hash)]\n"
-"    struct PlayingCard {\n"
-"        suit: Suit,\n"
-"        value: u8,  // A=1, J=11, Q=12, K=13\n"
-"    }\n"
-"\n"
-"    enum Suit {\n"
-"        Clubs,\n"
-"        Diamonds,\n"
-"        Hearts,\n"
-"        Spades,\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/cpp/shared-types.md:9
+msgid "// A=1, J=11, Q=12, K=13\n"
 msgstr ""
 
 #: src/android/interoperability/cpp/shared-types.md:23
@@ -11919,24 +10623,12 @@ msgid ""
 "Rust representation needs to have the same behavior."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md:3
-msgid ""
-"```rust,ignore\n"
-"#[cxx::bridge]\n"
-"mod ffi {\n"
-"    extern \"Rust\" {\n"
-"        fn fallible(depth: usize) -> Result<String>;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn fallible(depth: usize) -> anyhow::Result<String> {\n"
-"    if depth == 0 {\n"
-"        return Err(anyhow::Error::msg(\"fallible1 requires depth > 0\"));\n"
-"    }\n"
-"\n"
-"    Ok(\"Success!\".into())\n"
-"}\n"
-"```"
+#: src/android/interoperability/cpp/rust-result.md:13
+msgid "\"fallible1 requires depth > 0\""
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:16
+msgid "\"Success!\""
 msgstr ""
 
 #: src/android/interoperability/cpp/rust-result.md:22
@@ -11958,24 +10650,12 @@ msgid ""
 "immediately terminate."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md:3
-msgid ""
-"```rust,ignore\n"
-"#[cxx::bridge]\n"
-"mod ffi {\n"
-"    unsafe extern \"C++\" {\n"
-"        include!(\"example/include/example.h\");\n"
-"        fn fallible(depth: usize) -> Result<String>;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    if let Err(err) = ffi::fallible(99) {\n"
-"        eprintln!(\"Error: {}\", err);\n"
-"        process::exit(1);\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/cpp/cpp-exception.md:7
+msgid "\"example/include/example.h\""
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:14
+msgid "\"Error: {}\""
 msgstr ""
 
 #: src/android/interoperability/cpp/cpp-exception.md:22
@@ -12107,19 +10787,27 @@ msgid ""
 "generated header and source file."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:6
-msgid ""
-"```javascript\n"
-"cc_library_static {\n"
-"    name: \"libcxx_test_cpp\",\n"
-"    srcs: [\"cxx_test.cpp\"],\n"
-"    generated_headers: [\n"
-"        \"cxx-bridge-header\",\n"
-"        \"libcxx_test_bridge_header\"\n"
-"    ],\n"
-"    generated_sources: [\"libcxx_test_bridge_code\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/cpp/android-build-cpp.md:8
+#: src/android/interoperability/cpp/android-build-rust.md:10
+msgid "\"libcxx_test_cpp\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:9
+msgid "\"cxx_test.cpp\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:11
+msgid "\"cxx-bridge-header\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:12
+#: src/android/interoperability/cpp/android-cpp-genrules.md:10
+msgid "\"libcxx_test_bridge_header\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:14
+#: src/android/interoperability/cpp/android-cpp-genrules.md:19
+msgid "\"libcxx_test_bridge_code\""
 msgstr ""
 
 #: src/android/interoperability/cpp/android-build-cpp.md:20
@@ -12150,28 +10838,41 @@ msgid ""
 "CXX source file. These are then used as inputs to the `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:6
+#: src/android/interoperability/cpp/android-cpp-genrules.md:7
 msgid ""
-"```javascript\n"
 "// Generate a C++ header containing the C++ bindings\n"
 "// to the Rust exported functions in lib.rs.\n"
-"genrule {\n"
-"    name: \"libcxx_test_bridge_header\",\n"
-"    tools: [\"cxxbridge\"],\n"
-"    cmd: \"$(location cxxbridge) $(in) --header > $(out)\",\n"
-"    srcs: [\"lib.rs\"],\n"
-"    out: [\"lib.rs.h\"],\n"
-"}\n"
-"\n"
-"// Generate the C++ code that Rust calls into.\n"
-"genrule {\n"
-"    name: \"libcxx_test_bridge_code\",\n"
-"    tools: [\"cxxbridge\"],\n"
-"    cmd: \"$(location cxxbridge) $(in) > $(out)\",\n"
-"    srcs: [\"lib.rs\"],\n"
-"    out: [\"lib.rs.cc\"],\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:11
+#: src/android/interoperability/cpp/android-cpp-genrules.md:20
+msgid "\"cxxbridge\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:12
+msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:13
+#: src/android/interoperability/cpp/android-cpp-genrules.md:22
+#: src/android/interoperability/cpp/android-build-rust.md:8
+msgid "\"lib.rs\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:14
+msgid "\"lib.rs.h\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:16
+msgid "// Generate the C++ code that Rust calls into.\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:21
+msgid "\"$(location cxxbridge) $(in) > $(out)\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:23
+msgid "\"lib.rs.cc\""
 msgstr ""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md:29
@@ -12192,16 +10893,12 @@ msgid ""
 "Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md:5
-msgid ""
-"```javascript\n"
-"rust_binary {\n"
-"    name: \"cxx_test\",\n"
-"    srcs: [\"lib.rs\"],\n"
-"    rustlibs: [\"libcxx\"],\n"
-"    static_libs: [\"libcxx_test_cpp\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/cpp/android-build-rust.md:7
+msgid "\"cxx_test\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-rust.md:9
+msgid "\"libcxx\""
 msgstr ""
 
 #: src/android/interoperability/java.md:1
@@ -12223,28 +10920,20 @@ msgstr ""
 msgid "_interoperability/java/src/lib.rs_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:11
-msgid ""
-"```rust,compile_fail\n"
-"//! Rust <-> Java FFI demo.\n"
-"\n"
-"use jni::objects::{JClass, JString};\n"
-"use jni::sys::jstring;\n"
-"use jni::JNIEnv;\n"
-"\n"
-"/// HelloWorld::hello method implementation.\n"
-"#[no_mangle]\n"
-"pub extern \"system\" fn Java_HelloWorld_hello(\n"
-"    env: JNIEnv,\n"
-"    _class: JClass,\n"
-"    name: JString,\n"
-") -> jstring {\n"
-"    let input: String = env.get_string(name).unwrap().into();\n"
-"    let greeting = format!(\"Hello, {input}!\");\n"
-"    let output = env.new_string(greeting).unwrap();\n"
-"    output.into_inner()\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:12
+msgid "//! Rust <-> Java FFI demo.\n"
+msgstr ""
+
+#: src/android/interoperability/java.md:17
+msgid "/// HelloWorld::hello method implementation.\n"
+msgstr ""
+
+#: src/android/interoperability/java.md:20
+msgid "\"system\""
+msgstr ""
+
+#: src/android/interoperability/java.md:26
+msgid "\"Hello, {input}!\""
 msgstr ""
 
 #: src/android/interoperability/java.md:32
@@ -12252,16 +10941,18 @@ msgstr ""
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:34
-msgid ""
-"```javascript\n"
-"rust_ffi_shared {\n"
-"    name: \"libhello_jni\",\n"
-"    crate_name: \"hello_jni\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
-"    rustlibs: [\"libjni\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:36
+#: src/android/interoperability/java.md:69
+msgid "\"libhello_jni\""
+msgstr ""
+
+#: src/android/interoperability/java.md:37
+#: src/android/interoperability/java.md:52
+msgid "\"hello_jni\""
+msgstr ""
+
+#: src/android/interoperability/java.md:39
+msgid "\"libjni\""
 msgstr ""
 
 #: src/android/interoperability/java.md:43
@@ -12272,34 +10963,16 @@ msgstr ""
 msgid "_interoperability/java/HelloWorld.java_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:47
-msgid ""
-"```java\n"
-"class HelloWorld {\n"
-"    private static native String hello(String name);\n"
-"\n"
-"    static {\n"
-"        System.loadLibrary(\"hello_jni\");\n"
-"    }\n"
-"\n"
-"    public static void main(String[] args) {\n"
-"        String output = HelloWorld.hello(\"Alice\");\n"
-"        System.out.println(output);\n"
-"    }\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:66
+msgid "\"helloworld_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:64
-msgid ""
-"```javascript\n"
-"java_binary {\n"
-"    name: \"helloworld_jni\",\n"
-"    srcs: [\"HelloWorld.java\"],\n"
-"    main_class: \"HelloWorld\",\n"
-"    required: [\"libhello_jni\"],\n"
-"}\n"
-"```"
+#: src/android/interoperability/java.md:67
+msgid "\"HelloWorld.java\""
+msgstr ""
+
+#: src/android/interoperability/java.md:68
+msgid "\"HelloWorld\""
 msgstr ""
 
 #: src/android/interoperability/java.md:73
@@ -12550,39 +11223,21 @@ msgstr ""
 "`alloc`を使うためには、[グローバル（ヒープ）アロケータ](https://doc.rust-"
 "lang.org/stable/std/alloc/trait.GlobalAlloc.html)を実装しなければなりません。"
 
-#: src/bare-metal/alloc.md:6
+#: src/bare-metal/alloc.md:23
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate alloc;\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use alloc::string::ToString;\n"
-"use alloc::vec::Vec;\n"
-"use buddy_system_allocator::LockedHeap;\n"
-"\n"
-"#[global_allocator]\n"
-"static HEAP_ALLOCATOR: LockedHeap<32> = LockedHeap::<32>::new();\n"
-"\n"
-"static mut HEAP: [u8; 65536] = [0; 65536];\n"
-"\n"
-"pub fn entry() {\n"
-"    // Safe because `HEAP` is only used here and `entry` is only called "
-"once.\n"
-"    unsafe {\n"
-"        // Give the allocator some memory to allocate.\n"
-"        HEAP_ALLOCATOR\n"
-"            .lock()\n"
-"            .init(HEAP.as_mut_ptr() as usize, HEAP.len());\n"
-"    }\n"
-"\n"
-"    // Now we can do things that require heap allocation.\n"
-"    let mut v = Vec::new();\n"
-"    v.push(\"A string\".to_string());\n"
-"}\n"
-"```"
+"// Safe because `HEAP` is only used here and `entry` is only called once.\n"
+msgstr ""
+
+#: src/bare-metal/alloc.md:25
+msgid "// Give the allocator some memory to allocate.\n"
+msgstr ""
+
+#: src/bare-metal/alloc.md:31
+msgid "// Now we can do things that require heap allocation.\n"
+msgstr ""
+
+#: src/bare-metal/alloc.md:33
+msgid "\"A string\""
 msgstr ""
 
 #: src/bare-metal/alloc.md:39
@@ -12663,69 +11318,35 @@ msgstr ""
 "大半のマイクロコントローラはメモリマップドRIO空間を通して周辺I/Oにアクセスし"
 "ます。micro:bitのLEDを光らせてみましょう:"
 
-#: src/bare-metal/microcontrollers/mmio.md:6
+#: src/bare-metal/microcontrollers/mmio.md:16
+msgid "/// GPIO port 0 peripheral address\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:19
+msgid "// GPIO peripheral offsets\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:24
+msgid "// PIN_CNF fields\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:34
+#: src/bare-metal/microcontrollers/pacs.md:21
+#: src/bare-metal/microcontrollers/hals.md:25
+msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:37
+#: src/bare-metal/microcontrollers/mmio.md:51
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"mod interrupts;\n"
-"\n"
-"use core::mem::size_of;\n"
-"use cortex_m_rt::entry;\n"
-"\n"
-"/// GPIO port 0 peripheral address\n"
-"const GPIO_P0: usize = 0x5000_0000;\n"
-"\n"
-"// GPIO peripheral offsets\n"
-"const PIN_CNF: usize = 0x700;\n"
-"const OUTSET: usize = 0x508;\n"
-"const OUTCLR: usize = 0x50c;\n"
-"\n"
-"// PIN_CNF fields\n"
-"const DIR_OUTPUT: u32 = 0x1;\n"
-"const INPUT_DISCONNECT: u32 = 0x1 << 1;\n"
-"const PULL_DISABLED: u32 = 0x0 << 2;\n"
-"const DRIVE_S0S1: u32 = 0x0 << 8;\n"
-"const SENSE_DISABLED: u32 = 0x0 << 16;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-"    let pin_cnf_21 = (GPIO_P0 + PIN_CNF + 21 * size_of::<u32>()) as *mut "
-"u32;\n"
-"    let pin_cnf_28 = (GPIO_P0 + PIN_CNF + 28 * size_of::<u32>()) as *mut "
-"u32;\n"
-"    // Safe because the pointers are to valid peripheral control registers, "
-"and\n"
+"// Safe because the pointers are to valid peripheral control registers, and\n"
 "    // no aliases exist.\n"
-"    unsafe {\n"
-"        pin_cnf_21.write_volatile(\n"
-"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
-"SENSE_DISABLED,\n"
-"        );\n"
-"        pin_cnf_28.write_volatile(\n"
-"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
-"SENSE_DISABLED,\n"
-"        );\n"
-"    }\n"
-"\n"
-"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
-"    let gpio0_outset = (GPIO_P0 + OUTSET) as *mut u32;\n"
-"    let gpio0_outclr = (GPIO_P0 + OUTCLR) as *mut u32;\n"
-"    // Safe because the pointers are to valid peripheral control registers, "
-"and\n"
-"    // no aliases exist.\n"
-"    unsafe {\n"
-"        gpio0_outclr.write_volatile(1 << 28);\n"
-"        gpio0_outset.write_volatile(1 << 21);\n"
-"    }\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/mmio.md:48
+#: src/bare-metal/microcontrollers/pacs.md:39
+#: src/bare-metal/microcontrollers/hals.md:29
+msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
@@ -12756,49 +11377,6 @@ msgstr ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) は[CMSIS-SVD](https://www."
 "keil.com/pack/doc/CMSIS/SVD/html/index.html) ファイルから、メモリマップされた"
 "周辺I/Oに対するほぼ安全（mostly-safe）なRustラッパーを生成します。"
-
-#: src/bare-metal/microcontrollers/pacs.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use cortex_m_rt::entry;\n"
-"use nrf52833_pac::Peripherals;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let p = Peripherals::take().unwrap();\n"
-"    let gpio0 = p.P0;\n"
-"\n"
-"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-"    gpio0.pin_cnf[21].write(|w| {\n"
-"        w.dir().output();\n"
-"        w.input().disconnect();\n"
-"        w.pull().disabled();\n"
-"        w.drive().s0s1();\n"
-"        w.sense().disabled();\n"
-"        w\n"
-"    });\n"
-"    gpio0.pin_cnf[28].write(|w| {\n"
-"        w.dir().output();\n"
-"        w.input().disconnect();\n"
-"        w.pull().disabled();\n"
-"        w.drive().s0s1();\n"
-"        w.sense().disabled();\n"
-"        w\n"
-"    });\n"
-"\n"
-"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
-"    gpio0.outclr.write(|w| w.pin28().clear());\n"
-"    gpio0.outset.write(|w| w.pin21().set());\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
-msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
@@ -12854,37 +11432,8 @@ msgstr ""
 "するラッパーを提供しています。これらのクレートの多くは[`embedded-hal`]"
 "(https://crates.io/crates/embedded-hal)が定義するトレイトを実装しています。"
 
-#: src/bare-metal/microcontrollers/hals.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use cortex_m_rt::entry;\n"
-"use nrf52833_hal::gpio::{p0, Level};\n"
-"use nrf52833_hal::pac::Peripherals;\n"
-"use nrf52833_hal::prelude::*;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let p = Peripherals::take().unwrap();\n"
-"\n"
-"    // Create HAL wrapper for GPIO port 0.\n"
-"    let gpio0 = p0::Parts::new(p.P0);\n"
-"\n"
-"    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-"    let mut col1 = gpio0.p0_28.into_push_pull_output(Level::High);\n"
-"    let mut row1 = gpio0.p0_21.into_push_pull_output(Level::Low);\n"
-"\n"
-"    // Set pin 28 low and pin 21 high to turn the LED on.\n"
-"    col1.set_low().unwrap();\n"
-"    row1.set_high().unwrap();\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+#: src/bare-metal/microcontrollers/hals.md:22
+msgid "// Create HAL wrapper for GPIO port 0.\n"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
@@ -12938,37 +11487,12 @@ msgstr "`microbit-v2`はマトリクスLEDに対する簡単なドライバを�
 msgid "The type state pattern"
 msgstr "タイプステートパターン"
 
-#: src/bare-metal/microcontrollers/type-state.md:3
-msgid ""
-"```rust,editable,compile_fail\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let p = Peripherals::take().unwrap();\n"
-"    let gpio0 = p0::Parts::new(p.P0);\n"
-"\n"
-"    let pin: P0_01<Disconnected> = gpio0.p0_01;\n"
-"\n"
-"    // let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
-"    let pin_input: P0_01<Input<Floating>> = pin.into_floating_input();\n"
-"    if pin_input.is_high().unwrap() {\n"
-"        // ...\n"
-"    }\n"
-"    let mut pin_output: P0_01<Output<OpenDrain>> = pin_input\n"
-"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
-"Level::Low);\n"
-"    pin_output.set_high().unwrap();\n"
-"    // pin_input.is_high(); // Error, moved.\n"
-"\n"
-"    let _pin2: P0_02<Output<OpenDrain>> = gpio0\n"
-"        .p0_02\n"
-"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
-"Level::Low);\n"
-"    let _pin3: P0_03<Output<PushPull>> = gpio0.p0_03."
-"into_push_pull_output(Level::Low);\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+#: src/bare-metal/microcontrollers/type-state.md:11
+msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:19
+msgid "// pin_input.is_high(); // Error, moved.\n"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
@@ -13375,41 +11899,26 @@ msgstr ""
 msgid "_src/main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:30
+#: src/exercises/bare-metal/compass.md:44
+#: src/exercises/bare-metal/solutions-morning.md:32
+msgid "// Configure serial port.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:52
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use core::fmt::Write;\n"
-"use cortex_m_rt::entry;\n"
-"use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let board = Board::take().unwrap();\n"
-"\n"
-"    // Configure serial port.\n"
-"    let mut serial = Uarte::new(\n"
-"        board.UARTE0,\n"
-"        board.uart.into(),\n"
-"        Parity::EXCLUDED,\n"
-"        Baudrate::BAUD115200,\n"
-"    );\n"
-"\n"
-"    // Set up the I2C controller and Inertial Measurement Unit.\n"
+"// Set up the I2C controller and Inertial Measurement Unit.\n"
 "    // TODO\n"
-"\n"
-"    writeln!(serial, \"Ready.\").unwrap();\n"
-"\n"
-"    loop {\n"
-"        // Read compass data and log it to the serial port.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:55
+#: src/exercises/bare-metal/solutions-morning.md:56
+msgid "\"Ready.\""
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:58
+msgid ""
+"// Read compass data and log it to the serial port.\n"
 "        // TODO\n"
-"    }\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:64 src/exercises/bare-metal/rtc.md:385
@@ -13622,40 +12131,46 @@ msgid ""
 "firmware to power off the system:"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:6
+#: src/bare-metal/aps/inline-assembly.md:19
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"use core::arch::asm;\n"
-"use core::panic::PanicInfo;\n"
-"\n"
-"mod exceptions;\n"
-"\n"
-"const PSCI_SYSTEM_OFF: u32 = 0x84000008;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(_x0: u64, _x1: u64, _x2: u64, _x3: u64) {\n"
-"    // Safe because this only uses the declared registers and doesn't do\n"
+"// Safe because this only uses the declared registers and doesn't do\n"
 "    // anything with memory.\n"
-"    unsafe {\n"
-"        asm!(\"hvc #0\",\n"
-"            inout(\"w0\") PSCI_SYSTEM_OFF => _,\n"
-"            inout(\"w1\") 0 => _,\n"
-"            inout(\"w2\") 0 => _,\n"
-"            inout(\"w3\") 0 => _,\n"
-"            inout(\"w4\") 0 => _,\n"
-"            inout(\"w5\") 0 => _,\n"
-"            inout(\"w6\") 0 => _,\n"
-"            inout(\"w7\") 0 => _,\n"
-"            options(nomem, nostack)\n"
-"        );\n"
-"    }\n"
-"\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:22
+msgid "\"hvc #0\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:23
+msgid "\"w0\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:24
+msgid "\"w1\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:25
+msgid "\"w2\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:26
+msgid "\"w3\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:27
+msgid "\"w4\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:28
+msgid "\"w5\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:29
+msgid "\"w6\""
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:30
+msgid "\"w7\""
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
@@ -13755,22 +12270,13 @@ msgid ""
 "documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:5
+#: src/bare-metal/aps/uart.md:9
+msgid "/// Minimal driver for a PL011 UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:17 src/bare-metal/aps/better-uart/driver.md:13
 msgid ""
-"```rust,editable\n"
-"const FLAG_REGISTER_OFFSET: usize = 0x18;\n"
-"const FR_BUSY: u8 = 1 << 3;\n"
-"const FR_TXFF: u8 = 1 << 5;\n"
-"\n"
-"/// Minimal driver for a PL011 UART.\n"
-"#[derive(Debug)]\n"
-"pub struct Uart {\n"
-"    base_address: *mut u8,\n"
-"}\n"
-"\n"
-"impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at "
-"the\n"
+"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -13780,34 +12286,32 @@ msgid ""
 "    /// PL011 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u8) -> Self {\n"
-"        Self { base_address }\n"
-"    }\n"
-"\n"
-"    /// Writes a single byte to the UART.\n"
-"    pub fn write_byte(&self, byte: u8) {\n"
-"        // Wait until there is room in the TX buffer.\n"
-"        while self.read_flag_register() & FR_TXFF != 0 {}\n"
-"\n"
-"        // Safe because we know that the base address points to the control\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:27
+#: src/exercises/bare-metal/rtc.md:336
+msgid "/// Writes a single byte to the UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:29
+#: src/exercises/bare-metal/rtc.md:338
+msgid "// Wait until there is room in the TX buffer.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:34 src/bare-metal/aps/uart.md:46
+msgid ""
+"// Safe because we know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe {\n"
-"            // Write to the TX buffer.\n"
-"            self.base_address.write_volatile(byte);\n"
-"        }\n"
-"\n"
-"        // Wait until the UART is no longer busy.\n"
-"        while self.read_flag_register() & FR_BUSY != 0 {}\n"
-"    }\n"
-"\n"
-"    fn read_flag_register(&self) -> u8 {\n"
-"        // Safe because we know that the base address points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET)."
-"read_volatile() }\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:35
+#: src/exercises/bare-metal/rtc.md:344
+msgid "// Write to the TX buffer.\n"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:39
+#: src/exercises/bare-metal/rtc.md:348
+msgid "// Wait until the UART is no longer busy.\n"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
@@ -13844,24 +12348,11 @@ msgid ""
 "traits too."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:5
+#: src/bare-metal/aps/uart/traits.md:16 src/exercises/bare-metal/rtc.md:379
+#: src/exercises/bare-metal/solutions-afternoon.md:231
 msgid ""
-"```rust,editable,compile_fail\n"
-"use core::fmt::{self, Write};\n"
-"\n"
-"impl Write for Uart {\n"
-"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
-"        for c in s.as_bytes() {\n"
-"            self.write_byte(*c);\n"
-"        }\n"
-"        Ok(())\n"
-"    }\n"
-"}\n"
-"\n"
 "// Safe because it just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
-"unsafe impl Send for Uart {}\n"
-"```"
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
@@ -14056,37 +12547,54 @@ msgid ""
 "working with bitflags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use bitflags::bitflags;\n"
-"\n"
-"bitflags! {\n"
-"    /// Flags from the UART flag register.\n"
-"    #[repr(transparent)]\n"
-"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"    struct Flags: u16 {\n"
-"        /// Clear to send.\n"
-"        const CTS = 1 << 0;\n"
-"        /// Data set ready.\n"
-"        const DSR = 1 << 1;\n"
-"        /// Data carrier detect.\n"
-"        const DCD = 1 << 2;\n"
-"        /// UART busy transmitting data.\n"
-"        const BUSY = 1 << 3;\n"
-"        /// Receive FIFO is empty.\n"
-"        const RXFE = 1 << 4;\n"
-"        /// Transmit FIFO is full.\n"
-"        const TXFF = 1 << 5;\n"
-"        /// Receive FIFO is full.\n"
-"        const RXFF = 1 << 6;\n"
-"        /// Transmit FIFO is empty.\n"
-"        const TXFE = 1 << 7;\n"
-"        /// Ring indicator.\n"
-"        const RI = 1 << 8;\n"
-"    }\n"
-"}\n"
-"```"
+#: src/bare-metal/aps/better-uart/bitflags.md:9
+#: src/exercises/bare-metal/rtc.md:238
+msgid "/// Flags from the UART flag register.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:13
+#: src/exercises/bare-metal/rtc.md:242
+msgid "/// Clear to send.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:15
+#: src/exercises/bare-metal/rtc.md:244
+msgid "/// Data set ready.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:17
+#: src/exercises/bare-metal/rtc.md:246
+msgid "/// Data carrier detect.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:19
+#: src/exercises/bare-metal/rtc.md:248
+msgid "/// UART busy transmitting data.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:21
+#: src/exercises/bare-metal/rtc.md:250
+msgid "/// Receive FIFO is empty.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:23
+#: src/exercises/bare-metal/rtc.md:252
+msgid "/// Transmit FIFO is full.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:25
+#: src/exercises/bare-metal/rtc.md:254
+msgid "/// Receive FIFO is full.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:27
+#: src/exercises/bare-metal/rtc.md:256
+msgid "/// Transmit FIFO is empty.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/bitflags.md:29
+#: src/exercises/bare-metal/rtc.md:258
+msgid "/// Ring indicator.\n"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
@@ -14117,69 +12625,28 @@ msgstr ""
 msgid "Now let's use the new `Registers` struct in our driver."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:5
+#: src/bare-metal/aps/better-uart/driver.md:6
+msgid "/// Driver for a PL011 UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:32
+#: src/bare-metal/aps/better-uart/driver.md:55
+#: src/exercises/bare-metal/rtc.md:341 src/exercises/bare-metal/rtc.md:364
 msgid ""
-"```rust,editable,compile_fail\n"
-"/// Driver for a PL011 UART.\n"
-"#[derive(Debug)]\n"
-"pub struct Uart {\n"
-"    registers: *mut Registers,\n"
-"}\n"
-"\n"
-"impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at "
-"the\n"
-"    /// given base address.\n"
-"    ///\n"
-"    /// # Safety\n"
-"    ///\n"
-"    /// The given base address must point to the 8 MMIO control registers of "
-"a\n"
-"    /// PL011 device, which must be mapped into the address space of the "
-"process\n"
-"    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
-"        Self {\n"
-"            registers: base_address as *mut Registers,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Writes a single byte to the UART.\n"
-"    pub fn write_byte(&self, byte: u8) {\n"
-"        // Wait until there is room in the TX buffer.\n"
-"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
-"\n"
-"        // Safe because we know that self.registers points to the control\n"
+"// Safe because we know that self.registers points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe {\n"
-"            // Write to the TX buffer.\n"
-"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
-"        }\n"
-"\n"
-"        // Wait until the UART is no longer busy.\n"
-"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
-"    }\n"
-"\n"
-"    /// Reads and returns a pending byte, or `None` if nothing has been "
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:43
+#: src/exercises/bare-metal/rtc.md:352
+msgid ""
+"/// Reads and returns a pending byte, or `None` if nothing has been "
 "received.\n"
-"    pub fn read_byte(&self) -> Option<u8> {\n"
-"        if self.read_flag_register().contains(Flags::RXFE) {\n"
-"            None\n"
-"        } else {\n"
-"            let data = unsafe { addr_of!((*self.registers).dr)."
-"read_volatile() };\n"
-"            // TODO: Check for error conditions in bits 8-11.\n"
-"            Some(data as u8)\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn read_flag_register(&self) -> Flags {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:49
+#: src/exercises/bare-metal/rtc.md:358
+msgid "// TODO: Check for error conditions in bits 8-11.\n"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
@@ -14199,51 +12666,40 @@ msgid ""
 "and echo incoming bytes."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:6
+#: src/bare-metal/aps/better-uart/using.md:19
+#: src/bare-metal/aps/logging/using.md:18 src/exercises/bare-metal/rtc.md:41
+#: src/exercises/bare-metal/solutions-afternoon.md:33
+msgid "/// Base address of the primary PL011 UART.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:25
+#: src/bare-metal/aps/logging/using.md:24 src/exercises/bare-metal/rtc.md:47
+#: src/exercises/bare-metal/solutions-afternoon.md:44
 msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod pl011;\n"
-"\n"
-"use crate::pl011::Uart;\n"
-"use core::fmt::Write;\n"
-"use core::panic::PanicInfo;\n"
-"use log::error;\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
+"// Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
 "    // and nothing else accesses that address range.\n"
-"    let mut uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"\n"
-"    writeln!(uart, \"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\").unwrap();\n"
-"\n"
-"    loop {\n"
-"        if let Some(byte) = uart.read_byte() {\n"
-"            uart.write_byte(byte);\n"
-"            match byte {\n"
-"                b'\\r' => {\n"
-"                    uart.write_byte(b'\\n');\n"
-"                }\n"
-"                b'q' => break,\n"
-"                _ => {}\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"\n"
-"    writeln!(uart, \"Bye!\").unwrap();\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:29
+#: src/bare-metal/aps/logging/using.md:29
+msgid "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:35
+msgid "b'\\r'"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:36
+#: src/async/pitfalls/cancellation.md:27
+msgid "b'\\n'"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:38
+msgid "b'q'"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:44
+msgid "\"Bye!\""
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
@@ -14265,50 +12721,12 @@ msgid ""
 "`Log` trait."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use crate::pl011::Uart;\n"
-"use core::fmt::Write;\n"
-"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
-"use spin::mutex::SpinMutex;\n"
-"\n"
-"static LOGGER: Logger = Logger {\n"
-"    uart: SpinMutex::new(None),\n"
-"};\n"
-"\n"
-"struct Logger {\n"
-"    uart: SpinMutex<Option<Uart>>,\n"
-"}\n"
-"\n"
-"impl Log for Logger {\n"
-"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
-"        true\n"
-"    }\n"
-"\n"
-"    fn log(&self, record: &Record) {\n"
-"        writeln!(\n"
-"            self.uart.lock().as_mut().unwrap(),\n"
-"            \"[{}] {}\",\n"
-"            record.level(),\n"
-"            record.args()\n"
-"        )\n"
-"        .unwrap();\n"
-"    }\n"
-"\n"
-"    fn flush(&self) {}\n"
-"}\n"
-"\n"
-"/// Initialises UART logger.\n"
-"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
-"SetLoggerError> {\n"
-"    LOGGER.uart.lock().replace(uart);\n"
-"\n"
-"    log::set_logger(&LOGGER)?;\n"
-"    log::set_max_level(max_level);\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/bare-metal/aps/logging.md:28 src/exercises/bare-metal/rtc.md:190
+msgid "\"[{}] {}\""
+msgstr ""
+
+#: src/bare-metal/aps/logging.md:37 src/exercises/bare-metal/rtc.md:199
+msgid "/// Initialises UART logger.\n"
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
@@ -14321,47 +12739,9 @@ msgstr ""
 msgid "We need to initialise the logger before we use it."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod logger;\n"
-"mod pl011;\n"
-"\n"
-"use crate::pl011::Uart;\n"
-"use core::panic::PanicInfo;\n"
-"use log::{error, info, LevelFilter};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
-"    // and nothing else accesses that address range.\n"
-"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
-"\n"
-"    info!(\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\");\n"
-"\n"
-"    assert_eq!(x1, 42);\n"
-"\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[panic_handler]\n"
-"fn panic(info: &PanicInfo) -> ! {\n"
-"    error!(\"{info}\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"    loop {}\n"
-"}\n"
-"```"
+#: src/bare-metal/aps/logging/using.md:38 src/exercises/bare-metal/rtc.md:69
+#: src/exercises/bare-metal/solutions-afternoon.md:121
+msgid "\"{info}\""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
@@ -14536,27 +12916,16 @@ msgid ""
 "Architecture."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:6
-msgid ""
-"```rust,editable,compile_fail\n"
-"use aarch64_paging::{\n"
-"    idmap::IdMap,\n"
-"    paging::{Attributes, MemoryRegion},\n"
-"};\n"
-"\n"
-"const ASID: usize = 1;\n"
-"const ROOT_LEVEL: usize = 1;\n"
-"\n"
-"// Create a new page table with identity mapping.\n"
-"let mut idmap = IdMap::new(ASID, ROOT_LEVEL);\n"
-"// Map a 2 MiB region of memory as read-only.\n"
-"idmap.map_range(\n"
-"    &MemoryRegion::new(0x80200000, 0x80400000),\n"
-"    Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,\n"
-").unwrap();\n"
-"// Set `TTBR0_EL1` to activate the page table.\n"
-"idmap.activate();\n"
-"```"
+#: src/bare-metal/useful-crates/aarch64-paging.md:14
+msgid "// Create a new page table with identity mapping.\n"
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:16
+msgid "// Map a 2 MiB region of memory as read-only.\n"
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:21
+msgid "// Set `TTBR0_EL1` to activate the page table.\n"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
@@ -14748,62 +13117,30 @@ msgid ""
 "look in the `rtc` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:23
+#: src/exercises/bare-metal/rtc.md:37
+#: src/exercises/bare-metal/solutions-afternoon.md:29
+msgid "/// Base addresses of the GICv3.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:52
+#: src/exercises/bare-metal/solutions-afternoon.md:49
+msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:54
+#: src/exercises/bare-metal/solutions-afternoon.md:51
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod logger;\n"
-"mod pl011;\n"
-"\n"
-"use crate::pl011::Uart;\n"
-"use arm_gic::gicv3::GicV3;\n"
-"use core::panic::PanicInfo;\n"
-"use log::{error, info, trace, LevelFilter};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base addresses of the GICv3.\n"
-"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
-"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
-"    // and nothing else accesses that address range.\n"
-"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
-"\n"
-"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
-"\n"
-"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
-"base\n"
+"// Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
-"GICR_BASE_ADDRESS) };\n"
-"    gic.setup();\n"
-"\n"
-"    // TODO: Create instance of RTC driver and print current time.\n"
-"\n"
-"    // TODO: Wait for 3 seconds.\n"
-"\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[panic_handler]\n"
-"fn panic(info: &PanicInfo) -> ! {\n"
-"    error!(\"{info}\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:60
+msgid "// TODO: Create instance of RTC driver and print current time.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:62
+msgid "// TODO: Wait for 3 seconds.\n"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:75
@@ -14812,9 +13149,9 @@ msgid ""
 "the exercise):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:79
+#: src/exercises/bare-metal/rtc.md:80 src/exercises/bare-metal/rtc.md:154
+#: src/exercises/bare-metal/rtc.md:215 src/exercises/bare-metal/rtc.md:415
 msgid ""
-"```rust,compile_fail\n"
 "// Copyright 2023 Google LLC\n"
 "//\n"
 "// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
@@ -14828,245 +13165,106 @@ msgid ""
 "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
 "// See the License for the specific language governing permissions and\n"
 "// limitations under the License.\n"
-"\n"
-"use arm_gic::gicv3::GicV3;\n"
-"use log::{error, info, trace};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn sync_exception_current(_elr: u64, _spsr: u64) {\n"
-"    error!(\"sync_exception_current\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn irq_current(_elr: u64, _spsr: u64) {\n"
-"    trace!(\"irq_current\");\n"
-"    let intid = GicV3::get_and_acknowledge_interrupt().expect(\"No pending "
-"interrupt\");\n"
-"    info!(\"IRQ {intid:?}\");\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn fiq_current(_elr: u64, _spsr: u64) {\n"
-"    error!(\"fiq_current\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn serr_current(_elr: u64, _spsr: u64) {\n"
-"    error!(\"serr_current\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn sync_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"sync_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn irq_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"irq_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn fiq_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"fiq_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn serr_lower(_elr: u64, _spsr: u64) {\n"
-"    error!(\"serr_lower\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:101
+msgid "\"sync_exception_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:107
+msgid "\"irq_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:108
+msgid "\"No pending interrupt\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:109
+msgid "\"IRQ {intid:?}\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:114
+msgid "\"fiq_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:120
+msgid "\"serr_current\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:126
+msgid "\"sync_lower\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:132
+msgid "\"irq_lower\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:138
+msgid "\"fiq_lower\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:144
+msgid "\"serr_lower\""
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:149
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:153
-msgid ""
-"```rust,compile_fail\n"
-"// Copyright 2023 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License.\n"
-"\n"
-"// ANCHOR: main\n"
-"use crate::pl011::Uart;\n"
-"use core::fmt::Write;\n"
-"use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};\n"
-"use spin::mutex::SpinMutex;\n"
-"\n"
-"static LOGGER: Logger = Logger {\n"
-"    uart: SpinMutex::new(None),\n"
-"};\n"
-"\n"
-"struct Logger {\n"
-"    uart: SpinMutex<Option<Uart>>,\n"
-"}\n"
-"\n"
-"impl Log for Logger {\n"
-"    fn enabled(&self, _metadata: &Metadata) -> bool {\n"
-"        true\n"
-"    }\n"
-"\n"
-"    fn log(&self, record: &Record) {\n"
-"        writeln!(\n"
-"            self.uart.lock().as_mut().unwrap(),\n"
-"            \"[{}] {}\",\n"
-"            record.level(),\n"
-"            record.args()\n"
-"        )\n"
-"        .unwrap();\n"
-"    }\n"
-"\n"
-"    fn flush(&self) {}\n"
-"}\n"
-"\n"
-"/// Initialises UART logger.\n"
-"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
-"SetLoggerError> {\n"
-"    LOGGER.uart.lock().replace(uart);\n"
-"\n"
-"    log::set_logger(&LOGGER)?;\n"
-"    log::set_max_level(max_level);\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/exercises/bare-metal/rtc.md:167
+msgid "// ANCHOR: main\n"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:214
+#: src/exercises/bare-metal/rtc.md:233
+msgid "// ANCHOR: Flags\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:261
+msgid "// ANCHOR_END: Flags\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:265
 msgid ""
-"```rust,compile_fail\n"
-"// Copyright 2023 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License.\n"
-"\n"
-"#![allow(unused)]\n"
-"\n"
-"use core::fmt::{self, Write};\n"
-"use core::ptr::{addr_of, addr_of_mut};\n"
-"\n"
-"// ANCHOR: Flags\n"
-"use bitflags::bitflags;\n"
-"\n"
-"bitflags! {\n"
-"    /// Flags from the UART flag register.\n"
-"    #[repr(transparent)]\n"
-"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"    struct Flags: u16 {\n"
-"        /// Clear to send.\n"
-"        const CTS = 1 << 0;\n"
-"        /// Data set ready.\n"
-"        const DSR = 1 << 1;\n"
-"        /// Data carrier detect.\n"
-"        const DCD = 1 << 2;\n"
-"        /// UART busy transmitting data.\n"
-"        const BUSY = 1 << 3;\n"
-"        /// Receive FIFO is empty.\n"
-"        const RXFE = 1 << 4;\n"
-"        /// Transmit FIFO is full.\n"
-"        const TXFF = 1 << 5;\n"
-"        /// Receive FIFO is full.\n"
-"        const RXFF = 1 << 6;\n"
-"        /// Transmit FIFO is empty.\n"
-"        const TXFE = 1 << 7;\n"
-"        /// Ring indicator.\n"
-"        const RI = 1 << 8;\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: Flags\n"
-"\n"
-"bitflags! {\n"
-"    /// Flags from the UART Receive Status Register / Error Clear Register.\n"
-"    #[repr(transparent)]\n"
-"    #[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"    struct ReceiveStatus: u16 {\n"
-"        /// Framing error.\n"
-"        const FE = 1 << 0;\n"
-"        /// Parity error.\n"
-"        const PE = 1 << 1;\n"
-"        /// Break error.\n"
-"        const BE = 1 << 2;\n"
-"        /// Overrun error.\n"
-"        const OE = 1 << 3;\n"
-"    }\n"
-"}\n"
-"\n"
-"// ANCHOR: Registers\n"
-"#[repr(C, align(4))]\n"
-"struct Registers {\n"
-"    dr: u16,\n"
-"    _reserved0: [u8; 2],\n"
-"    rsr: ReceiveStatus,\n"
-"    _reserved1: [u8; 19],\n"
-"    fr: Flags,\n"
-"    _reserved2: [u8; 6],\n"
-"    ilpr: u8,\n"
-"    _reserved3: [u8; 3],\n"
-"    ibrd: u16,\n"
-"    _reserved4: [u8; 2],\n"
-"    fbrd: u8,\n"
-"    _reserved5: [u8; 3],\n"
-"    lcr_h: u8,\n"
-"    _reserved6: [u8; 3],\n"
-"    cr: u16,\n"
-"    _reserved7: [u8; 3],\n"
-"    ifls: u8,\n"
-"    _reserved8: [u8; 3],\n"
-"    imsc: u16,\n"
-"    _reserved9: [u8; 2],\n"
-"    ris: u16,\n"
-"    _reserved10: [u8; 2],\n"
-"    mis: u16,\n"
-"    _reserved11: [u8; 2],\n"
-"    icr: u16,\n"
-"    _reserved12: [u8; 2],\n"
-"    dmacr: u8,\n"
-"    _reserved13: [u8; 3],\n"
-"}\n"
-"// ANCHOR_END: Registers\n"
-"\n"
+"/// Flags from the UART Receive Status Register / Error Clear Register.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:269
+msgid "/// Framing error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:271
+msgid "/// Parity error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:273
+msgid "/// Break error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:275
+msgid "/// Overrun error.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:279
+msgid "// ANCHOR: Registers\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:311
+msgid "// ANCHOR_END: Registers\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:313
+msgid ""
 "// ANCHOR: Uart\n"
 "/// Driver for a PL011 UART.\n"
-"#[derive(Debug)]\n"
-"pub struct Uart {\n"
-"    registers: *mut Registers,\n"
-"}\n"
-"\n"
-"impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at "
-"the\n"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:322
+msgid ""
+"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -15076,101 +13274,46 @@ msgid ""
 "    /// PL011 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
-"        Self {\n"
-"            registers: base_address as *mut Registers,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Writes a single byte to the UART.\n"
-"    pub fn write_byte(&self, byte: u8) {\n"
-"        // Wait until there is room in the TX buffer.\n"
-"        while self.read_flag_register().contains(Flags::TXFF) {}\n"
-"\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe {\n"
-"            // Write to the TX buffer.\n"
-"            addr_of_mut!((*self.registers).dr).write_volatile(byte.into());\n"
-"        }\n"
-"\n"
-"        // Wait until the UART is no longer busy.\n"
-"        while self.read_flag_register().contains(Flags::BUSY) {}\n"
-"    }\n"
-"\n"
-"    /// Reads and returns a pending byte, or `None` if nothing has been "
-"received.\n"
-"    pub fn read_byte(&self) -> Option<u8> {\n"
-"        if self.read_flag_register().contains(Flags::RXFE) {\n"
-"            None\n"
-"        } else {\n"
-"            let data = unsafe { addr_of!((*self.registers).dr)."
-"read_volatile() };\n"
-"            // TODO: Check for error conditions in bits 8-11.\n"
-"            Some(data as u8)\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn read_flag_register(&self) -> Flags {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { addr_of!((*self.registers).fr).read_volatile() }\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: Uart\n"
-"\n"
-"impl Write for Uart {\n"
-"    fn write_str(&mut self, s: &str) -> fmt::Result {\n"
-"        for c in s.as_bytes() {\n"
-"            self.write_byte(*c);\n"
-"        }\n"
-"        Ok(())\n"
-"    }\n"
-"}\n"
-"\n"
-"// Safe because it just contains a pointer to device memory, which can be\n"
-"// accessed from any context.\n"
-"unsafe impl Send for Uart {}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:368
+msgid "// ANCHOR_END: Uart\n"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:410
 msgid "_build.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:414
-msgid ""
-"```rust,compile_fail\n"
-"// Copyright 2023 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License.\n"
-"\n"
-"use cc::Build;\n"
-"use std::env;\n"
-"\n"
-"fn main() {\n"
-"    #[cfg(target_os = \"linux\")]\n"
-"    env::set_var(\"CROSS_COMPILE\", \"aarch64-linux-gnu\");\n"
-"    #[cfg(not(target_os = \"linux\"))]\n"
-"    env::set_var(\"CROSS_COMPILE\", \"aarch64-none-elf\");\n"
-"\n"
-"    Build::new()\n"
-"        .file(\"entry.S\")\n"
-"        .file(\"exceptions.S\")\n"
-"        .file(\"idmap.S\")\n"
-"        .compile(\"empty\")\n"
-"}\n"
-"```"
+#: src/exercises/bare-metal/rtc.md:433 src/exercises/bare-metal/rtc.md:435
+msgid "\"linux\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:434 src/exercises/bare-metal/rtc.md:436
+msgid "\"CROSS_COMPILE\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:434
+msgid "\"aarch64-linux-gnu\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:436
+msgid "\"aarch64-none-elf\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:439
+msgid "\"entry.S\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:440
+msgid "\"exceptions.S\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:441
+msgid "\"idmap.S\""
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:442
+msgid "\"empty\""
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
@@ -15709,49 +13852,24 @@ msgstr ""
 msgid "_Makefile_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:944
-msgid ""
-"```makefile\n"
-"# Copyright 2023 Google LLC\n"
-"#\n"
-"# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"# you may not use this file except in compliance with the License.\n"
-"# You may obtain a copy of the License at\n"
-"#\n"
-"#      http://www.apache.org/licenses/LICENSE-2.0\n"
-"#\n"
-"# Unless required by applicable law or agreed to in writing, software\n"
-"# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"# See the License for the specific language governing permissions and\n"
-"# limitations under the License.\n"
-"\n"
-"UNAME := $(shell uname -s)\n"
-"ifeq ($(UNAME),Linux)\n"
-"\tTARGET = aarch64-linux-gnu\n"
-"else\n"
-"\tTARGET = aarch64-none-elf\n"
-"endif\n"
-"OBJCOPY = $(TARGET)-objcopy\n"
-"\n"
-".PHONY: build qemu_minimal qemu qemu_logger\n"
-"\n"
-"all: rtc.bin\n"
-"\n"
-"build:\n"
-"\tcargo build\n"
-"\n"
-"rtc.bin: build\n"
-"\t$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@\n"
-"\n"
-"qemu: rtc.bin\n"
-"\tqemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio "
-"-display none -kernel $< -s\n"
-"\n"
-"clean:\n"
-"\tcargo clean\n"
-"\trm -f *.bin\n"
-"```"
+#: src/exercises/bare-metal/rtc.md:945
+msgid "# Copyright 2023 Google LLC"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:959
+msgid "$(shell uname -s)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:961
+msgid "aarch64-linux-gnu"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:978
+msgid "stdio -display none -kernel $< -s"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:981
+msgid "cargo clean"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:995
@@ -15785,26 +13903,12 @@ msgstr ""
 msgid "Rust threads work similarly to threads in other languages:"
 msgstr "Rustのスレッドは他の言語のスレッドと似た挙動をします:"
 
-#: src/concurrency/threads.md:5
-msgid ""
-"```rust,editable\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"fn main() {\n"
-"    thread::spawn(|| {\n"
-"        for i in 1..10 {\n"
-"            println!(\"Count in thread: {i}!\");\n"
-"            thread::sleep(Duration::from_millis(5));\n"
-"        }\n"
-"    });\n"
-"\n"
-"    for i in 1..5 {\n"
-"        println!(\"Main thread: {i}\");\n"
-"        thread::sleep(Duration::from_millis(5));\n"
-"    }\n"
-"}\n"
-"```"
+#: src/concurrency/threads.md:12
+msgid "\"Count in thread: {i}!\""
+msgstr ""
+
+#: src/concurrency/threads.md:18
+msgid "\"Main thread: {i}\""
 msgstr ""
 
 #: src/concurrency/threads.md:24
@@ -15858,22 +13962,8 @@ msgstr ""
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "通常のスレッドはそれらの環境から借用することはできません:"
 
-#: src/concurrency/scoped-threads.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::thread;\n"
-"\n"
-"fn foo() {\n"
-"    let s = String::from(\"Hello\");\n"
-"    thread::spawn(|| {\n"
-"        println!(\"Length: {}\", s.len());\n"
-"    });\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    foo();\n"
-"}\n"
-"```"
+#: src/concurrency/scoped-threads.md:11 src/concurrency/scoped-threads.md:30
+msgid "\"Length: {}\""
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:20
@@ -15883,23 +13973,6 @@ msgid ""
 msgstr ""
 "しかし、そのために[スコープ付きスレッド](https://doc.rust-lang.org/std/"
 "thread/fn.scope.html)を使うことができます:"
-
-#: src/concurrency/scoped-threads.md:22
-msgid ""
-"```rust,editable\n"
-"use std::thread;\n"
-"\n"
-"fn main() {\n"
-"    let s = String::from(\"Hello\");\n"
-"\n"
-"    thread::scope(|scope| {\n"
-"        scope.spawn(|| {\n"
-"            println!(\"Length: {}\", s.len());\n"
-"        });\n"
-"    });\n"
-"}\n"
-"```"
-msgstr ""
 
 #: src/concurrency/scoped-threads.md:40
 msgid ""
@@ -15926,25 +13999,9 @@ msgstr ""
 "の２つの部品はチャネルによって繋がっていますが、見ることができるのはエンドポ"
 "イントだけです。"
 
-#: src/concurrency/channels.md:6
-msgid ""
-"```rust,editable\n"
-"use std::sync::mpsc;\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::channel();\n"
-"\n"
-"    tx.send(10).unwrap();\n"
-"    tx.send(20).unwrap();\n"
-"\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"\n"
-"    let tx2 = tx.clone();\n"
-"    tx2.send(30).unwrap();\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"}\n"
-"```"
+#: src/concurrency/channels.md:15 src/concurrency/channels.md:16
+#: src/concurrency/channels.md:20
+msgid "\"Received: {:?}\""
 msgstr ""
 
 #: src/concurrency/channels.md:26
@@ -15970,31 +14027,24 @@ msgstr ""
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr "Unboundedで非同期的なチャネルは`mpsc::channel()`によって得られます："
 
-#: src/concurrency/channels/unbounded.md:5
-msgid ""
-"```rust,editable\n"
-"use std::sync::mpsc;\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::channel();\n"
-"\n"
-"    thread::spawn(move || {\n"
-"        let thread_id = thread::current().id();\n"
-"        for i in 1..10 {\n"
-"            tx.send(format!(\"Message {i}\")).unwrap();\n"
-"            println!(\"{thread_id:?}: sent Message {i}\");\n"
-"        }\n"
-"        println!(\"{thread_id:?}: done\");\n"
-"    });\n"
-"    thread::sleep(Duration::from_millis(100));\n"
-"\n"
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {msg}\");\n"
-"    }\n"
-"}\n"
-"```"
+#: src/concurrency/channels/unbounded.md:16
+#: src/concurrency/channels/bounded.md:16
+msgid "\"Message {i}\""
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:17
+#: src/concurrency/channels/bounded.md:17
+msgid "\"{thread_id:?}: sent Message {i}\""
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:19
+#: src/concurrency/channels/bounded.md:19
+msgid "\"{thread_id:?}: done\""
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:24
+#: src/concurrency/channels/bounded.md:24
+msgid "\"Main: got {msg}\""
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:3
@@ -16003,33 +14053,6 @@ msgid ""
 msgstr ""
 "Bounded（かつ同期的）なチャネルを用いたとき、`send`は現在のスレッドをブロック"
 "することがあります："
-
-#: src/concurrency/channels/bounded.md:5
-msgid ""
-"```rust,editable\n"
-"use std::sync::mpsc;\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::sync_channel(3);\n"
-"\n"
-"    thread::spawn(move || {\n"
-"        let thread_id = thread::current().id();\n"
-"        for i in 1..10 {\n"
-"            tx.send(format!(\"Message {i}\")).unwrap();\n"
-"            println!(\"{thread_id:?}: sent Message {i}\");\n"
-"        }\n"
-"        println!(\"{thread_id:?}: done\");\n"
-"    });\n"
-"    thread::sleep(Duration::from_millis(100));\n"
-"\n"
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {msg}\");\n"
-"    }\n"
-"}\n"
-"```"
-msgstr ""
 
 #: src/concurrency/channels/bounded.md:31
 msgid ""
@@ -16329,27 +14352,14 @@ msgid ""
 "read-only access via `Arc::clone`:"
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md:5
-msgid ""
-"```rust,editable\n"
-"use std::thread;\n"
-"use std::sync::Arc;\n"
-"\n"
-"fn main() {\n"
-"    let v = Arc::new(vec![10, 20, 30]);\n"
-"    let mut handles = Vec::new();\n"
-"    for _ in 1..5 {\n"
-"        let v = Arc::clone(&v);\n"
-"        handles.push(thread::spawn(move || {\n"
-"            let thread_id = thread::current().id();\n"
-"            println!(\"{thread_id:?}: {v:?}\");\n"
-"        }));\n"
-"    }\n"
-"\n"
-"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
-"```"
+#: src/concurrency/shared_state/arc.md:16
+msgid "\"{thread_id:?}: {v:?}\""
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:21
+#: src/concurrency/shared_state/example.md:17
+#: src/concurrency/shared_state/example.md:45
+msgid "\"v: {v:?}\""
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
@@ -16391,23 +14401,9 @@ msgid ""
 "interface:"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:6
-msgid ""
-"```rust,editable\n"
-"use std::sync::Mutex;\n"
-"\n"
-"fn main() {\n"
-"    let v = Mutex::new(vec![10, 20, 30]);\n"
-"    println!(\"v: {:?}\", v.lock().unwrap());\n"
-"\n"
-"    {\n"
-"        let mut guard = v.lock().unwrap();\n"
-"        guard.push(40);\n"
-"    }\n"
-"\n"
-"    println!(\"v: {:?}\", v.lock().unwrap());\n"
-"}\n"
-"```"
+#: src/concurrency/shared_state/mutex.md:11
+#: src/concurrency/shared_state/mutex.md:18
+msgid "\"v: {:?}\""
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
@@ -16462,54 +14458,12 @@ msgstr ""
 msgid "Let us see `Arc` and `Mutex` in action:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::thread;\n"
-"// use std::sync::{Arc, Mutex};\n"
-"\n"
-"fn main() {\n"
-"    let v = vec![10, 20, 30];\n"
-"    let handle = thread::spawn(|| {\n"
-"        v.push(10);\n"
-"    });\n"
-"    v.push(1000);\n"
-"\n"
-"    handle.join().unwrap();\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
-"```"
+#: src/concurrency/shared_state/example.md:6
+msgid "// use std::sync::{Arc, Mutex};\n"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:23
 msgid "Possible solution:"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:25
-msgid ""
-"```rust,editable\n"
-"use std::sync::{Arc, Mutex};\n"
-"use std::thread;\n"
-"\n"
-"fn main() {\n"
-"    let v = Arc::new(Mutex::new(vec![10, 20, 30]));\n"
-"\n"
-"    let v2 = Arc::clone(&v);\n"
-"    let handle = thread::spawn(move || {\n"
-"        let mut v2 = v2.lock().unwrap();\n"
-"        v2.push(10);\n"
-"    });\n"
-"\n"
-"    {\n"
-"        let mut v = v.lock().unwrap();\n"
-"        v.push(1000);\n"
-"    }\n"
-"\n"
-"    handle.join().unwrap();\n"
-"\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:49
@@ -16577,49 +14531,89 @@ msgid ""
 "out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md:19
+#: src/exercises/concurrency/dining-philosophers.md:28
+#: src/exercises/concurrency/dining-philosophers-async.md:23
 msgid ""
-"```rust,compile_fail\n"
-"use std::sync::{mpsc, Arc, Mutex};\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // left_fork: ...\n"
+"// left_fork: ...\n"
 "    // right_fork: ...\n"
 "    // thoughts: ...\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"fn main() {\n"
-"    // Create forks\n"
-"\n"
-"    // Create philosophers\n"
-"\n"
-"    // Make each of them think and eat 100 times\n"
-"\n"
-"    // Output their thoughts\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:36
+#: src/exercises/concurrency/dining-philosophers-async.md:31
+#: src/exercises/concurrency/solutions-morning.md:24
+#: src/exercises/concurrency/solutions-afternoon.md:25
+msgid "\"Eureka! {} has a new idea!\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:41
+#: src/exercises/concurrency/dining-philosophers-async.md:36
+#: src/exercises/concurrency/solutions-afternoon.md:30
+msgid "// Pick up forks...\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:42
+#: src/exercises/concurrency/dining-philosophers-async.md:37
+#: src/exercises/concurrency/solutions-morning.md:33
+#: src/exercises/concurrency/solutions-afternoon.md:37
+msgid "\"{} is eating...\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Socrates\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Hypatia\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Plato\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Aristotle\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:48
+#: src/exercises/concurrency/dining-philosophers-async.md:43
+#: src/exercises/concurrency/solutions-morning.md:39
+#: src/exercises/concurrency/solutions-afternoon.md:45
+msgid "\"Pythagoras\""
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:51
+#: src/exercises/concurrency/dining-philosophers-async.md:47
+#: src/exercises/concurrency/solutions-afternoon.md:49
+msgid "// Create forks\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:53
+#: src/exercises/concurrency/dining-philosophers-async.md:49
+#: src/exercises/concurrency/solutions-afternoon.md:53
+msgid "// Create philosophers\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:55
+msgid "// Make each of them think and eat 100 times\n"
+msgstr ""
+
+#: src/exercises/concurrency/dining-philosophers.md:57
+#: src/exercises/concurrency/dining-philosophers-async.md:53
+#: src/exercises/concurrency/solutions-afternoon.md:88
+msgid "// Output their thoughts\n"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:61
@@ -16700,73 +14694,42 @@ msgstr ""
 msgid "Your `src/main.rs` file should look something like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:57
-msgid ""
-"```rust,compile_fail\n"
-"use reqwest::{blocking::Client, Url};\n"
-"use scraper::{Html, Selector};\n"
-"use thiserror::Error;\n"
-"\n"
-"#[derive(Error, Debug)]\n"
-"enum Error {\n"
-"    #[error(\"request error: {0}\")]\n"
-"    ReqwestError(#[from] reqwest::Error),\n"
-"    #[error(\"bad http response: {0}\")]\n"
-"    BadResponse(String),\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct CrawlCommand {\n"
-"    url: Url,\n"
-"    extract_links: bool,\n"
-"}\n"
-"\n"
-"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
-"Error> {\n"
-"    println!(\"Checking {:#}\", command.url);\n"
-"    let response = client.get(command.url.clone()).send()?;\n"
-"    if !response.status().is_success() {\n"
-"        return Err(Error::BadResponse(response.status().to_string()));\n"
-"    }\n"
-"\n"
-"    let mut link_urls = Vec::new();\n"
-"    if !command.extract_links {\n"
-"        return Ok(link_urls);\n"
-"    }\n"
-"\n"
-"    let base_url = response.url().to_owned();\n"
-"    let body_text = response.text()?;\n"
-"    let document = Html::parse_document(&body_text);\n"
-"\n"
-"    let selector = Selector::parse(\"a\").unwrap();\n"
-"    let href_values = document\n"
-"        .select(&selector)\n"
-"        .filter_map(|element| element.value().attr(\"href\"));\n"
-"    for href in href_values {\n"
-"        match base_url.join(href) {\n"
-"            Ok(link_url) => {\n"
-"                link_urls.push(link_url);\n"
-"            }\n"
-"            Err(err) => {\n"
-"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
-"{err}\");\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"    Ok(link_urls)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let client = Client::new();\n"
-"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
-"    let crawl_command = CrawlCommand{ url: start_url, extract_links: "
-"true };\n"
-"    match visit_page(&client, &crawl_command) {\n"
-"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
-"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/link-checker.md:64
+#: src/exercises/concurrency/solutions-morning.md:95
+msgid "\"request error: {0}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:66
+#: src/exercises/concurrency/solutions-morning.md:97
+msgid "\"bad http response: {0}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:77
+#: src/exercises/concurrency/solutions-morning.md:108
+msgid "\"Checking {:#}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:95
+#: src/exercises/concurrency/solutions-morning.md:126
+msgid "\"href\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:102
+#: src/exercises/concurrency/solutions-morning.md:133
+msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:111
+#: src/exercises/concurrency/solutions-morning.md:246
+msgid "\"https://www.google.org\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:114
+msgid "\"Links: {links:#?}\""
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:115
+msgid "\"Could not extract links: {err:#}\""
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:120
@@ -16861,25 +14824,8 @@ msgstr ""
 "おおまかには、Rustの非同期コードはほとんど「通常の」逐次的なコードのように見"
 "えます:"
 
-#: src/async/async-await.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use futures::executor::block_on;\n"
-"\n"
-"async fn count_to(count: i32) {\n"
-"    for i in 1..=count {\n"
-"        println!(\"Count is: {i}!\");\n"
-"    }\n"
-"}\n"
-"\n"
-"async fn async_main(count: i32) {\n"
-"    count_to(count).await;\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    block_on(async_main(10));\n"
-"}\n"
-"```"
+#: src/async/async-await.md:10
+msgid "\"Count is: {i}!\""
 msgstr ""
 
 #: src/async/async-await.md:27
@@ -17012,9 +14958,9 @@ msgid ""
 "_reactor_) and is responsible for executing futures (an _executor_). Rust "
 "does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
-"_runtime_は非同期な演算（_reactor_）のサポートを提供し、また、futureを実行す"
-"ること（_executor_）を担当しています。Rustには「ビルトイン」のランタイムはあ"
-"りませんが、いくつかのランタイムの選択肢があります: "
+"\\_runtime_は非同期な演算（_reactor_）のサポートを提供し、また、futureを実行"
+"すること（_executor_）を担当しています。Rustには「ビルトイン」のランタイムは"
+"ありませんが、いくつかのランタイムの選択肢があります: "
 
 #: src/async/runtimes.md:7
 #, fuzzy
@@ -17089,28 +15035,12 @@ msgstr "標準ライブラリの非同期バージョン。"
 msgid "A large ecosystem of libraries."
 msgstr "大きなライブラリのエコシステム。"
 
-#: src/async/runtimes/tokio.md:10
-msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::time;\n"
-"\n"
-"async fn count_to(count: i32) {\n"
-"    for i in 1..=count {\n"
-"        println!(\"Count in task: {i}!\");\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    tokio::spawn(count_to(10));\n"
-"\n"
-"    for i in 1..5 {\n"
-"        println!(\"Main task: {i}\");\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"    }\n"
-"}\n"
-"```"
+#: src/async/runtimes/tokio.md:15
+msgid "\"Count in task: {i}!\""
+msgstr ""
+
+#: src/async/runtimes/tokio.md:25
+msgid "\"Main task: {i}\""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
@@ -17169,48 +15099,28 @@ msgstr ""
 "行処理は、例えば競合タイマーや入出力操作など、複数の子のfutureをポーリングす"
 "ることにより可能になります。"
 
-#: src/async/tasks.md:10
-msgid ""
-"```rust,compile_fail\n"
-"use tokio::io::{self, AsyncReadExt, AsyncWriteExt};\n"
-"use tokio::net::TcpListener;\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> io::Result<()> {\n"
-"    let listener = TcpListener::bind(\"127.0.0.1:6142\").await?;\n"
-"\tprintln!(\"listening on port 6142\");\n"
-"\n"
-"    loop {\n"
-"        let (mut socket, addr) = listener.accept().await?;\n"
-"\n"
-"        println!(\"connection from {addr:?}\");\n"
-"\n"
-"        tokio::spawn(async move {\n"
-"            if let Err(e) = socket.write_all(b\"Who are you?\\n\").await {\n"
-"                println!(\"socket error: {e:?}\");\n"
-"                return;\n"
-"            }\n"
-"\n"
-"            let mut buf = vec![0; 1024];\n"
-"            let reply = match socket.read(&mut buf).await {\n"
-"                Ok(n) => {\n"
-"                    let name = std::str::from_utf8(&buf[..n]).unwrap()."
-"trim();\n"
-"                    format!(\"Thanks for dialing in, {name}!\\n\")\n"
-"                }\n"
-"                Err(e) => {\n"
-"                    println!(\"socket error: {e:?}\");\n"
-"                    return;\n"
-"                }\n"
-"            };\n"
-"\n"
-"            if let Err(e) = socket.write_all(reply.as_bytes()).await {\n"
-"                println!(\"socket error: {e:?}\");\n"
-"            }\n"
-"        });\n"
-"    }\n"
-"}\n"
-"```"
+#: src/async/tasks.md:16
+msgid "\"127.0.0.1:6142\""
+msgstr ""
+
+#: src/async/tasks.md:17
+msgid "\"listening on port 6142\""
+msgstr ""
+
+#: src/async/tasks.md:22
+msgid "\"connection from {addr:?}\""
+msgstr ""
+
+#: src/async/tasks.md:25
+msgid "b\"Who are you?\\n\""
+msgstr ""
+
+#: src/async/tasks.md:26 src/async/tasks.md:37 src/async/tasks.md:43
+msgid "\"socket error: {e:?}\""
+msgstr ""
+
+#: src/async/tasks.md:34
+msgid "\"Thanks for dialing in, {name}!\\n\""
 msgstr ""
 
 #: src/async/tasks.md:52 src/async/control-flow/join.md:36
@@ -17262,36 +15172,24 @@ msgstr ""
 "いくつかのクレートは`async`/`await`をサポートしています。例えば、`tokio`チャ"
 "ネルは:"
 
-#: src/async/channels.md:5
-msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::sync::mpsc::{self, Receiver};\n"
-"\n"
-"async fn ping_handler(mut input: Receiver<()>) {\n"
-"    let mut count: usize = 0;\n"
-"\n"
-"    while let Some(_) = input.recv().await {\n"
-"        count += 1;\n"
-"        println!(\"Received {count} pings so far.\");\n"
-"    }\n"
-"\n"
-"    println!(\"ping_handler complete\");\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let (sender, receiver) = mpsc::channel(32);\n"
-"    let ping_handler_task = tokio::spawn(ping_handler(receiver));\n"
-"    for i in 0..10 {\n"
-"        sender.send(()).await.expect(\"Failed to send ping.\");\n"
-"        println!(\"Sent {} pings so far.\", i + 1);\n"
-"    }\n"
-"\n"
-"    drop(sender);\n"
-"    ping_handler_task.await.expect(\"Something went wrong in ping handler "
-"task.\");\n"
-"}\n"
-"```"
+#: src/async/channels.md:13
+msgid "\"Received {count} pings so far.\""
+msgstr ""
+
+#: src/async/channels.md:16
+msgid "\"ping_handler complete\""
+msgstr ""
+
+#: src/async/channels.md:24
+msgid "\"Failed to send ping.\""
+msgstr ""
+
+#: src/async/channels.md:25
+msgid "\"Sent {} pings so far.\""
+msgstr ""
+
+#: src/async/channels.md:29
+msgid "\"Something went wrong in ping handler task.\""
 msgstr ""
 
 #: src/async/channels.md:35
@@ -17364,34 +15262,25 @@ msgstr ""
 "て返します。これはJavaScriptにおける `Promise.all` やPythonにおける`asyncio."
 "gather`に似ています。"
 
-#: src/async/control-flow/join.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use anyhow::Result;\n"
-"use futures::future;\n"
-"use reqwest;\n"
-"use std::collections::HashMap;\n"
-"\n"
-"async fn size_of_page(url: &str) -> Result<usize> {\n"
-"    let resp = reqwest::get(url).await?;\n"
-"    Ok(resp.text().await?.len())\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let urls: [&str; 4] = [\n"
-"        \"https://google.com\",\n"
-"        \"https://httpbin.org/ip\",\n"
-"        \"https://play.rust-lang.org/\",\n"
-"        \"BAD_URL\",\n"
-"    ];\n"
-"    let futures_iter = urls.into_iter().map(size_of_page);\n"
-"    let results = future::join_all(futures_iter).await;\n"
-"    let page_sizes_dict: HashMap<&str, Result<usize>> =\n"
-"        urls.into_iter().zip(results.into_iter()).collect();\n"
-"    println!(\"{:?}\", page_sizes_dict);\n"
-"}\n"
-"```"
+#: src/async/control-flow/join.md:21
+msgid "\"https://google.com\""
+msgstr ""
+
+#: src/async/control-flow/join.md:22
+msgid "\"https://httpbin.org/ip\""
+msgstr ""
+
+#: src/async/control-flow/join.md:23
+msgid "\"https://play.rust-lang.org/\""
+msgstr ""
+
+#: src/async/control-flow/join.md:24
+msgid "\"BAD_URL\""
+msgstr ""
+
+#: src/async/control-flow/join.md:30
+#: src/exercises/day-1/solutions-morning.md:78
+msgid "\"{:?}\""
 msgstr ""
 
 #: src/async/control-flow/join.md:38
@@ -17451,54 +15340,28 @@ msgstr ""
 "整った時、その`statement`は`future`の結果に紐づく`pattern`の変数を用いて実行"
 "されます。"
 
-#: src/async/control-flow/select.md:13
-msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::sync::mpsc::{self, Receiver};\n"
-"use tokio::time::{sleep, Duration};\n"
-"\n"
-"#[derive(Debug, PartialEq)]\n"
-"enum Animal {\n"
-"    Cat { name: String },\n"
-"    Dog { name: String },\n"
-"}\n"
-"\n"
-"async fn first_animal_to_finish_race(\n"
-"    mut cat_rcv: Receiver<String>,\n"
-"    mut dog_rcv: Receiver<String>,\n"
-") -> Option<Animal> {\n"
-"    tokio::select! {\n"
-"        cat_name = cat_rcv.recv() => Some(Animal::Cat { name: cat_name? }),\n"
-"        dog_name = dog_rcv.recv() => Some(Animal::Dog { name: dog_name? })\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let (cat_sender, cat_receiver) = mpsc::channel(32);\n"
-"    let (dog_sender, dog_receiver) = mpsc::channel(32);\n"
-"    tokio::spawn(async move {\n"
-"        sleep(Duration::from_millis(500)).await;\n"
-"        cat_sender\n"
-"            .send(String::from(\"Felix\"))\n"
-"            .await\n"
-"            .expect(\"Failed to send cat.\");\n"
-"    });\n"
-"    tokio::spawn(async move {\n"
-"        sleep(Duration::from_millis(50)).await;\n"
-"        dog_sender\n"
-"            .send(String::from(\"Rex\"))\n"
-"            .await\n"
-"            .expect(\"Failed to send dog.\");\n"
-"    });\n"
-"\n"
-"    let winner = first_animal_to_finish_race(cat_receiver, dog_receiver)\n"
-"        .await\n"
-"        .expect(\"Failed to receive winner\");\n"
-"\n"
-"    println!(\"Winner is {winner:?}\");\n"
-"}\n"
-"```"
+#: src/async/control-flow/select.md:40
+msgid "\"Felix\""
+msgstr ""
+
+#: src/async/control-flow/select.md:42
+msgid "\"Failed to send cat.\""
+msgstr ""
+
+#: src/async/control-flow/select.md:47
+msgid "\"Rex\""
+msgstr ""
+
+#: src/async/control-flow/select.md:49
+msgid "\"Failed to send dog.\""
+msgstr ""
+
+#: src/async/control-flow/select.md:54
+msgid "\"Failed to receive winner\""
+msgstr ""
+
+#: src/async/control-flow/select.md:56
+msgid "\"Winner is {winner:?}\""
 msgstr ""
 
 #: src/async/control-flow/select.md:62
@@ -17588,27 +15451,12 @@ msgid ""
 "possible."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use futures::future::join_all;\n"
-"use std::time::Instant;\n"
-"\n"
-"async fn sleep_ms(start: &Instant, id: u64, duration_ms: u64) {\n"
-"    std::thread::sleep(std::time::Duration::from_millis(duration_ms));\n"
-"    println!(\n"
-"        \"future {id} slept for {duration_ms}ms, finished after {}ms\",\n"
-"        start.elapsed().as_millis()\n"
-"    );\n"
-"}\n"
-"\n"
-"#[tokio::main(flavor = \"current_thread\")]\n"
-"async fn main() {\n"
-"    let start = Instant::now();\n"
-"    let sleep_futures = (1..=10).map(|t| sleep_ms(&start, t, t * 10));\n"
-"    join_all(sleep_futures).await;\n"
-"}\n"
-"```"
+#: src/async/pitfalls/blocking-executor.md:14
+msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:19
+msgid "\"current_thread\""
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
@@ -17666,61 +15514,42 @@ msgid ""
 "repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:12
+#: src/async/pitfalls/pin.md:16
 msgid ""
-"```rust,editable,compile_fail\n"
-"use tokio::sync::{mpsc, oneshot};\n"
-"use tokio::task::spawn;\n"
-"use tokio::time::{sleep, Duration};\n"
-"\n"
 "// A work item. In this case, just sleep for the given time and respond\n"
 "// with a message on the `respond_on` channel.\n"
-"#[derive(Debug)]\n"
-"struct Work {\n"
-"    input: u32,\n"
-"    respond_on: oneshot::Sender<u32>,\n"
-"}\n"
-"\n"
-"// A worker which listens for work on a queue and performs it.\n"
-"async fn worker(mut work_queue: mpsc::Receiver<Work>) {\n"
-"    let mut iterations = 0;\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            Some(work) = work_queue.recv() => {\n"
-"                sleep(Duration::from_millis(10)).await; // Pretend to work.\n"
-"                work.respond_on\n"
-"                    .send(work.input * 1000)\n"
-"                    .expect(\"failed to send response\");\n"
-"                iterations += 1;\n"
-"            }\n"
-"            // TODO: report number of iterations every 100ms\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"// A requester which requests work and waits for it to complete.\n"
-"async fn do_work(work_queue: &mpsc::Sender<Work>, input: u32) -> u32 {\n"
-"    let (tx, rx) = oneshot::channel();\n"
-"    work_queue\n"
-"        .send(Work {\n"
-"            input,\n"
-"            respond_on: tx,\n"
-"        })\n"
-"        .await\n"
-"        .expect(\"failed to send on work queue\");\n"
-"    rx.await.expect(\"failed waiting for response\")\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let (tx, rx) = mpsc::channel(10);\n"
-"    spawn(worker(rx));\n"
-"    for i in 0..100 {\n"
-"        let resp = do_work(&tx, i).await;\n"
-"        println!(\"work result for iteration {i}: {resp}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:24
+msgid "// A worker which listens for work on a queue and performs it.\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:31
+msgid "// Pretend to work.\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:34
+msgid "\"failed to send response\""
+msgstr ""
+
+#: src/async/pitfalls/pin.md:37
+msgid "// TODO: report number of iterations every 100ms\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:41
+msgid "// A requester which requests work and waits for it to complete.\n"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:51
+msgid "\"failed to send on work queue\""
+msgstr ""
+
+#: src/async/pitfalls/pin.md:52
+msgid "\"failed waiting for response\""
+msgstr ""
+
+#: src/async/pitfalls/pin.md:61
+msgid "\"work result for iteration {i}: {resp}\""
 msgstr ""
 
 #: src/async/pitfalls/pin.md:68
@@ -17787,50 +15616,12 @@ msgid ""
 "provides a workaround through a macro:"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:7
-msgid ""
-"```rust,editable,compile_fail\n"
-"use async_trait::async_trait;\n"
-"use std::time::Instant;\n"
-"use tokio::time::{sleep, Duration};\n"
-"\n"
-"#[async_trait]\n"
-"trait Sleeper {\n"
-"    async fn sleep(&self);\n"
-"}\n"
-"\n"
-"struct FixedSleeper {\n"
-"    sleep_ms: u64,\n"
-"}\n"
-"\n"
-"#[async_trait]\n"
-"impl Sleeper for FixedSleeper {\n"
-"    async fn sleep(&self) {\n"
-"        sleep(Duration::from_millis(self.sleep_ms)).await;\n"
-"    }\n"
-"}\n"
-"\n"
-"async fn run_all_sleepers_multiple_times(sleepers: Vec<Box<dyn Sleeper>>, "
-"n_times: usize) {\n"
-"    for _ in 0..n_times {\n"
-"        println!(\"running all sleepers..\");\n"
-"        for sleeper in &sleepers {\n"
-"            let start = Instant::now();\n"
-"            sleeper.sleep().await;\n"
-"            println!(\"slept for {}ms\", start.elapsed().as_millis());\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    let sleepers: Vec<Box<dyn Sleeper>> = vec![\n"
-"        Box::new(FixedSleeper { sleep_ms: 50 }),\n"
-"        Box::new(FixedSleeper { sleep_ms: 100 }),\n"
-"    ];\n"
-"    run_all_sleepers_multiple_times(sleepers, 5).await;\n"
-"}\n"
-"```"
+#: src/async/pitfalls/async-traits.md:30
+msgid "\"running all sleepers..\""
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:34
+msgid "\"slept for {}ms\""
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:51
@@ -17862,72 +15653,16 @@ msgid ""
 "example, it shouldn't deadlock or lose data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:8
-msgid ""
-"```rust,editable,compile_fail\n"
-"use std::io::{self, ErrorKind};\n"
-"use std::time::Duration;\n"
-"use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};\n"
-"\n"
-"struct LinesReader {\n"
-"    stream: DuplexStream,\n"
-"}\n"
-"\n"
-"impl LinesReader {\n"
-"    fn new(stream: DuplexStream) -> Self {\n"
-"        Self { stream }\n"
-"    }\n"
-"\n"
-"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
-"        let mut bytes = Vec::new();\n"
-"        let mut buf = [0];\n"
-"        while self.stream.read(&mut buf[..]).await? != 0 {\n"
-"            bytes.push(buf[0]);\n"
-"            if buf[0] == b'\\n' {\n"
-"                break;\n"
-"            }\n"
-"        }\n"
-"        if bytes.is_empty() {\n"
-"            return Ok(None)\n"
-"        }\n"
-"        let s = String::from_utf8(bytes)\n"
-"            .map_err(|_| io::Error::new(ErrorKind::InvalidData, \"not "
-"UTF-8\"))?;\n"
-"        Ok(Some(s))\n"
-"    }\n"
-"}\n"
-"\n"
-"async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::"
-"Result<()> {\n"
-"    for b in source.bytes() {\n"
-"        dest.write_u8(b).await?;\n"
-"        tokio::time::sleep(Duration::from_millis(10)).await\n"
-"    }\n"
-"    Ok(())\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> std::io::Result<()> {\n"
-"    let (client, server) = tokio::io::duplex(5);\n"
-"    let handle = tokio::spawn(slow_copy(\"hi\\nthere\\n\".to_owned(), "
-"client));\n"
-"\n"
-"    let mut lines = LinesReader::new(server);\n"
-"    let mut interval = tokio::time::interval(Duration::from_millis(60));\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            _ = interval.tick() => println!(\"tick!\"),\n"
-"            line = lines.next() => if let Some(l) = line? {\n"
-"                print!(\"{}\", l)\n"
-"            } else {\n"
-"                break\n"
-"            },\n"
-"        }\n"
-"    }\n"
-"    handle.await.unwrap()?;\n"
-"    Ok(())\n"
-"}\n"
-"```"
+#: src/async/pitfalls/cancellation.md:35
+msgid "\"not UTF-8\""
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:51
+msgid "\"hi\\nthere\\n\""
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:57
+msgid "\"tick!\""
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:72
@@ -17958,28 +15693,10 @@ msgid ""
 "struct:"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:83
+#: src/async/pitfalls/cancellation.md:95
 msgid ""
-"```rust,compile_fail\n"
-"struct LinesReader {\n"
-"    stream: DuplexStream,\n"
-"    bytes: Vec<u8>,\n"
-"    buf: [u8; 1],\n"
-"}\n"
-"\n"
-"impl LinesReader {\n"
-"    fn new(stream: DuplexStream) -> Self {\n"
-"        Self { stream, bytes: Vec::new(), buf: [0] }\n"
-"    }\n"
-"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
-"        // prefix buf and bytes with self.\n"
+"// prefix buf and bytes with self.\n"
 "        // ...\n"
-"        let raw = std::mem::take(&mut self.bytes);\n"
-"        let s = String::from_utf8(raw)\n"
-"        // ...\n"
-"    }\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:104
@@ -18038,52 +15755,9 @@ msgid ""
 "main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:13
-msgid ""
-"```rust,compile_fail\n"
-"use std::sync::Arc;\n"
-"use tokio::time;\n"
-"use tokio::sync::mpsc::{self, Sender};\n"
-"use tokio::sync::Mutex;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // left_fork: ...\n"
-"    // right_fork: ...\n"
-"    // thoughts: ...\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    async fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
-"await\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    async fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    // Create forks\n"
-"\n"
-"    // Create philosophers\n"
-"\n"
-"    // Make them think and eat\n"
-"\n"
-"    // Output their thoughts\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/dining-philosophers-async.md:51
+#: src/exercises/concurrency/solutions-afternoon.md:77
+msgid "// Make them think and eat\n"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
@@ -18224,47 +15898,29 @@ msgstr ""
 msgid "_src/bin/server.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:63
-msgid ""
-"```rust,compile_fail\n"
-"use futures_util::sink::SinkExt;\n"
-"use futures_util::stream::StreamExt;\n"
-"use std::error::Error;\n"
-"use std::net::SocketAddr;\n"
-"use tokio::net::{TcpListener, TcpStream};\n"
-"use tokio::sync::broadcast::{channel, Sender};\n"
-"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
-"\n"
-"async fn handle_connection(\n"
-"    addr: SocketAddr,\n"
-"    mut ws_stream: WebsocketStream<TcpStream>,\n"
-"    bcast_tx: Sender<String>,\n"
-") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"\n"
-"    // TODO: For a hint, see the description of the task below.\n"
-"\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"    let (bcast_tx, _) = channel(16);\n"
-"\n"
-"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
-"    println!(\"listening on port 2000\");\n"
-"\n"
-"    loop {\n"
-"        let (socket, addr) = listener.accept().await?;\n"
-"        println!(\"New connection from {addr:?}\");\n"
-"        let bcast_tx = bcast_tx.clone();\n"
-"        tokio::spawn(async move {\n"
-"            // Wrap the raw TCP stream into a websocket.\n"
-"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
-"\n"
-"            handle_connection(addr, ws_stream, bcast_tx).await\n"
-"        });\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/chat-app.md:78
+#: src/exercises/concurrency/chat-app.md:125
+msgid "// TODO: For a hint, see the description of the task below.\n"
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:86
+#: src/exercises/concurrency/solutions-afternoon.md:149
+msgid "\"127.0.0.1:2000\""
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:87
+#: src/exercises/concurrency/solutions-afternoon.md:150
+msgid "\"listening on port 2000\""
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:91
+#: src/exercises/concurrency/solutions-afternoon.md:154
+msgid "\"New connection from {addr:?}\""
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:94
+#: src/exercises/concurrency/solutions-afternoon.md:157
+msgid "// Wrap the raw TCP stream into a websocket.\n"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:103
@@ -18272,30 +15928,9 @@ msgstr ""
 msgid "_src/bin/client.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:107
-msgid ""
-"```rust,compile_fail\n"
-"use futures_util::stream::StreamExt;\n"
-"use futures_util::SinkExt;\n"
-"use http::Uri;\n"
-"use tokio::io::{AsyncBufReadExt, BufReader};\n"
-"use tokio_websockets::{ClientBuilder, Message};\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), tokio_websockets::Error> {\n"
-"    let (mut ws_stream, _) =\n"
-"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
-"            .connect()\n"
-"            .await?;\n"
-"\n"
-"    let stdin = tokio::io::stdin();\n"
-"    let mut stdin = BufReader::new(stdin).lines();\n"
-"\n"
-"\n"
-"    // TODO: For a hint, see the description of the task below.\n"
-"\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/chat-app.md:117
+#: src/exercises/concurrency/solutions-afternoon.md:178
+msgid "\"ws://127.0.0.1:2000\""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:130
@@ -18993,58 +16628,13 @@ msgstr ""
 msgid "([back to exercise](for-loops.md))"
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:7
-msgid ""
-"```rust\n"
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    let mut result = [[0; 3]; 3];\n"
-"    for i in 0..3 {\n"
-"        for j in 0..3 {\n"
-"            result[j][i] = matrix[i][j];\n"
-"        }\n"
-"    }\n"
-"    return result;\n"
-"}\n"
-"\n"
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    for row in matrix {\n"
-"        println!(\"{row:?}\");\n"
-"    }\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_transpose() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], //\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];\n"
-"    let transposed = transpose(matrix);\n"
-"    assert_eq!(\n"
-"        transposed,\n"
-"        [\n"
-"            [101, 201, 301], //\n"
-"            [102, 202, 302],\n"
-"            [103, 203, 303],\n"
-"        ]\n"
-"    );\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];\n"
-"\n"
-"    println!(\"matrix:\");\n"
-"    pretty_print(&matrix);\n"
-"\n"
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-morning.md:20
+msgid "\"{row:?}\""
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:27
+#: src/exercises/day-1/solutions-morning.md:35
+msgid "//\n"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:57
@@ -19073,34 +16663,24 @@ msgid ""
 "abstract over anything that can be referenced as a slice."
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:65
-msgid ""
-"```rust\n"
-"use std::convert::AsRef;\n"
-"use std::fmt::Debug;\n"
-"\n"
-"fn pretty_print<T, Line, Matrix>(matrix: Matrix)\n"
-"where\n"
-"    T: Debug,\n"
-"    // A line references a slice of items\n"
-"    Line: AsRef<[T]>,\n"
-"    // A matrix references a slice of lines\n"
-"    Matrix: AsRef<[Line]>\n"
-"{\n"
-"    for row in matrix.as_ref() {\n"
-"        println!(\"{:?}\", row.as_ref());\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    // &[&[i32]]\n"
-"    pretty_print(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);\n"
-"    // [[&str; 2]; 2]\n"
-"    pretty_print([[\"a\", \"b\"], [\"c\", \"d\"]]);\n"
-"    // Vec<Vec<i32>>\n"
-"    pretty_print(vec![vec![1, 2], vec![3, 4]]);\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-morning.md:72
+msgid "// A line references a slice of items\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:74
+msgid "// A matrix references a slice of lines\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:83
+msgid "// &[&[i32]]\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:85
+msgid "// [[&str; 2]; 2]\n"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:87
+msgid "// Vec<Vec<i32>>\n"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:92
@@ -19117,86 +16697,12 @@ msgstr ""
 msgid "([back to exercise](luhn.md))"
 msgstr ""
 
-#: src/exercises/day-1/solutions-afternoon.md:7
-msgid ""
-"```rust\n"
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    let mut sum = 0;\n"
-"    let mut double = false;\n"
-"    let mut digit_seen = 0;\n"
-"\n"
-"    for c in cc_number.chars().filter(|&f| f != ' ').rev() {\n"
-"        if let Some(digit) = c.to_digit(10) {\n"
-"            if double {\n"
-"                let double_digit = digit * 2;\n"
-"                sum += if double_digit > 9 {\n"
-"                    double_digit - 9\n"
-"                } else {\n"
-"                    double_digit\n"
-"                };\n"
-"            } else {\n"
-"                sum += digit;\n"
-"            }\n"
-"            double = !double;\n"
-"            digit_seen += 1;\n"
-"        } else {\n"
-"            return false;\n"
-"        }\n"
-"    }\n"
-"\n"
-"    if digit_seen < 2 {\n"
-"        return false;\n"
-"    }\n"
-"\n"
-"    sum % 10 == 0\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let cc_number = \"1234 5678 1234 5670\";\n"
-"    println!(\n"
-"        \"Is {cc_number} a valid credit card number? {}\",\n"
-"        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_non_digit_cc_number() {\n"
-"    assert!(!luhn(\"foo\"));\n"
-"    assert!(!luhn(\"foo 0 0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_empty_cc_number() {\n"
-"    assert!(!luhn(\"\"));\n"
-"    assert!(!luhn(\" \"));\n"
-"    assert!(!luhn(\"  \"));\n"
-"    assert!(!luhn(\"    \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_single_digit_cc_number() {\n"
-"    assert!(!luhn(\"0\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_two_digit_cc_number() {\n"
-"    assert!(luhn(\" 0 0 \"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_valid_cc_number() {\n"
-"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
-"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
-"    assert!(luhn(\"7992 7398 713\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-afternoon.md:40
+msgid "\"1234 5678 1234 5670\""
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:42
+msgid "\"Is {cc_number} a valid credit card number? {}\""
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:86
@@ -19204,135 +16710,12 @@ msgstr ""
 msgid "Pattern matching"
 msgstr "パターンマッチング"
 
-#: src/exercises/day-1/solutions-afternoon.md:88
-msgid ""
-"```rust\n"
-"/// An operation to perform on two subexpressions.\n"
-"#[derive(Debug)]\n"
-"enum Operation {\n"
-"    Add,\n"
-"    Sub,\n"
-"    Mul,\n"
-"    Div,\n"
-"}\n"
-"\n"
-"/// An expression, in tree form.\n"
-"#[derive(Debug)]\n"
-"enum Expression {\n"
-"    /// An operation on two subexpressions.\n"
-"    Op {\n"
-"        op: Operation,\n"
-"        left: Box<Expression>,\n"
-"        right: Box<Expression>,\n"
-"    },\n"
-"\n"
-"    /// A literal value\n"
-"    Value(i64),\n"
-"}\n"
-"\n"
-"/// The result of evaluating an expression.\n"
-"#[derive(Debug, PartialEq, Eq)]\n"
-"enum Res {\n"
-"    /// Evaluation was successful, with the given result.\n"
-"    Ok(i64),\n"
-"    /// Evaluation failed, with the given error message.\n"
-"    Err(String),\n"
-"}\n"
-"// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
-"use Res::{Err, Ok};\n"
-"\n"
-"fn eval(e: Expression) -> Res {\n"
-"    match e {\n"
-"        Expression::Op { op, left, right } => {\n"
-"            let left = match eval(*left) {\n"
-"                Ok(v) => v,\n"
-"                Err(msg) => return Err(msg),\n"
-"            };\n"
-"            let right = match eval(*right) {\n"
-"                Ok(v) => v,\n"
-"                Err(msg) => return Err(msg),\n"
-"            };\n"
-"            Ok(match op {\n"
-"                Operation::Add => left + right,\n"
-"                Operation::Sub => left - right,\n"
-"                Operation::Mul => left * right,\n"
-"                Operation::Div => {\n"
-"                    if right == 0 {\n"
-"                        return Err(String::from(\"division by zero\"));\n"
-"                    } else {\n"
-"                        left / right\n"
-"                    }\n"
-"                }\n"
-"            })\n"
-"        }\n"
-"        Expression::Value(v) => Ok(v),\n"
-"    }\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_value() {\n"
-"    assert_eq!(eval(Expression::Value(19)), Ok(19));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_sum() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(Expression::Value(10)),\n"
-"            right: Box::new(Expression::Value(20)),\n"
-"        }),\n"
-"        Ok(30)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_recursion() {\n"
-"    let term1 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Value(10)),\n"
-"        right: Box::new(Expression::Value(9)),\n"
-"    };\n"
-"    let term2 = Expression::Op {\n"
-"        op: Operation::Mul,\n"
-"        left: Box::new(Expression::Op {\n"
-"            op: Operation::Sub,\n"
-"            left: Box::new(Expression::Value(3)),\n"
-"            right: Box::new(Expression::Value(4)),\n"
-"        }),\n"
-"        right: Box::new(Expression::Value(5)),\n"
-"    };\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Add,\n"
-"            left: Box::new(term1),\n"
-"            right: Box::new(term2),\n"
-"        }),\n"
-"        Ok(85)\n"
-"    );\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_error() {\n"
-"    assert_eq!(\n"
-"        eval(Expression::Op {\n"
-"            op: Operation::Div,\n"
-"            left: Box::new(Expression::Value(99)),\n"
-"            right: Box::new(Expression::Value(0)),\n"
-"        }),\n"
-"        Err(String::from(\"division by zero\"))\n"
-"    );\n"
-"}\n"
-"fn main() {\n"
-"    let expr = Expression::Op {\n"
-"        op: Operation::Sub,\n"
-"        left: Box::new(Expression::Value(20)),\n"
-"        right: Box::new(Expression::Value(10)),\n"
-"    };\n"
-"    println!(\"expr: {:?}\", expr);\n"
-"    println!(\"result: {:?}\", eval(expr));\n"
-"}\n"
-"```"
+#: src/exercises/day-1/solutions-afternoon.md:211
+msgid "\"expr: {:?}\""
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:212
+msgid "\"result: {:?}\""
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
@@ -19347,281 +16730,28 @@ msgstr "ライブラリをデザイン"
 msgid "([back to exercise](book-library.md))"
 msgstr ""
 
-#: src/exercises/day-2/solutions-morning.md:7
+#: src/exercises/day-2/solutions-morning.md:54
+msgid "\"{}, published in {}\""
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:59
 msgid ""
-"```rust\n"
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}\n"
-"\n"
-"struct Book {\n"
-"    title: String,\n"
-"    year: u16,\n"
-"}\n"
-"\n"
-"impl Book {\n"
-"    // This is a constructor, used below.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"// Implement the methods below. Notice how the `self` parameter\n"
-"// changes type to indicate the method's required level of ownership\n"
-"// over the object:\n"
-"//\n"
-"// - `&self` for shared read-only access,\n"
-"// - `&mut self` for unique and mutable access,\n"
-"// - `self` for unique access by value.\n"
-"impl Library {\n"
-"\n"
-"    fn new() -> Library {\n"
-"        Library { books: Vec::new() }\n"
-"    }\n"
-"\n"
-"    fn len(&self) -> usize {\n"
-"        self.books.len()\n"
-"    }\n"
-"\n"
-"    fn is_empty(&self) -> bool {\n"
-"        self.books.is_empty()\n"
-"    }\n"
-"\n"
-"    fn add_book(&mut self, book: Book) {\n"
-"        self.books.push(book)\n"
-"    }\n"
-"\n"
-"    fn print_books(&self) {\n"
-"        for book in &self.books {\n"
-"            println!(\"{}, published in {}\", book.title, book.year);\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn oldest_book(&self) -> Option<&Book> {\n"
-"        // Using a closure and a built-in method:\n"
+"// Using a closure and a built-in method:\n"
 "        // self.books.iter().min_by_key(|book| book.year)\n"
-"\n"
-"        // Longer hand-written solution:\n"
-"        let mut oldest: Option<&Book> = None;\n"
-"        for book in self.books.iter() {\n"
-"            if oldest.is_none() || book.year < oldest.unwrap().year {\n"
-"                oldest = Some(book);\n"
-"            }\n"
-"        }\n"
-"\n"
-"        oldest\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut library = Library::new();\n"
-"\n"
-"    println!(\n"
-"        \"The library is empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"\n"
-"    println!(\n"
-"        \"The library is no longer empty: library.is_empty() -> {}\",\n"
-"        library.is_empty()\n"
-"    );\n"
-"\n"
-"    library.print_books();\n"
-"\n"
-"    match library.oldest_book() {\n"
-"        Some(book) => println!(\"The oldest book is {}\", book.title),\n"
-"        None => println!(\"The library is empty!\"),\n"
-"    }\n"
-"\n"
-"    println!(\"The library has {} books\", library.len());\n"
-"    library.print_books();\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_len() {\n"
-"    let mut library = Library::new();\n"
-"    assert_eq!(library.len(), 0);\n"
-"    assert!(library.is_empty());\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    assert_eq!(library.len(), 2);\n"
-"    assert!(!library.is_empty());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_is_empty() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.is_empty());\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert!(!library.is_empty());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_print_books() {\n"
-"    let mut library = Library::new();\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    // We could try and capture stdout, but let us just call the\n"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:62
+msgid "// Longer hand-written solution:\n"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:127
+msgid ""
+"// We could try and capture stdout, but let us just call the\n"
 "    // method to start with.\n"
-"    library.print_books();\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_library_oldest_book() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.oldest_book().is_none());\n"
-"\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Lord of the Rings\")\n"
-"    );\n"
-"\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Alice's Adventures in Wonderland\")\n"
-"    );\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:153
 msgid "([back to exercise](health-statistics.md))"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:155
-msgid ""
-"```rust\n"
-"pub struct User {\n"
-"    name: String,\n"
-"    age: u32,\n"
-"    height: f32,\n"
-"    visit_count: usize,\n"
-"    last_blood_pressure: Option<(u32, u32)>,\n"
-"}\n"
-"\n"
-"pub struct Measurements {\n"
-"    height: f32,\n"
-"    blood_pressure: (u32, u32),\n"
-"}\n"
-"\n"
-"pub struct HealthReport<'a> {\n"
-"    patient_name: &'a str,\n"
-"    visit_count: u32,\n"
-"    height_change: f32,\n"
-"    blood_pressure_change: Option<(i32, i32)>,\n"
-"}\n"
-"\n"
-"impl User {\n"
-"    pub fn new(name: String, age: u32, height: f32) -> Self {\n"
-"        Self {\n"
-"            name,\n"
-"            age,\n"
-"            height,\n"
-"            visit_count: 0,\n"
-"            last_blood_pressure: None,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    pub fn name(&self) -> &str {\n"
-"        &self.name\n"
-"    }\n"
-"\n"
-"    pub fn age(&self) -> u32 {\n"
-"        self.age\n"
-"    }\n"
-"\n"
-"    pub fn height(&self) -> f32 {\n"
-"        self.height\n"
-"    }\n"
-"\n"
-"    pub fn doctor_visits(&self) -> u32 {\n"
-"        self.visit_count as u32\n"
-"    }\n"
-"\n"
-"    pub fn set_age(&mut self, new_age: u32) {\n"
-"        self.age = new_age\n"
-"    }\n"
-"\n"
-"    pub fn set_height(&mut self, new_height: f32) {\n"
-"        self.height = new_height\n"
-"    }\n"
-"\n"
-"    pub fn visit_doctor(&mut self, measurements: Measurements) -> "
-"HealthReport {\n"
-"        self.visit_count += 1;\n"
-"        let bp = measurements.blood_pressure;\n"
-"        let report = HealthReport {\n"
-"            patient_name: &self.name,\n"
-"            visit_count: self.visit_count as u32,\n"
-"            height_change: measurements.height - self.height,\n"
-"            blood_pressure_change: match self.last_blood_pressure {\n"
-"                Some(lbp) => Some((\n"
-"                    bp.0 as i32 - lbp.0 as i32,\n"
-"                    bp.1 as i32 - lbp.1 as i32\n"
-"                )),\n"
-"                None => None,\n"
-"            }\n"
-"        };\n"
-"        self.height = measurements.height;\n"
-"        self.last_blood_pressure = Some(bp);\n"
-"        report\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_height() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.height(), 155.2);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_set_age() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.age(), 32);\n"
-"    bob.set_age(33);\n"
-"    assert_eq!(bob.age(), 33);\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_visit() {\n"
-"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.doctor_visits(), 0);\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (120, 80),\n"
-"    });\n"
-"    assert_eq!(report.patient_name, \"Bob\");\n"
-"    assert_eq!(report.visit_count, 1);\n"
-"    assert_eq!(report.blood_pressure_change, None);\n"
-"\n"
-"    let report = bob.visit_doctor(Measurements {\n"
-"        height: 156.1,\n"
-"        blood_pressure: (115, 76),\n"
-"    });\n"
-"\n"
-"    assert_eq!(report.visit_count, 2);\n"
-"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
-"}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
@@ -19632,24 +16762,18 @@ msgstr ""
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-afternoon.md:10
+#: src/exercises/day-2/solutions-afternoon.md:12
+msgid "'/'"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:16
+msgid "\"*\""
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:22
 msgid ""
-"```rust\n"
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"\n"
-"    let mut request_segments = request_path.split('/');\n"
-"\n"
-"    for prefix_segment in prefix.split('/') {\n"
-"        let Some(request_segment) = request_segments.next() else {\n"
-"            return false;\n"
-"        };\n"
-"        if request_segment != prefix_segment && prefix_segment != \"*\" {\n"
-"            return false;\n"
-"        }\n"
-"    }\n"
-"    true\n"
-"\n"
-"    // Alternatively, Iterator::zip() lets us iterate simultaneously over "
+"// Alternatively, Iterator::zip() lets us iterate simultaneously over "
 "prefix\n"
 "    // and request segments. The zip() iterator is finished as soon as one "
 "of\n"
@@ -19660,47 +16784,6 @@ msgid ""
 "    // to produce an iterator that returns Some(str) for each pattern "
 "segments,\n"
 "    // and then returns None indefinitely.\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
-"abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
-"books\"));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
-"publishers\"));\n"
-"}\n"
-"\n"
-"#[test]\n"
-"fn test_matches_with_wildcard() {\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/bar/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books/book1\"\n"
-"    ));\n"
-"\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
-"publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
-"\n"
-"fn main() {}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
@@ -19711,230 +16794,54 @@ msgstr ""
 msgid "([back to exercise](simple-gui.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-morning.md:7
+#: src/exercises/day-3/solutions-morning.md:75
+msgid "// Add 4 paddings for borders\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:87
 msgid ""
-"```rust\n"
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;\n"
-"\n"
-"    /// Draw the widget into a buffer.\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
-"\n"
-"    /// Draw the widget on standard output.\n"
-"    fn draw(&self) {\n"
-"        let mut buffer = String::new();\n"
-"        self.draw_into(&mut buffer);\n"
-"        println!(\"{buffer}\");\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Label {\n"
-"    label: String,\n"
-"}\n"
-"\n"
-"impl Label {\n"
-"    fn new(label: &str) -> Label {\n"
-"        Label {\n"
-"            label: label.to_owned(),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Button {\n"
-"    label: Label,\n"
-"}\n"
-"\n"
-"impl Button {\n"
-"    fn new(label: &str) -> Button {\n"
-"        Button {\n"
-"            label: Label::new(label),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Window {\n"
-"    title: String,\n"
-"    widgets: Vec<Box<dyn Widget>>,\n"
-"}\n"
-"\n"
-"impl Window {\n"
-"    fn new(title: &str) -> Window {\n"
-"        Window {\n"
-"            title: title.to_owned(),\n"
-"            widgets: Vec::new(),\n"
-"        }\n"
-"    }\n"
-"\n"
-"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
-"        self.widgets.push(widget);\n"
-"    }\n"
-"\n"
-"    fn inner_width(&self) -> usize {\n"
-"        std::cmp::max(\n"
-"            self.title.chars().count(),\n"
-"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-"        )\n"
-"    }\n"
-"}\n"
-"\n"
-"\n"
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        // Add 4 paddings for borders\n"
-"        self.inner_width() + 4\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        let mut inner = String::new();\n"
-"        for widget in &self.widgets {\n"
-"            widget.draw_into(&mut inner);\n"
-"        }\n"
-"\n"
-"        let inner_width = self.inner_width();\n"
-"\n"
-"        // TODO: after learning about error handling, you can change\n"
+"// TODO: after learning about error handling, you can change\n"
 "        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
 "        // the ?-operator here instead of .unwrap().\n"
-"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
-"        writeln!(buffer, \"| {:^inner_width$} |\", &self.title).unwrap();\n"
-"        writeln!(buffer, \"+={:=<inner_width$}=+\", \"\").unwrap();\n"
-"        for line in inner.lines() {\n"
-"            writeln!(buffer, \"| {:inner_width$} |\", line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+-{:-<inner_width$}-+\", \"\").unwrap();\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        self.label.width() + 8 // add a bit of padding\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        let width = self.width();\n"
-"        let mut label = String::new();\n"
-"        self.label.draw_into(&mut label);\n"
-"\n"
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
-"        for line in label.lines() {\n"
-"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        self.label\n"
-"            .lines()\n"
-"            .map(|line| line.chars().count())\n"
-"            .max()\n"
-"            .unwrap_or(0)\n"
-"    }\n"
-"\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
-"\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\"\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:90
+#: src/exercises/day-3/solutions-morning.md:96
+msgid "\"+-{:-<inner_width$}-+\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:91
+msgid "\"| {:^inner_width$} |\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:92
+msgid "\"+={:=<inner_width$}=+\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:94
+msgid "\"| {:inner_width$} |\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:102
+msgid "// add a bit of padding\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:110
+#: src/exercises/day-3/solutions-morning.md:114
+msgid "\"+{:-<width$}+\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:112
+msgid "\"|{:^width$}|\""
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:144
 msgid "([back to exercise](points-polygons.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-morning.md:146
+#: src/exercises/day-3/solutions-morning.md:223
 msgid ""
-"```rust\n"
-"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-"pub struct Point {\n"
-"    x: i32,\n"
-"    y: i32,\n"
-"}\n"
-"\n"
-"impl Point {\n"
-"    pub fn new(x: i32, y: i32) -> Point {\n"
-"        Point { x, y }\n"
-"    }\n"
-"\n"
-"    pub fn magnitude(self) -> f64 {\n"
-"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-"    }\n"
-"\n"
-"    pub fn dist(self, other: Point) -> f64 {\n"
-"        (self - other).magnitude()\n"
-"    }\n"
-"}\n"
-"\n"
-"impl std::ops::Add for Point {\n"
-"    type Output = Self;\n"
-"\n"
-"    fn add(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x + other.x,\n"
-"            y: self.y + other.y,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"impl std::ops::Sub for Point {\n"
-"    type Output = Self;\n"
-"\n"
-"    fn sub(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x - other.x,\n"
-"            y: self.y - other.y,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Polygon {\n"
-"    points: Vec<Point>,\n"
-"}\n"
-"\n"
-"impl Polygon {\n"
-"    pub fn new() -> Polygon {\n"
-"        Polygon { points: Vec::new() }\n"
-"    }\n"
-"\n"
-"    pub fn add_point(&mut self, point: Point) {\n"
-"        self.points.push(point);\n"
-"    }\n"
-"\n"
-"    pub fn left_most_point(&self) -> Option<Point> {\n"
-"        self.points.iter().min_by_key(|p| p.x).copied()\n"
-"    }\n"
-"\n"
-"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-"        self.points.iter()\n"
-"    }\n"
-"\n"
-"    pub fn length(&self) -> f64 {\n"
-"        if self.points.is_empty() {\n"
-"            return 0.0;\n"
-"        }\n"
-"\n"
-"        let mut result = 0.0;\n"
-"        let mut last_point = self.points[0];\n"
-"        for point in &self.points[1..] {\n"
-"            result += last_point.dist(*point);\n"
-"            last_point = *point;\n"
-"        }\n"
-"        result += last_point.dist(self.points[0]);\n"
-"        result\n"
-"        // Alternatively, Iterator::zip() lets us iterate over the points as "
-"pairs\n"
+"// Alternatively, Iterator::zip() lets us iterate over the points as pairs\n"
 "        // but we need to pair each point with the next one, and the last "
 "point\n"
 "        // with the first point. The zip() iterator is finished as soon as "
@@ -19944,127 +16851,6 @@ msgid ""
 "        // with Iterator::skip to create the second iterator for the zip and "
 "using map \n"
 "        // and sum to calculate the total length.\n"
-"    }\n"
-"}\n"
-"\n"
-"pub struct Circle {\n"
-"    center: Point,\n"
-"    radius: i32,\n"
-"}\n"
-"\n"
-"impl Circle {\n"
-"    pub fn new(center: Point, radius: i32) -> Circle {\n"
-"        Circle { center, radius }\n"
-"    }\n"
-"\n"
-"    pub fn circumference(&self) -> f64 {\n"
-"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-"    }\n"
-"\n"
-"    pub fn dist(&self, other: &Self) -> f64 {\n"
-"        self.center.dist(other.center)\n"
-"    }\n"
-"}\n"
-"\n"
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}\n"
-"\n"
-"impl From<Polygon> for Shape {\n"
-"    fn from(poly: Polygon) -> Self {\n"
-"        Shape::Polygon(poly)\n"
-"    }\n"
-"}\n"
-"\n"
-"impl From<Circle> for Shape {\n"
-"    fn from(circle: Circle) -> Self {\n"
-"        Shape::Circle(circle)\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Shape {\n"
-"    pub fn perimeter(&self) -> f64 {\n"
-"        match self {\n"
-"            Shape::Polygon(poly) => poly.length(),\n"
-"            Shape::Circle(circle) => circle.circumference(),\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"\n"
-"    fn round_two_digits(x: f64) -> f64 {\n"
-"        (x * 100.0).round() / 100.0\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_magnitude() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_dist() {\n"
-"        let p1 = Point::new(10, 10);\n"
-"        let p2 = Point::new(14, 13);\n"
-"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_point_add() {\n"
-"        let p1 = Point::new(16, 16);\n"
-"        let p2 = p1 + Point::new(-4, 3);\n"
-"        assert_eq!(p2, Point::new(12, 19));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_left_most_point() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"        assert_eq!(poly.left_most_point(), Some(p1));\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_polygon_iter() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);\n"
-"\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"\n"
-"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
-"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {}\n"
-"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
@@ -20075,172 +16861,81 @@ msgstr ""
 msgid "([back to exercise](safe-ffi-wrapper.md))"
 msgstr ""
 
-#: src/exercises/day-3/solutions-afternoon.md:7
+#: src/exercises/day-3/solutions-afternoon.md:77
+msgid "\"Invalid path: {err}\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:78
+msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:81
+msgid "\"Could not open {:?}\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:91
 msgid ""
-"```rust\n"
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int};\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    use std::os::raw::{c_long, c_ulong, c_ushort, c_uchar};\n"
-"\n"
-"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-"    #[repr(C)]\n"
-"    pub struct DIR {\n"
-"        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
-"PhantomPinned)>,\n"
-"    }\n"
-"\n"
-"    // Layout according to the Linux man page for readdir(3), where ino_t "
-"and\n"
-"    // off_t are resolved according to the definitions in\n"
-"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
-"    #[cfg(not(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_ino: c_ulong,\n"
-"        pub d_off: c_long,\n"
-"        pub d_reclen: c_ushort,\n"
-"        pub d_type: c_uchar,\n"
-"        pub d_name: [c_char; 256],\n"
-"    }\n"
-"\n"
-"    // Layout according to the macOS man page for dir(5).\n"
-"    #[cfg(all(target_os = \"macos\"))]\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_fileno: u64,\n"
-"        pub d_seekoff: u64,\n"
-"        pub d_reclen: u16,\n"
-"        pub d_namlen: u16,\n"
-"        pub d_type: u8,\n"
-"        pub d_name: [c_char; 1024],\n"
-"    }\n"
-"\n"
-"    extern \"C\" {\n"
-"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
-"\n"
-"        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        // See https://github.com/rust-lang/libc/issues/414 and the section "
-"on\n"
-"        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
-"        //\n"
-"        // \"Platforms that existed before these updates were available\" "
-"refers\n"
-"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
-"PowerPC.\n"
-"        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
-"        #[link_name = \"readdir$INODE64\"]\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"\n"
-"        pub fn closedir(s: *mut DIR) -> c_int;\n"
-"    }\n"
-"}\n"
-"\n"
-"use std::ffi::{CStr, CString, OsStr, OsString};\n"
-"use std::os::unix::ffi::OsStrExt;\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}\n"
-"\n"
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
-"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
-"{err}\"))?;\n"
-"        // SAFETY: path.as_ptr() cannot be NULL.\n"
-"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
-"        if dir.is_null() {\n"
-"            Err(format!(\"Could not open {:?}\", path))\n"
-"        } else {\n"
-"            Ok(DirectoryIterator { path, dir })\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
+"// Keep calling readdir until we get a NULL pointer back.\n"
 "        // SAFETY: self.dir is never NULL.\n"
-"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
-"        if dirent.is_null() {\n"
-"            // We have reached the end of the directory.\n"
-"            return None;\n"
-"        }\n"
-"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:95
+msgid "// We have reached the end of the directory.\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:98
+msgid ""
+"// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
 "        // terminated.\n"
-"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
-"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
-"        Some(os_str.to_owned())\n"
-"    }\n"
-"}\n"
-"\n"
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        if !self.dir.is_null() {\n"
-"            // SAFETY: self.dir is not NULL.\n"
-"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
-"                panic!(\"Could not close {:?}\", self.path);\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;\n"
-"    use std::error::Error;\n"
-"\n"
-"    #[test]\n"
-"    fn test_nonexisting_directory() {\n"
-"        let iter = DirectoryIterator::new(\"no-such-directory\");\n"
-"        assert!(iter.is_err());\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_empty_directory() -> Result<(), Box<dyn Error>> {\n"
-"        let tmp = tempfile::TempDir::new()?;\n"
-"        let iter = DirectoryIterator::new(\n"
-"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
-"        )?;\n"
-"        let mut entries = iter.collect::<Vec<_>>();\n"
-"        entries.sort();\n"
-"        assert_eq!(entries, &[\".\", \"..\"]);\n"
-"        Ok(())\n"
-"    }\n"
-"\n"
-"    #[test]\n"
-"    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
-"        let tmp = tempfile::TempDir::new()?;\n"
-"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo "
-"Diaries\\n\")?;\n"
-"        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n\")?;\n"
-"        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n\")?;\n"
-"        let iter = DirectoryIterator::new(\n"
-"            tmp.path().to_str().ok_or(\"Non UTF-8 character in path\")?,\n"
-"        )?;\n"
-"        let mut entries = iter.collect::<Vec<_>>();\n"
-"        entries.sort();\n"
-"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", \"foo."
-"txt\"]);\n"
-"        Ok(())\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:110
+msgid "// SAFETY: self.dir is not NULL.\n"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:112
+msgid "\"Could not close {:?}\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:131
+msgid "\"no-such-directory\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:139
+#: src/exercises/day-3/solutions-afternoon.md:154
+msgid "\"Non UTF-8 character in path\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:143
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"..\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:150
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"foo.txt\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:150
+msgid "\"The Foo Diaries\\n\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:151
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"bar.png\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:151
+msgid "\"<PNG>\\n\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:152
+#: src/exercises/day-3/solutions-afternoon.md:158
+msgid "\"crab.rs\""
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:152
+msgid "\"//! Crab\\n\""
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
@@ -20251,151 +16946,30 @@ msgstr ""
 msgid "([back to exercise](compass.md))"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:7
+#: src/exercises/bare-metal/solutions-morning.md:40
+msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:41
+msgid "\"Setting up IMU...\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:49
+msgid "// Set up display and timer.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:59
+msgid "// Read compass data and log it to the serial port.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:67
+msgid "\"{},{},{}\\t{},{},{}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:103
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"extern crate panic_halt as _;\n"
-"\n"
-"use core::fmt::Write;\n"
-"use cortex_m_rt::entry;\n"
-"use core::cmp::{max, min};\n"
-"use lsm303agr::{AccelOutputDataRate, Lsm303agr, MagOutputDataRate};\n"
-"use microbit::display::blocking::Display;\n"
-"use microbit::hal::prelude::*;\n"
-"use microbit::hal::twim::Twim;\n"
-"use microbit::hal::uarte::{Baudrate, Parity, Uarte};\n"
-"use microbit::hal::Timer;\n"
-"use microbit::pac::twim0::frequency::FREQUENCY_A;\n"
-"use microbit::Board;\n"
-"\n"
-"const COMPASS_SCALE: i32 = 30000;\n"
-"const ACCELEROMETER_SCALE: i32 = 700;\n"
-"\n"
-"#[entry]\n"
-"fn main() -> ! {\n"
-"    let board = Board::take().unwrap();\n"
-"\n"
-"    // Configure serial port.\n"
-"    let mut serial = Uarte::new(\n"
-"        board.UARTE0,\n"
-"        board.uart.into(),\n"
-"        Parity::EXCLUDED,\n"
-"        Baudrate::BAUD115200,\n"
-"    );\n"
-"\n"
-"    // Set up the I2C controller and Inertial Measurement Unit.\n"
-"    writeln!(serial, \"Setting up IMU...\").unwrap();\n"
-"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::"
-"K100);\n"
-"    let mut imu = Lsm303agr::new_with_i2c(i2c);\n"
-"    imu.init().unwrap();\n"
-"    imu.set_mag_odr(MagOutputDataRate::Hz50).unwrap();\n"
-"    imu.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();\n"
-"    let mut imu = imu.into_mag_continuous().ok().unwrap();\n"
-"\n"
-"    // Set up display and timer.\n"
-"    let mut timer = Timer::new(board.TIMER0);\n"
-"    let mut display = Display::new(board.display_pins);\n"
-"\n"
-"    let mut mode = Mode::Compass;\n"
-"    let mut button_pressed = false;\n"
-"\n"
-"    writeln!(serial, \"Ready.\").unwrap();\n"
-"\n"
-"    loop {\n"
-"        // Read compass data and log it to the serial port.\n"
-"        while !(imu.mag_status().unwrap().xyz_new_data\n"
-"            && imu.accel_status().unwrap().xyz_new_data)\n"
-"        {}\n"
-"        let compass_reading = imu.mag_data().unwrap();\n"
-"        let accelerometer_reading = imu.accel_data().unwrap();\n"
-"        writeln!(\n"
-"            serial,\n"
-"            \"{},{},{}\\t{},{},{}\",\n"
-"            compass_reading.x,\n"
-"            compass_reading.y,\n"
-"            compass_reading.z,\n"
-"            accelerometer_reading.x,\n"
-"            accelerometer_reading.y,\n"
-"            accelerometer_reading.z,\n"
-"        )\n"
-"        .unwrap();\n"
-"\n"
-"        let mut image = [[0; 5]; 5];\n"
-"        let (x, y) = match mode {\n"
-"            Mode::Compass => (\n"
-"                scale(-compass_reading.x, -COMPASS_SCALE, COMPASS_SCALE, 0, "
-"4) as usize,\n"
-"                scale(compass_reading.y, -COMPASS_SCALE, COMPASS_SCALE, 0, "
-"4) as usize,\n"
-"            ),\n"
-"            Mode::Accelerometer => (\n"
-"                scale(\n"
-"                    accelerometer_reading.x,\n"
-"                    -ACCELEROMETER_SCALE,\n"
-"                    ACCELEROMETER_SCALE,\n"
-"                    0,\n"
-"                    4,\n"
-"                ) as usize,\n"
-"                scale(\n"
-"                    -accelerometer_reading.y,\n"
-"                    -ACCELEROMETER_SCALE,\n"
-"                    ACCELEROMETER_SCALE,\n"
-"                    0,\n"
-"                    4,\n"
-"                ) as usize,\n"
-"            ),\n"
-"        };\n"
-"        image[y][x] = 255;\n"
-"        display.show(&mut timer, image, 100);\n"
-"\n"
-"        // If button A is pressed, switch to the next mode and briefly blink "
-"all LEDs on.\n"
-"        if board.buttons.button_a.is_low().unwrap() {\n"
-"            if !button_pressed {\n"
-"                mode = mode.next();\n"
-"                display.show(&mut timer, [[255; 5]; 5], 200);\n"
-"            }\n"
-"            button_pressed = true;\n"
-"        } else {\n"
-"            button_pressed = false;\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[derive(Copy, Clone, Debug, Eq, PartialEq)]\n"
-"enum Mode {\n"
-"    Compass,\n"
-"    Accelerometer,\n"
-"}\n"
-"\n"
-"impl Mode {\n"
-"    fn next(self) -> Self {\n"
-"        match self {\n"
-"            Self::Compass => Self::Accelerometer,\n"
-"            Self::Accelerometer => Self::Compass,\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -"
-"> i32 {\n"
-"    let range_in = max_in - min_in;\n"
-"    let range_out = max_out - min_out;\n"
-"    cap(\n"
-"        min_out + range_out * (value - min_in) / range_in,\n"
-"        min_out,\n"
-"        max_out,\n"
-"    )\n"
-"}\n"
-"\n"
-"fn cap(value: i32, min_value: i32, max_value: i32) -> i32 {\n"
-"    max(min_value, min(value, max_value))\n"
-"}\n"
-"```"
+"// If button A is pressed, switch to the next mode and briefly blink all "
+"LEDs on.\n"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -20406,174 +16980,92 @@ msgstr ""
 msgid "_main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:9
+#: src/exercises/bare-metal/solutions-afternoon.md:36
+msgid "/// Base address of the PL031 RTC.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:38
+msgid "/// The IRQ used by the PL031 RTC.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:57
 msgid ""
-"```rust,compile_fail\n"
-"#![no_main]\n"
-"#![no_std]\n"
-"\n"
-"mod exceptions;\n"
-"mod logger;\n"
-"mod pl011;\n"
-"mod pl031;\n"
-"\n"
-"use crate::pl031::Rtc;\n"
-"use arm_gic::gicv3::{IntId, Trigger};\n"
-"use arm_gic::{irq_enable, wfi};\n"
-"use chrono::{TimeZone, Utc};\n"
-"use core::hint::spin_loop;\n"
-"use crate::pl011::Uart;\n"
-"use arm_gic::gicv3::GicV3;\n"
-"use core::panic::PanicInfo;\n"
-"use log::{error, info, trace, LevelFilter};\n"
-"use smccc::psci::system_off;\n"
-"use smccc::Hvc;\n"
-"\n"
-"/// Base addresses of the GICv3.\n"
-"const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;\n"
-"const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;\n"
-"\n"
-"/// Base address of the primary PL011 UART.\n"
-"const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;\n"
-"\n"
-"/// Base address of the PL031 RTC.\n"
-"const PL031_BASE_ADDRESS: *mut u32 = 0x901_0000 as _;\n"
-"/// The IRQ used by the PL031 RTC.\n"
-"const PL031_IRQ: IntId = IntId::spi(2);\n"
-"\n"
-"#[no_mangle]\n"
-"extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
-"device,\n"
+"// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
 "    // and nothing else accesses that address range.\n"
-"    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
-"    logger::init(uart, LevelFilter::Trace).unwrap();\n"
-"\n"
-"    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
-"\n"
-"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
-"base\n"
-"    // addresses of a GICv3 distributor and redistributor respectively, and\n"
-"    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
-"GICR_BASE_ADDRESS) };\n"
-"    gic.setup();\n"
-"\n"
-"    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 "
-"device,\n"
-"    // and nothing else accesses that address range.\n"
-"    let mut rtc = unsafe { Rtc::new(PL031_BASE_ADDRESS) };\n"
-"    let timestamp = rtc.read();\n"
-"    let time = Utc.timestamp_opt(timestamp.into(), 0).unwrap();\n"
-"    info!(\"RTC: {time}\");\n"
-"\n"
-"    GicV3::set_priority_mask(0xff);\n"
-"    gic.set_interrupt_priority(PL031_IRQ, 0x80);\n"
-"    gic.set_trigger(PL031_IRQ, Trigger::Level);\n"
-"    irq_enable();\n"
-"    gic.enable_interrupt(PL031_IRQ, true);\n"
-"\n"
-"    // Wait for 3 seconds, without interrupts.\n"
-"    let target = timestamp + 3;\n"
-"    rtc.set_match(target);\n"
-"    info!(\n"
-"        \"Waiting for {}\",\n"
-"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
-"    );\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    while !rtc.matched() {\n"
-"        spin_loop();\n"
-"    }\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    info!(\"Finished waiting\");\n"
-"\n"
-"    // Wait another 3 seconds for an interrupt.\n"
-"    let target = timestamp + 6;\n"
-"    info!(\n"
-"        \"Waiting for {}\",\n"
-"        Utc.timestamp_opt(target.into(), 0).unwrap()\n"
-"    );\n"
-"    rtc.set_match(target);\n"
-"    rtc.clear_interrupt();\n"
-"    rtc.enable_interrupt(true);\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    while !rtc.interrupt_pending() {\n"
-"        wfi();\n"
-"    }\n"
-"    trace!(\n"
-"        \"matched={}, interrupt_pending={}\",\n"
-"        rtc.matched(),\n"
-"        rtc.interrupt_pending()\n"
-"    );\n"
-"    info!(\"Finished waiting\");\n"
-"\n"
-"    system_off::<Hvc>().unwrap();\n"
-"}\n"
-"\n"
-"#[panic_handler]\n"
-"fn panic(info: &PanicInfo) -> ! {\n"
-"    error!(\"{info}\");\n"
-"    system_off::<Hvc>().unwrap();\n"
-"    loop {}\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:62
+msgid "\"RTC: {time}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:70
+msgid "// Wait for 3 seconds, without interrupts.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:74
+#: src/exercises/bare-metal/solutions-afternoon.md:95
+msgid "\"Waiting for {}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:78
+#: src/exercises/bare-metal/solutions-afternoon.md:86
+#: src/exercises/bare-metal/solutions-afternoon.md:102
+#: src/exercises/bare-metal/solutions-afternoon.md:110
+msgid "\"matched={}, interrupt_pending={}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:90
+#: src/exercises/bare-metal/solutions-afternoon.md:114
+msgid "\"Finished waiting\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:92
+msgid "// Wait another 3 seconds for an interrupt.\n"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:127
 msgid "_pl031.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:129
+#: src/exercises/bare-metal/solutions-afternoon.md:134
+msgid "/// Data register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:136
+msgid "/// Match register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:138
+msgid "/// Load register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:140
+msgid "/// Control register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:143
+msgid "/// Interrupt Mask Set or Clear register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:146
+msgid "/// Raw Interrupt Status\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:149
+msgid "/// Masked Interrupt Status\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:152
+msgid "/// Interrupt Clear Register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:156
+msgid "/// Driver for a PL031 real-time clock.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:164
 msgid ""
-"```rust\n"
-"use core::ptr::{addr_of, addr_of_mut};\n"
-"\n"
-"#[repr(C, align(4))]\n"
-"struct Registers {\n"
-"    /// Data register\n"
-"    dr: u32,\n"
-"    /// Match register\n"
-"    mr: u32,\n"
-"    /// Load register\n"
-"    lr: u32,\n"
-"    /// Control register\n"
-"    cr: u8,\n"
-"    _reserved0: [u8; 3],\n"
-"    /// Interrupt Mask Set or Clear register\n"
-"    imsc: u8,\n"
-"    _reserved1: [u8; 3],\n"
-"    /// Raw Interrupt Status\n"
-"    ris: u8,\n"
-"    _reserved2: [u8; 3],\n"
-"    /// Masked Interrupt Status\n"
-"    mis: u8,\n"
-"    _reserved3: [u8; 3],\n"
-"    /// Interrupt Clear Register\n"
-"    icr: u8,\n"
-"    _reserved4: [u8; 3],\n"
-"}\n"
-"\n"
-"/// Driver for a PL031 real-time clock.\n"
-"#[derive(Debug)]\n"
-"pub struct Rtc {\n"
-"    registers: *mut Registers,\n"
-"}\n"
-"\n"
-"impl Rtc {\n"
-"    /// Constructs a new instance of the RTC driver for a PL031 device at "
-"the\n"
+"/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
@@ -20583,76 +17075,55 @@ msgid ""
 "    /// PL031 device, which must be mapped into the address space of the "
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
-"    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
-"        Self {\n"
-"            registers: base_address as *mut Registers,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Reads the current RTC value.\n"
-"    pub fn read(&self) -> u32 {\n"
-"        // Safe because we know that self.registers points to the control\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:178
+msgid "/// Reads the current RTC value.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:180
+#: src/exercises/bare-metal/solutions-afternoon.md:188
+#: src/exercises/bare-metal/solutions-afternoon.md:196
+#: src/exercises/bare-metal/solutions-afternoon.md:207
+#: src/exercises/bare-metal/solutions-afternoon.md:219
+#: src/exercises/bare-metal/solutions-afternoon.md:226
+msgid ""
+"// Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of!((*self.registers).dr).read_volatile() }\n"
-"    }\n"
-"\n"
-"    /// Writes a match value. When the RTC value matches this then an "
-"interrupt\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:185
+msgid ""
+"/// Writes a match value. When the RTC value matches this then an interrupt\n"
 "    /// will be generated (if it is enabled).\n"
-"    pub fn set_match(&mut self, value: u32) {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).mr).write_volatile(value) }\n"
-"    }\n"
-"\n"
-"    /// Returns whether the match register matches the RTC value, whether or "
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:193
+msgid ""
+"/// Returns whether the match register matches the RTC value, whether or "
 "not\n"
 "    /// the interrupt is enabled.\n"
-"    pub fn matched(&self) -> bool {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).ris)."
-"read_volatile() };\n"
-"        (ris & 0x01) != 0\n"
-"    }\n"
-"\n"
-"    /// Returns whether there is currently an interrupt pending.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:202
+msgid ""
+"/// Returns whether there is currently an interrupt pending.\n"
 "    ///\n"
 "    /// This should be true if and only if `matched` returns true and the\n"
 "    /// interrupt is masked.\n"
-"    pub fn interrupt_pending(&self) -> bool {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).mis)."
-"read_volatile() };\n"
-"        (ris & 0x01) != 0\n"
-"    }\n"
-"\n"
-"    /// Sets or clears the interrupt mask.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:213
+msgid ""
+"/// Sets or clears the interrupt mask.\n"
 "    ///\n"
 "    /// When the mask is true the interrupt is enabled; when it is false "
 "the\n"
 "    /// interrupt is disabled.\n"
-"    pub fn enable_interrupt(&mut self, mask: bool) {\n"
-"        let imsc = if mask { 0x01 } else { 0x00 };\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).imsc)."
-"write_volatile(imsc) }\n"
-"    }\n"
-"\n"
-"    /// Clears a pending interrupt, if any.\n"
-"    pub fn clear_interrupt(&mut self) {\n"
-"        // Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).icr).write_volatile(0x01) }\n"
-"    }\n"
-"}\n"
-"\n"
-"// Safe because it just contains a pointer to device memory, which can be\n"
-"// accessed from any context.\n"
-"unsafe impl Send for Rtc {}\n"
-"```"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:224
+msgid "/// Clears a pending interrupt, if any.\n"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
@@ -20663,82 +17134,19 @@ msgstr ""
 msgid "([back to exercise](dining-philosophers.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md:7
+#: src/exercises/concurrency/solutions-morning.md:29
+msgid "\"{} is trying to eat\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:53
 msgid ""
-"```rust\n"
-"use std::sync::{mpsc, Arc, Mutex};\n"
-"use std::thread;\n"
-"use std::time::Duration;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    left_fork: Arc<Mutex<Fork>>,\n"
-"    right_fork: Arc<Mutex<Fork>>,\n"
-"    thoughts: mpsc::SyncSender<String>,\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    fn eat(&self) {\n"
-"        println!(\"{} is trying to eat\", &self.name);\n"
-"        let left = self.left_fork.lock().unwrap();\n"
-"        let right = self.right_fork.lock().unwrap();\n"
-"\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"fn main() {\n"
-"    let (tx, rx) = mpsc::sync_channel(10);\n"
-"\n"
-"    let forks = (0..PHILOSOPHERS.len())\n"
-"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
-"        .collect::<Vec<_>>();\n"
-"\n"
-"    for i in 0..forks.len() {\n"
-"        let tx = tx.clone();\n"
-"        let mut left_fork = Arc::clone(&forks[i]);\n"
-"        let mut right_fork = Arc::clone(&forks[(i + 1) % forks.len()]);\n"
-"\n"
-"        // To avoid a deadlock, we have to break the symmetry\n"
+"// To avoid a deadlock, we have to break the symmetry\n"
 "        // somewhere. This will swap the forks without deinitializing\n"
 "        // either of them.\n"
-"        if i == forks.len() - 1 {\n"
-"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
-"        }\n"
-"\n"
-"        let philosopher = Philosopher {\n"
-"            name: PHILOSOPHERS[i].to_string(),\n"
-"            thoughts: tx,\n"
-"            left_fork,\n"
-"            right_fork,\n"
-"        };\n"
-"\n"
-"        thread::spawn(move || {\n"
-"            for _ in 0..100 {\n"
-"                philosopher.eat();\n"
-"                philosopher.think();\n"
-"            }\n"
-"        });\n"
-"    }\n"
-"\n"
-"    drop(tx);\n"
-"    for thought in rx {\n"
-"        println!(\"{thought}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:77
+msgid "\"{thought}\""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:82
@@ -20750,181 +17158,27 @@ msgstr "マルチスレッド・リンクチェッカー"
 msgid "([back to exercise](link-checker.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md:86
+#: src/exercises/concurrency/solutions-morning.md:155
 msgid ""
-"```rust,compile_fail\n"
-"use std::{sync::Arc, sync::Mutex, sync::mpsc, thread};\n"
-"\n"
-"use reqwest::{blocking::Client, Url};\n"
-"use scraper::{Html, Selector};\n"
-"use thiserror::Error;\n"
-"\n"
-"#[derive(Error, Debug)]\n"
-"enum Error {\n"
-"    #[error(\"request error: {0}\")]\n"
-"    ReqwestError(#[from] reqwest::Error),\n"
-"    #[error(\"bad http response: {0}\")]\n"
-"    BadResponse(String),\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"struct CrawlCommand {\n"
-"    url: Url,\n"
-"    extract_links: bool,\n"
-"}\n"
-"\n"
-"fn visit_page(client: &Client, command: &CrawlCommand) -> Result<Vec<Url>, "
-"Error> {\n"
-"    println!(\"Checking {:#}\", command.url);\n"
-"    let response = client.get(command.url.clone()).send()?;\n"
-"    if !response.status().is_success() {\n"
-"        return Err(Error::BadResponse(response.status().to_string()));\n"
-"    }\n"
-"\n"
-"    let mut link_urls = Vec::new();\n"
-"    if !command.extract_links {\n"
-"        return Ok(link_urls);\n"
-"    }\n"
-"\n"
-"    let base_url = response.url().to_owned();\n"
-"    let body_text = response.text()?;\n"
-"    let document = Html::parse_document(&body_text);\n"
-"\n"
-"    let selector = Selector::parse(\"a\").unwrap();\n"
-"    let href_values = document\n"
-"        .select(&selector)\n"
-"        .filter_map(|element| element.value().attr(\"href\"));\n"
-"    for href in href_values {\n"
-"        match base_url.join(href) {\n"
-"            Ok(link_url) => {\n"
-"                link_urls.push(link_url);\n"
-"            }\n"
-"            Err(err) => {\n"
-"                println!(\"On {base_url:#}: ignored unparsable {href:?}: "
-"{err}\");\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"    Ok(link_urls)\n"
-"}\n"
-"\n"
-"struct CrawlState {\n"
-"    domain: String,\n"
-"    visited_pages: std::collections::HashSet<String>,\n"
-"}\n"
-"\n"
-"impl CrawlState {\n"
-"    fn new(start_url: &Url) -> CrawlState {\n"
-"        let mut visited_pages = std::collections::HashSet::new();\n"
-"        visited_pages.insert(start_url.as_str().to_string());\n"
-"        CrawlState {\n"
-"            domain: start_url.domain().unwrap().to_string(),\n"
-"            visited_pages,\n"
-"        }\n"
-"    }\n"
-"\n"
-"    /// Determine whether links within the given page should be extracted.\n"
-"    fn should_extract_links(&self, url: &Url) -> bool {\n"
-"        let Some(url_domain) = url.domain() else {\n"
-"            return false;\n"
-"        };\n"
-"        url_domain == self.domain\n"
-"    }\n"
-"\n"
-"    /// Mark the given page as visited, returning false if it had already\n"
+"/// Determine whether links within the given page should be extracted.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:163
+msgid ""
+"/// Mark the given page as visited, returning false if it had already\n"
 "    /// been visited.\n"
-"    fn mark_visited(&mut self, url: &Url) -> bool {\n"
-"        self.visited_pages.insert(url.as_str().to_string())\n"
-"    }\n"
-"}\n"
-"\n"
-"type CrawlResult = Result<Vec<Url>, (Url, Error)>;\n"
-"fn spawn_crawler_threads(\n"
-"    command_receiver: mpsc::Receiver<CrawlCommand>,\n"
-"    result_sender: mpsc::Sender<CrawlResult>,\n"
-"    thread_count: u32,\n"
-") {\n"
-"    let command_receiver = Arc::new(Mutex::new(command_receiver));\n"
-"\n"
-"    for _ in 0..thread_count {\n"
-"        let result_sender = result_sender.clone();\n"
-"        let command_receiver = command_receiver.clone();\n"
-"        thread::spawn(move || {\n"
-"            let client = Client::new();\n"
-"            loop {\n"
-"                let command_result = {\n"
-"                    let receiver_guard = command_receiver.lock().unwrap();\n"
-"                    receiver_guard.recv()\n"
-"                };\n"
-"                let Ok(crawl_command) = command_result else {\n"
-"                    // The sender got dropped. No more commands coming in.\n"
-"                    break;\n"
-"                };\n"
-"                let crawl_result = match visit_page(&client, &crawl_command) "
-"{\n"
-"                    Ok(link_urls) => Ok(link_urls),\n"
-"                    Err(error) => Err((crawl_command.url, error)),\n"
-"                };\n"
-"                result_sender.send(crawl_result).unwrap();\n"
-"            }\n"
-"        });\n"
-"    }\n"
-"}\n"
-"\n"
-"fn control_crawl(\n"
-"    start_url: Url,\n"
-"    command_sender: mpsc::Sender<CrawlCommand>,\n"
-"    result_receiver: mpsc::Receiver<CrawlResult>,\n"
-") -> Vec<Url> {\n"
-"    let mut crawl_state = CrawlState::new(&start_url);\n"
-"    let start_command = CrawlCommand { url: start_url, extract_links: "
-"true };\n"
-"    command_sender.send(start_command).unwrap();\n"
-"    let mut pending_urls = 1;\n"
-"\n"
-"    let mut bad_urls = Vec::new();\n"
-"    while pending_urls > 0 {\n"
-"        let crawl_result = result_receiver.recv().unwrap();\n"
-"        pending_urls -= 1;\n"
-"\n"
-"        match crawl_result {\n"
-"            Ok(link_urls) => {\n"
-"                for url in link_urls {\n"
-"                    if crawl_state.mark_visited(&url) {\n"
-"                        let extract_links = crawl_state."
-"should_extract_links(&url);\n"
-"                        let crawl_command = CrawlCommand { url, "
-"extract_links };\n"
-"                        command_sender.send(crawl_command).unwrap();\n"
-"                        pending_urls += 1;\n"
-"                    }\n"
-"                }\n"
-"            }\n"
-"            Err((url, error)) => {\n"
-"                bad_urls.push(url);\n"
-"                println!(\"Got crawling error: {:#}\", error);\n"
-"                continue;\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"    bad_urls\n"
-"}\n"
-"\n"
-"fn check_links(start_url: Url) -> Vec<Url> {\n"
-"    let (result_sender, result_receiver) = mpsc::channel::<CrawlResult>();\n"
-"    let (command_sender, command_receiver) = mpsc::channel::"
-"<CrawlCommand>();\n"
-"    spawn_crawler_threads(command_receiver, result_sender, 16);\n"
-"    control_crawl(start_url, command_sender, result_receiver)\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    let start_url = reqwest::Url::parse(\"https://www.google.org\")."
-"unwrap();\n"
-"    let bad_urls = check_links(start_url);\n"
-"    println!(\"Bad URLs: {:#?}\", bad_urls);\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:189
+msgid "// The sender got dropped. No more commands coming in.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:230
+msgid "\"Got crawling error: {:#}\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:248
+msgid "\"Bad URLs: {:#?}\""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
@@ -20935,485 +17189,54 @@ msgstr ""
 msgid "([back to exercise](dining-philosophers-async.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:7
+#: src/exercises/concurrency/solutions-afternoon.md:32
 msgid ""
-"```rust,compile_fail\n"
-"use std::sync::Arc;\n"
-"use tokio::time;\n"
-"use tokio::sync::mpsc::{self, Sender};\n"
-"use tokio::sync::Mutex;\n"
-"\n"
-"struct Fork;\n"
-"\n"
-"struct Philosopher {\n"
-"    name: String,\n"
-"    left_fork: Arc<Mutex<Fork>>,\n"
-"    right_fork: Arc<Mutex<Fork>>,\n"
-"    thoughts: Sender<String>,\n"
-"}\n"
-"\n"
-"impl Philosopher {\n"
-"    async fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
-"await\n"
-"            .unwrap();\n"
-"    }\n"
-"\n"
-"    async fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        let _first_lock = self.left_fork.lock().await;\n"
-"        // Add a delay before picking the second fork to allow the "
-"execution\n"
+"// Add a delay before picking the second fork to allow the execution\n"
 "        // to transfer to another task\n"
-"        time::sleep(time::Duration::from_millis(1)).await;\n"
-"        let _second_lock = self.right_fork.lock().await;\n"
-"\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        time::sleep(time::Duration::from_millis(5)).await;\n"
-"\n"
-"        // The locks are dropped here\n"
-"    }\n"
-"}\n"
-"\n"
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Hypatia\", \"Plato\", \"Aristotle\", \"Pythagoras\"];\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() {\n"
-"    // Create forks\n"
-"    let mut forks = vec![];\n"
-"    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::"
-"new(Fork))));\n"
-"\n"
-"    // Create philosophers\n"
-"    let (philosophers, mut rx) = {\n"
-"        let mut philosophers = vec![];\n"
-"        let (tx, rx) = mpsc::channel(10);\n"
-"        for (i, name) in PHILOSOPHERS.iter().enumerate() {\n"
-"            let left_fork = Arc::clone(&forks[i]);\n"
-"            let right_fork = Arc::clone(&forks[(i + 1) % PHILOSOPHERS."
-"len()]);\n"
-"            // To avoid a deadlock, we have to break the symmetry\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:40
+msgid "// The locks are dropped here\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:60
+msgid ""
+"// To avoid a deadlock, we have to break the symmetry\n"
 "            // somewhere. This will swap the forks without deinitializing\n"
 "            // either of them.\n"
-"            if i  == 0 {\n"
-"                std::mem::swap(&mut left_fork, &mut right_fork);\n"
-"            }\n"
-"            philosophers.push(Philosopher {\n"
-"                name: name.to_string(),\n"
-"                left_fork,\n"
-"                right_fork,\n"
-"                thoughts: tx.clone(),\n"
-"            });\n"
-"        }\n"
-"        (philosophers, rx)\n"
-"        // tx is dropped here, so we don't need to explicitly drop it later\n"
-"    };\n"
-"\n"
-"    // Make them think and eat\n"
-"    for phil in philosophers {\n"
-"        tokio::spawn(async move {\n"
-"            for _ in 0..100 {\n"
-"                phil.think().await;\n"
-"                phil.eat().await;\n"
-"            }\n"
-"        });\n"
-"\n"
-"    }\n"
-"\n"
-"    // Output their thoughts\n"
-"    while let Some(thought) = rx.recv().await {\n"
-"        println!(\"Here is a thought: {thought}\");\n"
-"    }\n"
-"}\n"
-"```"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:74
+msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:90
+msgid "\"Here is a thought: {thought}\""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:97
 msgid "([back to exercise](chat-app.md))"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:101
+#: src/exercises/concurrency/solutions-afternoon.md:117
+msgid "\"Welcome to chat! Type a message\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:121
 msgid ""
-"```rust,compile_fail\n"
-"use futures_util::sink::SinkExt;\n"
-"use futures_util::stream::StreamExt;\n"
-"use std::error::Error;\n"
-"use std::net::SocketAddr;\n"
-"use tokio::net::{TcpListener, TcpStream};\n"
-"use tokio::sync::broadcast::{channel, Sender};\n"
-"use tokio_websockets::{Message, ServerBuilder, WebsocketStream};\n"
-"\n"
-"async fn handle_connection(\n"
-"    addr: SocketAddr,\n"
-"    mut ws_stream: WebsocketStream<TcpStream>,\n"
-"    bcast_tx: Sender<String>,\n"
-") -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"\n"
-"    ws_stream\n"
-"        .send(Message::text(\"Welcome to chat! Type a message\".into()))\n"
-"        .await?;\n"
-"    let mut bcast_rx = bcast_tx.subscribe();\n"
-"\n"
-"    // A continuous loop for concurrently performing two tasks: (1) "
-"receiving\n"
+"// A continuous loop for concurrently performing two tasks: (1) receiving\n"
 "    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
 "    // messages on `bcast_rx` and sending them to the client.\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            incoming = ws_stream.next() => {\n"
-"                match incoming {\n"
-"                    Some(Ok(msg)) => {\n"
-"                        if let Some(text) = msg.as_text() {\n"
-"                            println!(\"From client {addr:?} {text:?}\");\n"
-"                            bcast_tx.send(text.into())?;\n"
-"                        }\n"
-"                    }\n"
-"                    Some(Err(err)) => return Err(err.into()),\n"
-"                    None => return Ok(()),\n"
-"                }\n"
-"            }\n"
-"            msg = bcast_rx.recv() => {\n"
-"                ws_stream.send(Message::text(msg?)).await?;\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"}\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {\n"
-"    let (bcast_tx, _) = channel(16);\n"
-"\n"
-"    let listener = TcpListener::bind(\"127.0.0.1:2000\").await?;\n"
-"    println!(\"listening on port 2000\");\n"
-"\n"
-"    loop {\n"
-"        let (socket, addr) = listener.accept().await?;\n"
-"        println!(\"New connection from {addr:?}\");\n"
-"        let bcast_tx = bcast_tx.clone();\n"
-"        tokio::spawn(async move {\n"
-"            // Wrap the raw TCP stream into a websocket.\n"
-"            let ws_stream = ServerBuilder::new().accept(socket).await?;\n"
-"\n"
-"            handle_connection(addr, ws_stream, bcast_tx).await\n"
-"        });\n"
-"    }\n"
-"}\n"
-"```"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md:168
-msgid ""
-"```rust,compile_fail\n"
-"use futures_util::stream::StreamExt;\n"
-"use futures_util::SinkExt;\n"
-"use http::Uri;\n"
-"use tokio::io::{AsyncBufReadExt, BufReader};\n"
-"use tokio_websockets::{ClientBuilder, Message};\n"
-"\n"
-"#[tokio::main]\n"
-"async fn main() -> Result<(), tokio_websockets::Error> {\n"
-"    let (mut ws_stream, _) =\n"
-"        ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
-"            .connect()\n"
-"            .await?;\n"
-"\n"
-"    let stdin = tokio::io::stdin();\n"
-"    let mut stdin = BufReader::new(stdin).lines();\n"
-"\n"
-"    // Continuous loop for concurrently sending and receiving messages.\n"
-"    loop {\n"
-"        tokio::select! {\n"
-"            incoming = ws_stream.next() => {\n"
-"                match incoming {\n"
-"                    Some(Ok(msg)) => {\n"
-"                        if let Some(text) = msg.as_text() {\n"
-"                            println!(\"From server: {}\", text);\n"
-"                        }\n"
-"                    },\n"
-"                    Some(Err(err)) => return Err(err.into()),\n"
-"                    None => return Ok(()),\n"
-"                }\n"
-"            }\n"
-"            res = stdin.next_line() => {\n"
-"                match res {\n"
-"                    Ok(None) => return Ok(()),\n"
-"                    Ok(Some(line)) => ws_stream.send(Message::text(line."
-"to_string())).await?,\n"
-"                    Err(err) => return Err(err.into()),\n"
-"                }\n"
-"            }\n"
-"\n"
-"        }\n"
-"    }\n"
-"}\n"
-"```"
+#: src/exercises/concurrency/solutions-afternoon.md:130
+msgid "\"From client {addr:?} {text:?}\""
 msgstr ""
 
-#, fuzzy
-#~ msgid "concurrency:"
-#~ msgstr "並行性"
+#: src/exercises/concurrency/solutions-afternoon.md:185
+msgid "// Continuous loop for concurrently sending and receiving messages.\n"
+msgstr ""
 
-#, fuzzy
-#~ msgid "control flow:"
-#~ msgstr "制御フロー"
-
-#, fuzzy
-#~ msgid "enumeration:"
-#~ msgstr "実装"
-
-#, fuzzy
-#~ msgid "error handling:"
-#~ msgstr "エラー処理"
-
-#, fuzzy
-#~ msgid "exercise:"
-#~ msgstr "練習問題"
-
-#, fuzzy
-#~ msgid "function:"
-#~ msgstr "関数"
-
-#, fuzzy
-#~ msgid "garbage collector:"
-#~ msgstr "ガベージコレクション"
-
-#, fuzzy
-#~ msgid "generics:"
-#~ msgstr "ジェネリクス（generics）"
-
-#, fuzzy
-#~ msgid "integration test:"
-#~ msgstr "インテグレーションテスト"
-
-#, fuzzy
-#~ msgid "library:"
-#~ msgstr "ライブラリ"
-
-#, fuzzy
-#~ msgid "main function:"
-#~ msgstr "Unsafe関数の呼び出し"
-
-#, fuzzy
-#~ msgid "method:"
-#~ msgstr "メソッド"
-
-#, fuzzy
-#~ msgid "module:"
-#~ msgstr "モジュール"
-
-#, fuzzy
-#~ msgid "ownership:"
-#~ msgstr "所有権"
-
-#, fuzzy
-#~ msgid "panic:"
-#~ msgstr "パニック（panic）"
-
-#, fuzzy
-#~ msgid "receiver:"
-#~ msgstr "ドライバ"
-
-#, fuzzy
-#~ msgid "Rust:"
-#~ msgstr "Rustdoc"
-
-#, fuzzy
-#~ msgid "standard library:"
-#~ msgstr "標準ライブラリ"
-
-#, fuzzy
-#~ msgid "struct:"
-#~ msgstr "構造体（structs）"
-
-#, fuzzy
-#~ msgid "thread:"
-#~ msgstr "スレッド"
-
-#, fuzzy
-#~ msgid "trait:"
-#~ msgstr "トレイト（trait）"
-
-#, fuzzy
-#~ msgid "type inference:"
-#~ msgstr "型推論"
-
-#, fuzzy
-#~ msgid "undefined behavior:"
-#~ msgstr "実行時に未定義の動作はありません："
-
-#, fuzzy
-#~ msgid "union:"
-#~ msgstr "共用体"
-
-#, fuzzy
-#~ msgid "unit test:"
-#~ msgstr "ユニットテスト"
-
-#, fuzzy
-#~ msgid "variable:\\"
-#~ msgstr "変数"
-
-#~ msgid ""
-#~ "```shell\n"
-#~ "$ cargo new exercise\n"
-#~ "     Created binary (application) `exercise` package\n"
-#~ "```"
-#~ msgstr ""
-#~ "```shell\n"
-#~ "$ cargo new exercise\n"
-#~ "     Created binary (application) `exercise` package\n"
-#~ "```"
-
-#~ msgid ""
-#~ "```shell\n"
-#~ "$ cd exercise\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Hello, world!\n"
-#~ "```"
-#~ msgstr ""
-#~ "```shell\n"
-#~ "$ cd exercise\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Hello, world!\n"
-#~ "```"
-
-#~ msgid ""
-#~ "```shell\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Edit me!\n"
-#~ "```"
-#~ msgstr ""
-#~ "```shell\n"
-#~ "$ cargo run\n"
-#~ "   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-#~ "    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-#~ "     Running `target/debug/exercise`\n"
-#~ "Edit me!\n"
-#~ "```"
-
-#, fuzzy
-#~ msgid ""
-#~ "```rust,editable\n"
-#~ "fn main() {\n"
-#~ "    let mut x = 10;\n"
-#~ "    while x != 1 {\n"
-#~ "        x = if x % 2 == 0 {\n"
-#~ "            x / 2\n"
-#~ "        } else {\n"
-#~ "            3 * x + 1\n"
-#~ "        };\n"
-#~ "    }\n"
-#~ "    println!(\"x: {x}\");\n"
-#~ "}\n"
-#~ "```"
-#~ msgstr ""
-#~ "```rust,editable\n"
-#~ "fn main() {              // プログラムのエントリーポイント\n"
-#~ "    let mut x: i32 = 6;  // 可変変数のバインディング\n"
-#~ "    print!(\"{x}\");       // printfのような、出力用マクロ\n"
-#~ "    while x != 1 {       // 式を囲む括弧は不要\n"
-#~ "        if x % 2 == 0 {  // 他の言語と同様の演算\n"
-#~ "            x = x / 2;\n"
-#~ "        } else {\n"
-#~ "            x = 3 * x + 1;\n"
-#~ "        }\n"
-#~ "        print!(\" -> {x}\");\n"
-#~ "    }\n"
-#~ "    println!();\n"
-#~ "}\n"
-#~ "```"
-
-#, fuzzy
-#~ msgid "Pattern Matching (TBD)"
-#~ msgstr "パターンマッチング"
-
-#~ msgid "Comparison"
-#~ msgstr "比較"
-
-#~ msgid "The course is fast paced and covers a lot of ground:"
-#~ msgstr "本講座はペースが早く、多くの内容をカバーします："
-
-#, fuzzy
-#~ msgid ""
-#~ "We suggest using [VS Code](https://code.visualstudio.com/) to edit the "
-#~ "code (but any LSP compatible editor works with rust-analyzer[3](https://"
-#~ "rust-analyzer.github.io/))."
-#~ msgstr ""
-#~ "これで\\[rust-analyzer\\]\\[1\\]を使って定義に飛べるようになります。コード"
-#~ "の編集には、[VS Code](https://code.visualstudio.com/)を推奨しています（た"
-#~ "だし、LSP互換エディタならどれでも大丈夫です）。"
-
-#~ msgid ""
-#~ "Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
-#~ "clion/) family of IDEs, which do their own analysis but have their own "
-#~ "tradeoffs. If you prefer them, you can install the [Rust Plugin](https://"
-#~ "www.jetbrains.com/rust/). Please take note that as of January 2023 "
-#~ "debugging only works on the CLion version of the JetBrains IDEA suite."
-#~ msgstr ""
-#~ "[JetBrains](https://www.jetbrains.com/clion/)ファミリのIDEを使いたい人もい"
-#~ "るでしょう。これらは独自の分析を提供してくれますが、トレードオフもありま"
-#~ "す。もし使用したい場合、[Rust Plugin](https://www.jetbrains.com/rust/)のイ"
-#~ "ンストールが可能です。ただし、2023年1月時点では、デバッグがJetBrains IDEA "
-#~ "suiteのCLionバージョンでしか動作しない点に注意してください。"
-
-#, fuzzy
-#~ msgid "Extra Work in Modern C++"
-#~ msgstr "現代C++の二重解放"
-
-#~ msgid ""
-#~ "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
-#~ "comprehensive-rust?style=flat-square)](https://github.com/google/"
-#~ "comprehensive-rust/graphs/contributors) [![GitHub stars](https://img."
-#~ "shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
-#~ "(https://github.com/google/comprehensive-rust/stargazers)"
-#~ msgstr ""
-#~ "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
-#~ "comprehensive-rust?style=flat-square)](https://github.com/google/"
-#~ "comprehensive-rust/graphs/contributors) [![GitHub stars](https://img."
-#~ "shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
-#~ "(https://github.com/google/comprehensive-rust/stargazers)"
-
-#~ msgid ""
-#~ "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-#~ "rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-#~ "stargazers)"
-#~ msgstr ""
-#~ "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-#~ "rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-#~ "stargazers)"
-
-#~ msgid "Day 1: Basic Rust, ownership and the borrow checker."
-#~ msgstr "Day 1： Rustの基本、所有権と借用チェッカー"
-
-#~ msgid "Rustup (Recommended)"
-#~ msgstr "Rustup (推奨)"
-
-#~ msgid ""
-#~ "You can follow the instructions to install cargo and rust compiler, among "
-#~ "other standard ecosystem tools with the [rustup](https://rust-analyzer."
-#~ "github.io/) tool, which is maintained by the Rust Foundation."
-#~ msgstr ""
-#~ "[rustup](https://rust-analyzer.github.io/)ツールを使用して、cargoやrustコ"
-#~ "ンパイラなどの標準エコシステムツールをインストールします。RustupはRust "
-#~ "Foundationによってメンテナンスされています。"
-
-#~ msgid "Package Managers"
-#~ msgstr "パッケージマネージャ"
-
-#~ msgid ""
-#~ "Runtimes have the concept of a \"task\", similar to a thread but much "
-#~ "less resource-intensive."
-#~ msgstr ""
-#~ "ランタイムには「タスク」という概念があり、スレッドに似ているものの、スレッ"
-#~ "ドよりリソースの消費ははるかに小さいです。"
+#: src/exercises/concurrency/solutions-afternoon.md:192
+msgid "\"From server: {}\""
+msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2023-10-15T23:41:49Z\n"
+"POT-Creation-Date: 2023-11-17T12:51:38+09:00\n"
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -53,7 +53,7 @@ msgid "Day 1: Morning"
 msgstr "Day 1： AM"
 
 #: src/SUMMARY.md:19 src/SUMMARY.md:80 src/SUMMARY.md:135 src/SUMMARY.md:193
-#: src/SUMMARY.md:219 src/SUMMARY.md:269
+#: src/SUMMARY.md:231 src/SUMMARY.md:281
 msgid "Welcome"
 msgstr "Welcome"
 
@@ -136,8 +136,8 @@ msgid "Overloading"
 msgstr "オーバーロード"
 
 #: src/SUMMARY.md:39 src/SUMMARY.md:72 src/SUMMARY.md:106 src/SUMMARY.md:126
-#: src/SUMMARY.md:155 src/SUMMARY.md:185 src/SUMMARY.md:212 src/SUMMARY.md:233
-#: src/SUMMARY.md:261 src/SUMMARY.md:283 src/SUMMARY.md:304
+#: src/SUMMARY.md:155 src/SUMMARY.md:185 src/SUMMARY.md:224 src/SUMMARY.md:245
+#: src/SUMMARY.md:273 src/SUMMARY.md:295 src/SUMMARY.md:316
 #: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
 #: src/exercises/bare-metal/afternoon.md:1
 #: src/exercises/concurrency/morning.md:1
@@ -157,7 +157,7 @@ msgstr "配列とforループ"
 msgid "Day 1: Afternoon"
 msgstr "Day 1： PM"
 
-#: src/SUMMARY.md:45 src/SUMMARY.md:296 src/control-flow.md:1
+#: src/SUMMARY.md:45 src/SUMMARY.md:308 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "制御フロー"
 
@@ -347,7 +347,7 @@ msgstr "フィールドの省略"
 msgid "Method Receiver"
 msgstr "メソッドレシーバ"
 
-#: src/SUMMARY.md:105 src/SUMMARY.md:167 src/SUMMARY.md:282
+#: src/SUMMARY.md:105 src/SUMMARY.md:167 src/SUMMARY.md:294
 #: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "例"
@@ -621,7 +621,7 @@ msgstr "Unsafeなトレイトの実装"
 msgid "Safe FFI Wrapper"
 msgstr "安全なFFIラッパ"
 
-#: src/SUMMARY.md:189 src/SUMMARY.md:259 src/bare-metal/android.md:1
+#: src/SUMMARY.md:189 src/SUMMARY.md:271 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
@@ -669,7 +669,7 @@ msgstr "クライアント"
 msgid "Changing API"
 msgstr "APIの変更"
 
-#: src/SUMMARY.md:205 src/SUMMARY.md:249 src/android/logging.md:1
+#: src/SUMMARY.md:205 src/SUMMARY.md:261 src/android/logging.md:1
 #: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "ログ出力"
@@ -694,346 +694,399 @@ msgstr "CからRust呼び出し"
 msgid "With C++"
 msgstr "C++"
 
-#: src/SUMMARY.md:211
+#: src/SUMMARY.md:211 src/android/interoperability/cpp/bridge.md:1
+#, fuzzy
+msgid "The Bridge Module"
+msgstr "テストモジュール"
+
+#: src/SUMMARY.md:212
+#, fuzzy
+msgid "Rust Bridge"
+msgstr "Android"
+
+#: src/SUMMARY.md:213 src/android/interoperability/cpp/generated-cpp.md:1
+msgid "Generated C++"
+msgstr ""
+
+#: src/SUMMARY.md:214
+msgid "C++ Bridge"
+msgstr ""
+
+#: src/SUMMARY.md:215 src/android/interoperability/cpp/shared-types.md:1
+#, fuzzy
+msgid "Shared Types"
+msgstr "状態共有"
+
+#: src/SUMMARY.md:216 src/android/interoperability/cpp/shared-enums.md:1
+msgid "Shared Enums"
+msgstr ""
+
+#: src/SUMMARY.md:217 src/android/interoperability/cpp/rust-result.md:1
+#, fuzzy
+msgid "Rust Error Handling"
+msgstr "エラー処理"
+
+#: src/SUMMARY.md:218 src/android/interoperability/cpp/cpp-exception.md:1
+#, fuzzy
+msgid "C++ Error Handling"
+msgstr "エラー処理"
+
+#: src/SUMMARY.md:219 src/android/interoperability/cpp/type-mapping.md:1
+msgid "Additional Types"
+msgstr ""
+
+#: src/SUMMARY.md:220
+msgid "Building for Android: C++"
+msgstr ""
+
+#: src/SUMMARY.md:221
+msgid "Building for Android: Genrules"
+msgstr ""
+
+#: src/SUMMARY.md:222
+msgid "Building for Android: Rust"
+msgstr ""
+
+#: src/SUMMARY.md:223
 msgid "With Java"
 msgstr "Java"
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:227
 msgid "Bare Metal: Morning"
 msgstr "ベアメタル： AM"
 
-#: src/SUMMARY.md:220
+#: src/SUMMARY.md:232
 msgid "no_std"
 msgstr "no_std"
 
-#: src/SUMMARY.md:221
+#: src/SUMMARY.md:233
 msgid "A Minimal Example"
 msgstr "例"
 
-#: src/SUMMARY.md:222
+#: src/SUMMARY.md:234
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:223 src/bare-metal/microcontrollers.md:1
+#: src/SUMMARY.md:235 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "マイクロコントローラ"
 
-#: src/SUMMARY.md:224 src/bare-metal/microcontrollers/mmio.md:1
+#: src/SUMMARY.md:236 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "生MMIO（メモリマップドI/O）"
 
-#: src/SUMMARY.md:225
+#: src/SUMMARY.md:237
 msgid "PACs"
 msgstr "PACs"
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:238
 msgid "HAL Crates"
 msgstr "HALクレート"
 
-#: src/SUMMARY.md:227
+#: src/SUMMARY.md:239
 msgid "Board Support Crates"
 msgstr "ボードサポートクレート"
 
-#: src/SUMMARY.md:228
+#: src/SUMMARY.md:240
 msgid "The Type State Pattern"
 msgstr "タイプステートパターン"
 
-#: src/SUMMARY.md:229
+#: src/SUMMARY.md:241
 msgid "embedded-hal"
 msgstr "embedded-hal"
 
-#: src/SUMMARY.md:230
+#: src/SUMMARY.md:242
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs, cargo-embed"
 
-#: src/SUMMARY.md:231 src/bare-metal/microcontrollers/debugging.md:1
+#: src/SUMMARY.md:243 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: src/SUMMARY.md:232 src/SUMMARY.md:252
+#: src/SUMMARY.md:244 src/SUMMARY.md:264
 msgid "Other Projects"
 msgstr "他のプロジェクト"
 
-#: src/SUMMARY.md:234 src/exercises/bare-metal/compass.md:1
+#: src/SUMMARY.md:246 src/exercises/bare-metal/compass.md:1
 #: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "コンパス"
 
-#: src/SUMMARY.md:236
+#: src/SUMMARY.md:248
 msgid "Bare Metal: Afternoon"
 msgstr "ベアメタル： PM"
 
-#: src/SUMMARY.md:238
+#: src/SUMMARY.md:250
 msgid "Application Processors"
 msgstr "アプリケーションプロセッサ"
 
-#: src/SUMMARY.md:239 src/bare-metal/aps/entry-point.md:1
+#: src/SUMMARY.md:251 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr ""
 
-#: src/SUMMARY.md:240
+#: src/SUMMARY.md:252
 msgid "Inline Assembly"
 msgstr "インラインアセンブリ"
 
-#: src/SUMMARY.md:241
+#: src/SUMMARY.md:253
 msgid "MMIO"
 msgstr "MMIO"
 
-#: src/SUMMARY.md:242
+#: src/SUMMARY.md:254
 msgid "Let's Write a UART Driver"
 msgstr "UARTドライバを書いてみよう"
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md:255
 msgid "More Traits"
 msgstr "他のトレイト"
 
-#: src/SUMMARY.md:244
+#: src/SUMMARY.md:256
 msgid "A Better UART Driver"
 msgstr "UARTドライバの改善"
 
-#: src/SUMMARY.md:245 src/bare-metal/aps/better-uart/bitflags.md:1
+#: src/SUMMARY.md:257 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "ビットフラッグ"
 
-#: src/SUMMARY.md:246
+#: src/SUMMARY.md:258
 msgid "Multiple Registers"
 msgstr "複数のレジスタ"
 
-#: src/SUMMARY.md:247 src/bare-metal/aps/better-uart/driver.md:1
+#: src/SUMMARY.md:259 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "ドライバ"
 
-#: src/SUMMARY.md:248 src/SUMMARY.md:250
+#: src/SUMMARY.md:260 src/SUMMARY.md:262
 msgid "Using It"
 msgstr "使用例"
 
-#: src/SUMMARY.md:251 src/bare-metal/aps/exceptions.md:1
+#: src/SUMMARY.md:263 src/bare-metal/aps/exceptions.md:1
 #, fuzzy
 msgid "Exceptions"
 msgstr "関数"
 
-#: src/SUMMARY.md:253
+#: src/SUMMARY.md:265
 msgid "Useful Crates"
 msgstr "便利クレート"
 
-#: src/SUMMARY.md:254
+#: src/SUMMARY.md:266
 msgid "zerocopy"
 msgstr "zerocopy"
 
-#: src/SUMMARY.md:255
+#: src/SUMMARY.md:267
 msgid "aarch64-paging"
 msgstr "aarch64-paging"
 
-#: src/SUMMARY.md:256
+#: src/SUMMARY.md:268
 msgid "buddy_system_allocator"
 msgstr "buddy_system_allocator"
 
-#: src/SUMMARY.md:257
+#: src/SUMMARY.md:269
 msgid "tinyvec"
 msgstr "tinyvec"
 
-#: src/SUMMARY.md:258
+#: src/SUMMARY.md:270
 msgid "spin"
 msgstr "spin"
 
-#: src/SUMMARY.md:260 src/bare-metal/android/vmbase.md:1
+#: src/SUMMARY.md:272 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:274
 msgid "RTC Driver"
 msgstr "RTC（リアルタイムクロック）ドライバ"
 
-#: src/SUMMARY.md:265
+#: src/SUMMARY.md:277
 msgid "Concurrency: Morning"
 msgstr "並行性： AM"
 
-#: src/SUMMARY.md:270 src/concurrency/threads.md:1
+#: src/SUMMARY.md:282 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "スレッド"
 
-#: src/SUMMARY.md:271 src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:283 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "スコープ付きスレッド"
 
-#: src/SUMMARY.md:272 src/concurrency/channels.md:1
+#: src/SUMMARY.md:284 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "チャネル"
 
-#: src/SUMMARY.md:273 src/concurrency/channels/unbounded.md:1
+#: src/SUMMARY.md:285 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Unboundedチャネル"
 
-#: src/SUMMARY.md:274 src/concurrency/channels/bounded.md:1
+#: src/SUMMARY.md:286 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Boundedチャネル"
 
-#: src/SUMMARY.md:275
+#: src/SUMMARY.md:287
 msgid "Send and Sync"
 msgstr "SendとSync"
 
-#: src/SUMMARY.md:275
+#: src/SUMMARY.md:287
 msgid "Send"
 msgstr "Send"
 
-#: src/SUMMARY.md:275
+#: src/SUMMARY.md:287
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:278 src/concurrency/send-sync/examples.md:1
+#: src/SUMMARY.md:290 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "例"
 
-#: src/SUMMARY.md:279 src/concurrency/shared_state.md:1
+#: src/SUMMARY.md:291 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "状態共有"
 
-#: src/SUMMARY.md:280
+#: src/SUMMARY.md:292
 msgid "Arc"
 msgstr "Arc"
 
-#: src/SUMMARY.md:281
+#: src/SUMMARY.md:293
 msgid "Mutex"
 msgstr "Mutex"
 
-#: src/SUMMARY.md:284 src/SUMMARY.md:305
+#: src/SUMMARY.md:296 src/SUMMARY.md:317
 #: src/exercises/concurrency/dining-philosophers.md:1
 #: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "食事する哲学者"
 
-#: src/SUMMARY.md:285 src/exercises/concurrency/link-checker.md:1
+#: src/SUMMARY.md:297 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "マルチスレッド・リンクチェッカー"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:299
 msgid "Concurrency: Afternoon"
 msgstr "並行性： PM"
 
-#: src/SUMMARY.md:289
+#: src/SUMMARY.md:301
 msgid "Async Basics"
 msgstr "Asyncの基礎"
 
-#: src/SUMMARY.md:290
+#: src/SUMMARY.md:302
 msgid "async/await"
 msgstr "async/await"
 
-#: src/SUMMARY.md:291 src/async/futures.md:1
+#: src/SUMMARY.md:303 src/async/futures.md:1
 msgid "Futures"
 msgstr "Future"
 
-#: src/SUMMARY.md:292 src/async/runtimes.md:1
+#: src/SUMMARY.md:304 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "ランタイム"
 
-#: src/SUMMARY.md:293 src/async/runtimes/tokio.md:1
+#: src/SUMMARY.md:305 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:294 src/exercises/concurrency/link-checker.md:126
+#: src/SUMMARY.md:306 src/exercises/concurrency/link-checker.md:126
 #: src/async/tasks.md:1 src/exercises/concurrency/chat-app.md:143
 msgid "Tasks"
 msgstr "タスク"
 
-#: src/SUMMARY.md:295 src/async/channels.md:1
+#: src/SUMMARY.md:307 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "Asyncチャネル"
 
-#: src/SUMMARY.md:297 src/async/control-flow/join.md:1
+#: src/SUMMARY.md:309 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:298 src/async/control-flow/select.md:1
+#: src/SUMMARY.md:310 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
-#: src/SUMMARY.md:299
+#: src/SUMMARY.md:311
 msgid "Pitfalls"
 msgstr "落とし穴"
 
-#: src/SUMMARY.md:300
+#: src/SUMMARY.md:312
 msgid "Blocking the Executor"
 msgstr "エグゼキュータのブロッキング"
 
-#: src/SUMMARY.md:301 src/async/pitfalls/pin.md:1
+#: src/SUMMARY.md:313 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr "Pin"
 
-#: src/SUMMARY.md:302 src/async/pitfalls/async-traits.md:1
+#: src/SUMMARY.md:314 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "Asyncトレイト"
 
-#: src/SUMMARY.md:303 src/async/pitfalls/cancellation.md:1
+#: src/SUMMARY.md:315 src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
 msgstr "インストール"
 
-#: src/SUMMARY.md:306 src/exercises/concurrency/chat-app.md:1
+#: src/SUMMARY.md:318 src/exercises/concurrency/chat-app.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:95
 msgid "Broadcast Chat Application"
 msgstr "ブロードキャスト・チャットアプリ"
 
-#: src/SUMMARY.md:309
+#: src/SUMMARY.md:321
 msgid "Final Words"
 msgstr "最後に"
 
-#: src/SUMMARY.md:313 src/thanks.md:1
+#: src/SUMMARY.md:325 src/thanks.md:1
 msgid "Thanks!"
 msgstr "ありがとうございました！"
 
-#: src/SUMMARY.md:314 src/glossary.md:1
+#: src/SUMMARY.md:326 src/glossary.md:1
 msgid "Glossary"
 msgstr ""
 
-#: src/SUMMARY.md:315
+#: src/SUMMARY.md:327
 msgid "Other Resources"
 msgstr "参考資料"
 
-#: src/SUMMARY.md:316 src/credits.md:1
+#: src/SUMMARY.md:328 src/credits.md:1
 msgid "Credits"
 msgstr "クレジット"
 
-#: src/SUMMARY.md:319 src/exercises/solutions.md:1
+#: src/SUMMARY.md:331 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "解答"
 
-#: src/SUMMARY.md:324
+#: src/SUMMARY.md:336
 msgid "Day 1 Morning"
 msgstr "Day 1 AM"
 
-#: src/SUMMARY.md:325
+#: src/SUMMARY.md:337
 msgid "Day 1 Afternoon"
 msgstr "Day 1 PM"
 
-#: src/SUMMARY.md:326
+#: src/SUMMARY.md:338
 msgid "Day 2 Morning"
 msgstr "Day 2 AM"
 
-#: src/SUMMARY.md:327
+#: src/SUMMARY.md:339
 msgid "Day 2 Afternoon"
 msgstr "Day 2 PM"
 
-#: src/SUMMARY.md:328
+#: src/SUMMARY.md:340
 msgid "Day 3 Morning"
 msgstr "Day 3 AM"
 
-#: src/SUMMARY.md:329
+#: src/SUMMARY.md:341
 msgid "Day 3 Afternoon"
 msgstr "Day 3 PM"
 
-#: src/SUMMARY.md:330
+#: src/SUMMARY.md:342
 msgid "Bare Metal Rust Morning"
 msgstr "ベアメタルRust AM"
 
-#: src/SUMMARY.md:331 src/exercises/bare-metal/solutions-afternoon.md:1
+#: src/SUMMARY.md:343 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "ベアメタルRust PM"
 
-#: src/SUMMARY.md:332
+#: src/SUMMARY.md:344
 msgid "Concurrency Morning"
 msgstr "並行性 AM"
 
-#: src/SUMMARY.md:333
+#: src/SUMMARY.md:345
 msgid "Concurrency Afternoon"
 msgstr "並行性 PM"
 
@@ -1503,54 +1556,56 @@ msgstr ""
 
 #: src/running-the-course/translations.md:7
 msgid ""
+"[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
+"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
+"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
+"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
+"github.com/superwhd), [@SketchK](https://github.com/SketchK), and [@nodmp]"
+"(https://github.com/nodmp)."
+msgstr ""
+
+#: src/running-the-course/translations.md:8
+msgid ""
+"[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
+"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
+"victorhsieh), [@mingyc](https://github.com/mingyc), [@kuanhungchen](https://"
+"github.com/kuanhungchen), and [@johnathan79717](https://github.com/"
+"johnathan79717)."
+msgstr ""
+
+#: src/running-the-course/translations.md:9
+msgid ""
 "[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
 "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
 
-#: src/running-the-course/translations.md:8
+#: src/running-the-course/translations.md:10
 msgid ""
 "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
 "(https://github.com/deavid)."
 msgstr ""
 
-#: src/running-the-course/translations.md:10
+#: src/running-the-course/translations.md:12
 msgid ""
 "Use the language picker in the top-right corner to switch between languages."
 msgstr "画面右上の言語切り替えボタンから、切り替えを行なってください。"
 
-#: src/running-the-course/translations.md:12
+#: src/running-the-course/translations.md:14
 #, fuzzy
 msgid "Incomplete Translations"
 msgstr "翻訳"
 
-#: src/running-the-course/translations.md:14
+#: src/running-the-course/translations.md:16
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
 
-#: src/running-the-course/translations.md:17
+#: src/running-the-course/translations.md:19
 msgid ""
 "[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
 "(https://github.com/raselmandol)."
-msgstr ""
-
-#: src/running-the-course/translations.md:18
-msgid ""
-"[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
-"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
-"victorhsieh), [@mingyc](https://github.com/mingyc), and [@johnathan79717]"
-"(https://github.com/johnathan79717)."
-msgstr ""
-
-#: src/running-the-course/translations.md:19
-msgid ""
-"[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
-"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
-"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
-"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
-"github.com/superwhd), and [@SketchK](https://github.com/SketchK)."
 msgstr ""
 
 #: src/running-the-course/translations.md:20
@@ -2549,8 +2604,8 @@ msgstr ""
 #: src/why-rust/an-example-in-c.md:73
 msgid ""
 "Forgotten `break` in a `switch` statement: [The break that broke sudo]"
-"(https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-"
-"break-that-broke-sudo)"
+"(https://www.lufsec.com/anatomy-of-a-security-hole-the-break-that-broke-"
+"sudo/)"
 msgstr ""
 
 #: src/why-rust/an-example-in-c.md:75
@@ -2954,6 +3009,7 @@ msgid "Strings"
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:8
+#: src/android/interoperability/cpp/type-mapping.md:6
 msgid "`&str`"
 msgstr ""
 
@@ -3077,10 +3133,11 @@ msgstr ""
 
 #: src/basic-syntax/compound-types.md:42
 msgid ""
-"In the main function, the print statement asks for the debug implementation "
-"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
-"the debug output. We could also have used `{a}` and `{a:?}` without "
-"specifying the value after the format string."
+"The `println!` macro asks for the debug implementation with the `?` format "
+"parameter: `{}` gives the default output, `{:?}` gives the debug output. "
+"Types such as integers and strings implement the default output, but arrays "
+"only implement the debug output. This means that we must use debug output "
+"here."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:47
@@ -4458,27 +4515,37 @@ msgid ""
 "optimization, see below)."
 msgstr ""
 
-#: src/enums/sizes.md:61
+#: src/enums/sizes.md:61 src/memory-management/stack.md:32
+msgid "More to Explore"
+msgstr ""
+
+#: src/enums/sizes.md:63
+msgid ""
+"Rust has several optimizations it can employ to make enums take up less "
+"space."
+msgstr ""
+
+#: src/enums/sizes.md:65
 msgid ""
 "Niche optimization: Rust will merge unused bit patterns for the enum "
 "discriminant."
 msgstr ""
 
-#: src/enums/sizes.md:64
+#: src/enums/sizes.md:68
 msgid ""
 "Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
 "option/#representation), Rust guarantees that `size_of::<T>()` equals "
 "`size_of::<Option<T>>()`."
 msgstr ""
 
-#: src/enums/sizes.md:68
+#: src/enums/sizes.md:72
 msgid ""
 "Example code if you want to show how the bitwise representation _may_ look "
 "like in practice. It's important to note that the compiler provides no "
 "guarantees regarding this representation, therefore this is totally unsafe."
 msgstr ""
 
-#: src/enums/sizes.md:105
+#: src/enums/sizes.md:109
 msgid ""
 "More complex example if you want to discuss what happens when we chain more "
 "than 256 `Option`s together."
@@ -4643,7 +4710,7 @@ msgstr ""
 
 #: src/pattern-matching.md:3
 msgid ""
-"The `match` keyword let you match a value against one or more _patterns_. "
+"The `match` keyword lets you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
@@ -5313,13 +5380,13 @@ msgid ""
 "[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
 
-#: src/memory-management/stack.md:32
+#: src/memory-management/stack.md:34
 msgid ""
-"We can inspect the memory layout with `unsafe` code. However, you should "
+"We can inspect the memory layout with `unsafe` Rust. However, you should "
 "point out that this is rightfully unsafe!"
 msgstr ""
 
-#: src/memory-management/stack.md:34
+#: src/memory-management/stack.md:37
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
@@ -6083,7 +6150,7 @@ msgstr ""
 
 #: src/structs.md:38
 msgid ""
-"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Zero-sized structs (e.g. `struct Foo;`) might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
 "value itself. "
 msgstr ""
@@ -6156,7 +6223,7 @@ msgstr ""
 #: src/structs/tuple-structs.md:39
 msgid ""
 "The value passed some validation when it was created, so you no longer have "
-"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+"to validate it again at every use: `PhoneNumber(String)` or `OddNumber(u32)`."
 msgstr ""
 
 #: src/structs/tuple-structs.md:40
@@ -6726,7 +6793,7 @@ msgstr ""
 #: src/std.md:3
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types used by Rust library and programs. This way, two libraries can work "
+"types used by Rust libraries and programs. This way, two libraries can work "
 "together smoothly because they both use the same `String` type."
 msgstr ""
 
@@ -7075,7 +7142,7 @@ msgstr ""
 msgid ""
 "```rust,ignore\n"
 "  let pc1 = page_counts\n"
-"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone\")\n"
 "      .unwrap_or(&336);\n"
 "  let pc2 = page_counts\n"
 "      .entry(\"The Hunger Games\".to_string())\n"
@@ -9591,7 +9658,7 @@ msgstr ""
 #: src/error-handling/converting-error-types.md:18
 msgid ""
 "The `From::from` call here means we attempt to convert the error type to the "
-"type returned by the function:"
+"type returned by the function."
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:3
@@ -10232,7 +10299,7 @@ msgid ""
 "}\n"
 "\n"
 "fn count_chars(s: &str) -> usize {\n"
-"    s.chars().map(|_| 1).sum()\n"
+"    s.chars().count()\n"
 "}\n"
 "```"
 msgstr ""
@@ -10781,7 +10848,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:33
 msgid "_hello_rust/src/main.rs_:"
 msgstr ""
 
@@ -10844,7 +10911,6 @@ msgid ""
 "        \"libgreetings\",\n"
 "        \"libtextwrap\",\n"
 "    ],\n"
-"    prefer_rlib: true,\n"
 "}\n"
 "\n"
 "rust_library {\n"
@@ -10855,7 +10921,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/build-rules/library.md:36
+#: src/android/build-rules/library.md:35
 msgid ""
 "```rust,ignore\n"
 "//! Rust demo.\n"
@@ -10870,11 +10936,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/build-rules/library.md:48
+#: src/android/build-rules/library.md:47
 msgid "_hello_rust/src/lib.rs_:"
 msgstr ""
 
-#: src/android/build-rules/library.md:50
+#: src/android/build-rules/library.md:49
 msgid ""
 "```rust,ignore\n"
 "//! Greeting library.\n"
@@ -10886,11 +10952,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/build-rules/library.md:59
+#: src/android/build-rules/library.md:58
 msgid "You build, push, and run the binary like before:"
 msgstr ""
 
-#: src/android/build-rules/library.md:61
+#: src/android/build-rules/library.md:60
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
@@ -11060,7 +11126,6 @@ msgid ""
 "        \"libbinder_rs\",\n"
 "        \"libbirthdayservice\",\n"
 "    ],\n"
-"    prefer_rlib: true,\n"
 "}\n"
 "```"
 msgstr ""
@@ -11146,20 +11211,19 @@ msgid ""
 "        \"com.example.birthdayservice-rust\",\n"
 "        \"libbinder_rs\",\n"
 "    ],\n"
-"    prefer_rlib: true,\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/android/aidl/client.md:52
+#: src/android/aidl/client.md:51
 msgid "Notice that the client does not depend on `libbirthdayservice`."
 msgstr ""
 
-#: src/android/aidl/client.md:54
+#: src/android/aidl/client.md:53
 msgid "Build, push, and run the client on your device:"
 msgstr ""
 
-#: src/android/aidl/client.md:56
+#: src/android/aidl/client.md:55
 msgid ""
 "```shell\n"
 "m birthday_client\n"
@@ -11196,17 +11260,16 @@ msgid ""
 "        \"liblog_rust\",\n"
 "        \"liblogger\",\n"
 "    ],\n"
-"    prefer_rlib: true,\n"
 "    host_supported: true,\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/android/logging.md:22
+#: src/android/logging.md:21
 msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
-#: src/android/logging.md:24
+#: src/android/logging.md:23
 msgid ""
 "```rust,ignore\n"
 "//! Rust logging demo.\n"
@@ -11227,12 +11290,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
+#: src/android/logging.md:41 src/android/interoperability/with-c/bindgen.md:98
 #: src/android/interoperability/with-c/rust.md:73
 msgid "Build, push, and run the binary on your device:"
 msgstr ""
 
-#: src/android/logging.md:44
+#: src/android/logging.md:43
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
@@ -11242,7 +11305,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:50
+#: src/android/logging.md:49
 msgid "The logs show up in `adb logcat`:"
 msgstr ""
 
@@ -11600,46 +11663,545 @@ msgstr ""
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:10
+#: src/android/interoperability/cpp/bridge.md:3
 msgid ""
-"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
-"using this."
+"CXX relies on a description of the function signatures that will be exposed "
+"from each language to the other. You provide this description using extern "
+"blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:14
+#: src/android/interoperability/cpp/bridge.md:7
 msgid ""
-"At this point, the instructor should switch to the [CXX tutorial](https://"
-"cxx.rs/tutorial.html)."
+"```rust,ignore\n"
+"#[allow(unsafe_op_in_unsafe_fn)]\n"
+"#[cxx::bridge(namespace = \"org::blobstore\")]\n"
+"mod ffi {\n"
+"    // Shared structs with fields visible to both languages.\n"
+"    struct BlobMetadata {\n"
+"        size: usize,\n"
+"        tags: Vec<String>,\n"
+"    }\n"
+"\n"
+"    // Rust types and signatures exposed to C++.\n"
+"    extern \"Rust\" {\n"
+"        type MultiBuf;\n"
+"\n"
+"        fn next_chunk(buf: &mut MultiBuf) -> &[u8];\n"
+"    }\n"
+"\n"
+"    // C++ types and signatures exposed to Rust.\n"
+"    unsafe extern \"C++\" {\n"
+"        include!(\"include/blobstore.h\");\n"
+"\n"
+"        type BlobstoreClient;\n"
+"\n"
+"        fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;\n"
+"        fn put(self: Pin<&mut BlobstoreClient>, parts: &mut MultiBuf) -> "
+"u64;\n"
+"        fn tag(self: Pin<&mut BlobstoreClient>, blobid: u64, tag: &str);\n"
+"        fn metadata(&self, blobid: u64) -> BlobMetadata;\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:16
-msgid "Walk the students through the tutorial step by step."
+#: src/android/interoperability/cpp/bridge.md:40
+msgid "The bridge is generally declared in an `ffi` module within your crate."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:18
+#: src/android/interoperability/cpp/bridge.md:41
 msgid ""
-"Highlight how CXX presents a clean interface without unsafe code in _both "
-"languages_."
+"From the declarations made in the bridge module, CXX will generate matching "
+"Rust and C++ type/function definitions in order to expose those items to "
+"both languages."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:20
+#: src/android/interoperability/cpp/bridge.md:44
 msgid ""
-"Show the correspondence between [Rust and C++ types](https://cxx.rs/bindings."
-"html):"
+"To view the generated Rust code, use [cargo-expand](https://github.com/"
+"dtolnay/cargo-expand) to view the expanded proc macro. For most of the "
+"examples you would use `cargo expand ::ffi` to expand just the `ffi` module "
+"(though this doesn't apply for Android projects)."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:22
-msgid ""
-"Explain how a Rust `String` cannot map to a C++ `std::string` (the latter "
-"does not uphold the UTF-8 invariant). Show that despite being different "
-"types, `rust::String` in C++ can be easily constructed from a C++ `std::"
-"string`, making it very ergonomic to use."
+#: src/android/interoperability/cpp/bridge.md:47
+msgid "To view the generated C++ code, look in `target/cxxbridge`."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:28
+#: src/android/interoperability/cpp/rust-bridge.md:1
+msgid "Rust Bridge Declarations"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:3
 msgid ""
-"Explain that a Rust function returning `Result<T, E>` becomes a function "
-"which throws a `E` exception in C++ (and vice versa)."
+"```rust,ignore\n"
+"#[cxx::bridge]\n"
+"mod ffi {\n"
+"    extern \"Rust\" {\n"
+"        type MyType; // Opaque type\n"
+"        fn foo(&self); // Method on `MyType`\n"
+"        fn bar() -> Box<MyType>; // Free function\n"
+"    }\n"
+"}\n"
+"\n"
+"struct MyType(i32);\n"
+"\n"
+"impl MyType {\n"
+"    fn foo(&self) {\n"
+"        println!(\"{}\", self.0);\n"
+"    }\n"
+"}\n"
+"\n"
+"fn bar() -> Box<MyType> {\n"
+"    Box::new(MyType(123))\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:28
+msgid ""
+"Items declared in the `extern \"Rust\"` reference items that are in scope in "
+"the parent module."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:30
+msgid ""
+"The CXX code generator uses your `extern \"Rust\"` section(s) to produce a C+"
+"+ header file containing the corresponding C++ declarations. The generated "
+"header has the same path as the Rust source file containing the bridge, "
+"except with a .rs.h file extension."
+msgstr ""
+
+#: src/android/interoperability/cpp/generated-cpp.md:3
+msgid ""
+"```rust,ignore\n"
+"#[cxx::bridge]\n"
+"mod ffi {\n"
+"    // Rust types and signatures exposed to C++.\n"
+"    extern \"Rust\" {\n"
+"        type MultiBuf;\n"
+"\n"
+"        fn next_chunk(buf: &mut MultiBuf) -> &[u8];\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/generated-cpp.md:15
+msgid "Results in (roughly) the following C++:"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:1
+msgid "C++ Bridge Declarations"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:3
+msgid ""
+"```rust,ignore\n"
+"#[cxx::bridge]\n"
+"mod ffi {\n"
+"    // C++ types and signatures exposed to Rust.\n"
+"    unsafe extern \"C++\" {\n"
+"        include!(\"include/blobstore.h\");\n"
+"\n"
+"        type BlobstoreClient;\n"
+"\n"
+"        fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;\n"
+"        fn put(self: Pin<&mut BlobstoreClient>, parts: &mut MultiBuf) -> "
+"u64;\n"
+"        fn tag(self: Pin<&mut BlobstoreClient>, blobid: u64, tag: &str);\n"
+"        fn metadata(&self, blobid: u64) -> BlobMetadata;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:20
+msgid "Results in (roughly) the following Rust:"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:22
+msgid ""
+"```rust,ignore\n"
+"#[repr(C)]\n"
+"pub struct BlobstoreClient {\n"
+"    _private: ::cxx::private::Opaque,\n"
+"}\n"
+"\n"
+"pub fn new_blobstore_client() -> ::cxx::UniquePtr<BlobstoreClient> {\n"
+"    extern \"C\" {\n"
+"        #[link_name = \"org$blobstore$cxxbridge1$new_blobstore_client\"]\n"
+"        fn __new_blobstore_client() -> *mut BlobstoreClient;\n"
+"    }\n"
+"    unsafe { ::cxx::UniquePtr::from_raw(__new_blobstore_client()) }\n"
+"}\n"
+"\n"
+"impl BlobstoreClient {\n"
+"    pub fn put(&self, parts: &mut MultiBuf) -> u64 {\n"
+"        extern \"C\" {\n"
+"            #[link_name = \"org$blobstore$cxxbridge1$BlobstoreClient$put\"]\n"
+"            fn __put(\n"
+"                _: &BlobstoreClient,\n"
+"                parts: *mut ::cxx::core::ffi::c_void,\n"
+"            ) -> u64;\n"
+"        }\n"
+"        unsafe {\n"
+"            __put(self, parts as *mut MultiBuf as *mut ::cxx::core::ffi::"
+"c_void)\n"
+"        }\n"
+"    }\n"
+"}\n"
+"\n"
+"// ...\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:56
+msgid ""
+"The programmer does not need to promise that the signatures they have typed "
+"in are accurate. CXX performs static assertions that the signatures exactly "
+"correspond with what is declared in C++."
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:59
+msgid ""
+"`unsafe extern` blocks allow you to declare C++ functions that are safe to "
+"call from Rust."
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-types.md:3
+msgid ""
+"```rust,ignore\n"
+"#[cxx::bridge]\n"
+"mod ffi {\n"
+"    #[derive(Clone, Debug, Hash)]\n"
+"    struct PlayingCard {\n"
+"        suit: Suit,\n"
+"        value: u8,  // A=1, J=11, Q=12, K=13\n"
+"    }\n"
+"\n"
+"    enum Suit {\n"
+"        Clubs,\n"
+"        Diamonds,\n"
+"        Hearts,\n"
+"        Spades,\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-types.md:23
+msgid "Only C-like (unit) enums are supported."
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-types.md:24
+msgid ""
+"A limited number of traits are supported for `#[derive()]` on shared types. "
+"Corresponding functionality is also generated for the C++ code, e.g. if you "
+"derive `Hash` also generates an implementation of `std::hash` for the "
+"corresponding C++ type."
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-enums.md:15
+#, fuzzy
+msgid "Generated Rust:"
+msgstr "Unsafe Rust"
+
+#: src/android/interoperability/cpp/shared-enums.md:33
+msgid "Generated C++:"
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-enums.md:46
+msgid ""
+"On the Rust side, the code generated for shared enums is actually a struct "
+"wrapping a numeric value. This is because it is not UB in C++ for an enum "
+"class to hold a value different from all of the listed variants, and our "
+"Rust representation needs to have the same behavior."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:3
+msgid ""
+"```rust,ignore\n"
+"#[cxx::bridge]\n"
+"mod ffi {\n"
+"    extern \"Rust\" {\n"
+"        fn fallible(depth: usize) -> Result<String>;\n"
+"    }\n"
+"}\n"
+"\n"
+"fn fallible(depth: usize) -> anyhow::Result<String> {\n"
+"    if depth == 0 {\n"
+"        return Err(anyhow::Error::msg(\"fallible1 requires depth > 0\"));\n"
+"    }\n"
+"\n"
+"    Ok(\"Success!\".into())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:22
+msgid ""
+"Rust functions that return `Result` are translated to exceptions on the C++ "
+"side."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:24
+msgid ""
+"The exception thrown will always be of type `rust::Error`, which primarily "
+"exposes a way to get the error message string. The error message will come "
+"from the error type's `Display` impl."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:27
+msgid ""
+"A panic unwinding from Rust to C++ will always cause the process to "
+"immediately terminate."
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:3
+msgid ""
+"```rust,ignore\n"
+"#[cxx::bridge]\n"
+"mod ffi {\n"
+"    unsafe extern \"C++\" {\n"
+"        include!(\"example/include/example.h\");\n"
+"        fn fallible(depth: usize) -> Result<String>;\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    if let Err(err) = ffi::fallible(99) {\n"
+"        eprintln!(\"Error: {}\", err);\n"
+"        process::exit(1);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:22
+msgid ""
+"C++ functions declared to return a `Result` will catch any thrown exception "
+"on the C++ side and return it as an `Err` value to the calling Rust function."
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:24
+msgid ""
+"If an exception is thrown from an extern \"C++\" function that is not "
+"declared by the CXX bridge to return `Result`, the program calls C++'s `std::"
+"terminate`. The behavior is equivalent to the same exception being thrown "
+"through a `noexcept` C++ function."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:3
+#, fuzzy
+msgid "Rust Type"
+msgstr "再帰的データ型"
+
+#: src/android/interoperability/cpp/type-mapping.md:3
+msgid "C++ Type"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:5
+#, fuzzy
+msgid "`String`"
+msgstr "文字列（String）"
+
+#: src/android/interoperability/cpp/type-mapping.md:5
+#, fuzzy
+msgid "`rust::String`"
+msgstr "文字列（String）"
+
+#: src/android/interoperability/cpp/type-mapping.md:6
+msgid "`rust::Str`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:7
+#, fuzzy
+msgid "`CxxString`"
+msgstr "文字列（String）"
+
+#: src/android/interoperability/cpp/type-mapping.md:7
+#, fuzzy
+msgid "`std::string`"
+msgstr "文字列（String）"
+
+#: src/android/interoperability/cpp/type-mapping.md:8
+msgid "`&[T]`/`&mut [T]`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:8
+msgid "`rust::Slice`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:9
+msgid "`Box<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:9
+msgid "`rust::Box<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:10
+msgid "`UniquePtr<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:10
+msgid "`std::unique_ptr<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:11
+msgid "`Vec<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:11
+msgid "`rust::Vec<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:12
+msgid "`CxxVector<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:12
+msgid "`std::vector<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:16
+msgid ""
+"These types can be used in the fields of shared structs and the arguments "
+"and returns of extern functions."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:18
+msgid ""
+"Note that Rust's `String` does not map directly to `std::string`. There are "
+"a few reasons for this:"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:20
+msgid ""
+"`std::string` does not uphold the UTF-8 invariant that `String` requires."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:21
+msgid ""
+"The two types have different layouts in memory and so can't be passed "
+"directly between languages."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:23
+msgid ""
+"`std::string` requires move constructors that don't match Rust's move "
+"semantics, so a `std::string` can't be passed by value to Rust."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:1
+#: src/android/interoperability/cpp/android-cpp-genrules.md:1
+#: src/android/interoperability/cpp/android-build-rust.md:1
+#, fuzzy
+msgid "Building in Android"
+msgstr "Android"
+
+#: src/android/interoperability/cpp/android-build-cpp.md:3
+msgid ""
+"Create a `cc_library_static` to build the C++ library, including the CXX "
+"generated header and source file."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:6
+msgid ""
+"```javascript\n"
+"cc_library_static {\n"
+"    name: \"libcxx_test_cpp\",\n"
+"    srcs: [\"cxx_test.cpp\"],\n"
+"    generated_headers: [\n"
+"        \"cxx-bridge-header\",\n"
+"        \"libcxx_test_bridge_header\"\n"
+"    ],\n"
+"    generated_sources: [\"libcxx_test_bridge_code\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:20
+msgid ""
+"Point out that `libcxx_test_bridge_header` and `libcxx_test_bridge_code` are "
+"the dependencies for the CXX-generated C++ bindings. We'll show how these "
+"are setup on the next slide."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:23
+msgid ""
+"Note that you also need to depend on the `cxx-bridge-header` library in "
+"order to pull in common CXX definitions."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:25
+msgid ""
+"Full docs for using CXX in Android can be found in [the Android docs]"
+"(https://source.android.com/docs/setup/build/rust/building-rust-modules/"
+"android-rust-patterns#rust-cpp-interop-using-cxx). You may want to share "
+"that link with the class so that students know where they can find these "
+"instructions again in the future."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:3
+msgid ""
+"Create two genrules: One to generate the CXX header, and one to generate the "
+"CXX source file. These are then used as inputs to the `cc_library_static`."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:6
+msgid ""
+"```javascript\n"
+"// Generate a C++ header containing the C++ bindings\n"
+"// to the Rust exported functions in lib.rs.\n"
+"genrule {\n"
+"    name: \"libcxx_test_bridge_header\",\n"
+"    tools: [\"cxxbridge\"],\n"
+"    cmd: \"$(location cxxbridge) $(in) --header > $(out)\",\n"
+"    srcs: [\"lib.rs\"],\n"
+"    out: [\"lib.rs.h\"],\n"
+"}\n"
+"\n"
+"// Generate the C++ code that Rust calls into.\n"
+"genrule {\n"
+"    name: \"libcxx_test_bridge_code\",\n"
+"    tools: [\"cxxbridge\"],\n"
+"    cmd: \"$(location cxxbridge) $(in) > $(out)\",\n"
+"    srcs: [\"lib.rs\"],\n"
+"    out: [\"lib.rs.cc\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:29
+msgid ""
+"The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
+"bridge module. It is included in Android and available as a Soong tool."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:31
+msgid ""
+"By convention, if your Rust source file is `lib.rs` your header file will be "
+"named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
+"convention isn't enforced, though."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-rust.md:3
+msgid ""
+"Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-rust.md:5
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"cxx_test\",\n"
+"    srcs: [\"lib.rs\"],\n"
+"    rustlibs: [\"libcxx\"],\n"
+"    static_libs: [\"libcxx_test_cpp\"],\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:1
@@ -16659,6 +17221,13 @@ msgstr ""
 
 #: src/async/tasks.md:54
 msgid ""
+"Try connecting to it with a TCP connection tool like [nc](https://www.unix."
+"com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
+"telnet/)."
+msgstr ""
+
+#: src/async/tasks.md:56
+msgid ""
 "Ask students to visualize what the state of the example server would be with "
 "a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
@@ -16666,7 +17235,7 @@ msgstr ""
 "あるのかを、可視化するように受講者に指示してください。どんなタスクが存在して"
 "いますか？それらのfutureは何ですか？"
 
-#: src/async/tasks.md:57
+#: src/async/tasks.md:59
 msgid ""
 "This is the first time we've seen an `async` block. This is similar to a "
 "closure, but does not take any arguments. Its return value is a Future, "
@@ -16676,10 +17245,11 @@ msgstr ""
 "すが、何も引数は取りません。この返り値はFutureであり、`async fn`と似ていま"
 "す。"
 
-#: src/async/tasks.md:61
+#: src/async/tasks.md:63
+#, fuzzy
 msgid ""
 "Refactor the async block into a function, and improve the error handling "
-"using `?`."
+"using `?`. "
 msgstr ""
 "mainのasyncブロックを関数にリファクタして、`?`を使ったエラーハンドリングを改"
 "善してみましょう。"
@@ -17797,308 +18367,421 @@ msgid ""
 msgstr ""
 
 #: src/glossary.md:32
-msgid "argument:"
+msgid ""
+"argument:  \n"
+"Information that is passed into a function or method."
 msgstr ""
 
-#: src/glossary.md:33
+#: src/glossary.md:34
 msgid ""
 "Bare-metal Rust:  \n"
 "Low-level Rust development, often deployed to a system without an operating "
 "system. See [Bare-metal Rust](bare-metal.md)."
 msgstr ""
 
-#: src/glossary.md:36
+#: src/glossary.md:37
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
 msgstr ""
 
-#: src/glossary.md:38
+#: src/glossary.md:39
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
 msgstr ""
 
-#: src/glossary.md:40
+#: src/glossary.md:41
 msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
 msgstr ""
 
-#: src/glossary.md:42
+#: src/glossary.md:43
 msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
 msgstr ""
 
-#: src/glossary.md:44
-msgid "build:"
-msgstr ""
-
 #: src/glossary.md:45
-msgid "call:"
+msgid ""
+"build:  \n"
+"The process of converting source code into executable code or a usable "
+"program."
 msgstr ""
 
-#: src/glossary.md:46
+#: src/glossary.md:47
+msgid ""
+"call:  \n"
+"To invoke or execute a function or method."
+msgstr ""
+
+#: src/glossary.md:49
 msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
 msgstr ""
 
-#: src/glossary.md:48
+#: src/glossary.md:51
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
 msgstr ""
 
-#: src/glossary.md:50
-#, fuzzy
-msgid "concurrency:"
-msgstr "並行性"
+#: src/glossary.md:53
+msgid ""
+"concurrency:  \n"
+"The execution of multiple tasks or processes at the same time."
+msgstr ""
 
-#: src/glossary.md:51
+#: src/glossary.md:55
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
 msgstr ""
 
-#: src/glossary.md:53
-msgid "constant:"
-msgstr ""
-
-#: src/glossary.md:54
-#, fuzzy
-msgid "control flow:"
-msgstr "制御フロー"
-
-#: src/glossary.md:55
-msgid "crash:"
-msgstr ""
-
-#: src/glossary.md:56
-#, fuzzy
-msgid "enumeration:"
-msgstr "実装"
-
 #: src/glossary.md:57
-msgid "error:"
+msgid ""
+"constant:  \n"
+"A value that does not change during the execution of a program."
 msgstr ""
-
-#: src/glossary.md:58
-#, fuzzy
-msgid "error handling:"
-msgstr "エラー処理"
 
 #: src/glossary.md:59
-#, fuzzy
-msgid "exercise:"
-msgstr "練習問題"
-
-#: src/glossary.md:60
-#, fuzzy
-msgid "function:"
-msgstr "関数"
+msgid ""
+"control flow:  \n"
+"The order in which the individual statements or instructions are executed in "
+"a program."
+msgstr ""
 
 #: src/glossary.md:61
-#, fuzzy
-msgid "garbage collector:"
-msgstr "ガベージコレクション"
-
-#: src/glossary.md:62
-#, fuzzy
-msgid "generics:"
-msgstr "ジェネリクス（generics）"
+msgid ""
+"crash:  \n"
+"An unexpected and unhandled failure or termination of a program."
+msgstr ""
 
 #: src/glossary.md:63
-msgid "immutable:"
+msgid ""
+"enumeration:  \n"
+"A data type that consists of named constant values."
 msgstr ""
-
-#: src/glossary.md:64
-#, fuzzy
-msgid "integration test:"
-msgstr "インテグレーションテスト"
 
 #: src/glossary.md:65
-msgid "keyword:"
+msgid ""
+"error:  \n"
+"An unexpected condition or result that deviates from the expected behavior."
 msgstr ""
-
-#: src/glossary.md:66
-#, fuzzy
-msgid "library:"
-msgstr "ライブラリ"
 
 #: src/glossary.md:67
-msgid "macro:"
+msgid ""
+"error handling:  \n"
+"The process of managing and responding to errors that occur during program "
+"execution."
 msgstr ""
-
-#: src/glossary.md:68
-#, fuzzy
-msgid "main function:"
-msgstr "Unsafe関数の呼び出し"
 
 #: src/glossary.md:69
-msgid "match:"
-msgstr ""
-
-#: src/glossary.md:70
-msgid "memory leak:"
+msgid ""
+"exercise:  \n"
+"A task or problem designed to practice and test programming skills."
 msgstr ""
 
 #: src/glossary.md:71
-#, fuzzy
-msgid "method:"
-msgstr "メソッド"
-
-#: src/glossary.md:72
-#, fuzzy
-msgid "module:"
-msgstr "モジュール"
-
-#: src/glossary.md:73
-msgid "move:"
+msgid ""
+"function:  \n"
+"A reusable block of code that performs a specific task."
 msgstr ""
 
-#: src/glossary.md:74
-msgid "mutable:"
+#: src/glossary.md:73
+msgid ""
+"garbage collector:  \n"
+"A mechanism that automatically frees up memory occupied by objects that are "
+"no longer in use."
 msgstr ""
 
 #: src/glossary.md:75
-#, fuzzy
-msgid "ownership:"
-msgstr "所有権"
-
-#: src/glossary.md:76
-#, fuzzy
-msgid "panic:"
-msgstr "パニック（panic）"
-
-#: src/glossary.md:77
-msgid "parameter:"
+msgid ""
+"generics:  \n"
+"A feature that allows writing code with placeholders for types, enabling "
+"code reuse with different data types."
 msgstr ""
 
-#: src/glossary.md:78
-msgid "pattern:"
+#: src/glossary.md:77
+msgid ""
+"immutable:  \n"
+"Unable to be changed after creation."
 msgstr ""
 
 #: src/glossary.md:79
-msgid "payload:"
-msgstr ""
-
-#: src/glossary.md:80
-msgid "program:"
+msgid ""
+"integration test:  \n"
+"A type of test that verifies the interactions between different parts or "
+"components of a system."
 msgstr ""
 
 #: src/glossary.md:81
-msgid "programming language:"
+msgid ""
+"keyword:  \n"
+"A reserved word in a programming language that has a specific meaning and "
+"cannot be used as an identifier."
 msgstr ""
-
-#: src/glossary.md:82
-#, fuzzy
-msgid "receiver:"
-msgstr "ドライバ"
 
 #: src/glossary.md:83
-msgid "reference counting:"
-msgstr ""
-
-#: src/glossary.md:84
-msgid "return:"
+msgid ""
+"library:  \n"
+"A collection of precompiled routines or code that can be used by programs."
 msgstr ""
 
 #: src/glossary.md:85
-#, fuzzy
-msgid "Rust:"
-msgstr "Rustdoc"
+msgid ""
+"macro:  \n"
+"Rust macros can be recognized by a `!` in the name. Macros are used when "
+"normal functions are not enough. A typical example is `format!`, which takes "
+"a variable number of arguments, which isn't supported by Rust functions."
+msgstr ""
 
-#: src/glossary.md:86
+#: src/glossary.md:90
+msgid ""
+"`main` function:  \n"
+"Rust programs start executing with the `main` function."
+msgstr ""
+
+#: src/glossary.md:92
+msgid ""
+"match:  \n"
+"A control flow construct in Rust that allows for pattern matching on the "
+"value of an expression."
+msgstr ""
+
+#: src/glossary.md:94
+msgid ""
+"memory leak:  \n"
+"A situation where a program fails to release memory that is no longer "
+"needed, leading to a gradual increase in memory usage."
+msgstr ""
+
+#: src/glossary.md:96
+msgid ""
+"method:  \n"
+"A function associated with an object or a type in Rust."
+msgstr ""
+
+#: src/glossary.md:98
+msgid ""
+"module:  \n"
+"A namespace that contains definitions, such as functions, types, or traits, "
+"to organize code in Rust."
+msgstr ""
+
+#: src/glossary.md:100
+msgid ""
+"move:  \n"
+"The transfer of ownership of a value from one variable to another in Rust."
+msgstr ""
+
+#: src/glossary.md:102
+msgid ""
+"mutable:  \n"
+"A property in Rust that allows variables to be modified after they have been "
+"declared."
+msgstr ""
+
+#: src/glossary.md:104
+msgid ""
+"ownership:  \n"
+"The concept in Rust that defines which part of the code is responsible for "
+"managing the memory associated with a value."
+msgstr ""
+
+#: src/glossary.md:106
+msgid ""
+"panic:  \n"
+"An unrecoverable error condition in Rust that results in the termination of "
+"the program."
+msgstr ""
+
+#: src/glossary.md:108
+msgid ""
+"parameter:  \n"
+"A value that is passed into a function or method when it is called."
+msgstr ""
+
+#: src/glossary.md:110
+msgid ""
+"pattern:  \n"
+"A combination of values, literals, or structures that can be matched against "
+"an expression in Rust."
+msgstr ""
+
+#: src/glossary.md:112
+msgid ""
+"payload:  \n"
+"The data or information carried by a message, event, or data structure."
+msgstr ""
+
+#: src/glossary.md:114
+msgid ""
+"program:  \n"
+"A set of instructions that a computer can execute to perform a specific task "
+"or solve a particular problem."
+msgstr ""
+
+#: src/glossary.md:116
+msgid ""
+"programming language:  \n"
+"A formal system used to communicate instructions to a computer, such as Rust."
+msgstr ""
+
+#: src/glossary.md:118
+msgid ""
+"receiver:  \n"
+"The first parameter in a Rust method that represents the instance on which "
+"the method is called."
+msgstr ""
+
+#: src/glossary.md:120
+msgid ""
+"reference counting:  \n"
+"A memory management technique in which the number of references to an object "
+"is tracked, and the object is deallocated when the count reaches zero."
+msgstr ""
+
+#: src/glossary.md:122
+msgid ""
+"return:  \n"
+"A keyword in Rust used to indicate the value to be returned from a function."
+msgstr ""
+
+#: src/glossary.md:124
+msgid ""
+"Rust:  \n"
+"A systems programming language that focuses on safety, performance, and "
+"concurrency."
+msgstr ""
+
+#: src/glossary.md:126
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 3 of this course."
 msgstr ""
 
-#: src/glossary.md:88
+#: src/glossary.md:128
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
 msgstr ""
 
-#: src/glossary.md:90
-msgid "safe:"
+#: src/glossary.md:130
+msgid ""
+"safe:  \n"
+"Refers to code that adheres to Rust's ownership and borrowing rules, "
+"preventing memory-related errors."
 msgstr ""
 
-#: src/glossary.md:91
-msgid "scope:"
+#: src/glossary.md:132
+msgid ""
+"scope:  \n"
+"The region of a program where a variable is valid and can be used."
 msgstr ""
 
-#: src/glossary.md:92
-#, fuzzy
-msgid "standard library:"
-msgstr "標準ライブラリ"
-
-#: src/glossary.md:93
-msgid "static:"
+#: src/glossary.md:134
+msgid ""
+"standard library:  \n"
+"A collection of modules providing essential functionality in Rust."
 msgstr ""
 
-#: src/glossary.md:94
-#, fuzzy
-msgid "string:"
-msgstr "文字列（String）"
-
-#: src/glossary.md:95
-#, fuzzy
-msgid "struct:"
-msgstr "構造体（structs）"
-
-#: src/glossary.md:96
-msgid "test:"
+#: src/glossary.md:136
+msgid ""
+"static:  \n"
+"A keyword in Rust used to define static variables or items with a `'static` "
+"lifetime."
 msgstr ""
 
-#: src/glossary.md:97
-#, fuzzy
-msgid "thread:"
-msgstr "スレッド"
-
-#: src/glossary.md:98
-msgid "thread safety:"
+#: src/glossary.md:138
+msgid ""
+"string:  \n"
+"A data type storing textual data. See [`String` vs `str`](basic-syntax/"
+"string-slices.html) for more."
 msgstr ""
 
-#: src/glossary.md:99
-#, fuzzy
-msgid "trait:"
-msgstr "トレイト（trait）"
-
-#: src/glossary.md:100
-msgid "type:"
+#: src/glossary.md:140
+msgid ""
+"struct:  \n"
+"A composite data type in Rust that groups together variables of different "
+"types under a single name."
 msgstr ""
 
-#: src/glossary.md:101
-#, fuzzy
-msgid "type inference:"
-msgstr "型推論"
-
-#: src/glossary.md:102
-#, fuzzy
-msgid "undefined behavior:"
-msgstr "実行時に未定義の動作はありません："
-
-#: src/glossary.md:103
-#, fuzzy
-msgid "union:"
-msgstr "共用体"
-
-#: src/glossary.md:104
-#, fuzzy
-msgid "unit test:"
-msgstr "ユニットテスト"
-
-#: src/glossary.md:105
-msgid "unsafe:"
+#: src/glossary.md:142
+msgid ""
+"test:  \n"
+"A Rust module containing functions that test the correctness of other "
+"functions."
 msgstr ""
 
-#: src/glossary.md:106
-#, fuzzy
-msgid "variable:\\"
-msgstr "変数"
+#: src/glossary.md:144
+msgid ""
+"thread:  \n"
+"A separate sequence of execution in a program, allowing concurrent execution."
+msgstr ""
+
+#: src/glossary.md:146
+msgid ""
+"thread safety:  \n"
+"The property of a program that ensures correct behavior in a multithreaded "
+"environment."
+msgstr ""
+
+#: src/glossary.md:148
+msgid ""
+"trait:  \n"
+"A collection of methods defined for an unknown type, providing a way to "
+"achieve polymorphism in Rust."
+msgstr ""
+
+#: src/glossary.md:150
+msgid ""
+"type:  \n"
+"A classification that specifies which operations can be performed on values "
+"of a particular kind in Rust."
+msgstr ""
+
+#: src/glossary.md:152
+msgid ""
+"type inference:  \n"
+"The ability of the Rust compiler to deduce the type of a variable or "
+"expression."
+msgstr ""
+
+#: src/glossary.md:154
+msgid ""
+"undefined behavior:  \n"
+"Actions or conditions in Rust that have no specified result, often leading "
+"to unpredictable program behavior."
+msgstr ""
+
+#: src/glossary.md:156
+msgid ""
+"union:  \n"
+"A data type that can hold values of different types but only one at a time."
+msgstr ""
+
+#: src/glossary.md:158
+msgid ""
+"unit test:  \n"
+"Rust comes with built-in support for running small unit tests and larger "
+"integration tests. See [Unit Tests](testing/unit-tests.html)."
+msgstr ""
+
+#: src/glossary.md:161
+msgid ""
+"unsafe:  \n"
+"The subset of Rust which allows you to trigger _undefined behavior_. See "
+"[Unsafe Rust](unsafe.html)."
+msgstr ""
+
+#: src/glossary.md:163
+msgid ""
+"variable:  \n"
+"A memory location storing data. Variables are valid in a _scope_. "
+msgstr ""
 
 #: src/other-resources.md:1
 msgid "Other Rust Resources"
@@ -18438,25 +19121,30 @@ msgstr ""
 msgid ""
 "```rust\n"
 "pub fn luhn(cc_number: &str) -> bool {\n"
-"    let mut digits_seen = 0;\n"
 "    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
-"enumerate() {\n"
-"        match ch.to_digit(10) {\n"
-"            Some(d) => {\n"
-"                sum += if i % 2 == 1 {\n"
-"                    let dd = d * 2;\n"
-"                    dd / 10 + dd % 10\n"
+"    let mut double = false;\n"
+"    let mut digit_seen = 0;\n"
+"\n"
+"    for c in cc_number.chars().filter(|&f| f != ' ').rev() {\n"
+"        if let Some(digit) = c.to_digit(10) {\n"
+"            if double {\n"
+"                let double_digit = digit * 2;\n"
+"                sum += if double_digit > 9 {\n"
+"                    double_digit - 9\n"
 "                } else {\n"
-"                    d\n"
+"                    double_digit\n"
 "                };\n"
-"                digits_seen += 1;\n"
+"            } else {\n"
+"                sum += digit;\n"
 "            }\n"
-"            None => return false,\n"
+"            double = !double;\n"
+"            digit_seen += 1;\n"
+"        } else {\n"
+"            return false;\n"
 "        }\n"
 "    }\n"
 "\n"
-"    if digits_seen < 2 {\n"
+"    if digit_seen < 2 {\n"
 "        return false;\n"
 "    }\n"
 "\n"
@@ -18511,12 +19199,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-1/solutions-afternoon.md:80
+#: src/exercises/day-1/solutions-afternoon.md:86
 #, fuzzy
 msgid "Pattern matching"
 msgstr "パターンマッチング"
 
-#: src/exercises/day-1/solutions-afternoon.md:82
+#: src/exercises/day-1/solutions-afternoon.md:88
 msgid ""
 "```rust\n"
 "/// An operation to perform on two subexpressions.\n"
@@ -20462,6 +21150,110 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+
+#, fuzzy
+#~ msgid "concurrency:"
+#~ msgstr "並行性"
+
+#, fuzzy
+#~ msgid "control flow:"
+#~ msgstr "制御フロー"
+
+#, fuzzy
+#~ msgid "enumeration:"
+#~ msgstr "実装"
+
+#, fuzzy
+#~ msgid "error handling:"
+#~ msgstr "エラー処理"
+
+#, fuzzy
+#~ msgid "exercise:"
+#~ msgstr "練習問題"
+
+#, fuzzy
+#~ msgid "function:"
+#~ msgstr "関数"
+
+#, fuzzy
+#~ msgid "garbage collector:"
+#~ msgstr "ガベージコレクション"
+
+#, fuzzy
+#~ msgid "generics:"
+#~ msgstr "ジェネリクス（generics）"
+
+#, fuzzy
+#~ msgid "integration test:"
+#~ msgstr "インテグレーションテスト"
+
+#, fuzzy
+#~ msgid "library:"
+#~ msgstr "ライブラリ"
+
+#, fuzzy
+#~ msgid "main function:"
+#~ msgstr "Unsafe関数の呼び出し"
+
+#, fuzzy
+#~ msgid "method:"
+#~ msgstr "メソッド"
+
+#, fuzzy
+#~ msgid "module:"
+#~ msgstr "モジュール"
+
+#, fuzzy
+#~ msgid "ownership:"
+#~ msgstr "所有権"
+
+#, fuzzy
+#~ msgid "panic:"
+#~ msgstr "パニック（panic）"
+
+#, fuzzy
+#~ msgid "receiver:"
+#~ msgstr "ドライバ"
+
+#, fuzzy
+#~ msgid "Rust:"
+#~ msgstr "Rustdoc"
+
+#, fuzzy
+#~ msgid "standard library:"
+#~ msgstr "標準ライブラリ"
+
+#, fuzzy
+#~ msgid "struct:"
+#~ msgstr "構造体（structs）"
+
+#, fuzzy
+#~ msgid "thread:"
+#~ msgstr "スレッド"
+
+#, fuzzy
+#~ msgid "trait:"
+#~ msgstr "トレイト（trait）"
+
+#, fuzzy
+#~ msgid "type inference:"
+#~ msgstr "型推論"
+
+#, fuzzy
+#~ msgid "undefined behavior:"
+#~ msgstr "実行時に未定義の動作はありません："
+
+#, fuzzy
+#~ msgid "union:"
+#~ msgstr "共用体"
+
+#, fuzzy
+#~ msgid "unit test:"
+#~ msgstr "ユニットテスト"
+
+#, fuzzy
+#~ msgid "variable:\\"
+#~ msgstr "変数"
 
 #~ msgid ""
 #~ "```shell\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2023-11-17 12:51+0900\n"
+"POT-Creation-Date: 2023-10-15T23:41:50Z\n"
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2023-10-15T23:41:49Z\n"
+"POT-Creation-Date: 2023-11-17 12:51+0900\n"
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"


### PR DESCRIPTION
Hello, JA translation team! (https://github.com/google/comprehensive-rust/issues/652) 

As part of #1460, I normalized ja.po using mdbook-i18n-normalize 0.3.0.

Steps taken:

1. Refreshed `po` file using the following command:

```
MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' \
  mdbook build -d po
msgmerge --update po/ja.po po/messages.pot
```

2. Ran `mdbook-i18n-normalize`

I'm open to any feedback or suggestions. Thank you in advance!