### PR TITLE
Use type annotation instead of turbo fish in method chapter

### DIFF
--- a/src/methods-and-traits/methods.md
+++ b/src/methods-and-traits/methods.md
@@ -31,7 +31,7 @@ impl Race {
     }
 
     fn finish(self) {  // Exclusive ownership of self
-        let total = self.laps.iter().sum::<i32>();
+        let total: i32 = self.laps.iter().sum();
         println!("Race {} is finished, total lap time: {}", self.name, total);
     }
 }


### PR DESCRIPTION
If we use a type annotation, we get around explaining the turbo fish,
which isn't trivial without having introduced generics. Type
annotations on the other hand are known already.