### PR TITLE
Chromium: Add `redox_syscall` to speaker notes for the third-party exercise.

### DIFF
--- a/src/exercises/chromium/third-party.md
+++ b/src/exercises/chromium/third-party.md
@@ -9,13 +9,23 @@ skip ahead and do that now if you like. Or, you could create a new
 [`rust_executable` target][2] which uses `uwuify`).
 
 <details>
+
 Students will need to download lots of transitive dependencies.
 
-The total crates needed are: uwuify, smallvec, scopeguard, parking_lot,
-parking_lot_core, lock_api and instant. If students are downloading even
+The total crates needed are:
+instant,
+lock_api,
+parking_lot,
+parking_lot_core,
+redox_syscall,
+scopeguard,
+smallvec,
+and uwuify.
+If students are downloading even
 more than that, they probably forgot to turn off the default features.
 
 Thanks to [Daniel Liu][3] for this crate!
+
 </detail>
 
 


### PR DESCRIPTION
Speaker notes for Chromium's third-party crate exercise list the transitive dependencies that will be downloaded during the exercise. Before this commit the list was missing the `redox_syscall` crate.

Additionally, the commit sorts the crates to make it easier to compare with the output of `git status` or `ls`.