### PR TITLE
Remove an incorrect note

### DIFF
--- a/src/smart-pointers/box.md
+++ b/src/smart-pointers/box.md
@@ -60,7 +60,6 @@ fn main() {
 <details>
 
 * `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be not null.
-* In the above example, you can even leave out the `*` in the `println!` statement thanks to `Deref`.
 * A `Box` can be useful when you:
    * have a type whose size that can't be known at compile time, but the Rust compiler wants to know an exact size.
    * want to transfer ownership of a large amount of data. To avoid copying large amounts of data on the stack, instead store the data on the heap in a `Box` so only the pointer is moved.


### PR DESCRIPTION
People are often confused by this: the fact that we can remove the `*` in the `println!()` is not because the compiler auto-derefs here (it does not), but because `Display` is implemented for `&T where T: Display` (a blanket implementation).