### PR TITLE
Remove unnecessary ref mut in binary tree exercise

### DIFF
--- a/src/smart-pointers/exercise.rs
+++ b/src/smart-pointers/exercise.rs
@@ -42,7 +42,7 @@ impl<T: Ord + Copy> BinaryTree<T> {
                     right: BinaryTree::new(),
                 }));
             }
-            Some(ref mut n) => {
+            Some(n) => {
                 if value < n.value {
                     n.left.insert(value);
                 } else if value > n.value {


### PR DESCRIPTION
There's no need for the `ref mut` in the pattern. So, let's just drop
it for the sake of simplicity.