### PR TITLE
Add safety comment

### DIFF
--- a/src/android/interoperability/with-c/bindgen/main.rs
+++ b/src/android/interoperability/with-c/bindgen/main.rs
@@ -23,6 +23,7 @@ fn main() {
         name: name.as_ptr(),
         years: 42,
     };
+    // SAFETY: `print_card` is safe to call with a valid `card` pointer.
     unsafe {
         print_card(&card as *const card);
     }


### PR DESCRIPTION
```
error: unsafe block missing a safety comment
  --> interoperability/bindgen/main.rs:11:5
   |
11 |     unsafe {
   |     ^^^^^^^^
   |
   = help: consider adding a safety comment on the preceding line
   = help: for further information visit https://rust-lang.github.io/rust-clippy
/master/index.html#undocumented_unsafe_blocks
   = note: requested on the command line with `-D clippy::undocumented-unsafe-bl
ocks`
```