### PR TITLE
Fix `mdbook` redirection table

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,13 @@ jobs:
           MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' mdbook build -d po
           msgfmt -o /dev/null --statistics po/messages.pot
 
+      # Build the translation without redirects just like publish.yml does.
+      - name: Build ${{ matrix.language }} translation
+        if: matrix.language != 'en'
+        run: MDBOOK_OUTPUT__HTML__REDIRECT='{}' mdbook build
+
       - name: Build course
+        if: matrix.language == 'en'
         run: mdbook build
 
       - name: Zip exercise templates

--- a/book.toml
+++ b/book.toml
@@ -50,6 +50,9 @@ level = 0
 editable = true
 line-numbers = true
 
+[output.html.search]
+use-boolean-and = true
+
 [output.html.redirect]
 # Redirects in the form of "old-path" = "new-path", where the new path
 # is relative to the old path.
@@ -85,11 +88,7 @@ line-numbers = true
 # Send people to canonical URL instead of index.html
 "welcome.html" = "./"
 
-[output.html.search]
-use-boolean-and = true
-
 # redirects from course v1 to v2
-'welcome-day-1.html' = 'hello-world/welcome.html'
 'welcome-day-1/what-is-rust.html' = '../hello-world/what-is-rust.html'
 'hello-world/small-example.html' = '../hello-world/hello-world.html'
 'why-rust.html' = 'hello-world/benefits.html'
@@ -121,7 +120,6 @@ use-boolean-and = true
 'exercises/day-3/afternoon.html' = '../../control-flow-basics/exercise.html'
 'basic-syntax/compound-types.html' = '../tuples-and-arrays/tuples-and-arrays.html'
 'control-flow/match-expressions.html' = '../tuples-and-arrays/match.html'
-'pattern-matching.html' = 'tuples-and-arrays/match.html'
 'pattern-matching/match-guards.html' = '../tuples-and-arrays/match.html'
 'pattern-matching/destructuring-arrays.html' = '../tuples-and-arrays/destructuring.html'
 'exercises/day-1/for-loops.html' = '../../tuples-and-arrays/exercise.html'
@@ -141,7 +139,6 @@ use-boolean-and = true
 'control-flow/if-let-expressions.html' = '../pattern-matching/let-control-flow.html'
 'control-flow/while-let-expressions.html' = '../pattern-matching/let-control-flow.html'
 'exercises/day-1/pattern-matching.html' = '../../user-defined-types/exercise.html'
-'welcome-day-2.html' = 'methods-and-traits/welcome.html'
 'methods.html' = 'methods-and-traits/methods.html'
 'methods/receiver.html' = '../methods-and-traits/methods.html'
 'methods/example.html' = '../methods-and-traits/methods.html'
@@ -149,7 +146,6 @@ use-boolean-and = true
 'traits/default-methods.html' = '../methods-and-traits/traits.html'
 'traits/trait-objects.html' = '../methods-and-traits/trait-objects.html'
 'exercises/day-3/simple-gui.html' = '../../methods-and-traits/exercise.html'
-'generics.html' = 'generics/generic-functions.html'
 'generics/monomorphization.html' = '../generics/generic-functions.html'
 'generics/data-types.html' = '../generics/generic-data.html'
 'generics/methods.html' = '../generics/generic-data.html'
@@ -173,16 +169,11 @@ use-boolean-and = true
 'exercises/day-2/iterators-and-ownership.html' = '../../iterators/intoiterator.html'
 'traits/from-iterator.html' = '../iterators/fromiterator.html'
 'exercises/day-2/strings-iterators.html' = '../../iterators/exercise.html'
-'modules.html' = 'modules/modules.html'
-'testing.html' = 'testing/unit-tests.html'
-'testing/unit-tests.html' = '../testing/unit-tests.html'
 'testing/integration-tests.html' = '../testing/other.html'
 'testing/doc-tests.html' = '../testing/other.html'
 'exercises/day-1/luhn.html' = '../../testing/exercise.html'
-'welcome-day-3.html' = 'memory-management/welcome.html'
 'memory-management/stack-vs-heap.html' = '../memory-management/review.html'
 'memory-management/stack.html' = '../memory-management/review.html'
-'memory-management.html' = 'memory-management/approaches.html'
 'memory-management/manual.html' = '../memory-management/approaches.html'
 'memory-management/scope-based.html' = '../memory-management/approaches.html'
 'memory-management/garbage-collection.html' = '../memory-management/approaches.html'
@@ -202,7 +193,6 @@ use-boolean-and = true
 'ownership/shared-unique-borrows.html' = '../borrowing/shared.html'
 'std/cell.html' = '../borrowing/interior-mutability.html'
 'exercises/day-2/health-statistics.html' = '../../borrowing/exercise.html'
-'error-handling.html' = 'error-handling/panics.html'
 'error-handling/panic-unwind.html' = '../error-handling/panics.html'
 'error-handling/try-operator.html' = '../error-handling/try.html'
 'error-handling/converting-error-types.html' = '../error-handling/try-conversions.html'


### PR DESCRIPTION
There must have been a merge conflict at some point which resulted in
a malformed table. The result was that most redirects were blindly
ignored by `mdbook`.

An example page that stopped working is
https://google.github.io/comprehensive-rust/enums.html.

I took out several unnecessary redirects (`mdbook` helpfully emits an
error if you redirect a file that actually exists).

I also took out the redirects for the build step: we do the same at
publish time since redirects are only expected to be valid for the
English version.
