### PR TITLE
Do not include timing info in sub-chapters of slides

### DIFF
--- a/mdbook-course/src/course.rs
+++ b/mdbook-course/src/course.rs
@@ -447,6 +447,13 @@ impl Slide {
         Ok(())
     }
 
+    /// Determine whether the given chapter is a sub-chapter of this slide.
+    pub fn is_sub_chapter(&self, chapter: &Chapter) -> bool {
+        // The first souce_path in the slide is the "parent" chapter, so anything
+        // else is a sub-chapter.
+        chapter.source_path.as_ref() != self.source_paths.get(0)
+    }
+
     /// Return the total duration of this slide.
     pub fn minutes(&self) -> u64 {
         self.minutes

--- a/mdbook-course/src/course.rs
+++ b/mdbook-course/src/course.rs
@@ -449,7 +449,7 @@ impl Slide {
 
     /// Determine whether the given chapter is a sub-chapter of this slide.
     pub fn is_sub_chapter(&self, chapter: &Chapter) -> bool {
-        // The first souce_path in the slide is the "parent" chapter, so anything
+        // The first `source_path` in the slide is the "parent" chapter, so anything
         // else is a sub-chapter.
         chapter.source_path.as_ref() != self.source_paths.get(0)
     }

--- a/mdbook-course/src/timing_info.rs
+++ b/mdbook-course/src/timing_info.rs
@@ -17,7 +17,7 @@ use mdbook::book::Chapter;
 
 /// Insert timing information for this slide into the speaker notes.
 pub fn insert_timing_info(slide: &Slide, chapter: &mut Chapter) {
-    if slide.minutes > 0 && chapter.content.contains("<details>") {
+    if slide.minutes > 0 && !slide.is_sub_chapter(chapter) && chapter.content.contains("<details>") {
         // Include the minutes in the speaker notes.
         let minutes = slide.minutes;
         let plural = if slide.minutes == 1 {

--- a/mdbook-course/src/timing_info.rs
+++ b/mdbook-course/src/timing_info.rs
@@ -17,7 +17,10 @@ use mdbook::book::Chapter;
 
 /// Insert timing information for this slide into the speaker notes.
 pub fn insert_timing_info(slide: &Slide, chapter: &mut Chapter) {
-    if slide.minutes > 0 && !slide.is_sub_chapter(chapter) && chapter.content.contains("<details>") {
+    if slide.minutes > 0
+        && !slide.is_sub_chapter(chapter)
+        && chapter.content.contains("<details>")
+    {
         // Include the minutes in the speaker notes.
         let minutes = slide.minutes;
         let plural = if slide.minutes == 1 {


### PR DESCRIPTION
Timing information is for a slide as a whole, so we use a sentence like "This slide and its sub-slides should take about 15 minutes" in the first chapter in the slide. Subsequent chapters in the same slide do not need timing information.

Fixes #1522.