### PR TITLE
Fix typo in lifetime annotations section

### DIFF
--- a/src/slices-and-lifetimes/lifetime-annotations.md
+++ b/src/slices-and-lifetimes/lifetime-annotations.md
@@ -19,7 +19,7 @@ ambiguity; the compiler verifies that there is a valid solution.
 Lifetimes become more complicated when considering passing values to and
 returning values from functions.
 
-```rust,eitable,compile_fail
+```rust,editable,compile_fail
 #[derive(Debug)]
 struct Point(i32, i32);
 


### PR DESCRIPTION
The code example was meant to be `editable` but was marked as
`eitable`.