### PR TITLE
Skip calling “apt update” in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,7 @@ jobs:
         uses: ./.github/workflows/setup-rust-cache
 
       - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu
+        run: sudo apt install gcc-aarch64-linux-gnu
 
       - name: Install toolchain
         run: rustup target add ${{ matrix.target }}
@@ -122,9 +120,7 @@ jobs:
         uses: ./.github/workflows/setup-rust-cache
 
       - name: Install Gettext
-        run: |
-          sudo apt update
-          sudo apt install gettext
+        run: sudo apt install gettext
 
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook


### PR DESCRIPTION
We are currently getting an error when we run “apt update”:

    Reading package lists...
    E: Repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' changed its 'Origin' value from 'microsoft-ubuntu-jammy-prod jammy' to 'Pulp 3'
    E: Repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' changed its 'Label' value from 'microsoft-ubuntu-jammy-prod jammy' to ''
    Error: Process completed with exit code 100.

I’m not sure why we get this, but updating should not be necessary in the first place: the Ubuntu images already come with an up-to-date list of packages.