### PR TITLE
Update expression-evaluation exercise: more patterns, more enums

### DIFF
--- a/src/pattern-matching/exercise.md
+++ b/src/pattern-matching/exercise.md
@@ -8,12 +8,14 @@ Let's write a simple recursive evaluator for arithmetic expressions.
 
 The `Box` type here is a smart pointer, and will be covered in detail later in
 the course. An expression can be "boxed" with `Box::new` as seen in the tests.
-To evaluate a boxed expression, use the deref operator to "unbox" it:
+To evaluate a boxed expression, use the deref operator (`*`) to "unbox" it:
 `eval(*boxed_expr)`.
 
-Some expressions cannot be evaluated and will return an error. The `Res`
-type represents either a successful value or an error with a message. This is
-very similar to the standard-library `Result` which we will see later.
+Some expressions cannot be evaluated and will return an error. The standard
+[`Result<Value,
+String>`](https://doc.rust-lang.org/std/result/enum.Result.html) type is an
+enum that represents either a successful value (`Ok(Value)`) or an error
+(`Err(String)`). We will cover this type in detail later.
 
 Copy and paste the code into the Rust playground, and begin implementing
 `eval`. The final product should pass the tests. It may be helpful to use
@@ -27,15 +29,15 @@ temporarily with
 fn test_value() { .. }
 ```
 
-If you finish early, try writing a test that results in an integer overflow.
-How could you handle this with `Res::Err` instead of a panic?
+If you finish early, try writing a test that results in division by zero or
+integer overflow. How could you handle this with `Result` instead of a panic?
 
 ```rust
 {{#include exercise.rs:Operation}}
 
-{{#include exercise.rs:Expression}}
+{{#include exercise.rs:Value}}
 
-{{#include exercise.rs:Res}}
+{{#include exercise.rs:Expression}}
 
 {{#include exercise.rs:eval}}
     todo!()

--- a/src/pattern-matching/exercise.md
+++ b/src/pattern-matching/exercise.md
@@ -4,22 +4,7 @@ minutes: 30
 
 # Exercise: Expression Evaluation
 
-Let's write a simple recursive evaluator for arithmetic expressions. Start with
-an enum defining the binary operations:
-
-```rust
-{{#include exercise.rs:Operation}}
-
-{{#include exercise.rs:Expression}}
-
-{{#include exercise.rs:Res}}
-
-{{#include exercise.rs:eval}}
-    todo!()
-}
-
-{{#include exercise.rs:tests}}
-```
+Let's write a simple recursive evaluator for arithmetic expressions.
 
 The `Box` type here is a smart pointer, and will be covered in detail later in
 the course. An expression can be "boxed" with `Box::new` as seen in the tests.
@@ -44,3 +29,18 @@ fn test_value() { .. }
 
 If you finish early, try writing a test that results in an integer overflow.
 How could you handle this with `Res::Err` instead of a panic?
+
+```rust
+{{#include exercise.rs:Operation}}
+
+{{#include exercise.rs:Expression}}
+
+{{#include exercise.rs:Res}}
+
+{{#include exercise.rs:eval}}
+    todo!()
+}
+
+{{#include exercise.rs:tests}}
+```
+

--- a/src/pattern-matching/exercise.md
+++ b/src/pattern-matching/exercise.md
@@ -35,8 +35,6 @@ integer overflow. How could you handle this with `Result` instead of a panic?
 ```rust
 {{#include exercise.rs:Operation}}
 
-{{#include exercise.rs:Value}}
-
 {{#include exercise.rs:Expression}}
 
 {{#include exercise.rs:eval}}

--- a/src/pattern-matching/exercise.rs
+++ b/src/pattern-matching/exercise.rs
@@ -37,7 +37,7 @@ enum Value {
 // ANCHOR_END: Value
 
 // ANCHOR: Expression
-/// A numerical expression, in tree form.
+/// An expression, in tree form.
 #[derive(Debug)]
 enum Expression {
     /// An operation on two subexpressions.


### PR DESCRIPTION
This modifies the exercise to use the standard `Result` type, based on feedback that students could understand it sufficiently at this point in the course.

Addresses #1565.