### PR TITLE
Fix Fibonacci numbers example

### DIFF
--- a/src/types-and-values/exercise.rs
+++ b/src/types-and-values/exercise.rs
@@ -16,7 +16,7 @@
 // ANCHOR: fib
 fn fib(n: u32) -> u32 {
     // ANCHOR_END: fib
-    if n < 2 {
+    if n <= 2 {
         return 1;
     } else {
         return fib(n - 1) + fib(n - 2);


### PR DESCRIPTION
The exercise has n <= 2 for the base case, but it is n < 2 in the solution. 
You currently get fib(n) = 10946 for n = 20, but it should be 6765.