### PR TITLE
Swap `Err` and `OtherErr`, it's `Err` that must implement `From`

### DIFF
--- a/src/error-handling/error.md
+++ b/src/error-handling/error.md
@@ -39,4 +39,10 @@ the program. As such it's generally not a good idea to use `Box<dyn Error>` in t
 library, but it can be a good option in a program where you just want to display the error message
 somewhere.
 
+Make sure to implement the `std::error::Error` trait when defining a custom
+error type so it can be boxed. But if you need to support the `no_std`
+attribute, keep in mind that the `std::error::Error` trait is currently
+compatible with `no_std` in
+[nightly](https://github.com/rust-lang/rust/issues/103765) only.
+
 </details>


### PR DESCRIPTION
It's clear from the above text and example that the error type returned by the outer function (`Err` in this case) must implement the `From` trait to accept the error returned by the inner function (`OtherErr` in this case).