### PR TITLE
Add course and session markers for deep-dives

### DIFF
--- a/mdbook-course/src/course.rs
+++ b/mdbook-course/src/course.rs
@@ -321,6 +321,9 @@ impl Session {
     /// Return the total duration of this session.
     pub fn minutes(&self) -> u64 {
         let instructional_time: u64 = self.into_iter().map(|s| s.minutes()).sum();
+        if instructional_time == 0 {
+            return instructional_time;
+        }
         let breaks = (self.into_iter().filter(|s| s.minutes() > 0).count() - 1) as u64
             * BREAK_DURATION;
         instructional_time + breaks

--- a/src/android.md
+++ b/src/android.md
@@ -1,5 +1,6 @@
 ---
-course: none
+course: Android
+session: Android
 ---
 # Welcome to Rust in Android
 

--- a/src/async.md
+++ b/src/async.md
@@ -1,3 +1,6 @@
+---
+session: Afternoon
+---
 # Async Rust
 
 "Async" is a concurrency model where multiple tasks are executed concurrently by

--- a/src/bare-metal.md
+++ b/src/bare-metal.md
@@ -1,3 +1,7 @@
+---
+course: Bare Metal
+session: Morning
+---
 # Welcome to Bare Metal Rust
 
 This is a standalone one-day course about bare-metal Rust, aimed at people who are familiar with the

--- a/src/bare-metal/aps.md
+++ b/src/bare-metal/aps.md
@@ -1,3 +1,6 @@
+---
+session: Afternoon
+---
 # Application processors
 
 So far we've talked about microcontrollers, such as the Arm Cortex-M series. Now let's try writing

--- a/src/chromium.md
+++ b/src/chromium.md
@@ -1,3 +1,7 @@
+---
+course: Chromium
+session: Chromium
+---
 # Welcome to Rust in Chromium
 
 Rust is supported for third-party libraries in Chromium, with first-party glue

--- a/src/concurrency.md
+++ b/src/concurrency.md
@@ -1,3 +1,7 @@
+---
+course: Concurrency
+session: Morning
+---
 # Welcome to Concurrency in Rust
 
 Rust has full support for concurrency using OS threads with mutexes and

--- a/src/thanks.md
+++ b/src/thanks.md
@@ -1,3 +1,6 @@
+---
+course: none
+---
 # Thanks!
 
 _Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that it


### PR DESCRIPTION
This doesn't add any timing information. The authors of each deep-dive can do that separately.

Fixes #1510.