### PR TITLE
Add trait bounds to glossary

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -149,7 +149,7 @@ Also, please keep the hard line breaks to ensure a nice formatting.
   The property of a program that ensures correct behavior in a multithreaded environment.
 - trait:\
   A collection of methods defined for an unknown type, providing a way to achieve polymorphism in Rust.
-- trait bounds:\
+- trait bound:\
   An abstraction where you can require types to implement some traits of your interest.
 - type:\
   A classification that specifies which operations can be performed on values of a particular kind in Rust.

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -149,6 +149,8 @@ Also, please keep the hard line breaks to ensure a nice formatting.
   The property of a program that ensures correct behavior in a multithreaded environment.
 - trait:\
   A collection of methods defined for an unknown type, providing a way to achieve polymorphism in Rust.
+- trait bounds:\
+  An abstraction where you can require types to implement some traits of your interest.
 - type:\
   A classification that specifies which operations can be performed on values of a particular kind in Rust.
 - type inference:\


### PR DESCRIPTION
Hi, this is a tiny MR to add glossary entry for "trait bound". Could you someone review it? I'm open to suggeston, too. Thank you!
Context: https://github.com/google/comprehensive-rust/pull/1436#discussion_r1394298992