### PR TITLE
Run translation tests to completion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,7 @@ jobs:
     strategy:
       matrix:
         language: ${{ fromJSON(needs.find-languages.outputs.languages) }}
+      fail-fast: false
     env:
       MDBOOK_BOOK__LANGUAGE: ${{ matrix.language }}
     steps:


### PR DESCRIPTION
This makes it easier to find and fix all problems in one iteration when something changes with the translation tooling.