### PR TITLE
Having a `Vec` allows accessing mutating slice methods, too

### DIFF
--- a/src/std-types/vec.md
+++ b/src/std-types/vec.md
@@ -48,6 +48,6 @@ methods on a `Vec`.
 * To index the vector you use `[` `]`, but they will panic if out of bounds. Alternatively, using
   `get` will return an `Option`. The `pop` function will remove the last element.
 * Slices are covered on day 3. For now, students only need to know that a value
-  of type `Vec` gives access to all of the documented read-only slice methods, too.
+  of type `Vec` gives access to all of the documented slice methods, too.
 
 </details>


### PR DESCRIPTION
I don't know why "read-only" was added.