### PR TITLE
Add back `apt update`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Install formatting dependencies
         run: |
+          sudo apt update
           sudo apt install gettext yapf3
 
       - name: Install nightly rustfmt
@@ -76,7 +77,9 @@ jobs:
         uses: ./.github/workflows/setup-rust-cache
 
       - name: Install dependencies
-        run: sudo apt install gcc-aarch64-linux-gnu
+        run: |
+          sudo apt update
+          sudo apt install gcc-aarch64-linux-gnu
 
       - name: Install toolchain
         run: rustup target add ${{ matrix.target }}
@@ -121,7 +124,9 @@ jobs:
         uses: ./.github/workflows/setup-rust-cache
 
       - name: Install Gettext
-        run: sudo apt install gettext
+        run: |
+          sudo apt update
+          sudo apt install gettext
 
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook


### PR DESCRIPTION
This reverts #1490 due to errors seen in https://github.com/google/comprehensive-rust/actions/runs/7188648811/job/19590765217. The error says

    Get:23 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libc6-dev-arm64-cross all 2.35-0ubuntu1cross3 [1546 kB]
    Fetched 41.7 MB in 1s (46.1 MB/s)
    E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.38-4ubuntu2.3_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
    E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
    Error: Process completed with exit code 100.

This seems less transient than the error which made us remove the `apt update` calls in #1490.