### PR TITLE
Use Self to create struct in method chapter

### DIFF
--- a/src/methods-and-traits/methods.md
+++ b/src/methods-and-traits/methods.md
@@ -16,7 +16,7 @@ struct Race {
 
 impl Race {
     fn new(name: &str) -> Self {  // No receiver, a static method
-        Race { name: String::from(name), laps: Vec::new() }
+        Self { name: String::from(name), laps: Vec::new() }
     }
 
     fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write access to self


### PR DESCRIPTION
If I'm not mistaken, it's idomatic to use `Self` in a struct constructor
rather than the name of the struct.