### PR TITLE
Remove unused "Summary" heading

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,5 +1,3 @@
-# Summary
-
 <!-- Keep first page as index.md to avoid giving it two names. -->
 [Welcome to Comprehensive Rust 🦀](index.md)
 - [Running the Course](running-the-course.md)


### PR DESCRIPTION
The first heading is not actually used, it just takes up space here and in the PO files.