### PR TITLE
Link statically to avoid dynamic link error

### DIFF
--- a/src/android/aidl/birthday_service/Android.bp
+++ b/src/android/aidl/birthday_service/Android.bp
@@ -20,6 +20,7 @@ rust_binary {
         "libbinder_rs",
         "libbirthdayservice",
     ],
+    prefer_rlib: true, // To avoid dynamic link error.
 }
 // ANCHOR_END: birthday_server
 
@@ -32,5 +33,6 @@ rust_binary {
         "com.example.birthdayservice-rust",
         "libbinder_rs",
     ],
+    prefer_rlib: true, // To avoid dynamic link error.
 }
 // ANCHOR_END: birthday_client

--- a/src/android/build-rules/library/Android.bp
+++ b/src/android/build-rules/library/Android.bp
@@ -6,7 +6,7 @@ rust_binary {
         "libgreetings",
         "libtextwrap",
     ],
-    prefer_rlib: true,
+    prefer_rlib: true, // Need this to avoid dynamic link error.
 }
 
 rust_library {

--- a/src/android/build-rules/library/Android.bp
+++ b/src/android/build-rules/library/Android.bp
@@ -6,6 +6,7 @@ rust_binary {
         "libgreetings",
         "libtextwrap",
     ],
+    prefer_rlib: true,
 }
 
 rust_library {


### PR DESCRIPTION
```
$ adb shell /data/local/tmp/hello_rust_with_dep
CANNOT LINK EXECUTABLE "/data/local/tmp/hello_rust_with_dep": library "libtextwrap.dylib.so" not found: needed by main executable
```