### PR TITLE
Make protobuf exercise slightly easier

### DIFF
--- a/src/slices-and-lifetimes/exercise.md
+++ b/src/slices-and-lifetimes/exercise.md
@@ -48,11 +48,9 @@ What remains for you is to implement the `parse_field` function and the
 
 
 {{#include exercise.rs:parse_field }}
-    // 1. Read and unpack the tag, which is a varint.
-    // 2. Based on the wire type, build a Field, consuming as many bytes as
-    //    necessary.
-    // 3. Return the field, and any un-consumed bytes.
-    todo!()
+        _ => todo!("Based on the wire type, build a Field, consuming as many bytes as necessary.")
+    };
+    todo!("Return the field, and any un-consumed bytes.")
 }
 
 {{#include exercise.rs:parse_message }}

--- a/src/slices-and-lifetimes/exercise.rs
+++ b/src/slices-and-lifetimes/exercise.rs
@@ -135,10 +135,10 @@ fn unpack_tag(tag: u64) -> Result<(u64, WireType), Error> {
 // ANCHOR: parse_field
 /// Parse a field, returning the remaining bytes
 fn parse_field(data: &[u8]) -> Result<(Field, &[u8]), Error> {
-    // ANCHOR_END: parse_field
     let (tag, remainder) = parse_varint(data)?;
     let (field_num, wire_type) = unpack_tag(tag)?;
     let (fieldvalue, remainder) = match wire_type {
+        // ANCHOR_END: parse_field
         WireType::Varint => {
             let (value, remainder) = parse_varint(remainder)?;
             (FieldValue::Varint(value), remainder)


### PR DESCRIPTION
As @djmitche suggested in
https://github.com/google/comprehensive-rust/pull/1591#pullrequestreview-1782012715
it might be a little easier for the students if we give them a prefix of
the code required for `parse_field`. That's exactly what we do here.