### PR TITLE
Rename test module into tests in smart pointer exercise

### DIFF
--- a/src/smart-pointers/exercise.rs
+++ b/src/smart-pointers/exercise.rs
@@ -85,7 +85,7 @@ fn main() {
 
 // ANCHOR: tests
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]


### PR DESCRIPTION
If I'm not mistaken, the naming convention for modules containing only tests is to call them `tests` (rather than `test`).