### PR TITLE
ja: refresh ja.po file

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -1390,8 +1390,8 @@ msgstr "前提知識"
 #, fuzzy
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically-typed language and we will sometimes make comparisons with C and C"
-"++ to better explain or contrast the Rust approach."
+"statically-typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
 "本講座では、既にプログラミングの知識がある事を前提としています。Rustは静的型"
 "付け言語であり、Rustのアプローチをより分かりやすく説明するために、時折CやC+"
@@ -1442,8 +1442,8 @@ msgid ""
 "Make yourself familiar with the course material. We've included speaker "
 "notes to help highlight the key points (please help us by contributing more "
 "speaker notes!). When presenting, you should make sure to open the speaker "
-"notes in a popup (click the link with a little arrow next to \"Speaker Notes"
-"\"). This way you have a clean screen to present to the class."
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
 "資料に慣れておいてください。要点を強調するためにスピーカーノートが用意されて"
 "います（内容の追加にご協力ください！）。プレゼン時には、スクリーンを見やすい"
@@ -3100,9 +3100,9 @@ msgstr ""
 
 #: src/types-and-values/strings.md:41
 msgid ""
-"Raw strings allow you to create a `&str` value with escapes disabled: `r\"\\n"
-"\" == \"\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on either side of the quotes:"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
 
 #: src/types-and-values/inference.md:3
@@ -4561,9 +4561,9 @@ msgstr ""
 #: src/user-defined-types/enums.md:45
 msgid ""
 "If the allowed variant values do not cover all bit patterns, it will use "
-"invalid bit patterns to encode the discriminant (the \"niche optimization"
-"\"). For example, `Option<&u8>` stores either a pointer to an integer or "
-"`NULL` for the `None` variant."
+"invalid bit patterns to encode the discriminant (the \"niche "
+"optimization\"). For example, `Option<&u8>` stores either a pointer to an "
+"integer or `NULL` for the `None` variant."
 msgstr ""
 
 #: src/user-defined-types/enums.md:49
@@ -5577,9 +5577,9 @@ msgid ""
 msgstr ""
 "ファットポインタはdouble-widthポインタです。これは二つの要素からなります：実"
 "際のオブジェクトへのポインタと、そのオブジェクトの`Pet`の実装のための[仮想関"
-"数テーブル](https://ja.wikipedia.org/wiki/%E4%BB%AE"
-"%E6%83%B3%E9%96%A2%E6%95%B0%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB) (vtable)で"
-"す。"
+"数テーブル](https://ja.wikipedia.org/wiki/"
+"%E4%BB%AE%E6%83%B3%E9%96%A2%E6%95%B0%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB) "
+"(vtable)です。"
 
 #: src/methods-and-traits/trait-objects.md:87
 msgid ""
@@ -6582,9 +6582,9 @@ msgstr ""
 #: src/std-types/hashmap.md:55
 msgid ""
 "Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
-"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C"
-"%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows us to "
-"easily initialize a hash map from a literal array:"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
 msgstr ""
 
 #: src/std-types/hashmap.md:65
@@ -8332,8 +8332,8 @@ msgstr ""
 
 #: src/borrowing/exercise.md:51
 msgid ""
-"\"Update a user's statistics based on measurements from a visit to the doctor"
-"\""
+"\"Update a user's statistics based on measurements from a visit to the "
+"doctor\""
 msgstr ""
 
 #: src/borrowing/exercise.md:56 src/borrowing/exercise.md:62
@@ -9178,8 +9178,9 @@ msgstr ""
 
 #: src/modules/filesystem.md:18
 msgid ""
-"Modules defined in files can be documented, too, using \"inner doc comments"
-"\". These document the item that contains them -- in this case, a module."
+"Modules defined in files can be documented, too, using \"inner doc "
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 
 #: src/modules/filesystem.md:22
@@ -13797,8 +13798,8 @@ msgstr ""
 
 #: src/exercises/chromium/interoperability-with-cpp.md:27
 msgid ""
-"You may also need to `#include \"third_party/rust/cxx/v1/crate/include/cxx.h"
-"\"`"
+"You may also need to `#include \"third_party/rust/cxx/v1/crate/include/cxx."
+"h\"`"
 msgstr ""
 
 #: src/exercises/chromium/interoperability-with-cpp.md:29
@@ -14263,8 +14264,8 @@ msgstr ""
 msgid ""
 "```bob\n"
 "                     +------------+      +----------------------+\n"
-"\"//third_party/rust\" | crate name | \"/v\" | major semver version | \":lib"
-"\"\n"
+"\"//third_party/rust\" | crate name | \"/v\" | major semver version | \":"
+"lib\"\n"
 "                     +------------+      +----------------------+\n"
 "```"
 msgstr ""
@@ -14824,8 +14825,8 @@ msgid ""
 "The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
 "in this case it can allocate regions of up to 2\\*\\*32 bytes."
 msgstr ""
-"パラメータ定数`LockedHeap`はアロケータの最大オーダを示します。この場合、2\\*"
-"\\*32バイトの領域を確保することが可能です。"
+"パラメータ定数`LockedHeap`はアロケータの最大オーダを示します。この場合、"
+"2\\*\\*32バイトの領域を確保することが可能です。"
 
 #: src/bare-metal/alloc.md:42
 msgid ""
@@ -18400,11 +18401,11 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:41
 msgid ""
-"If the thread that held the `Mutex` panicked, the `Mutex` becomes \"poisoned"
-"\" to signal that the data it protected might be in an inconsistent state. "
-"Calling `lock()` on a poisoned mutex fails with a [`PoisonError`](https://"
-"doc.rust-lang.org/std/sync/struct.PoisonError.html). You can call "
-"`into_inner()` on the error to recover the data regardless."
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:3
@@ -18630,8 +18631,8 @@ msgid ""
 "publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls"
-"\"] }\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -19826,8 +19827,8 @@ msgid ""
 "futures-util = { version = \"0.3.30\", features = [\"sink\"] }\n"
 "http = \"1.0.0\"\n"
 "tokio = { version = \"1.28.1\", features = [\"full\"] }\n"
-"tokio-websockets = { version = \"0.5.0\", features = [\"client\", \"fastrand"
-"\", \"server\", \"sha1_smol\"] }\n"
+"tokio-websockets = { version = \"0.5.0\", features = [\"client\", "
+"\"fastrand\", \"server\", \"sha1_smol\"] }\n"
 "```"
 msgstr ""
 
@@ -20034,8 +20035,8 @@ msgstr ""
 
 #: src/thanks.md:3
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
-"it was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
 msgstr ""
 
 #: src/thanks.md:6

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2023-10-15T23:41:50Z\n"
+"POT-Creation-Date: 2024-01-08T14:58:00+09:00\n"
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.3.2\n"
 
-#: src/SUMMARY.md:4 src/index.md:1
+#: src/SUMMARY.md:3 src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr ""
 
@@ -48,993 +48,1204 @@ msgstr ""
 msgid "Running Cargo Locally"
 msgstr "ローカル環境での実行"
 
-#: src/SUMMARY.md:15
+#: src/SUMMARY.md:16
 msgid "Day 1: Morning"
 msgstr "Day 1： AM"
 
-#: src/SUMMARY.md:19 src/SUMMARY.md:80 src/SUMMARY.md:135 src/SUMMARY.md:193
-#: src/SUMMARY.md:219 src/SUMMARY.md:269
+#: src/SUMMARY.md:18 src/SUMMARY.md:44 src/SUMMARY.md:70 src/SUMMARY.md:93
+#: src/SUMMARY.md:119 src/SUMMARY.md:138 src/SUMMARY.md:158 src/SUMMARY.md:184
+#: src/SUMMARY.md:207 src/SUMMARY.md:244 src/SUMMARY.md:286 src/SUMMARY.md:337
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/SUMMARY.md:20 src/welcome-day-1/what-is-rust.md:1
+#: src/SUMMARY.md:19 src/SUMMARY.md:21 src/hello-world.md:1
+#: src/hello-world/hello-world.md:1
+msgid "Hello, World"
+msgstr ""
+
+#: src/SUMMARY.md:20 src/hello-world/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Rustとは？"
 
-#: src/SUMMARY.md:21 src/hello-world.md:1
-msgid "Hello World!"
+#: src/SUMMARY.md:22 src/hello-world/benefits.md:1
+msgid "Benefits of Rust"
 msgstr ""
 
-#: src/SUMMARY.md:22 src/hello-world/small-example.md:1
-msgid "Small Example"
-msgstr "プログラムの例"
-
-#: src/SUMMARY.md:23 src/why-rust.md:1
-msgid "Why Rust?"
+#: src/SUMMARY.md:23 src/hello-world/playground.md:1
+msgid "Playground"
 msgstr ""
 
-#: src/SUMMARY.md:24 src/why-rust/an-example-in-c.md:1 src/credits.md:32
+#: src/SUMMARY.md:24 src/types-and-values.md:1
+msgid "Types and Values"
+msgstr ""
+
+#: src/SUMMARY.md:25 src/types-and-values/variables.md:1
+msgid "Variables"
+msgstr "変数"
+
+#: src/SUMMARY.md:26 src/types-and-values/values.md:1
+msgid "Values"
+msgstr ""
+
+#: src/SUMMARY.md:27 src/types-and-values/arithmetic.md:1
+msgid "Arithmetic"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/types-and-values/strings.md:1
+msgid "Strings"
+msgstr ""
+
+#: src/SUMMARY.md:29 src/types-and-values/inference.md:1
+msgid "Type Inference"
+msgstr "型推論"
+
+#: src/SUMMARY.md:30 src/types-and-values/exercise.md:1
+msgid "Exercise: Fibonacci"
+msgstr ""
+
+#: src/SUMMARY.md:31 src/SUMMARY.md:40 src/SUMMARY.md:51 src/SUMMARY.md:56
+#: src/SUMMARY.md:64 src/SUMMARY.md:75 src/SUMMARY.md:82 src/SUMMARY.md:89
+#: src/SUMMARY.md:103 src/SUMMARY.md:113 src/SUMMARY.md:129 src/SUMMARY.md:134
+#: src/SUMMARY.md:144 src/SUMMARY.md:152 src/SUMMARY.md:164 src/SUMMARY.md:171
+#: src/SUMMARY.md:180 src/SUMMARY.md:192 src/SUMMARY.md:201
+#: src/types-and-values/solution.md:1 src/control-flow-basics/solution.md:1
+#: src/tuples-and-arrays/solution.md:1 src/references/solution.md:1
+#: src/user-defined-types/solution.md:1 src/pattern-matching/solution.md:1
+#: src/methods-and-traits/solution.md:1 src/generics/solution.md:1
+#: src/std-types/solution.md:1 src/std-traits/solution.md:1
+#: src/memory-management/solution.md:1 src/smart-pointers/solution.md:1
+#: src/borrowing/solution.md:1 src/slices-and-lifetimes/solution.md:1
+#: src/iterators/solution.md:1 src/modules/solution.md:1
+#: src/testing/solution.md:1 src/error-handling/solution.md:1
+#: src/unsafe-rust/solution.md:1
 #, fuzzy
-msgid "An Example in C"
-msgstr "例"
+msgid "Solution"
+msgstr "解答"
 
-#: src/SUMMARY.md:25 src/why-rust/compile-time.md:1
-msgid "Compile Time Guarantees"
-msgstr "コンパイル時の保証"
+#: src/SUMMARY.md:32 src/control-flow-basics.md:1
+#, fuzzy
+msgid "Control Flow Basics"
+msgstr "制御フロー"
 
-#: src/SUMMARY.md:26 src/why-rust/runtime.md:1
-msgid "Runtime Guarantees"
-msgstr "実行時の保証"
-
-#: src/SUMMARY.md:27 src/why-rust/modern.md:1
-msgid "Modern Features"
-msgstr "現代的な機能"
-
-#: src/SUMMARY.md:28 src/basic-syntax.md:1
-msgid "Basic Syntax"
+#: src/SUMMARY.md:33 src/control-flow-basics/conditionals.md:1
+msgid "Conditionals"
 msgstr ""
 
-#: src/SUMMARY.md:29 src/basic-syntax/scalar-types.md:1
-msgid "Scalar Types"
+#: src/SUMMARY.md:34 src/control-flow-basics/loops.md:1
+msgid "Loops"
 msgstr ""
 
-#: src/SUMMARY.md:30 src/basic-syntax/compound-types.md:1
-msgid "Compound Types"
+#: src/SUMMARY.md:35 src/control-flow-basics/break-continue.md:1
+msgid "`break` and `continue`"
+msgstr "`break` と `continue`"
+
+#: src/SUMMARY.md:36 src/control-flow-basics/blocks-and-scopes.md:1
+msgid "Blocks and Scopes"
 msgstr ""
 
-#: src/SUMMARY.md:31 src/basic-syntax/references.md:1
-msgid "References"
-msgstr ""
-
-#: src/SUMMARY.md:32 src/basic-syntax/references-dangling.md:1
-msgid "Dangling References"
-msgstr ""
-
-#: src/SUMMARY.md:33 src/basic-syntax/slices.md:1
-msgid "Slices"
-msgstr "スライス型"
-
-#: src/SUMMARY.md:34
-msgid "String vs str"
-msgstr "文字列（String） vs 文字列スライス（str）"
-
-#: src/SUMMARY.md:35 src/basic-syntax/functions.md:1
+#: src/SUMMARY.md:37 src/control-flow-basics/functions.md:1
 msgid "Functions"
 msgstr "関数"
 
-#: src/SUMMARY.md:36 src/basic-syntax/rustdoc.md:1
-msgid "Rustdoc"
-msgstr "Rustdoc"
+#: src/SUMMARY.md:38 src/control-flow-basics/macros.md:1
+msgid "Macros"
+msgstr ""
 
-#: src/SUMMARY.md:37 src/SUMMARY.md:103 src/basic-syntax/methods.md:1
-#: src/methods.md:1
+#: src/SUMMARY.md:39 src/control-flow-basics/exercise.md:1
+msgid "Exercise: Collatz Sequence"
+msgstr ""
+
+#: src/SUMMARY.md:42
+msgid "Day 1: Afternoon"
+msgstr "Day 1： PM"
+
+#: src/SUMMARY.md:45 src/SUMMARY.md:46 src/tuples-and-arrays.md:1
+#: src/tuples-and-arrays/tuples-and-arrays.md:1
+msgid "Tuples and Arrays"
+msgstr ""
+
+#: src/SUMMARY.md:47 src/tuples-and-arrays/iteration.md:1
+#, fuzzy
+msgid "Array Iteration"
+msgstr "Cargoとのインテグレーション"
+
+#: src/SUMMARY.md:48 src/SUMMARY.md:71 src/tuples-and-arrays/match.md:1
+#: src/pattern-matching.md:1
+msgid "Pattern Matching"
+msgstr "パターンマッチング"
+
+#: src/SUMMARY.md:49 src/SUMMARY.md:72 src/tuples-and-arrays/destructuring.md:1
+#: src/pattern-matching/destructuring.md:1
+#, fuzzy
+msgid "Destructuring"
+msgstr "列挙型編"
+
+#: src/SUMMARY.md:50 src/tuples-and-arrays/exercise.md:1
+msgid "Exercise: Nested Arrays"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/references.md:1
+msgid "References"
+msgstr ""
+
+#: src/SUMMARY.md:53 src/references/shared.md:1
+msgid "Shared References"
+msgstr ""
+
+#: src/SUMMARY.md:54 src/references/exclusive.md:1
+msgid "Exclusive References"
+msgstr ""
+
+#: src/SUMMARY.md:55 src/references/exercise.md:1
+msgid "Exercise: Geometry"
+msgstr ""
+
+#: src/SUMMARY.md:57 src/user-defined-types.md:1
+msgid "User-Defined Types"
+msgstr ""
+
+#: src/SUMMARY.md:58 src/user-defined-types/named-structs.md:1
+#, fuzzy
+msgid "Named Structs"
+msgstr "構造体（structs）"
+
+#: src/SUMMARY.md:59 src/user-defined-types/tuple-structs.md:5
+msgid "Tuple Structs"
+msgstr "タプル構造体"
+
+#: src/SUMMARY.md:60 src/user-defined-types/enums.md:1
+#: src/pattern-matching/destructuring.md:24
+#: src/pattern-matching/destructuring.md:67
+msgid "Enums"
+msgstr "列挙型（enums）"
+
+#: src/SUMMARY.md:61 src/user-defined-types/static-and-const.md:1
+#, fuzzy
+msgid "Static and Const"
+msgstr "static & const"
+
+#: src/SUMMARY.md:62 src/user-defined-types/aliases.md:1
+msgid "Type Aliases"
+msgstr ""
+
+#: src/SUMMARY.md:63 src/user-defined-types/exercise.md:1
+msgid "Exercise: Elevator Events"
+msgstr ""
+
+#: src/SUMMARY.md:68
+msgid "Day 2: Morning"
+msgstr "Day 2： AM"
+
+#: src/SUMMARY.md:73 src/pattern-matching/let-control-flow.md:1
+#, fuzzy
+msgid "Let Control Flow"
+msgstr "制御フロー"
+
+#: src/SUMMARY.md:74 src/pattern-matching/exercise.md:1
+msgid "Exercise: Expression Evaluation"
+msgstr ""
+
+#: src/SUMMARY.md:76 src/methods-and-traits.md:1
+#, fuzzy
+msgid "Methods and Traits"
+msgstr "ReadとWrite"
+
+#: src/SUMMARY.md:77 src/methods-and-traits/methods.md:1
 msgid "Methods"
 msgstr "メソッド"
 
-#: src/SUMMARY.md:38
-msgid "Overloading"
-msgstr "オーバーロード"
+#: src/SUMMARY.md:78 src/methods-and-traits/traits.md:1
+msgid "Traits"
+msgstr "トレイト（trait）"
 
-#: src/SUMMARY.md:39 src/SUMMARY.md:72 src/SUMMARY.md:106 src/SUMMARY.md:126
-#: src/SUMMARY.md:155 src/SUMMARY.md:185 src/SUMMARY.md:212 src/SUMMARY.md:233
-#: src/SUMMARY.md:261 src/SUMMARY.md:283 src/SUMMARY.md:304
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/SUMMARY.md:79 src/methods-and-traits/deriving.md:1
+#, fuzzy
+msgid "Deriving"
+msgstr "トレイトの導出"
+
+#: src/SUMMARY.md:80 src/methods-and-traits/trait-objects.md:1
+msgid "Trait Objects"
+msgstr "トレイトオブジェクト"
+
+#: src/SUMMARY.md:81 src/methods-and-traits/exercise.md:1
+#, fuzzy
+msgid "Exercise: GUI Library"
+msgstr "GUIライブラリ"
+
+#: src/SUMMARY.md:83 src/generics.md:1
+msgid "Generics"
+msgstr "ジェネリクス（generics）"
+
+#: src/SUMMARY.md:84 src/generics/generic-functions.md:1
+#, fuzzy
+msgid "Generic Functions"
+msgstr "Extern関数"
+
+#: src/SUMMARY.md:85 src/generics/generic-data.md:1
+msgid "Generic Data Types"
+msgstr "ジェネリックデータ型"
+
+#: src/SUMMARY.md:86 src/generics/trait-bounds.md:1
+msgid "Trait Bounds"
+msgstr "トレイト制約"
+
+#: src/SUMMARY.md:87 src/generics/impl-trait.md:1
+msgid "`impl Trait`"
+msgstr ""
+
+#: src/SUMMARY.md:88 src/generics/exercise.md:1
+msgid "Exercise: Generic `min`"
+msgstr ""
+
+#: src/SUMMARY.md:91
+msgid "Day 2: Afternoon"
+msgstr "Day 2： PM"
+
+#: src/SUMMARY.md:94 src/std-types.md:1
+#, fuzzy
+msgid "Standard Library Types"
+msgstr "標準ライブラリ"
+
+#: src/SUMMARY.md:95 src/std-types/std.md:1
+msgid "Standard Library"
+msgstr "標準ライブラリ"
+
+#: src/SUMMARY.md:96 src/std-types/docs.md:1
+#, fuzzy
+msgid "Documentation"
+msgstr "ドキュメンテーションテスト"
+
+#: src/SUMMARY.md:97
+msgid "`Option`"
+msgstr ""
+
+#: src/SUMMARY.md:98
+msgid "`Result`"
+msgstr ""
+
+#: src/SUMMARY.md:99 src/android/interoperability/cpp/type-mapping.md:5
+#, fuzzy
+msgid "`String`"
+msgstr "文字列（String）"
+
+#: src/SUMMARY.md:100 src/std-types/vec.md:1
+msgid "`Vec`"
+msgstr ""
+
+#: src/SUMMARY.md:101 src/std-types/hashmap.md:1 src/bare-metal/no_std.md:46
+msgid "`HashMap`"
+msgstr ""
+
+#: src/SUMMARY.md:102 src/std-types/exercise.md:1
+#, fuzzy
+msgid "Exercise: Counter"
+msgstr "練習問題"
+
+#: src/SUMMARY.md:104 src/std-traits.md:1
+#, fuzzy
+msgid "Standard Library Traits"
+msgstr "標準ライブラリ"
+
+#: src/SUMMARY.md:105 src/std-traits/comparisons.md:1 src/async.md:17
+msgid "Comparisons"
+msgstr "他の言語との比較"
+
+#: src/SUMMARY.md:106 src/std-traits/operators.md:1
+#, fuzzy
+msgid "Operators"
+msgstr "Iterator"
+
+#: src/SUMMARY.md:107 src/std-traits/from-and-into.md:1
+msgid "`From` and `Into`"
+msgstr ""
+
+#: src/SUMMARY.md:108 src/std-traits/casting.md:1
+#, fuzzy
+msgid "Casting"
+msgstr "テスト"
+
+#: src/SUMMARY.md:109 src/std-traits/read-and-write.md:1
+msgid "`Read` and `Write`"
+msgstr ""
+
+#: src/SUMMARY.md:110
+msgid "`Default`, struct update syntax"
+msgstr ""
+
+#: src/SUMMARY.md:111 src/std-traits/closures.md:1
+msgid "Closures"
+msgstr ""
+
+#: src/SUMMARY.md:112 src/std-traits/exercise.md:1
+#, fuzzy
+msgid "Exercise: ROT13"
+msgstr "練習問題"
+
+#: src/SUMMARY.md:117
+msgid "Day 3: Morning"
+msgstr "Day 3： AM"
+
+#: src/SUMMARY.md:120 src/memory-management.md:1
+msgid "Memory Management"
+msgstr "メモリ管理"
+
+#: src/SUMMARY.md:121 src/memory-management/review.md:1
+msgid "Review of Program Memory"
+msgstr ""
+
+#: src/SUMMARY.md:122 src/memory-management/approaches.md:1
+#, fuzzy
+msgid "Approaches to Memory Management"
+msgstr "Rustのメモリ管理"
+
+#: src/SUMMARY.md:123 src/memory-management/ownership.md:1
+msgid "Ownership"
+msgstr "所有権"
+
+#: src/SUMMARY.md:124 src/memory-management/move.md:1
+msgid "Move Semantics"
+msgstr "ムーブセマンティクス"
+
+#: src/SUMMARY.md:125
+msgid "`Clone`"
+msgstr ""
+
+#: src/SUMMARY.md:126 src/memory-management/copy-types.md:5
+msgid "Copy Types"
+msgstr ""
+
+#: src/SUMMARY.md:127
+#, fuzzy
+msgid "`Drop`"
+msgstr "Drop"
+
+#: src/SUMMARY.md:128 src/memory-management/exercise.md:1
+msgid "Exercise: Builder Type"
+msgstr ""
+
+#: src/SUMMARY.md:130 src/smart-pointers.md:1
+msgid "Smart Pointers"
+msgstr ""
+
+#: src/SUMMARY.md:131 src/smart-pointers/box.md:1
+#: src/android/interoperability/cpp/type-mapping.md:9
+msgid "`Box<T>`"
+msgstr ""
+
+#: src/SUMMARY.md:132 src/smart-pointers/rc.md:1
+msgid "`Rc`"
+msgstr ""
+
+#: src/SUMMARY.md:133 src/smart-pointers/exercise.md:1
+msgid "Exercise: Binary Tree"
+msgstr ""
+
+#: src/SUMMARY.md:136
+msgid "Day 3: Afternoon"
+msgstr "Day 3： PM"
+
+#: src/SUMMARY.md:139 src/borrowing.md:1
+msgid "Borrowing"
+msgstr "借用"
+
+#: src/SUMMARY.md:140 src/borrowing/shared.md:1
+#, fuzzy
+msgid "Borrowing a Value"
+msgstr "借用"
+
+#: src/SUMMARY.md:141 src/borrowing/borrowck.md:1
+#, fuzzy
+msgid "Borrow Checking"
+msgstr "借用"
+
+#: src/SUMMARY.md:142 src/borrowing/interior-mutability.md:5
+#, fuzzy
+msgid "Interior Mutability"
+msgstr "相互運用性"
+
+#: src/SUMMARY.md:143 src/borrowing/exercise.md:1
+#, fuzzy
+msgid "Exercise: Health Statistics"
+msgstr "健康統計"
+
+#: src/SUMMARY.md:145 src/slices-and-lifetimes.md:1
+#, fuzzy
+msgid "Slices and Lifetimes"
+msgstr "ライフタイム"
+
+#: src/SUMMARY.md:146
+#, fuzzy
+msgid "Slices: `&[T]`"
+msgstr "スライス型"
+
+#: src/SUMMARY.md:147 src/slices-and-lifetimes/str.md:5
+#, fuzzy
+msgid "String References"
+msgstr "型推論"
+
+#: src/SUMMARY.md:148 src/slices-and-lifetimes/lifetime-annotations.md:1
+#, fuzzy
+msgid "Lifetime Annotations"
+msgstr "関数とライフタイム"
+
+#: src/SUMMARY.md:149
+#, fuzzy
+msgid "Lifetime Elision"
+msgstr "ライフタイム"
+
+#: src/SUMMARY.md:150
+#, fuzzy
+msgid "Struct Lifetimes"
+msgstr "ライフタイム"
+
+#: src/SUMMARY.md:151 src/slices-and-lifetimes/exercise.md:1
+msgid "Exercise: Protobuf Parsing"
+msgstr ""
+
+#: src/SUMMARY.md:156
+#, fuzzy
+msgid "Day 4: Morning"
+msgstr "Day 1： AM"
+
+#: src/SUMMARY.md:159 src/iterators.md:1
+msgid "Iterators"
+msgstr ""
+
+#: src/SUMMARY.md:160 src/iterators/iterator.md:5 src/bare-metal/no_std.md:28
+msgid "`Iterator`"
+msgstr ""
+
+#: src/SUMMARY.md:161 src/iterators/intoiterator.md:1
+msgid "`IntoIterator`"
+msgstr ""
+
+#: src/SUMMARY.md:162
+#, fuzzy
+msgid "`FromIterator`"
+msgstr "FromIterator"
+
+#: src/SUMMARY.md:163 src/iterators/exercise.md:1
+msgid "Exercise: Iterator Method Chaining"
+msgstr ""
+
+#: src/SUMMARY.md:165 src/SUMMARY.md:166 src/modules.md:1
+#: src/modules/modules.md:1
+msgid "Modules"
+msgstr "モジュール"
+
+#: src/SUMMARY.md:167 src/modules/filesystem.md:1
+msgid "Filesystem Hierarchy"
+msgstr "ファイルシステム階層"
+
+#: src/SUMMARY.md:168 src/modules/visibility.md:1
+msgid "Visibility"
+msgstr "可視性"
+
+#: src/SUMMARY.md:169
+msgid "`use`, `super`, `self`"
+msgstr ""
+
+#: src/SUMMARY.md:170 src/modules/exercise.md:1
+msgid "Exercise: Modules for the GUI Library"
+msgstr ""
+
+#: src/SUMMARY.md:172 src/SUMMARY.md:253 src/testing.md:1
+#: src/chromium/testing.md:1
+msgid "Testing"
+msgstr "テスト"
+
+#: src/SUMMARY.md:173
+msgid "Test Modules"
+msgstr "テストモジュール"
+
+#: src/SUMMARY.md:174 src/testing/other.md:1
+#, fuzzy
+msgid "Other Types of Tests"
+msgstr "他のプロジェクト"
+
+#: src/SUMMARY.md:175 src/SUMMARY.md:321 src/testing/useful-crates.md:1
+msgid "Useful Crates"
+msgstr "便利クレート"
+
+#: src/SUMMARY.md:176 src/testing/googletest.md:1
+msgid "GoogleTest"
+msgstr ""
+
+#: src/SUMMARY.md:177 src/testing/mocking.md:1
+msgid "Mocking"
+msgstr ""
+
+#: src/SUMMARY.md:178 src/testing/lints.md:1
+msgid "Compiler Lints and Clippy"
+msgstr ""
+
+#: src/SUMMARY.md:179 src/testing/exercise.md:1
+#, fuzzy
+msgid "Exercise: Luhn Algorithm"
+msgstr "Luhnアルゴリズム"
+
+#: src/SUMMARY.md:182
+#, fuzzy
+msgid "Day 4: Afternoon"
+msgstr "Day 1： PM"
+
+#: src/SUMMARY.md:185 src/error-handling.md:1
+msgid "Error Handling"
+msgstr "エラー処理"
+
+#: src/SUMMARY.md:186 src/error-handling/panics.md:1
+msgid "Panics"
+msgstr "パニック（panic）"
+
+#: src/SUMMARY.md:187 src/error-handling/try.md:1
+#, fuzzy
+msgid "Try Operator"
+msgstr "Iterator"
+
+#: src/SUMMARY.md:188 src/error-handling/try-conversions.md:1
+#, fuzzy
+msgid "Try Conversions"
+msgstr "暗黙的な型変換"
+
+#: src/SUMMARY.md:189
+#, fuzzy
+msgid "`Error` Trait"
+msgstr "他のトレイト"
+
+#: src/SUMMARY.md:190 src/error-handling/thiserror-and-anyhow.md:1
+msgid "`thiserror` and `anyhow`"
+msgstr ""
+
+#: src/SUMMARY.md:191
+msgid "Exercise: Rewriting with `Result`"
+msgstr ""
+
+#: src/SUMMARY.md:193 src/unsafe-rust.md:1 src/unsafe-rust/unsafe.md:1
+msgid "Unsafe Rust"
+msgstr "Unsafe Rust"
+
+#: src/SUMMARY.md:194
+#, fuzzy
+msgid "Unsafe"
+msgstr "Unsafe Rust"
+
+#: src/SUMMARY.md:195 src/unsafe-rust/dereferencing.md:1
+msgid "Dereferencing Raw Pointers"
+msgstr "生ポインタの参照外し"
+
+#: src/SUMMARY.md:196 src/unsafe-rust/mutable-static.md:1
+msgid "Mutable Static Variables"
+msgstr "可変なstatic変数"
+
+#: src/SUMMARY.md:197 src/unsafe-rust/unions.md:1
+msgid "Unions"
+msgstr "共用体"
+
+#: src/SUMMARY.md:198 src/unsafe-rust/unsafe-functions.md:1
+#, fuzzy
+msgid "Unsafe Functions"
+msgstr "Unsafe関数の呼び出し"
+
+#: src/SUMMARY.md:199
+#, fuzzy
+msgid "Unsafe Traits"
+msgstr "Unsafeなトレイトの実装"
+
+#: src/SUMMARY.md:200
+#, fuzzy
+msgid "Exercise: FFI Wrapper"
+msgstr "安全なFFIラッパ"
+
+#: src/SUMMARY.md:203 src/SUMMARY.md:327 src/bare-metal/android.md:1
+msgid "Android"
+msgstr "Android"
+
+#: src/SUMMARY.md:208 src/SUMMARY.md:245 src/android/setup.md:1
+#: src/chromium/setup.md:1
+msgid "Setup"
+msgstr "セットアップ"
+
+#: src/SUMMARY.md:209 src/SUMMARY.md:248 src/android/build-rules.md:1
+msgid "Build Rules"
+msgstr "ビルドのルール"
+
+#: src/SUMMARY.md:210
+msgid "Binary"
+msgstr "バイナリ"
+
+#: src/SUMMARY.md:211
+msgid "Library"
+msgstr "ライブラリ"
+
+#: src/SUMMARY.md:212 src/android/aidl.md:1
+msgid "AIDL"
+msgstr "AIDL（Androidインターフェイス定義言語）"
+
+#: src/SUMMARY.md:213
+msgid "Interface"
+msgstr "インターフェイス"
+
+#: src/SUMMARY.md:214
+msgid "Implementation"
+msgstr "実装"
+
+#: src/SUMMARY.md:215
+msgid "Server"
+msgstr "サーバ"
+
+#: src/SUMMARY.md:216 src/android/aidl/deploy.md:1
+msgid "Deploy"
+msgstr "デプロイ"
+
+#: src/SUMMARY.md:217
+msgid "Client"
+msgstr "クライアント"
+
+#: src/SUMMARY.md:218 src/android/aidl/changing.md:1
+msgid "Changing API"
+msgstr "APIの変更"
+
+#: src/SUMMARY.md:219 src/SUMMARY.md:317 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
+msgid "Logging"
+msgstr "ログ出力"
+
+#: src/SUMMARY.md:220 src/android/interoperability.md:1
+msgid "Interoperability"
+msgstr "相互運用性"
+
+#: src/SUMMARY.md:221
+msgid "With C"
+msgstr "C"
+
+#: src/SUMMARY.md:222
+msgid "Calling C with Bindgen"
+msgstr "BindgenによるCの呼び出し"
+
+#: src/SUMMARY.md:223
+msgid "Calling Rust from C"
+msgstr "CからRust呼び出し"
+
+#: src/SUMMARY.md:224
+#, fuzzy
+msgid "With C++)"
+msgstr "C++"
+
+#: src/SUMMARY.md:225 src/android/interoperability/cpp/bridge.md:1
+#, fuzzy
+msgid "The Bridge Module"
+msgstr "テストモジュール"
+
+#: src/SUMMARY.md:226
+#, fuzzy
+msgid "Rust Bridge"
+msgstr "Android"
+
+#: src/SUMMARY.md:227 src/android/interoperability/cpp/generated-cpp.md:1
+msgid "Generated C++"
+msgstr ""
+
+#: src/SUMMARY.md:228
+msgid "C++ Bridge"
+msgstr ""
+
+#: src/SUMMARY.md:229 src/android/interoperability/cpp/shared-types.md:1
+#, fuzzy
+msgid "Shared Types"
+msgstr "状態共有"
+
+#: src/SUMMARY.md:230 src/android/interoperability/cpp/shared-enums.md:1
+msgid "Shared Enums"
+msgstr ""
+
+#: src/SUMMARY.md:231 src/android/interoperability/cpp/rust-result.md:1
+#, fuzzy
+msgid "Rust Error Handling"
+msgstr "エラー処理"
+
+#: src/SUMMARY.md:232 src/android/interoperability/cpp/cpp-exception.md:1
+#, fuzzy
+msgid "C++ Error Handling"
+msgstr "エラー処理"
+
+#: src/SUMMARY.md:233 src/android/interoperability/cpp/type-mapping.md:1
+msgid "Additional Types"
+msgstr ""
+
+#: src/SUMMARY.md:234
+msgid "Building for Android: C++"
+msgstr ""
+
+#: src/SUMMARY.md:235
+msgid "Building for Android: Genrules"
+msgstr ""
+
+#: src/SUMMARY.md:236
+msgid "Building for Android: Rust"
+msgstr ""
+
+#: src/SUMMARY.md:237
+msgid "With Java"
+msgstr "Java"
+
+#: src/SUMMARY.md:238 src/SUMMARY.md:300 src/SUMMARY.md:329 src/SUMMARY.md:351
+#: src/SUMMARY.md:373 src/exercises/android/morning.md:1
+#: src/exercises/bare-metal/morning.md:1
 #: src/exercises/bare-metal/afternoon.md:1
 #: src/exercises/concurrency/morning.md:1
 #: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "練習問題"
 
-#: src/SUMMARY.md:40 src/exercises/day-1/implicit-conversions.md:1
-msgid "Implicit Conversions"
-msgstr "暗黙的な型変換"
-
-#: src/SUMMARY.md:41
-msgid "Arrays and for Loops"
-msgstr "配列とforループ"
-
-#: src/SUMMARY.md:43
-msgid "Day 1: Afternoon"
-msgstr "Day 1： PM"
-
-#: src/SUMMARY.md:45 src/SUMMARY.md:296 src/control-flow.md:1
-msgid "Control Flow"
-msgstr "制御フロー"
-
-#: src/SUMMARY.md:46 src/control-flow/blocks.md:1
-msgid "Blocks"
-msgstr "コードブロック"
-
-#: src/SUMMARY.md:47
-msgid "if expressions"
-msgstr "if式"
-
-#: src/SUMMARY.md:48
-msgid "for expressions"
-msgstr "for式"
-
-#: src/SUMMARY.md:49
-msgid "while expressions"
-msgstr "while式"
-
-#: src/SUMMARY.md:50
-msgid "break & continue"
-msgstr "break & continue"
-
-#: src/SUMMARY.md:51
-msgid "loop expressions"
-msgstr "loop式"
-
-#: src/SUMMARY.md:53 src/basic-syntax/variables.md:1
-msgid "Variables"
-msgstr "変数"
-
-#: src/SUMMARY.md:54 src/basic-syntax/type-inference.md:1
-msgid "Type Inference"
-msgstr "型推論"
-
-#: src/SUMMARY.md:55
-msgid "static & const"
-msgstr "static & const"
-
-#: src/SUMMARY.md:56 src/basic-syntax/scopes-shadowing.md:1
-msgid "Scopes and Shadowing"
-msgstr "スコープとシャドーイング"
-
-#: src/SUMMARY.md:57 src/enums.md:1
-msgid "Enums"
-msgstr "列挙型（enums）"
-
-#: src/SUMMARY.md:58 src/enums/variant-payloads.md:1
-msgid "Variant Payloads"
-msgstr "列挙子のペイロード"
-
-#: src/SUMMARY.md:59 src/enums/sizes.md:1
-msgid "Enum Sizes"
-msgstr "列挙型のサイズ"
-
-#: src/SUMMARY.md:61 src/control-flow/novel.md:1
-#, fuzzy
-msgid "Novel Control Flow"
-msgstr "制御フロー"
-
-#: src/SUMMARY.md:62
-msgid "if let expressions"
-msgstr "if let式"
-
-#: src/SUMMARY.md:63
-msgid "while let expressions"
-msgstr "while let式"
-
-#: src/SUMMARY.md:64
-msgid "match expressions"
-msgstr "match式"
-
-#: src/SUMMARY.md:66 src/SUMMARY.md:74 src/pattern-matching.md:1
-msgid "Pattern Matching"
-msgstr "パターンマッチング"
-
-#: src/SUMMARY.md:67 src/pattern-matching/destructuring-enums.md:1
-msgid "Destructuring Enums"
-msgstr "列挙型編"
-
-#: src/SUMMARY.md:68 src/pattern-matching/destructuring-structs.md:1
-msgid "Destructuring Structs"
-msgstr "構造体編"
-
-#: src/SUMMARY.md:69 src/pattern-matching/destructuring-arrays.md:1
-msgid "Destructuring Arrays"
-msgstr "配列編"
-
-#: src/SUMMARY.md:70 src/pattern-matching/match-guards.md:1
-msgid "Match Guards"
-msgstr "マッチガード"
-
-#: src/SUMMARY.md:73 src/exercises/day-1/luhn.md:1
-#: src/exercises/day-1/solutions-afternoon.md:3
-msgid "Luhn Algorithm"
-msgstr "Luhnアルゴリズム"
-
-#: src/SUMMARY.md:76
-msgid "Day 2: Morning"
-msgstr "Day 2： AM"
-
-#: src/SUMMARY.md:82 src/memory-management.md:1
-msgid "Memory Management"
-msgstr "メモリ管理"
-
-#: src/SUMMARY.md:83
-msgid "Stack vs Heap"
-msgstr "スタック vs ヒープ"
-
-#: src/SUMMARY.md:84
-msgid "Stack Memory"
-msgstr "スタックメモリ"
-
-#: src/SUMMARY.md:85 src/memory-management/manual.md:1
-msgid "Manual Memory Management"
-msgstr "手動でのメモリ管理"
-
-#: src/SUMMARY.md:86 src/memory-management/scope-based.md:1
-msgid "Scope-Based Memory Management"
-msgstr "スコープに基づくメモリ管理"
-
-#: src/SUMMARY.md:87
-msgid "Garbage Collection"
-msgstr "ガベージコレクション"
-
-#: src/SUMMARY.md:88
-msgid "Rust Memory Management"
-msgstr "Rustのメモリ管理"
-
-#: src/SUMMARY.md:89 src/ownership.md:1
-msgid "Ownership"
-msgstr "所有権"
-
-#: src/SUMMARY.md:90 src/ownership/move-semantics.md:1
-msgid "Move Semantics"
-msgstr "ムーブセマンティクス"
-
-#: src/SUMMARY.md:91 src/ownership/moved-strings-rust.md:1
-msgid "Moved Strings in Rust"
-msgstr "文字列のムーブ"
-
-#: src/SUMMARY.md:92
-msgid "Double Frees in Modern C++"
-msgstr "現代C++の二重解放"
-
-#: src/SUMMARY.md:93 src/ownership/moves-function-calls.md:1
-msgid "Moves in Function Calls"
-msgstr "関数とムーブ"
-
-#: src/SUMMARY.md:94 src/ownership/copy-clone.md:1
-msgid "Copying and Cloning"
-msgstr "コピーとクローン"
-
-#: src/SUMMARY.md:95 src/ownership/borrowing.md:1
-msgid "Borrowing"
-msgstr "借用"
-
-#: src/SUMMARY.md:96 src/ownership/shared-unique-borrows.md:1
-msgid "Shared and Unique Borrows"
-msgstr "共有参照と固有参照"
-
-#: src/SUMMARY.md:97 src/ownership/lifetimes.md:1
-msgid "Lifetimes"
-msgstr "ライフタイム"
-
-#: src/SUMMARY.md:98 src/ownership/lifetimes-function-calls.md:1
-msgid "Lifetimes in Function Calls"
-msgstr "関数とライフタイム"
-
-#: src/SUMMARY.md:99 src/ownership/lifetimes-data-structures.md:1
-msgid "Lifetimes in Data Structures"
-msgstr "データ構造とライフタイム"
-
-#: src/SUMMARY.md:100 src/structs.md:1
-msgid "Structs"
-msgstr "構造体（structs）"
-
-#: src/SUMMARY.md:101 src/structs/tuple-structs.md:1
-msgid "Tuple Structs"
-msgstr "タプル構造体"
-
-#: src/SUMMARY.md:102 src/structs/field-shorthand.md:1
-msgid "Field Shorthand Syntax"
-msgstr "フィールドの省略"
-
-#: src/SUMMARY.md:104 src/methods/receiver.md:1
-msgid "Method Receiver"
-msgstr "メソッドレシーバ"
-
-#: src/SUMMARY.md:105 src/SUMMARY.md:167 src/SUMMARY.md:282
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "Example"
-msgstr "例"
-
-#: src/SUMMARY.md:107 src/exercises/day-2/book-library.md:1
-#, fuzzy
-msgid "Storing Books"
-msgstr "文字列（String）"
-
-#: src/SUMMARY.md:108 src/exercises/day-2/health-statistics.md:1
-#: src/exercises/day-2/solutions-morning.md:151
-msgid "Health Statistics"
-msgstr "健康統計"
-
-#: src/SUMMARY.md:110
-msgid "Day 2: Afternoon"
-msgstr "Day 2： PM"
-
-#: src/SUMMARY.md:112 src/std.md:1
-msgid "Standard Library"
-msgstr "標準ライブラリ"
-
-#: src/SUMMARY.md:113
-msgid "Option and Result"
-msgstr "OptionとResult"
-
-#: src/SUMMARY.md:114 src/std/string.md:1
-msgid "String"
-msgstr "文字列（String）"
-
-#: src/SUMMARY.md:115
-msgid "Vec"
-msgstr "ベクタ（Vec）"
-
-#: src/SUMMARY.md:116
-msgid "HashMap"
-msgstr "ハッシュマップ（HashMap）"
-
-#: src/SUMMARY.md:117
-msgid "Box"
-msgstr "ボックス（Box）"
-
-#: src/SUMMARY.md:118
-msgid "Recursive Data Types"
-msgstr "再帰的データ型"
-
-#: src/SUMMARY.md:119 src/std/box-niche.md:1
-msgid "Niche Optimization"
-msgstr "Niche最適化"
-
-#: src/SUMMARY.md:120
-msgid "Rc"
-msgstr "Rc"
-
-#: src/SUMMARY.md:121
-msgid "Cell/RefCell"
+#: src/SUMMARY.md:240
+msgid "Chromium"
 msgstr ""
 
-#: src/SUMMARY.md:122 src/modules.md:1
-msgid "Modules"
-msgstr "モジュール"
+#: src/SUMMARY.md:246 src/chromium/cargo.md:1
+msgid "Comparing Chromium and Cargo Ecosystems"
+msgstr ""
 
-#: src/SUMMARY.md:123 src/modules/visibility.md:1
-msgid "Visibility"
-msgstr "可視性"
+#: src/SUMMARY.md:247
+msgid "Policy"
+msgstr ""
 
-#: src/SUMMARY.md:124 src/modules/paths.md:1
-msgid "Paths"
-msgstr "パス"
-
-#: src/SUMMARY.md:125 src/modules/filesystem.md:1
-msgid "Filesystem Hierarchy"
-msgstr "ファイルシステム階層"
-
-#: src/SUMMARY.md:127 src/exercises/day-2/iterators-and-ownership.md:1
-msgid "Iterators and Ownership"
-msgstr "イテレータと所有権"
-
-#: src/SUMMARY.md:128 src/exercises/day-2/strings-iterators.md:1
-#: src/exercises/day-2/solutions-afternoon.md:3
-msgid "Strings and Iterators"
-msgstr "文字列とイテレータ"
-
-#: src/SUMMARY.md:131
-msgid "Day 3: Morning"
-msgstr "Day 3： AM"
-
-#: src/SUMMARY.md:136 src/generics.md:1
-msgid "Generics"
-msgstr "ジェネリクス（generics）"
-
-#: src/SUMMARY.md:137 src/generics/data-types.md:1
-msgid "Generic Data Types"
-msgstr "ジェネリックデータ型"
-
-#: src/SUMMARY.md:138 src/generics/methods.md:1
-msgid "Generic Methods"
-msgstr "ジェネリックメソッド"
-
-#: src/SUMMARY.md:139 src/generics/monomorphization.md:1
-msgid "Monomorphization"
-msgstr "単相化"
-
-#: src/SUMMARY.md:140 src/traits.md:1
-msgid "Traits"
-msgstr "トレイト（trait）"
-
-#: src/SUMMARY.md:141 src/traits/trait-objects.md:1
-msgid "Trait Objects"
-msgstr "トレイトオブジェクト"
-
-#: src/SUMMARY.md:142 src/traits/deriving-traits.md:1
-msgid "Deriving Traits"
-msgstr "トレイトの導出"
-
-#: src/SUMMARY.md:143 src/traits/default-methods.md:1
-msgid "Default Methods"
-msgstr "デフォルトメソッド"
-
-#: src/SUMMARY.md:144 src/traits/trait-bounds.md:1
-msgid "Trait Bounds"
-msgstr "トレイト制約"
-
-#: src/SUMMARY.md:145
-msgid "impl Trait"
-msgstr "impl Trait"
-
-#: src/SUMMARY.md:146 src/traits/important-traits.md:1
-msgid "Important Traits"
-msgstr "重要なトレイト"
-
-#: src/SUMMARY.md:147
-msgid "Iterator"
-msgstr "Iterator"
-
-#: src/SUMMARY.md:148 src/traits/from-iterator.md:1
-msgid "FromIterator"
-msgstr "FromIterator"
-
-#: src/SUMMARY.md:149
-msgid "From and Into"
-msgstr "FromとInto"
-
-#: src/SUMMARY.md:150
-msgid "Read and Write"
-msgstr "ReadとWrite"
-
-#: src/SUMMARY.md:151
-msgid "Drop"
-msgstr "Drop"
-
-#: src/SUMMARY.md:152
-msgid "Default"
-msgstr "Default"
-
-#: src/SUMMARY.md:153
-msgid "Operators: Add, Mul, ..."
-msgstr "演算子： Add, Mul, …"
-
-#: src/SUMMARY.md:154
-msgid "Closures: Fn, FnMut, FnOnce"
-msgstr "クロージャ：Fn, FnMut, FnOnce"
-
-#: src/SUMMARY.md:156
-msgid "A Simple GUI Library"
-msgstr "GUIライブラリ"
-
-#: src/SUMMARY.md:157 src/exercises/day-3/solutions-morning.md:142
-msgid "Points and Polygons"
-msgstr "ポイントとポリゴン"
-
-#: src/SUMMARY.md:159
-msgid "Day 3: Afternoon"
-msgstr "Day 3： PM"
-
-#: src/SUMMARY.md:161 src/error-handling.md:1
-msgid "Error Handling"
-msgstr "エラー処理"
-
-#: src/SUMMARY.md:162 src/error-handling/panics.md:1
-msgid "Panics"
-msgstr "パニック（panic）"
-
-#: src/SUMMARY.md:163
-msgid "Catching Stack Unwinding"
-msgstr "スタックの巻き戻し"
-
-#: src/SUMMARY.md:164
-msgid "Structured Error Handling"
-msgstr "構造化されたエラー処理"
-
-#: src/SUMMARY.md:165
-msgid "Propagating Errors with ?"
-msgstr "？でエラーを伝播する"
-
-#: src/SUMMARY.md:166 src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-msgid "Converting Error Types"
-msgstr "エラーの型変換"
-
-#: src/SUMMARY.md:168 src/error-handling/deriving-error-enums.md:1
-msgid "Deriving Error Enums"
-msgstr "列挙型エラーの導出"
-
-#: src/SUMMARY.md:169 src/error-handling/dynamic-errors.md:1
-msgid "Dynamic Error Types"
-msgstr "動的なエラー型"
-
-#: src/SUMMARY.md:170 src/error-handling/error-contexts.md:1
-msgid "Adding Context to Errors"
-msgstr "コンテキストをエラーに追加"
-
-#: src/SUMMARY.md:171 src/testing.md:1
-msgid "Testing"
-msgstr "テスト"
-
-#: src/SUMMARY.md:172 src/testing/unit-tests.md:1
-msgid "Unit Tests"
-msgstr "ユニットテスト"
-
-#: src/SUMMARY.md:173 src/testing/test-modules.md:1
-msgid "Test Modules"
-msgstr "テストモジュール"
-
-#: src/SUMMARY.md:174 src/testing/doc-tests.md:1
-msgid "Documentation Tests"
-msgstr "ドキュメンテーションテスト"
-
-#: src/SUMMARY.md:175 src/testing/integration-tests.md:1
-msgid "Integration Tests"
-msgstr "インテグレーションテスト"
-
-#: src/SUMMARY.md:176 src/bare-metal/useful-crates.md:1
-msgid "Useful crates"
-msgstr "便利クレート"
-
-#: src/SUMMARY.md:177 src/unsafe.md:1
-msgid "Unsafe Rust"
+#: src/SUMMARY.md:249
+#, fuzzy
+msgid "Unsafe Code"
 msgstr "Unsafe Rust"
 
-#: src/SUMMARY.md:178 src/unsafe/raw-pointers.md:1
-msgid "Dereferencing Raw Pointers"
-msgstr "生ポインタの参照外し"
+#: src/SUMMARY.md:250 src/chromium/build-rules/depending.md:1
+msgid "Depending on Rust Code from Chromium C++"
+msgstr ""
 
-#: src/SUMMARY.md:179 src/unsafe/mutable-static-variables.md:1
-msgid "Mutable Static Variables"
-msgstr "可変なstatic変数"
+#: src/SUMMARY.md:251 src/chromium/build-rules/vscode.md:1
+msgid "Visual Studio Code"
+msgstr ""
 
-#: src/SUMMARY.md:180 src/unsafe/unions.md:1
-msgid "Unions"
-msgstr "共用体"
+#: src/SUMMARY.md:252 src/SUMMARY.md:257 src/SUMMARY.md:265 src/SUMMARY.md:278
+#: src/exercises/chromium/third-party.md:1
+#, fuzzy
+msgid "Exercise"
+msgstr "練習問題"
 
-#: src/SUMMARY.md:181 src/unsafe/calling-unsafe-functions.md:1
-msgid "Calling Unsafe Functions"
-msgstr "Unsafe関数の呼び出し"
+#: src/SUMMARY.md:254 src/chromium/testing/rust-gtest-interop.md:1
+msgid "`rust_gtest_interop` Library"
+msgstr ""
 
-#: src/SUMMARY.md:182 src/unsafe/writing-unsafe-functions.md:1
-msgid "Writing Unsafe Functions"
-msgstr "Unsafe関数の書き方"
+#: src/SUMMARY.md:255 src/chromium/testing/build-gn.md:1
+msgid "GN Rules for Rust Tests"
+msgstr ""
 
-#: src/SUMMARY.md:183
-msgid "Extern Functions"
-msgstr "Extern関数"
+#: src/SUMMARY.md:256 src/chromium/testing/chromium-import-macro.md:1
+msgid "`chromium::import!` Macro"
+msgstr ""
 
-#: src/SUMMARY.md:184 src/unsafe/unsafe-traits.md:1
-msgid "Implementing Unsafe Traits"
-msgstr "Unsafeなトレイトの実装"
-
-#: src/SUMMARY.md:186 src/exercises/day-3/safe-ffi-wrapper.md:1
-#: src/exercises/day-3/solutions-afternoon.md:3
-msgid "Safe FFI Wrapper"
-msgstr "安全なFFIラッパ"
-
-#: src/SUMMARY.md:189 src/SUMMARY.md:259 src/bare-metal/android.md:1
-msgid "Android"
-msgstr "Android"
-
-#: src/SUMMARY.md:194 src/android/setup.md:1
-msgid "Setup"
-msgstr "セットアップ"
-
-#: src/SUMMARY.md:195 src/android/build-rules.md:1
-msgid "Build Rules"
-msgstr "ビルドのルール"
-
-#: src/SUMMARY.md:196
-msgid "Binary"
-msgstr "バイナリ"
-
-#: src/SUMMARY.md:197
-msgid "Library"
-msgstr "ライブラリ"
-
-#: src/SUMMARY.md:198 src/android/aidl.md:1
-msgid "AIDL"
-msgstr "AIDL（Androidインターフェイス定義言語）"
-
-#: src/SUMMARY.md:199
-msgid "Interface"
-msgstr "インターフェイス"
-
-#: src/SUMMARY.md:200
-msgid "Implementation"
-msgstr "実装"
-
-#: src/SUMMARY.md:201
-msgid "Server"
-msgstr "サーバ"
-
-#: src/SUMMARY.md:202 src/android/aidl/deploy.md:1
-msgid "Deploy"
-msgstr "デプロイ"
-
-#: src/SUMMARY.md:203
-msgid "Client"
-msgstr "クライアント"
-
-#: src/SUMMARY.md:204 src/android/aidl/changing.md:1
-msgid "Changing API"
-msgstr "APIの変更"
-
-#: src/SUMMARY.md:205 src/SUMMARY.md:249 src/android/logging.md:1
-#: src/bare-metal/aps/logging.md:1
-msgid "Logging"
-msgstr "ログ出力"
-
-#: src/SUMMARY.md:206 src/android/interoperability.md:1
-msgid "Interoperability"
+#: src/SUMMARY.md:258 src/chromium/interoperability-with-cpp.md:1
+#, fuzzy
+msgid "Interoperability with C++"
 msgstr "相互運用性"
 
-#: src/SUMMARY.md:207
-msgid "With C"
-msgstr "C"
+#: src/SUMMARY.md:259
+#: src/chromium/interoperability-with-cpp/example-bindings.md:1
+#, fuzzy
+msgid "Example Bindings"
+msgstr "例"
 
-#: src/SUMMARY.md:208
-msgid "Calling C with Bindgen"
-msgstr "BindgenによるCの呼び出し"
+#: src/SUMMARY.md:260
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:1
+msgid "Limitations of CXX"
+msgstr ""
 
-#: src/SUMMARY.md:209
-msgid "Calling Rust from C"
-msgstr "CからRust呼び出し"
+#: src/SUMMARY.md:261
+#: src/chromium/interoperability-with-cpp/error-handling.md:1
+#, fuzzy
+msgid "CXX Error Handling"
+msgstr "エラー処理"
 
-#: src/SUMMARY.md:210 src/android/interoperability/cpp.md:1
-msgid "With C++"
-msgstr "C++"
+#: src/SUMMARY.md:262
+#, fuzzy
+msgid "Error Handling: QR Example"
+msgstr "エラー処理"
 
-#: src/SUMMARY.md:211
-msgid "With Java"
-msgstr "Java"
+#: src/SUMMARY.md:263
+#, fuzzy
+msgid "Error Handling: PNG Example"
+msgstr "エラー処理"
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:264
+msgid "Using CXX in Chromium"
+msgstr ""
+
+#: src/SUMMARY.md:266 src/chromium/adding-third-party-crates.md:1
+msgid "Adding Third Party Crates"
+msgstr ""
+
+#: src/SUMMARY.md:267
+msgid "Configuring Cargo.toml"
+msgstr ""
+
+#: src/SUMMARY.md:268
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:1
+msgid "Configuring `gnrt_config.toml`"
+msgstr ""
+
+#: src/SUMMARY.md:269
+#: src/chromium/adding-third-party-crates/downloading-crates.md:1
+msgid "Downloading Crates"
+msgstr ""
+
+#: src/SUMMARY.md:270
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:1
+msgid "Generating `gn` Build Rules"
+msgstr ""
+
+#: src/SUMMARY.md:271
+#: src/chromium/adding-third-party-crates/resolving-problems.md:1
+msgid "Resolving Problems"
+msgstr ""
+
+#: src/SUMMARY.md:272
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:1
+msgid "Build Scripts Which Generate Code"
+msgstr ""
+
+#: src/SUMMARY.md:273
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:1
+msgid "Build Scripts Which Build C++ or Take Arbitrary Actions"
+msgstr ""
+
+#: src/SUMMARY.md:274
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:1
+msgid "Depending on a Crate"
+msgstr ""
+
+#: src/SUMMARY.md:275
+msgid "Reviews and Audits"
+msgstr ""
+
+#: src/SUMMARY.md:276
+msgid "Checking into Chromium Source Code"
+msgstr ""
+
+#: src/SUMMARY.md:277
+#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:1
+msgid "Keeping Crates Up to Date"
+msgstr ""
+
+#: src/SUMMARY.md:279
+msgid "Bringing It Together - Exercise"
+msgstr ""
+
+#: src/SUMMARY.md:280 src/exercises/chromium/solutions.md:1
+#, fuzzy
+msgid "Exercise Solutions"
+msgstr "解答"
+
+#: src/SUMMARY.md:282
 msgid "Bare Metal: Morning"
 msgstr "ベアメタル： AM"
 
-#: src/SUMMARY.md:220
-msgid "no_std"
-msgstr "no_std"
+#: src/SUMMARY.md:287 src/bare-metal/no_std.md:1
+msgid "`no_std`"
+msgstr ""
 
-#: src/SUMMARY.md:221
+#: src/SUMMARY.md:288
 msgid "A Minimal Example"
 msgstr "例"
 
-#: src/SUMMARY.md:222
-msgid "alloc"
-msgstr "alloc"
+#: src/SUMMARY.md:289 src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
+msgid "`alloc`"
+msgstr ""
 
-#: src/SUMMARY.md:223 src/bare-metal/microcontrollers.md:1
+#: src/SUMMARY.md:290 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "マイクロコントローラ"
 
-#: src/SUMMARY.md:224 src/bare-metal/microcontrollers/mmio.md:1
+#: src/SUMMARY.md:291 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "生MMIO（メモリマップドI/O）"
 
-#: src/SUMMARY.md:225
+#: src/SUMMARY.md:292
 msgid "PACs"
 msgstr "PACs"
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:293
 msgid "HAL Crates"
 msgstr "HALクレート"
 
-#: src/SUMMARY.md:227
+#: src/SUMMARY.md:294
 msgid "Board Support Crates"
 msgstr "ボードサポートクレート"
 
-#: src/SUMMARY.md:228
+#: src/SUMMARY.md:295
 msgid "The Type State Pattern"
 msgstr "タイプステートパターン"
 
-#: src/SUMMARY.md:229
-msgid "embedded-hal"
-msgstr "embedded-hal"
+#: src/SUMMARY.md:296 src/bare-metal/microcontrollers/embedded-hal.md:1
+msgid "`embedded-hal`"
+msgstr ""
 
-#: src/SUMMARY.md:230
-msgid "probe-rs, cargo-embed"
+#: src/SUMMARY.md:297 src/bare-metal/microcontrollers/probe-rs.md:1
+#, fuzzy
+msgid "`probe-rs` and `cargo-embed`"
 msgstr "probe-rs, cargo-embed"
 
-#: src/SUMMARY.md:231 src/bare-metal/microcontrollers/debugging.md:1
+#: src/SUMMARY.md:298 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: src/SUMMARY.md:232 src/SUMMARY.md:252
+#: src/SUMMARY.md:299 src/SUMMARY.md:320
 msgid "Other Projects"
 msgstr "他のプロジェクト"
 
-#: src/SUMMARY.md:234 src/exercises/bare-metal/compass.md:1
+#: src/SUMMARY.md:301 src/exercises/bare-metal/compass.md:1
 #: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "コンパス"
 
-#: src/SUMMARY.md:236
+#: src/SUMMARY.md:302 src/SUMMARY.md:331 src/SUMMARY.md:354 src/SUMMARY.md:376
+msgid "Solutions"
+msgstr "解答"
+
+#: src/SUMMARY.md:304
 msgid "Bare Metal: Afternoon"
 msgstr "ベアメタル： PM"
 
-#: src/SUMMARY.md:238
+#: src/SUMMARY.md:306
 msgid "Application Processors"
 msgstr "アプリケーションプロセッサ"
 
-#: src/SUMMARY.md:239 src/bare-metal/aps/entry-point.md:1
+#: src/SUMMARY.md:307 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr ""
 
-#: src/SUMMARY.md:240
+#: src/SUMMARY.md:308
 msgid "Inline Assembly"
 msgstr "インラインアセンブリ"
 
-#: src/SUMMARY.md:241
+#: src/SUMMARY.md:309
 msgid "MMIO"
 msgstr "MMIO"
 
-#: src/SUMMARY.md:242
+#: src/SUMMARY.md:310
 msgid "Let's Write a UART Driver"
 msgstr "UARTドライバを書いてみよう"
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md:311
 msgid "More Traits"
 msgstr "他のトレイト"
 
-#: src/SUMMARY.md:244
+#: src/SUMMARY.md:312
 msgid "A Better UART Driver"
 msgstr "UARTドライバの改善"
 
-#: src/SUMMARY.md:245 src/bare-metal/aps/better-uart/bitflags.md:1
+#: src/SUMMARY.md:313 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "ビットフラッグ"
 
-#: src/SUMMARY.md:246
+#: src/SUMMARY.md:314
 msgid "Multiple Registers"
 msgstr "複数のレジスタ"
 
-#: src/SUMMARY.md:247 src/bare-metal/aps/better-uart/driver.md:1
+#: src/SUMMARY.md:315 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "ドライバ"
 
-#: src/SUMMARY.md:248 src/SUMMARY.md:250
+#: src/SUMMARY.md:316 src/SUMMARY.md:318
 msgid "Using It"
 msgstr "使用例"
 
-#: src/SUMMARY.md:251 src/bare-metal/aps/exceptions.md:1
+#: src/SUMMARY.md:319 src/bare-metal/aps/exceptions.md:1
 msgid "Exceptions"
 msgstr "例外"
 
-#: src/SUMMARY.md:253
-msgid "Useful Crates"
-msgstr "便利クレート"
+#: src/SUMMARY.md:322 src/bare-metal/useful-crates/zerocopy.md:1
+msgid "`zerocopy`"
+msgstr ""
 
-#: src/SUMMARY.md:254
-msgid "zerocopy"
-msgstr "zerocopy"
+#: src/SUMMARY.md:323 src/bare-metal/useful-crates/aarch64-paging.md:1
+msgid "`aarch64-paging`"
+msgstr ""
 
-#: src/SUMMARY.md:255
-msgid "aarch64-paging"
-msgstr "aarch64-paging"
+#: src/SUMMARY.md:324 src/bare-metal/useful-crates/buddy_system_allocator.md:1
+msgid "`buddy_system_allocator`"
+msgstr ""
 
-#: src/SUMMARY.md:256
-msgid "buddy_system_allocator"
-msgstr "buddy_system_allocator"
+#: src/SUMMARY.md:325 src/bare-metal/useful-crates/tinyvec.md:1
+msgid "`tinyvec`"
+msgstr ""
 
-#: src/SUMMARY.md:257
-msgid "tinyvec"
-msgstr "tinyvec"
+#: src/SUMMARY.md:326 src/bare-metal/useful-crates/spin.md:1
+msgid "`spin`"
+msgstr ""
 
-#: src/SUMMARY.md:258
-msgid "spin"
-msgstr "spin"
-
-#: src/SUMMARY.md:260 src/bare-metal/android/vmbase.md:1
-msgid "vmbase"
+#: src/SUMMARY.md:328
+#, fuzzy
+msgid "`vmbase`"
 msgstr "vmbase"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:330
 msgid "RTC Driver"
 msgstr "RTC（リアルタイムクロック）ドライバ"
 
-#: src/SUMMARY.md:265
+#: src/SUMMARY.md:333
 msgid "Concurrency: Morning"
 msgstr "並行性： AM"
 
-#: src/SUMMARY.md:270 src/concurrency/threads.md:1
+#: src/SUMMARY.md:338 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "スレッド"
 
-#: src/SUMMARY.md:271 src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:339 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "スコープ付きスレッド"
 
-#: src/SUMMARY.md:272 src/concurrency/channels.md:1
+#: src/SUMMARY.md:340 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "チャネル"
 
-#: src/SUMMARY.md:273 src/concurrency/channels/unbounded.md:1
+#: src/SUMMARY.md:341 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Unboundedチャネル"
 
-#: src/SUMMARY.md:274 src/concurrency/channels/bounded.md:1
+#: src/SUMMARY.md:342 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Boundedチャネル"
 
-#: src/SUMMARY.md:275
-msgid "Send and Sync"
-msgstr "SendとSync"
+#: src/SUMMARY.md:343 src/concurrency/send-sync.md:1
+msgid "`Send` and `Sync`"
+msgstr "`Send`と`Sync`"
 
-#: src/SUMMARY.md:275
-msgid "Send"
-msgstr "Send"
+#: src/SUMMARY.md:344 src/concurrency/send-sync/send.md:1
+msgid "`Send`"
+msgstr ""
 
-#: src/SUMMARY.md:275
-msgid "Sync"
-msgstr "Sync"
+#: src/SUMMARY.md:345 src/concurrency/send-sync/sync.md:1
+msgid "`Sync`"
+msgstr ""
 
-#: src/SUMMARY.md:278 src/concurrency/send-sync/examples.md:1
+#: src/SUMMARY.md:346 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "例"
 
-#: src/SUMMARY.md:279 src/concurrency/shared_state.md:1
+#: src/SUMMARY.md:347 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "状態共有"
 
-#: src/SUMMARY.md:280
-msgid "Arc"
-msgstr "Arc"
+#: src/SUMMARY.md:348 src/concurrency/shared_state/arc.md:1
+msgid "`Arc`"
+msgstr ""
 
-#: src/SUMMARY.md:281
-msgid "Mutex"
-msgstr "Mutex"
+#: src/SUMMARY.md:349 src/concurrency/shared_state/mutex.md:1
+msgid "`Mutex`"
+msgstr ""
 
-#: src/SUMMARY.md:284 src/SUMMARY.md:305
+#: src/SUMMARY.md:350 src/memory-management/review.md:16
+#: src/error-handling/try-conversions.md:23
+#: src/concurrency/shared_state/example.md:1
+msgid "Example"
+msgstr "例"
+
+#: src/SUMMARY.md:352 src/SUMMARY.md:374
 #: src/exercises/concurrency/dining-philosophers.md:1
 #: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "食事する哲学者"
 
-#: src/SUMMARY.md:285 src/exercises/concurrency/link-checker.md:1
+#: src/SUMMARY.md:353 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "マルチスレッド・リンクチェッカー"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:356
 msgid "Concurrency: Afternoon"
 msgstr "並行性： PM"
 
-#: src/SUMMARY.md:289
+#: src/SUMMARY.md:358
 msgid "Async Basics"
 msgstr "Asyncの基礎"
 
-#: src/SUMMARY.md:290
-msgid "async/await"
-msgstr "async/await"
+#: src/SUMMARY.md:359 src/async/async-await.md:1
+msgid "`async`/`await`"
+msgstr "`async`/`await`"
 
-#: src/SUMMARY.md:291 src/async/futures.md:1
+#: src/SUMMARY.md:360 src/async/futures.md:1
 msgid "Futures"
 msgstr "Future"
 
-#: src/SUMMARY.md:292 src/async/runtimes.md:1
+#: src/SUMMARY.md:361 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "ランタイム"
 
-#: src/SUMMARY.md:293 src/async/runtimes/tokio.md:1
+#: src/SUMMARY.md:362 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:294 src/exercises/concurrency/link-checker.md:126
+#: src/SUMMARY.md:363 src/exercises/concurrency/link-checker.md:127
 #: src/async/tasks.md:1 src/exercises/concurrency/chat-app.md:143
 msgid "Tasks"
 msgstr "タスク"
 
-#: src/SUMMARY.md:295 src/async/channels.md:1
+#: src/SUMMARY.md:364 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "Asyncチャネル"
 
-#: src/SUMMARY.md:297 src/async/control-flow/join.md:1
+#: src/SUMMARY.md:365
+msgid "Control Flow"
+msgstr "制御フロー"
+
+#: src/SUMMARY.md:366 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:298 src/async/control-flow/select.md:1
+#: src/SUMMARY.md:367 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
-#: src/SUMMARY.md:299
+#: src/SUMMARY.md:368
 msgid "Pitfalls"
 msgstr "落とし穴"
 
-#: src/SUMMARY.md:300
+#: src/SUMMARY.md:369
 msgid "Blocking the Executor"
 msgstr "エグゼキュータのブロッキング"
 
-#: src/SUMMARY.md:301 src/async/pitfalls/pin.md:1
-msgid "Pin"
-msgstr "Pin"
+#: src/SUMMARY.md:370 src/async/pitfalls/pin.md:1
+msgid "`Pin`"
+msgstr ""
 
-#: src/SUMMARY.md:302 src/async/pitfalls/async-traits.md:1
+#: src/SUMMARY.md:371 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "Asyncトレイト"
 
-#: src/SUMMARY.md:303 src/async/pitfalls/cancellation.md:1
+#: src/SUMMARY.md:372 src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
 msgstr "インストール"
 
-#: src/SUMMARY.md:306 src/exercises/concurrency/chat-app.md:1
+#: src/SUMMARY.md:375 src/exercises/concurrency/chat-app.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:95
 msgid "Broadcast Chat Application"
 msgstr "ブロードキャスト・チャットアプリ"
 
-#: src/SUMMARY.md:309
+#: src/SUMMARY.md:378
 msgid "Final Words"
 msgstr "最後に"
 
-#: src/SUMMARY.md:313 src/thanks.md:1
+#: src/SUMMARY.md:382 src/thanks.md:1
 msgid "Thanks!"
 msgstr "ありがとうございました！"
 
-#: src/SUMMARY.md:314 src/glossary.md:1
+#: src/SUMMARY.md:383 src/glossary.md:1
 msgid "Glossary"
 msgstr ""
 
-#: src/SUMMARY.md:315
+#: src/SUMMARY.md:384
 msgid "Other Resources"
 msgstr "参考資料"
 
-#: src/SUMMARY.md:316 src/credits.md:1
+#: src/SUMMARY.md:385 src/credits.md:1
 msgid "Credits"
 msgstr "クレジット"
-
-#: src/SUMMARY.md:319 src/exercises/solutions.md:1
-msgid "Solutions"
-msgstr "解答"
-
-#: src/SUMMARY.md:324
-msgid "Day 1 Morning"
-msgstr "Day 1 AM"
-
-#: src/SUMMARY.md:325
-msgid "Day 1 Afternoon"
-msgstr "Day 1 PM"
-
-#: src/SUMMARY.md:326
-msgid "Day 2 Morning"
-msgstr "Day 2 AM"
-
-#: src/SUMMARY.md:327
-msgid "Day 2 Afternoon"
-msgstr "Day 2 PM"
-
-#: src/SUMMARY.md:328
-msgid "Day 3 Morning"
-msgstr "Day 3 AM"
-
-#: src/SUMMARY.md:329
-msgid "Day 3 Afternoon"
-msgstr "Day 3 PM"
-
-#: src/SUMMARY.md:330
-msgid "Bare Metal Rust Morning"
-msgstr "ベアメタルRust AM"
-
-#: src/SUMMARY.md:331 src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "Bare Metal Rust Afternoon"
-msgstr "ベアメタルRust PM"
-
-#: src/SUMMARY.md:332
-msgid "Concurrency Morning"
-msgstr "並行性 AM"
-
-#: src/SUMMARY.md:333
-msgid "Concurrency Afternoon"
-msgstr "並行性 PM"
 
 #: src/index.md:3
 #, fuzzy
@@ -1094,7 +1305,7 @@ msgid "Show you common Rust idioms."
 msgstr "一般的なRustのイディオムを紹介する。"
 
 #: src/index.md:22
-msgid "We call the first three course days Rust Fundamentals."
+msgid "We call the first four course days Rust Fundamentals."
 msgstr ""
 
 #: src/index.md:24
@@ -1117,6 +1328,16 @@ msgstr ""
 #: src/index.md:28
 #, fuzzy
 msgid ""
+"[Chromium](chromium.md): a half-day course on using Rust within Chromium "
+"based browsers. This includes interoperability with C++ and how to include "
+"third-party crates in Chromium."
+msgstr ""
+"[Android](android.md)： Androidオープンソースプラットフォーム（AOSP）でRustを"
+"使用するための半日講座。C、C++、およびJavaとの相互運用性も含まれます。"
+
+#: src/index.md:31
+#, fuzzy
+msgid ""
 "[Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-metal "
 "(embedded) development. Both microcontrollers and application processors are "
 "covered."
@@ -1125,7 +1346,7 @@ msgstr ""
 "の1日講座。マイクロコントローラとアプリケーションプロセッサの両方が対象となり"
 "ます。"
 
-#: src/index.md:31
+#: src/index.md:34
 #, fuzzy
 msgid ""
 "[Concurrency](concurrency.md): a whole-day class on concurrency in Rust. We "
@@ -1137,11 +1358,11 @@ msgstr ""
 "ドとミューテックスを用いたプリエンプティブなスケジューリング）と、async/await"
 "を使用した並行性（futuresを用いた協調的マルチタスク）がカバーされます。"
 
-#: src/index.md:37
+#: src/index.md:38
 msgid "Non-Goals"
 msgstr "本講座の対象外"
 
-#: src/index.md:39
+#: src/index.md:40
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
 "days. Some non-goals of this course are:"
@@ -1149,7 +1370,7 @@ msgstr ""
 "Rustは非常に汎用性の高い言語であり、数日で全てを網羅する事はできません。本講"
 "座の目標として設定されていないものには、以下のようなものがあります："
 
-#: src/index.md:42
+#: src/index.md:43
 #, fuzzy
 msgid ""
 "Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
@@ -1161,22 +1382,22 @@ msgstr ""
 "版 Ch.17](http://doc.rust-jp.rs/rust-by-example-ja/macros.html)を参照してくだ"
 "さい。"
 
-#: src/index.md:46
+#: src/index.md:48
 msgid "Assumptions"
 msgstr "前提知識"
 
-#: src/index.md:48
+#: src/index.md:50
 #, fuzzy
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically-typed language and we will sometimes make comparisons with C and "
-"C++ to better explain or contrast the Rust approach."
+"statically-typed language and we will sometimes make comparisons with C and C"
+"++ to better explain or contrast the Rust approach."
 msgstr ""
 "本講座では、既にプログラミングの知識がある事を前提としています。Rustは静的型"
 "付け言語であり、Rustのアプローチをより分かりやすく説明するために、時折CやC+"
 "+との比較を行います。"
 
-#: src/index.md:52
+#: src/index.md:54
 #, fuzzy
 msgid ""
 "If you know how to program in a dynamically-typed language such as Python or "
@@ -1185,7 +1406,7 @@ msgstr ""
 "もし受講者の知識がPythonやJavaScriptなどの動的型付け言語に限定されている場合"
 "でも、本講座の受講は可能です。"
 
-#: src/index.md:57
+#: src/index.md:59
 msgid ""
 "This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
@@ -1206,43 +1427,42 @@ msgstr "以下は、Google内での講座の運営方法に関する情報です
 
 #: src/running-the-course.md:8
 msgid ""
-"We typically run classes from 10:00 am to 4:00 pm, with a 1 hour lunch break "
-"in the middle. This leaves 2.5 hours for the morning class and 2.5 hours for "
-"the afternoon class. Note that this is just a recommendation: you can also "
-"spend 3 hour on the morning session to give people more time for exercises. "
-"The downside of longer session is that people can become very tired after 6 "
-"full hours of class in the afternoon."
+"We typically run classes from 9:00 am to 4:00 pm, with a 1 hour lunch break "
+"in the middle. This leaves 3 hours for the morning class and 3 hours for the "
+"afternoon class. Both sessions contain multiple breaks and time for students "
+"to work on exercises."
 msgstr ""
 
-#: src/running-the-course.md:16
+#: src/running-the-course.md:13
 msgid "Before you run the course, you will want to:"
 msgstr "講座開始までに、以下にあげる準備を済ませておくと良いでしょう："
 
-#: src/running-the-course.md:18
+#: src/running-the-course.md:15
 msgid ""
 "Make yourself familiar with the course material. We've included speaker "
 "notes to help highlight the key points (please help us by contributing more "
 "speaker notes!). When presenting, you should make sure to open the speaker "
-"notes in a popup (click the link with a little arrow next to \"Speaker "
-"Notes\"). This way you have a clean screen to present to the class."
+"notes in a popup (click the link with a little arrow next to \"Speaker Notes"
+"\"). This way you have a clean screen to present to the class."
 msgstr ""
 "資料に慣れておいてください。要点を強調するためにスピーカーノートが用意されて"
 "います（内容の追加にご協力ください！）。プレゼン時には、スクリーンを見やすい"
 "状態で保つために、スピーカーノートはポップアップウィンドウで開いてください"
 "（スピーカーノートの横にある小さな矢印をクリック）。"
 
-#: src/running-the-course.md:24
+#: src/running-the-course.md:21
+#, fuzzy
 msgid ""
-"Decide on the dates. Since the course takes at least three full days, we "
-"recommend that you schedule the days over two weeks. Course participants "
-"have said that they find it helpful to have a gap in the course since it "
-"helps them process all the information we give them."
+"Decide on the dates. Since the course takes four days, we recommend that you "
+"schedule the days over two weeks. Course participants have said that they "
+"find it helpful to have a gap in the course since it helps them process all "
+"the information we give them."
 msgstr ""
 "あらかじめ日程を決めておいてください。講座は最低でも3日かかるため、2週間にわ"
 "たって日程を組む事を推奨しています。過去の受講者によると、講座の間に数日"
 "ギャップを設ける事で内容が吸収しやすくなります。"
 
-#: src/running-the-course.md:29
+#: src/running-the-course.md:26
 msgid ""
 "Find a room large enough for your in-person participants. We recommend a "
 "class size of 15-25 people. That's small enough that people are comfortable "
@@ -1258,7 +1478,7 @@ msgstr ""
 "た人数分の机を用意しておいてください。ライブコーディング形式での実施を想定し"
 "ているため、講壇は不要です。"
 
-#: src/running-the-course.md:37
+#: src/running-the-course.md:34
 msgid ""
 "On the day of your course, show up to the room a little early to set things "
 "up. We recommend presenting directly using `mdbook serve` running on your "
@@ -1273,7 +1493,7 @@ msgstr ""
 "遅延なしで最適なパフォーマンスが得られます。また、PCを使用する事で、受講者や"
 "自分自身が見つけたタイプミスなども修正可能になります。"
 
-#: src/running-the-course.md:43
+#: src/running-the-course.md:40
 msgid ""
 "Let people solve the exercises by themselves or in small groups. We "
 "typically spend 30-45 minutes on exercises in the morning and in the "
@@ -1289,14 +1509,14 @@ msgstr ""
 "ラス全体に対してそれを共有し、解決策を提供してください。例えば、探している情"
 "報が標準ライブラリのどこにあるかを示す、など。"
 
-#: src/running-the-course.md:51
+#: src/running-the-course.md:48
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
 "for you as it has been for us!"
 msgstr ""
 "以上です。運営頑張ってください！皆さんにとっても楽しい時間になりますように！"
 
-#: src/running-the-course.md:54
+#: src/running-the-course.md:51
 msgid ""
 "Please [provide feedback](https://github.com/google/comprehensive-rust/"
 "discussions/86) afterwards so that we can keep improving the course. We "
@@ -1315,44 +1535,162 @@ msgstr ""
 
 #: src/running-the-course/course-structure.md:7
 msgid ""
-"The first three days make up [Rust Fundaments](../welcome-day-1.md). The "
-"days are fast paced and we cover a lot of ground:"
+"The first four days make up [Rust Fundamentals](../welcome-day-1.md). The "
+"days are fast paced and we cover a lot of ground!"
 msgstr ""
 
 #: src/running-the-course/course-structure.md:10
-msgid "Day 1: Basic Rust, syntax, control flow, creating and consuming values."
+msgid "Course schedule:"
 msgstr ""
 
 #: src/running-the-course/course-structure.md:11
-#, fuzzy
-msgid ""
-"Day 2: Memory management, ownership, compound data types, and the standard "
-"library."
-msgstr "Day 2： 複合データ型、パターンマッチング、標準ライブラリ"
+msgid "Day 1 Morning (3 hours, including breaks)"
+msgstr ""
 
 #: src/running-the-course/course-structure.md:12
-#, fuzzy
-msgid "Day 3: Generics, traits, error handling, testing, and unsafe Rust."
-msgstr "Day 3： トレイトとジェネリクス、エラー処理、テスト、unsafe Rust"
+msgid "[Welcome](../welcome-day-1.md) (5 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:13
+msgid "[Hello, World](../hello-world.md) (20 minutes)"
+msgstr ""
 
 #: src/running-the-course/course-structure.md:14
+msgid "[Types and Values](../types-and-values.md) (1 hour and 5 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:15
+msgid "[Control Flow Basics](../control-flow-basics.md) (1 hour)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:16
+msgid "Day 1 Afternoon (2 hours and 55 minutes, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:17
+msgid "[Tuples and Arrays](../tuples-and-arrays.md) (1 hour)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:18
+msgid "[References](../references.md) (50 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:19
+msgid "[User-Defined Types](../user-defined-types.md) (50 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:20
+msgid "Day 2 Morning (3 hours and 15 minutes, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:21
+msgid "[Welcome](../welcome-day-2.md) (3 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:22
+msgid "[Pattern Matching](../pattern-matching.md) (50 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:23
+msgid "[Methods and Traits](../methods-and-traits.md) (1 hour and 5 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:24
+msgid "[Generics](../generics.md) (45 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:25
+msgid "Day 2 Afternoon (3 hours, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:26
+msgid "[Standard Library Types](../std-types.md) (1 hour and 10 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:27
+msgid "[Standard Library Traits](../std-traits.md) (1 hour and 40 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:28
+msgid "Day 3 Morning (2 hours and 15 minutes, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:29
+msgid "[Welcome](../welcome-day-3.md) (3 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:30
+msgid "[Memory Management](../memory-management.md) (1 hour and 10 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:31
+msgid "[Smart Pointers](../smart-pointers.md) (45 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:32
+msgid "Day 3 Afternoon (2 hours and 20 minutes, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:33
+msgid "[Borrowing](../borrowing.md) (1 hour)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:34
+msgid ""
+"[Slices and Lifetimes](../slices-and-lifetimes.md) (1 hour and 10 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:35
+msgid "Day 4 Morning (3 hours and 10 minutes, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:36
+msgid "[Welcome](../welcome-day-4.md) (3 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:37
+msgid "[Iterators](../iterators.md) (45 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:38
+msgid "[Modules](../modules.md) (45 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:39
+msgid "[Testing](../testing.md) (1 hour and 5 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:40
+msgid "Day 4 Afternoon (2 hours, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:41
+msgid "[Error Handling](../error-handling.md) (45 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:42
+msgid "[Unsafe Rust](../unsafe-rust.md) (1 hour and 5 minutes)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:45
 msgid "Deep Dives"
 msgstr "専門的なトピック"
 
-#: src/running-the-course/course-structure.md:16
+#: src/running-the-course/course-structure.md:47
+#, fuzzy
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more "
+"In addition to the 4-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
 msgstr ""
 "Rustの基礎に関する3日間の講座に加え、いくつかのより専門的なトピックも用意され"
 "ています："
 
-#: src/running-the-course/course-structure.md:19
+#: src/running-the-course/course-structure.md:50
 #, fuzzy
 msgid "Rust in Android"
 msgstr "Android"
 
-#: src/running-the-course/course-structure.md:21
+#: src/running-the-course/course-structure.md:52
 #, fuzzy
 msgid ""
 "The [Rust in Android](../android.md) deep dive is a half-day course on using "
@@ -1363,7 +1701,7 @@ msgstr ""
 "Rustを使用するための半日程度の講座です。C、C++、およびJavaとの相互運用性も含"
 "まれます。"
 
-#: src/running-the-course/course-structure.md:25
+#: src/running-the-course/course-structure.md:56
 msgid ""
 "You will need an [AOSP checkout](https://source.android.com/docs/setup/"
 "download/downloading). Make a checkout of the [course repository](https://"
@@ -1377,7 +1715,7 @@ msgstr ""
 "AOSPチェックアウトのルートに移動してください。これにより、Androidビルドシステ"
 "ムが`src/android/`内の`Android.bp`を確認できるようになります。"
 
-#: src/running-the-course/course-structure.md:30
+#: src/running-the-course/course-structure.md:61
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
 "all Android examples using `src/android/build_all.sh`. Read the script to "
@@ -1388,12 +1726,32 @@ msgstr ""
 "スクリプトを読んで実行コマンドを確認し、手動で実行した際に正常に動作する事を"
 "確認してください。"
 
-#: src/running-the-course/course-structure.md:37
+#: src/running-the-course/course-structure.md:68
+#, fuzzy
+msgid "Rust in Chromium"
+msgstr "Android"
+
+#: src/running-the-course/course-structure.md:70
+msgid ""
+"The [Rust in Chromium](../chromium.md) deep dive is a half-day course on "
+"using Rust as part of the Chromium browser. It includes using Rust in "
+"Chromium's `gn` build system, bringing in third-party libraries (\"crates\") "
+"and C++ interoperability."
+msgstr ""
+
+#: src/running-the-course/course-structure.md:75
+msgid ""
+"You will need to be able to build Chromium --- a debug, component build is "
+"[recommended](../chromium/setup.md) for speed but any build will work. "
+"Ensure that you can run the Chromium browser that you've built."
+msgstr ""
+
+#: src/running-the-course/course-structure.md:79
 #, fuzzy
 msgid "Bare-Metal Rust"
 msgstr "ベアメタル"
 
-#: src/running-the-course/course-structure.md:39
+#: src/running-the-course/course-structure.md:81
 #, fuzzy
 msgid ""
 "The [Bare-Metal Rust](../bare-metal.md) deep dive is a full day class on "
@@ -1404,7 +1762,7 @@ msgstr ""
 "るための1日講座です。マイクロコントローラとアプリケーションプロセッサの両方が"
 "対象となります。"
 
-#: src/running-the-course/course-structure.md:43
+#: src/running-the-course/course-structure.md:85
 msgid ""
 "For the microcontroller part, you will need to buy the [BBC micro:bit]"
 "(https://microbit.org/) v2 development board ahead of time. Everybody will "
@@ -1415,12 +1773,12 @@ msgstr ""
 "発ボードを購入する必要があります。また、[welcomeページ](../bare-metal.md)で説"
 "明されているように、複数のパッケージをインストールする必要があります。"
 
-#: src/running-the-course/course-structure.md:48
+#: src/running-the-course/course-structure.md:90
 #, fuzzy
 msgid "Concurrency in Rust"
 msgstr "Rustでの並行性へようこそ"
 
-#: src/running-the-course/course-structure.md:50
+#: src/running-the-course/course-structure.md:92
 #, fuzzy
 msgid ""
 "The [Concurrency in Rust](../concurrency.md) deep dive is a full day class "
@@ -1429,7 +1787,7 @@ msgstr ""
 "[並行性編](../concurrency.md) は、並行性とasync/awaitを使用した並行性について"
 "の1日講座です。"
 
-#: src/running-the-course/course-structure.md:53
+#: src/running-the-course/course-structure.md:95
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
 "to go. You can then copy/paste the examples into `src/main.rs` to experiment "
@@ -1438,11 +1796,11 @@ msgstr ""
 "新規クレートの作成と、依存関係（dependencies）のダウンロードが必要です。その"
 "後、例を`src/main.rs`にコピペして実行する事ができます："
 
-#: src/running-the-course/course-structure.md:64
+#: src/running-the-course/course-structure.md:106
 msgid "Format"
 msgstr "フォーマット"
 
-#: src/running-the-course/course-structure.md:66
+#: src/running-the-course/course-structure.md:108
 msgid ""
 "The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
@@ -1500,78 +1858,80 @@ msgid ""
 "[@henrif75](https://github.com/henrif75)."
 msgstr ""
 
-#: src/running-the-course/translations.md:7
+#: src/running-the-course/translations.md:8
+msgid ""
+"[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
+"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
+"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
+"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
+"github.com/superwhd), [@SketchK](https://github.com/SketchK), and [@nodmp]"
+"(https://github.com/nodmp)."
+msgstr ""
+
+#: src/running-the-course/translations.md:10
+msgid ""
+"[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
+"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
+"victorhsieh), [@mingyc](https://github.com/mingyc), [@kuanhungchen](https://"
+"github.com/kuanhungchen), and [@johnathan79717](https://github.com/"
+"johnathan79717)."
+msgstr ""
+
+#: src/running-the-course/translations.md:12
 msgid ""
 "[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
 "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
 
-#: src/running-the-course/translations.md:8
+#: src/running-the-course/translations.md:13
 msgid ""
 "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
 "(https://github.com/deavid)."
 msgstr ""
 
-#: src/running-the-course/translations.md:10
+#: src/running-the-course/translations.md:15
 msgid ""
 "Use the language picker in the top-right corner to switch between languages."
 msgstr "画面右上の言語切り替えボタンから、切り替えを行なってください。"
 
-#: src/running-the-course/translations.md:12
+#: src/running-the-course/translations.md:17
 #, fuzzy
 msgid "Incomplete Translations"
 msgstr "翻訳"
 
-#: src/running-the-course/translations.md:14
+#: src/running-the-course/translations.md:19
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
 
-#: src/running-the-course/translations.md:17
+#: src/running-the-course/translations.md:22
 msgid ""
 "[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
 "(https://github.com/raselmandol)."
 msgstr ""
 
-#: src/running-the-course/translations.md:18
-msgid ""
-"[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
-"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
-"victorhsieh), [@mingyc](https://github.com/mingyc), and [@johnathan79717]"
-"(https://github.com/johnathan79717)."
-msgstr ""
-
-#: src/running-the-course/translations.md:19
-msgid ""
-"[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
-"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
-"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
-"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
-"github.com/superwhd), and [@SketchK](https://github.com/SketchK)."
-msgstr ""
-
-#: src/running-the-course/translations.md:20
+#: src/running-the-course/translations.md:23
 msgid ""
 "[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
 "(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
 
-#: src/running-the-course/translations.md:21
+#: src/running-the-course/translations.md:24
 msgid ""
 "[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
 "(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
 msgstr ""
 
-#: src/running-the-course/translations.md:22
+#: src/running-the-course/translations.md:25
 msgid ""
 "[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
 "(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
 "momotaro1105)."
 msgstr ""
 
-#: src/running-the-course/translations.md:24
+#: src/running-the-course/translations.md:27
 msgid ""
 "If you want to help with this effort, please see [our instructions](https://"
 "github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
@@ -1596,15 +1956,15 @@ msgstr ""
 "準ツールに出会います。ここでは、Cargoの概要や使用方法、そして本講座における重"
 "要性について簡単に説明します。"
 
-#: src/cargo.md:8
+#: src/cargo.md:9
 msgid "Installation"
 msgstr "インストール"
 
-#: src/cargo.md:10
+#: src/cargo.md:11
 msgid "**Please follow the instructions on <https://rustup.rs/>.**"
 msgstr ""
 
-#: src/cargo.md:12
+#: src/cargo.md:13
 #, fuzzy
 msgid ""
 "This will give you the Cargo build tool (`cargo`) and the Rust compiler "
@@ -1615,7 +1975,7 @@ msgstr ""
 "されます。Rustupを使用することで、ツールチェーンのインストールや切り替え、ク"
 "ロスコンパイルの設定などが行えます。"
 
-#: src/cargo.md:14
+#: src/cargo.md:17
 msgid ""
 "After installing Rust, you should configure your editor or IDE to work with "
 "Rust. Most editors do this by talking to [rust-analyzer](https://rust-"
@@ -1626,7 +1986,7 @@ msgid ""
 "different IDE available called [RustRover](https://www.jetbrains.com/rust/)."
 msgstr ""
 
-#: src/cargo.md:18
+#: src/cargo.md:25
 #, fuzzy
 msgid ""
 "On Debian/Ubuntu, you can also install Cargo, the Rust source and the [Rust "
@@ -1669,9 +2029,10 @@ msgstr ""
 "ともできます。"
 
 #: src/cargo/rust-ecosystem.md:13
+#, fuzzy
 msgid ""
 "`rustup`: the Rust toolchain installer and updater. This tool is used to "
-"install and update `rustc` and `cargo` when new versions of Rust is "
+"install and update `rustc` and `cargo` when new versions of Rust are "
 "released. In addition, `rustup` can also download documentation for the "
 "standard library. You can have multiple versions of Rust installed at once "
 "and `rustup` will let you switch between them as needed."
@@ -1681,14 +2042,10 @@ msgstr ""
 "ンロードする事も可能です。また、複数のRustのバージョンがインストールされてい"
 "る場合、`rustup`で切り替えが行えます。"
 
-#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
-#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
-#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:32
-#: src/basic-syntax/references.md:24
-#: src/pattern-matching/destructuring-enums.md:35
-#: src/ownership/double-free-modern-cpp.md:55
-#: src/error-handling/try-operator.md:48
-#: src/error-handling/converting-error-types-example.md:50
+#: src/cargo/rust-ecosystem.md:21 src/hello-world/hello-world.md:26
+#: src/tuples-and-arrays/tuples-and-arrays.md:39 src/references/exclusive.md:20
+#: src/pattern-matching/destructuring.md:69 src/memory-management/move.md:153
+#: src/error-handling/try.md:53 src/android/setup.md:18
 #: src/concurrency/threads.md:30 src/async/async-await.md:25
 msgid "Key points:"
 msgstr "要点："
@@ -1720,7 +2077,7 @@ msgid ""
 "rust-lang.org/cargo/reference/registries.html), git, folders, and more."
 msgstr ""
 
-#: src/cargo/rust-ecosystem.md:34
+#: src/cargo/rust-ecosystem.md:35
 msgid ""
 "Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
 "current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
@@ -1729,13 +2086,13 @@ msgstr ""
 "があります：現在のエディションはRust2021です。以前はRust2015とRust2018でし"
 "た。"
 
-#: src/cargo/rust-ecosystem.md:37
+#: src/cargo/rust-ecosystem.md:38
 msgid ""
 "The editions are allowed to make backwards incompatible changes to the "
 "language."
 msgstr "エディションでは、後方非互換な変更を加える事ができます。"
 
-#: src/cargo/rust-ecosystem.md:40
+#: src/cargo/rust-ecosystem.md:41
 msgid ""
 "To prevent breaking code, editions are opt-in: you select the edition for "
 "your crate via the `Cargo.toml` file."
@@ -1743,7 +2100,7 @@ msgstr ""
 "コードの破損を防ぐために、エディションはオプトイン方式です：`Cargo.toml`で、"
 "クレートに対して適用したいエディションを選択します。"
 
-#: src/cargo/rust-ecosystem.md:43
+#: src/cargo/rust-ecosystem.md:44
 msgid ""
 "To avoid splitting the ecosystem, Rust compilers can mix code written for "
 "different editions."
@@ -1751,35 +2108,36 @@ msgstr ""
 "エコシステムの分断を避けるために、コンパイラは異なるエディションのコードを混"
 "在させる事ができます。"
 
-#: src/cargo/rust-ecosystem.md:46
+#: src/cargo/rust-ecosystem.md:47
 msgid ""
 "Mention that it is quite rare to ever use the compiler directly not through "
 "`cargo` (most users never do)."
 msgstr ""
 "コンパイラを直接使用する事は非常に稀であり、基本的には`cargo`を介します。"
 
-#: src/cargo/rust-ecosystem.md:48
+#: src/cargo/rust-ecosystem.md:50
+#, fuzzy
 msgid ""
 "It might be worth alluding that Cargo itself is an extremely powerful and "
-"comprehensive tool.  It is capable of many advanced features including but "
-"not limited to: "
+"comprehensive tool. It is capable of many advanced features including but "
+"not limited to:"
 msgstr "`Cargo`は非常に包括的なツールであり、多くの機能を備えています："
 
-#: src/cargo/rust-ecosystem.md:49
+#: src/cargo/rust-ecosystem.md:53
 msgid "Project/package structure"
 msgstr "プロジェクト・パッケージの構造管理"
 
-#: src/cargo/rust-ecosystem.md:50
+#: src/cargo/rust-ecosystem.md:54
 msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
 msgstr ""
 "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)（ワー"
 "クスペース）"
 
-#: src/cargo/rust-ecosystem.md:51
+#: src/cargo/rust-ecosystem.md:55
 msgid "Dev Dependencies and Runtime Dependency management/caching"
 msgstr "開発用とランタイム用の依存関係管理・キャッシュ"
 
-#: src/cargo/rust-ecosystem.md:52
+#: src/cargo/rust-ecosystem.md:56
 msgid ""
 "[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
 "html)"
@@ -1787,7 +2145,7 @@ msgstr ""
 "[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
 "html)（ビルドスクリプト）"
 
-#: src/cargo/rust-ecosystem.md:53
+#: src/cargo/rust-ecosystem.md:57
 msgid ""
 "[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
 "html)"
@@ -1795,7 +2153,7 @@ msgstr ""
 "[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
 "html)"
 
-#: src/cargo/rust-ecosystem.md:54
+#: src/cargo/rust-ecosystem.md:58
 msgid ""
 "It is also extensible with sub command plugins as well (such as [cargo "
 "clippy](https://github.com/rust-lang/rust-clippy))."
@@ -1803,7 +2161,7 @@ msgstr ""
 "[cargo clippy](https://github.com/rust-lang/rust-clippy)などのサブコマンドプ"
 "ラグインによる拡張"
 
-#: src/cargo/rust-ecosystem.md:55
+#: src/cargo/rust-ecosystem.md:60
 msgid ""
 "Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
 msgstr ""
@@ -1837,7 +2195,7 @@ msgstr ""
 msgid "The code blocks in this course are fully interactive:"
 msgstr "講座のコードブロックはインタラクティブです："
 
-#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:45
+#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:46
 msgid "\"Edit me!\""
 msgstr "\"Edit me!\""
 
@@ -1846,7 +2204,8 @@ msgid "You can use "
 msgstr "ボックス内にフォーカスがある状態で"
 
 #: src/cargo/code-samples.md:19
-msgid "to execute the code when focus is in the text box."
+#, fuzzy
+msgid " to execute the code when focus is in the text box."
 msgstr "を押すと、コードが実行されます。"
 
 #: src/cargo/code-samples.md:24
@@ -1893,13 +2252,13 @@ msgstr ""
 "インストールされたら、`rustc`と`cargo`が使えるようになります。最新のstableリ"
 "リースのバージョンは以下の通りです："
 
-#: src/cargo/running-locally.md:15
+#: src/cargo/running-locally.md:16
 msgid ""
 "You can use any later version too since Rust maintains backwards "
 "compatibility."
 msgstr ""
 
-#: src/cargo/running-locally.md:17
+#: src/cargo/running-locally.md:18
 #, fuzzy
 msgid ""
 "With this in place, follow these steps to build a Rust binary from one of "
@@ -1908,22 +2267,22 @@ msgstr ""
 "次に、本講座の例を参考にしながら、以下の手順に従ってRustのバイナリをビルドし"
 "てください："
 
-#: src/cargo/running-locally.md:20
+#: src/cargo/running-locally.md:21
 msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr "「Copy to clipboard」でコードをコピー。"
 
-#: src/cargo/running-locally.md:22
+#: src/cargo/running-locally.md:23
 msgid ""
 "Use `cargo new exercise` to create a new `exercise/` directory for your code:"
 msgstr "`cargo new exercise`で`exercise/`ディレクトリを作成："
 
-#: src/cargo/running-locally.md:29
+#: src/cargo/running-locally.md:30
 msgid ""
 "Navigate into `exercise/` and use `cargo run` to build and run your binary:"
 msgstr ""
 "`exercise/`ディレクトリに移動し、`cargo run`でバイナリをビルドして実行："
 
-#: src/cargo/running-locally.md:40
+#: src/cargo/running-locally.md:41
 msgid ""
 "Replace the boiler-plate code in `src/main.rs` with your own code. For "
 "example, using the example on the previous page, make `src/main.rs` look like"
@@ -1931,11 +2290,11 @@ msgstr ""
 "`src/main.rs`のボイラープレートコードを、コピーしたコードで置き換えてくださ"
 "い。例えば、前のページの例を使った場合、`src/main.rs`は以下のようになります。"
 
-#: src/cargo/running-locally.md:49
+#: src/cargo/running-locally.md:50
 msgid "Use `cargo run` to build and run your updated binary:"
 msgstr "`cargo run`で更新されたバイナリをビルドして実行："
 
-#: src/cargo/running-locally.md:59
+#: src/cargo/running-locally.md:60
 msgid ""
 "Use `cargo check` to quickly check your project for errors, use `cargo "
 "build` to compile it without running it. You will find the output in `target/"
@@ -1947,7 +2306,7 @@ msgstr ""
 "`target/debug/`に格納されます。最適化されたリリースビルドには`cargo build —"
 "release`を使い、ファイルは`target/release/`に格納されます。"
 
-#: src/cargo/running-locally.md:64
+#: src/cargo/running-locally.md:65
 msgid ""
 "You can add dependencies for your project by editing `Cargo.toml`. When you "
 "run `cargo` commands, it will automatically download and compile missing "
@@ -1957,7 +2316,7 @@ msgstr ""
 "`cargo`コマンドを実行すると、自動的に不足している依存関係がダウンロードされて"
 "コンパイルされます。"
 
-#: src/cargo/running-locally.md:72
+#: src/cargo/running-locally.md:73
 msgid ""
 "Try to encourage the class participants to install Cargo and use a local "
 "editor. It will make their life easier since they will have a normal "
@@ -1978,7 +2337,7 @@ msgid ""
 msgstr ""
 "「Comprehensive Rust」の初日です。本日は多岐にわたる内容をカバーします："
 
-#: src/welcome-day-1.md:6
+#: src/welcome-day-1.md:5
 msgid ""
 "Basic Rust syntax: variables, scalar and compound types, enums, structs, "
 "references, functions, and methods."
@@ -1986,27 +2345,66 @@ msgstr ""
 "Rustの基本的な構文： 変数、スカラー型と複合型、列挙型、構造体、参照、関数、メ"
 "ソッド。"
 
-#: src/welcome-day-1.md:9
-msgid ""
-"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
-"`continue`."
+#: src/welcome-day-1.md:7
+#, fuzzy
+msgid "Types and type inference."
+msgstr "型推論"
+
+#: src/welcome-day-1.md:8
+msgid "Control flow constructs: loops, conditionals, and so on."
 msgstr ""
 
-#: src/welcome-day-1.md:12
+#: src/welcome-day-1.md:9
+msgid "User-defined types: structs and enums."
+msgstr ""
+
+#: src/welcome-day-1.md:10
 msgid "Pattern matching: destructuring enums, structs, and arrays."
 msgstr ""
 
+#: src/welcome-day-1.md:12 src/welcome-day-2.md:12 src/welcome-day-3.md:9
+#: src/welcome-day-4.md:11
+msgid "Schedule"
+msgstr ""
+
+#: src/welcome-day-1.md:14 src/welcome-day-1-afternoon.md:3
+#: src/welcome-day-2.md:14 src/welcome-day-2-afternoon.md:3
+#: src/welcome-day-3.md:11 src/welcome-day-3-afternoon.md:3
+#: src/welcome-day-4.md:13 src/welcome-day-4-afternoon.md:3
+msgid "In this session:"
+msgstr ""
+
+#: src/welcome-day-1.md:15
+msgid "[Welcome](./welcome-day-1.md) (5 minutes)"
+msgstr ""
+
 #: src/welcome-day-1.md:16
+msgid "[Hello, World](./hello-world.md) (20 minutes)"
+msgstr ""
+
+#: src/welcome-day-1.md:17
+msgid "[Types and Values](./types-and-values.md) (1 hour and 5 minutes)"
+msgstr ""
+
+#: src/welcome-day-1.md:18
+msgid "[Control Flow Basics](./control-flow-basics.md) (1 hour)"
+msgstr ""
+
+#: src/welcome-day-1.md:20 src/welcome-day-2-afternoon.md:7
+msgid "Including 10 minute breaks, this session should take about 3 hours"
+msgstr ""
+
+#: src/welcome-day-1.md:26
 msgid "Please remind the students that:"
 msgstr "受講生に伝えてください："
 
-#: src/welcome-day-1.md:18
+#: src/welcome-day-1.md:28
 #, fuzzy
 msgid ""
 "They should ask questions when they get them, don't save them to the end."
 msgstr "分からない事があれば、最後まで待たずに質問をしてください。"
 
-#: src/welcome-day-1.md:19
+#: src/welcome-day-1.md:29
 #, fuzzy
 msgid ""
 "The class is meant to be interactive and discussions are very much "
@@ -2015,27 +2413,26 @@ msgstr ""
 "本講座はインタラクティブな形式で行うため、積極的にディスカッションをしてくだ"
 "さい！"
 
-#: src/welcome-day-1.md:20
+#: src/welcome-day-1.md:30
 #, fuzzy
 msgid ""
 "As an instructor, you should try to keep the discussions relevant, i.e., "
-"keep the discussions related to how Rust does things vs some other "
-"language.  It can be hard to find the right balance, but err on the side of "
-"allowing  discussions since they engage people much more than one-way "
-"communication."
+"keep the discussions related to how Rust does things vs some other language. "
+"It can be hard to find the right balance, but err on the side of allowing "
+"discussions since they engage people much more than one-way communication."
 msgstr ""
 "講師の方へ： ディスカッションはなるべく関連性を有する範囲に留めましょう。例え"
 "ば、他言語との比較を行う場合には、あくまでもRustとどう違うのかまでを議論の範"
 "囲に設定してください。また、バランスの取り方が難しいかもしれませんが、一方的"
 "に話すよりもなるべくディスカッションを許容するように心がけてください。"
 
-#: src/welcome-day-1.md:24
+#: src/welcome-day-1.md:34
 #, fuzzy
 msgid ""
 "The questions will likely mean that we talk about things ahead of the slides."
 msgstr "質問があった場合、おそらく将来的に話す内容に触れる事になります。"
 
-#: src/welcome-day-1.md:25
+#: src/welcome-day-1.md:35
 #, fuzzy
 msgid ""
 "This is perfectly okay! Repetition is an important part of learning. "
@@ -2045,40 +2442,53 @@ msgstr ""
 "これは全く問題ありません！復習は学びの重要な要素です。スライドはあくまでもサ"
 "ポートとして用意されているものであり、ご自身の判断でスキップも可能です。"
 
-#: src/welcome-day-1.md:29
-msgid ""
-"The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak about the famous borrow checker. The way Rust handles memory is a "
-"major feature and we should show students this right away."
-msgstr ""
-"本日の目的は、Rust特有の借用チェッカーについて話ができるように、Rustについて"
-"最低限の情報提供を行う事です。Rustがメモリをどのように扱うかは重要な機能であ"
-"り、なるべく早く受講生に説明すべき内容です。"
-
-#: src/welcome-day-1.md:33
-msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the "
-"schedule. We suggest splitting the day into two parts (following the slides):"
-msgstr ""
-"この時点でスケジュール確認を行なってください。以下のように1日を２パートに分け"
-"て実施する事を推奨しています："
-
-#: src/welcome-day-1.md:36
-msgid "Morning: 9:00 to 12:00,"
-msgstr "AM： 9:00 ~ 12:00"
-
-#: src/welcome-day-1.md:37
-msgid "Afternoon: 13:00 to 16:00."
-msgstr "PM： 13:00 ~ 16:00"
-
 #: src/welcome-day-1.md:39
 msgid ""
-"You can of course adjust this as necessary. Please make sure to include "
-"breaks, we recommend a break every hour!"
+"The idea for the first day is to show the \"basic\" things in Rust that "
+"should have immediate parallels in other languages. The more advanced parts "
+"of Rust come on the subsequent days."
 msgstr ""
-"必要に応じて調整してください。また、1時間ごとに休憩を取る事をおすすめします！"
 
-#: src/welcome-day-1/what-is-rust.md:3
+#: src/welcome-day-1.md:43
+msgid ""
+"If you're teaching this in a classroom, this is a good place to go over the "
+"schedule. Note that there is an exercise at the end of each segment, "
+"followed by a break. Plan to cover the exercise solution after the break. "
+"The times listed here are a suggestion in order to keep the course on "
+"schedule. Feel free to be flexible and adjust as necessary!"
+msgstr ""
+
+#: src/hello-world.md:3 src/types-and-values.md:3 src/control-flow-basics.md:3
+#: src/tuples-and-arrays.md:3 src/references.md:3 src/user-defined-types.md:3
+#: src/pattern-matching.md:3 src/methods-and-traits.md:3 src/generics.md:3
+#: src/std-types.md:3 src/std-traits.md:3 src/memory-management.md:3
+#: src/smart-pointers.md:3 src/borrowing.md:3 src/slices-and-lifetimes.md:3
+#: src/iterators.md:3 src/modules.md:3 src/testing.md:3 src/error-handling.md:3
+#: src/unsafe-rust.md:3
+msgid "In this segment:"
+msgstr ""
+
+#: src/hello-world.md:4
+msgid "[What is Rust?](./hello-world/what-is-rust.md) (10 minutes)"
+msgstr ""
+
+#: src/hello-world.md:5
+msgid "[Hello, World](./hello-world/hello-world.md) (5 minutes)"
+msgstr ""
+
+#: src/hello-world.md:6
+msgid "[Benefits of Rust](./hello-world/benefits.md) (3 minutes)"
+msgstr ""
+
+#: src/hello-world.md:7
+msgid "[Playground](./hello-world/playground.md) (2 minutes)"
+msgstr ""
+
+#: src/hello-world.md:9
+msgid "This segment should take about 20 minutes"
+msgstr ""
+
+#: src/hello-world/what-is-rust.md:3
 msgid ""
 "Rust is a new programming language which had its [1.0 release in 2015]"
 "(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
@@ -2086,15 +2496,15 @@ msgstr ""
 "Rustは[2015年に1.0版がリリース](https://blog.rust-lang.org/2015/05/15/"
 "Rust-1.0.html)された新しいプログラミング言語です："
 
-#: src/welcome-day-1/what-is-rust.md:5
+#: src/hello-world/what-is-rust.md:5
 msgid "Rust is a statically compiled language in a similar role as C++"
 msgstr "RustはC++と同様に、静的にコンパイルされる言語です"
 
-#: src/welcome-day-1/what-is-rust.md:6
+#: src/hello-world/what-is-rust.md:6
 msgid "`rustc` uses LLVM as its backend."
 msgstr "`rustc`はバックエンドにLLVMを使用しています。"
 
-#: src/welcome-day-1/what-is-rust.md:7
+#: src/hello-world/what-is-rust.md:7
 msgid ""
 "Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
 "nightly/rustc/platform-support.html):"
@@ -2102,111 +2512,111 @@ msgstr ""
 "Rustは多くの[プラットフォームとアーキテクチャ](https://doc.rust-lang.org/"
 "nightly/rustc/platform-support.html)をサポートしています："
 
-#: src/welcome-day-1/what-is-rust.md:9
+#: src/hello-world/what-is-rust.md:9
 msgid "x86, ARM, WebAssembly, ..."
 msgstr "x86, ARM, WebAssembly, …"
 
-#: src/welcome-day-1/what-is-rust.md:10
+#: src/hello-world/what-is-rust.md:10
 msgid "Linux, Mac, Windows, ..."
 msgstr "Linux, Mac, Windows, …"
 
-#: src/welcome-day-1/what-is-rust.md:11
+#: src/hello-world/what-is-rust.md:11
 msgid "Rust is used for a wide range of devices:"
 msgstr "Rustは様々なデバイスで使用されています："
 
-#: src/welcome-day-1/what-is-rust.md:12
+#: src/hello-world/what-is-rust.md:12
 msgid "firmware and boot loaders,"
 msgstr "ファームウェアやブートローダ"
 
-#: src/welcome-day-1/what-is-rust.md:13
+#: src/hello-world/what-is-rust.md:13
 msgid "smart displays,"
 msgstr "スマートディスプレイ"
 
-#: src/welcome-day-1/what-is-rust.md:14
+#: src/hello-world/what-is-rust.md:14
 msgid "mobile phones,"
 msgstr "携帯電話"
 
-#: src/welcome-day-1/what-is-rust.md:15
+#: src/hello-world/what-is-rust.md:15
 msgid "desktops,"
 msgstr "デスクトップ"
 
-#: src/welcome-day-1/what-is-rust.md:16
+#: src/hello-world/what-is-rust.md:16
 msgid "servers."
 msgstr "サーバ"
 
-#: src/welcome-day-1/what-is-rust.md:21
+#: src/hello-world/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "RustとC++が似ているところ:"
 
-#: src/welcome-day-1/what-is-rust.md:23
+#: src/hello-world/what-is-rust.md:23
 msgid "High flexibility."
 msgstr "高い柔軟性"
 
-#: src/welcome-day-1/what-is-rust.md:24
+#: src/hello-world/what-is-rust.md:24
 msgid "High level of control."
 msgstr "高度な制御性"
 
-#: src/welcome-day-1/what-is-rust.md:25
+#: src/hello-world/what-is-rust.md:25
 #, fuzzy
 msgid ""
 "Can be scaled down to very constrained devices such as microcontrollers."
 msgstr "携帯電話のようなデバイスにまでスケールダウンが可能"
 
-#: src/welcome-day-1/what-is-rust.md:26
+#: src/hello-world/what-is-rust.md:26
 msgid "Has no runtime or garbage collection."
 msgstr "ランタイムやガベージコレクションがない"
 
-#: src/welcome-day-1/what-is-rust.md:27
+#: src/hello-world/what-is-rust.md:27
 msgid "Focuses on reliability and safety without sacrificing performance."
 msgstr "パフォーマンスを犠牲にせず、信頼性と安全性に焦点を当てている"
 
-#: src/hello-world.md:3
+#: src/hello-world/hello-world.md:3
 msgid ""
 "Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
 "さっそく一番シンプルなプログラムである定番のHello Worldからみてみましょう："
 
-#: src/hello-world.md:8
+#: src/hello-world/hello-world.md:8
 msgid "\"Hello 🌍!\""
 msgstr ""
 
-#: src/hello-world.md:12
+#: src/hello-world/hello-world.md:12
 msgid "What you see:"
 msgstr "プログラムの中身："
 
-#: src/hello-world.md:14
+#: src/hello-world/hello-world.md:14
 msgid "Functions are introduced with `fn`."
 msgstr "関数は`fn`で導入されます。"
 
-#: src/hello-world.md:15
+#: src/hello-world/hello-world.md:15
 msgid "Blocks are delimited by curly braces like in C and C++."
 msgstr "CやC++と同様に、ブロックは波括弧で囲みます。"
 
-#: src/hello-world.md:16
+#: src/hello-world/hello-world.md:16
 msgid "The `main` function is the entry point of the program."
 msgstr "`main`関数はプログラムのエントリーポイントになります。"
 
-#: src/hello-world.md:17
+#: src/hello-world/hello-world.md:17
 msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr "Rustには衛生的なマクロがあり、`println!`はその一例です。"
 
-#: src/hello-world.md:18
+#: src/hello-world/hello-world.md:18
 msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
 "Rustの文字列はUTF-8でエンコードされ、どんなUnicode文字でも含む事ができます。"
 
-#: src/hello-world.md:22
+#: src/hello-world/hello-world.md:23
 #, fuzzy
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see a ton of it over the next three days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 "このスライドの目的は、Rustのコードに慣れてもらう事です。この4日間で大量のRust"
 "コードを見る事になるので、馴染みのあるものから始めてみましょう。"
 
-#: src/hello-world.md:27
+#: src/hello-world/hello-world.md:28
 #, fuzzy
 msgid ""
 "Rust is very much like other languages in the C/C++/Java tradition. It is "
@@ -2215,21 +2625,21 @@ msgstr ""
 "Rustは、C/C++/Java系統の言語によく似ています。Rustは、命令型（関数型ではな"
 "く）であり、必須でない限り機能の再発明はしません。"
 
-#: src/hello-world.md:31
+#: src/hello-world/hello-world.md:31
 #, fuzzy
 msgid "Rust is modern with full support for things like Unicode."
 msgstr "RustはUnicodeなどにも完全に対応している現代的な言語です。"
 
-#: src/hello-world.md:33
+#: src/hello-world/hello-world.md:33
 #, fuzzy
 msgid ""
 "Rust uses macros for situations where you want to have a variable number of "
-"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+"arguments (no function [overloading](../control-flow-basics/functions.md))."
 msgstr ""
 "Rustで可変長引数を用いたい場合は、マクロを使用します(関数[オーバーロード]"
 "(basic-syntax/functions-interlude.md)はありません)。"
 
-#: src/hello-world.md:36
+#: src/hello-world/hello-world.md:36
 #, fuzzy
 msgid ""
 "Macros being 'hygienic' means they don't accidentally capture identifiers "
@@ -2242,7 +2652,7 @@ msgstr ""
 "ます。Rustのマクロは、実際には[部分的にしか衛生的](https://veykril.github.io/"
 "tlborm/decl-macros/minutiae/hygiene.html)ではありません。"
 
-#: src/hello-world.md:40
+#: src/hello-world/hello-world.md:40
 msgid ""
 "Rust is multi-paradigm. For example, it has powerful [object-oriented "
 "programming features](https://doc.rust-lang.org/book/ch17-00-oop.html), and, "
@@ -2250,112 +2660,104 @@ msgid ""
 "concepts](https://doc.rust-lang.org/book/ch13-00-functional-features.html)."
 msgstr ""
 
-#: src/hello-world/small-example.md:3
-msgid "Here is a small example program in Rust:"
-msgstr "ここでは、Rustによる小さなサンプルプログラムを紹介します："
-
-#: src/hello-world/small-example.md:6
-msgid "// Program entry point\n"
-msgstr "// プログラムのエントリーポイント\n"
-
-#: src/hello-world/small-example.md:7
-msgid "// Mutable variable binding\n"
-msgstr "// 可変変数のバインディング\n"
-
-#: src/hello-world/small-example.md:8 src/traits/impl-trait.md:15
-msgid "\"{x}\""
-msgstr "\"{x}\""
-
-#: src/hello-world/small-example.md:8
-msgid "// Macro for printing, like printf\n"
-msgstr "// printfのような、出力用マクロ\n"
-
-#: src/hello-world/small-example.md:9
-msgid "// No parenthesis around expression\n"
-msgstr "// 式を囲む括弧は不要\n"
-
-#: src/hello-world/small-example.md:10
-msgid "// Math like in other languages\n"
-msgstr "// 他の言語と同様の演算\n"
-
-#: src/hello-world/small-example.md:15
-msgid "\" -> {x}\""
-msgstr "\" -> {x}\""
-
-#: src/hello-world/small-example.md:23
-msgid ""
-"The code implements the Collatz conjecture: it is believed that the loop "
-"will always end, but this is not yet proved. Edit the code and play with "
-"different inputs."
-msgstr ""
-"この例はCollatz予想を実装したものです： このループは必ず終了すると言われてい"
-"ますが、まだ証明はされていません。コードを編集して、異なる入力値で試してみて"
-"ください。"
-
-#: src/hello-world/small-example.md:29
-msgid ""
-"Explain that all variables are statically typed. Try removing `i32` to "
-"trigger type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow."
-msgstr ""
-"すべての変数が静的型付けされている事を説明してください。`i32`を削除して型推論"
-"を試してください。代わりに`i8`を使用して、実行時に整数オーバーフローを引き起"
-"こしてみてください。"
-
-#: src/hello-world/small-example.md:32
-msgid "Change `let mut x` to `let x`, discuss the compiler error."
-msgstr ""
-"`let mut x`を`let x`に変更し、コンパイルエラーについて説明してください。"
-
-#: src/hello-world/small-example.md:34
-msgid ""
-"Show how `print!` gives a compilation error if the arguments don't match the "
-"format string."
-msgstr ""
-"`print!`の引数がフォーマット文字列と一致しない場合、コンパイルエラーが発生す"
-"る事を実演してください。"
-
-#: src/hello-world/small-example.md:37
-msgid ""
-"Show how you need to use `{}` as a placeholder if you want to print an "
-"expression which is more complex than just a single variable."
-msgstr ""
-"単一の変数よりも複雑な式を表示したい場合は、`{}`をプレースホルダとして使用す"
-"る必要がある事を実演してください。"
-
-#: src/hello-world/small-example.md:40
-msgid ""
-"Show the students the standard library, show them how to search for `std::"
-"fmt` which has the rules of the formatting mini-language. It's important "
-"that the students become familiar with searching in the standard library."
-msgstr ""
-"受講生に標準ライブラリを紹介し、`std::fmt`の検索方法を説明してください。"
-"`std::fmt`には、フォーマット機能のルールや構文が説明されています。受講者が標"
-"準ライブラリの検索に慣れておく事は重要です。"
-
-#: src/hello-world/small-example.md:44
-msgid ""
-"In a shell `rustup doc std::fmt` will open a browser on the local std::fmt "
-"documentation"
-msgstr ""
-
-#: src/why-rust.md:3
+#: src/hello-world/benefits.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Rustのユニークなセールスポイントをいくつか紹介します："
 
-#: src/why-rust.md:5
-msgid "Compile time memory safety."
-msgstr "コンパイル時のメモリ安全性。"
+#: src/hello-world/benefits.md:5
+msgid ""
+"_Compile time memory safety_ - whole classes of memory bugs are prevented at "
+"compile time"
+msgstr ""
 
-#: src/why-rust.md:6
-msgid "Lack of undefined runtime behavior."
-msgstr "未定義の実行時動作がない。"
+#: src/hello-world/benefits.md:7
+msgid "No uninitialized variables."
+msgstr "未初期化の変数がない。"
 
-#: src/why-rust.md:7
-msgid "Modern language features."
-msgstr "現代的な言語機能。"
+#: src/hello-world/benefits.md:8
+msgid "No double-frees."
+msgstr "二重解放が起きない。"
 
-#: src/why-rust.md:11
+#: src/hello-world/benefits.md:9
+msgid "No use-after-free."
+msgstr "解放済みメモリ使用（use-after-free）がない。"
+
+#: src/hello-world/benefits.md:10
+msgid "No `NULL` pointers."
+msgstr "`NULL`（ヌル）ポインタがない。"
+
+#: src/hello-world/benefits.md:11
+msgid "No forgotten locked mutexes."
+msgstr "ミューテックス（mutex）のロックの解除忘れがない。"
+
+#: src/hello-world/benefits.md:12
+msgid "No data races between threads."
+msgstr "スレッド間でデータ競合しない。"
+
+#: src/hello-world/benefits.md:13
+msgid "No iterator invalidation."
+msgstr "イテレータが無効化されない。"
+
+#: src/hello-world/benefits.md:15
+msgid ""
+"_No undefined runtime behavior_ - what a Rust statement does is never left "
+"unspecified"
+msgstr ""
+
+#: src/hello-world/benefits.md:17
+msgid "Array access is bounds checked."
+msgstr "配列へのアクセスには境界チェックが行われる。"
+
+#: src/hello-world/benefits.md:18
+#, fuzzy
+msgid "Integer overflow is defined (panic or wrap-around)."
+msgstr "整数オーバーフローの挙動が定義されている。"
+
+#: src/hello-world/benefits.md:20
+msgid ""
+"_Modern language features_ - as expressive and ergonomic as higher-level "
+"languages"
+msgstr ""
+
+#: src/hello-world/benefits.md:22
+msgid "Enums and pattern matching."
+msgstr "列挙型とパターンマッチング"
+
+#: src/hello-world/benefits.md:23
+msgid "Generics."
+msgstr "ジェネリクス"
+
+#: src/hello-world/benefits.md:24
+msgid "No overhead FFI."
+msgstr "オーバーヘッドのないFFI"
+
+#: src/hello-world/benefits.md:25
+msgid "Zero-cost abstractions."
+msgstr "ゼロコスト抽象化"
+
+#: src/hello-world/benefits.md:26
+msgid "Great compiler errors."
+msgstr "優秀なコンパイルエラー。"
+
+#: src/hello-world/benefits.md:27
+msgid "Built-in dependency manager."
+msgstr "組み込みの依存関係マネージャ。"
+
+#: src/hello-world/benefits.md:28
+msgid "Built-in support for testing."
+msgstr "組み込みのテストサポート。"
+
+#: src/hello-world/benefits.md:29
+msgid "Excellent Language Server Protocol support."
+msgstr "Language Server Protocol（LSP）のサポート。"
+
+#: src/hello-world/benefits.md:34
+msgid ""
+"Do not spend much time here. All of these points will be covered in more "
+"depth later."
+msgstr ""
+
+#: src/hello-world/benefits.md:37
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
 "Depending on the answer you can highlight different features of Rust:"
@@ -2363,7 +2765,7 @@ msgstr ""
 "受講者にどの言語の経験があるかを尋ねてください。回答に応じて、Rustのさまざま"
 "な特徴を強調することができます："
 
-#: src/why-rust.md:14
+#: src/hello-world/benefits.md:40
 msgid ""
 "Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
 "via the borrow checker. You get performance like in C and C++, but you don't "
@@ -2375,7 +2777,7 @@ msgstr ""
 "メモリ安全性の問題はありません。さらに、パターンマッチングや組み込みの依存関"
 "係管理などの構造要素を含む現代的な言語です。"
 
-#: src/why-rust.md:19
+#: src/hello-world/benefits.md:45
 msgid ""
 "Experience with Java, Go, Python, JavaScript...: You get the same memory "
 "safety as in those languages, plus a similar high-level language feeling. In "
@@ -2387,1370 +2789,447 @@ msgstr ""
 "かつ予測可能なパフォーマンス（ガベージコレクタがない）を得ることができ、（必"
 "要なら）低水準なハードウェアへのアクセスも可能です"
 
-#: src/why-rust/an-example-in-c.md:4
-msgid "Let's consider the following \"minimum wrong example\" program in C:"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:7
-#: src/android/interoperability/with-c/bindgen.md:22
-msgid "<stdio.h>"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:8
-msgid "<stdlib.h>"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:9
-msgid "<sys/stat.h>"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:19
-msgid "\"Too few arguments!\\n\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:29
-msgid "\"malloc failed!\\n\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:32
-msgid "\"rb\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:35
-msgid "\"%s\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:37
-msgid "\"fread failed!\\n\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:40
-msgid "\"Too many arguments!\\n\""
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:48
-msgid "How many bugs do you spot?"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:52
+#: src/hello-world/playground.md:3
 msgid ""
-"Despite just 29 lines of code, this C example contains serious bugs in at "
-"least 11:"
+"The [Rust Playground](https://play.rust-lang.org/) provides an easy way to "
+"run short Rust programs, and is the basis for the examples and exercises in "
+"this course. Try running the \"hello-world\" program it starts with. It "
+"comes with a few handy features:"
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:54
-msgid "Assignment `=` instead of equality comparison `==` (line 28)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:55
-msgid "Excess argument to `printf` (line 23)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:56
-msgid "File descriptor leak (after line 26)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:57
-msgid "Forgotten braces in multi-line `if` (line 22)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:58
-msgid "Forgotten `break` in a `switch` statement (line 32)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:59
+#: src/hello-world/playground.md:8
 msgid ""
-"Forgotten NUL-termination of the `buf` string, leading to a buffer overflow "
-"(line 29)"
+"Under \"Tools\", use the `rustfmt` option to format your code in the "
+"\"standard\" way."
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:60
-msgid "Memory leak by not freeing the `malloc`\\-allocated buffer (line 21)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:61
-msgid "Out-of-bounds access (line 17)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:62
-msgid "Unchecked cases in the `switch` statement (line 11)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:63
-msgid "Unchecked return values of `stat` and `fopen` (lines 18 and 26)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:65
+#: src/hello-world/playground.md:11
 msgid ""
-"_Shouldn't these bugs be obvious even for a C compiler?_  \n"
-"No, surprisingly this code compiles warning-free at the default warning "
-"level, even in the latest GCC version (13.2 as of writing)."
+"Rust has two main \"profiles\" for generating code: Debug (extra runtime "
+"checks, less optimization) and Release (fewer runtime checks, lots of "
+"optimization). These are accessible under \"Debug\" at the top."
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:68
+#: src/hello-world/playground.md:15
 msgid ""
-"_Isn't this a highly unrealistic example?_  \n"
-"Absolutely not, these kind of bugs have lead to serious security "
-"vulnerabilities in the past. Some examples:"
+"If you're interested, use \"ASM\" under \"...\" to see the generated "
+"assembly code."
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:71
+#: src/hello-world/playground.md:21
 msgid ""
-"Assignment `=` instead of equality comparison `==`: [The Linux Backdoor "
-"Attempt of 2003](https://freedom-to-tinker.com/2013/10/09/the-linux-backdoor-"
-"attempt-of-2003)"
+"As students head into the break, encourage them to open up the playground "
+"and experiment a little. Encourage them to keep the tab open and try things "
+"out during the rest of the course. This is particularly helpful for advanced "
+"students who want to know more about Rust's optimizations or generated "
+"assembly."
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:72
+#: src/types-and-values.md:4
+msgid "[Variables](./types-and-values/variables.md) (5 minutes)"
+msgstr ""
+
+#: src/types-and-values.md:5
+msgid "[Values](./types-and-values/values.md) (10 minutes)"
+msgstr ""
+
+#: src/types-and-values.md:6
+msgid "[Arithmetic](./types-and-values/arithmetic.md) (5 minutes)"
+msgstr ""
+
+#: src/types-and-values.md:7
+msgid "[Strings](./types-and-values/strings.md) (10 minutes)"
+msgstr ""
+
+#: src/types-and-values.md:8
+msgid "[Type Inference](./types-and-values/inference.md) (5 minutes)"
+msgstr ""
+
+#: src/types-and-values.md:9
+msgid "[Exercise: Fibonacci](./types-and-values/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/types-and-values.md:11 src/methods-and-traits.md:10 src/testing.md:12
+#: src/unsafe-rust.md:12
+msgid "This segment should take about 1 hour and 5 minutes"
+msgstr ""
+
+#: src/types-and-values/variables.md:3
 msgid ""
-"Forgotten braces in multi-line `if`: [The Apple goto fail vulnerability]"
-"(https://dwheeler.com/essays/apple-goto-fail.html)"
+"Rust provides type safety via static typing. Variable bindings are made with "
+"`let`:"
 msgstr ""
 
-#: src/why-rust/an-example-in-c.md:73
-msgid ""
-"Forgotten `break` in a `switch` statement: [The break that broke sudo]"
-"(https://nakedsecurity.sophos.com/2012/05/21/anatomy-of-a-security-hole-the-"
-"break-that-broke-sudo)"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:75
-msgid ""
-"_How is Rust any better here?_  \n"
-"Safe Rust makes all of these bugs impossible:"
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:78
-msgid "Assignments inside an `if` clause are not supported."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:79
-msgid "Format strings are checked at compile-time."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:80
-msgid "Resources are freed at the end of scope via the `Drop` trait."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:81
-msgid "All `if` clauses require braces."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:82
-msgid ""
-"`match` (as the Rust equivalent to `switch`) does not fall-through, hence "
-"you can't accidentally forget a `break`."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:83
-msgid "Buffer slices carry their size and don't rely on a NUL terminator."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:84
-msgid ""
-"Heap-allocated memory is freed via the `Drop` trait when the corresponding "
-"`Box` leaves the scope."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:85
-msgid ""
-"Out-of-bounds accesses cause a panic or can be checked via the `get` method "
-"of a slice."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:86
-msgid "`match` mandates that all cases are handled."
-msgstr ""
-
-#: src/why-rust/an-example-in-c.md:87
-msgid ""
-"Fallible Rust functions return `Result` values that need to be unwrapped and "
-"thereby checked for success. Additionally, the compiler emits a warning if "
-"you miss to check the return value of a function marked with `#[must_use]`."
-msgstr ""
-
-#: src/why-rust/compile-time.md:3
-msgid "Static memory management at compile time:"
-msgstr "コンパイル時の静的メモリの管理："
-
-#: src/why-rust/compile-time.md:5
-msgid "No uninitialized variables."
-msgstr "未初期化の変数がない。"
-
-#: src/why-rust/compile-time.md:6
-msgid "No memory leaks (_mostly_, see notes)."
-msgstr "メモリリークの心配が（ほとんど）ない (ノートを参照)。"
-
-#: src/why-rust/compile-time.md:7
-msgid "No double-frees."
-msgstr "二重解放が起きない。"
-
-#: src/why-rust/compile-time.md:8
-msgid "No use-after-free."
-msgstr "解放済みメモリ使用（use-after-free）がない。"
-
-#: src/why-rust/compile-time.md:9
-msgid "No `NULL` pointers."
-msgstr "`NULL`（ヌル）ポインタがない。"
-
-#: src/why-rust/compile-time.md:10
-msgid "No forgotten locked mutexes."
-msgstr "ミューテックス（mutex）のロックの解除忘れがない。"
-
-#: src/why-rust/compile-time.md:11
-msgid "No data races between threads."
-msgstr "スレッド間でデータ競合しない。"
-
-#: src/why-rust/compile-time.md:12
-msgid "No iterator invalidation."
-msgstr "イテレータが無効化されない。"
-
-#: src/why-rust/compile-time.md:16
-msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
-msgstr ""
-"SafeなRustの範囲内でメモリリークを引き起こすことは可能です。例として以下のよ"
-"うな手段があります："
-
-#: src/why-rust/compile-time.md:19
+#: src/types-and-values/variables.md:9 src/control-flow-basics/loops.md:30
+#: src/control-flow-basics/break-continue.md:34
+#: src/control-flow-basics/blocks-and-scopes.md:16
 #, fuzzy
+msgid "\"x: {x}\""
+msgstr "\"{x}\""
+
+#: src/types-and-values/variables.md:10
 msgid ""
-"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
-"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
-"initialized and runtime-sized static variables"
+"// x = 20;\n"
+"    // println!(\"x: {x}\");\n"
 msgstr ""
-"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
-"leak)を使ってポインタをリークさせることができます。この関数は実行時に初期化さ"
-"れ、実行時にサイズが決まるstatic変数の取得などに使われます。"
 
-#: src/why-rust/compile-time.md:21
-#, fuzzy
+#: src/types-and-values/variables.md:18
 msgid ""
-"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
-"html) to make the compiler \"forget\" about a value (meaning the destructor "
-"is never run)."
+"Uncomment the `x = 20` to demonstrate that variables are immutable by "
+"default. Add the `mut` keyword to allow changes."
 msgstr ""
-"[`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html)を使っ"
-"て、コンパイラに値を忘れさせることができます (つまり、デストラクタが実行され"
-"ない)。"
 
-#: src/why-rust/compile-time.md:23
-#, fuzzy
+#: src/types-and-values/variables.md:21
 msgid ""
-"You can also accidentally create a [reference cycle](https://doc.rust-lang."
-"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+"The `i32` here is the type of the variable. This must be known at compile "
+"time, but type inference (covered later) allows the programmer to omit it in "
+"many cases."
 msgstr ""
-"`Rc`や`Arc`を使って\\[循環参照（reference cycle）\\]を誤って作成することがあ"
-"ります。"
 
-#: src/why-rust/compile-time.md:25
-#, fuzzy
+#: src/types-and-values/values.md:3
 msgid ""
-"In fact, some will consider infinitely populating a collection a memory leak "
-"and Rust does not protect from those."
-msgstr ""
-"コレクションを無限に拡張し続けることをメモリリークと見なす場合があり、Rustに"
-"はこれを防ぐ機能はありません。"
-
-#: src/why-rust/compile-time.md:28
-msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood as "
-"\"Pretty much no _accidental_ memory leaks\"."
-msgstr ""
-"本講座での「メモリリークが起きない」は「\\_意図しない_メモリリークはほとんど"
-"起きない」と解釈すべきです。"
-
-#: src/why-rust/runtime.md:3
-msgid "No undefined behavior at runtime:"
-msgstr "実行時に未定義の動作はありません："
-
-#: src/why-rust/runtime.md:5
-msgid "Array access is bounds checked."
-msgstr "配列へのアクセスには境界チェックが行われる。"
-
-#: src/why-rust/runtime.md:6
-#, fuzzy
-msgid "Integer overflow is defined (panic or wrap-around)."
-msgstr "整数オーバーフローの挙動が定義されている。"
-
-#: src/why-rust/runtime.md:12
-#, fuzzy
-msgid ""
-"Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
-"lang.org/rustc/codegen-options/index.html#overflow-checks) compile-time "
-"flag. If enabled, the program will panic (a controlled crash of the "
-"program), otherwise you get wrap-around semantics. By default, you get "
-"panics in debug mode (`cargo build`) and wrap-around in release mode (`cargo "
-"build --release`)."
-msgstr ""
-"整数オーバーフローは、コンパイル時のフラグで定義されます。選択肢として、パ"
-"ニック（プログラムの制御されたクラッシュ）またはラップアラウンドのセマンティ"
-"クスがあります。デフォルトとして、デバッグモード（`cargo build`）ではパニック"
-"が発生し、リリースモード（`cargo build —release`）ではラップアラウンドが行わ"
-"れます。"
-
-#: src/why-rust/runtime.md:18
-msgid ""
-"Bounds checking cannot be disabled with a compiler flag. It can also not be "
-"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
-"call functions such as `slice::get_unchecked` which does not do bounds "
-"checking."
-msgstr ""
-"境界チェックは、コンパイル時のフラグで無効にすることはできません。また、"
-"`unsafe`のキーワードを使って直接無効にすることもできません。しかし、`unsafe`"
-"を使って境界チェックを行わない`slice::get_unchecked`のような関数を呼び出すこ"
-"とができます。"
-
-#: src/why-rust/modern.md:3
-#, fuzzy
-msgid "Rust is built with all the experience gained in the last decades."
-msgstr "Rustは過去40年間の経験を基に構築されています。"
-
-#: src/why-rust/modern.md:5
-msgid "Language Features"
-msgstr "言語の特徴"
-
-#: src/why-rust/modern.md:7
-msgid "Enums and pattern matching."
-msgstr "列挙型とパターンマッチング"
-
-#: src/why-rust/modern.md:8
-msgid "Generics."
-msgstr "ジェネリクス"
-
-#: src/why-rust/modern.md:9
-msgid "No overhead FFI."
-msgstr "オーバーヘッドのないFFI"
-
-#: src/why-rust/modern.md:10
-msgid "Zero-cost abstractions."
-msgstr "ゼロコスト抽象化"
-
-#: src/why-rust/modern.md:12
-msgid "Tooling"
+"Here are some basic built-in types, and the syntax for literal values of "
+"each type."
 msgstr ""
 
-#: src/why-rust/modern.md:14
-msgid "Great compiler errors."
-msgstr "優秀なコンパイルエラー。"
-
-#: src/why-rust/modern.md:15
-msgid "Built-in dependency manager."
-msgstr "組み込みの依存関係マネージャ。"
-
-#: src/why-rust/modern.md:16
-msgid "Built-in support for testing."
-msgstr "組み込みのテストサポート。"
-
-#: src/why-rust/modern.md:17
-msgid "Excellent Language Server Protocol support."
-msgstr "Language Server Protocol（LSP）のサポート。"
-
-#: src/why-rust/modern.md:23
-msgid ""
-"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
-"for higher-level programming constructs with memory or CPU. For example, "
-"writing a loop using `for` should result in roughly the same low level "
-"instructions as using the `.iter().fold()` construct."
-msgstr ""
-"C++と同様に、ゼロコスト抽象化とは、より高水準なプログラミング構造の利用にメモ"
-"リやCPUのコストを支払う必要がないことを意味します。例えば、`for`を使ったルー"
-"プの場合、`iter().fold()`構文を使った場合とおおよそ同じ低水準の処理になりま"
-"す。"
-
-#: src/why-rust/modern.md:28
-msgid ""
-"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
-"known as 'sum types', which allow the type system to express things like "
-"`Option<T>` and `Result<T, E>`."
-msgstr ""
-"Rustの列挙型は「代数的データ型」であり、「直和型」と呼ばれます。`Option<T>`や"
-"`Result<T, E>`のような要素を表現することができます。"
-
-#: src/why-rust/modern.md:32
-msgid ""
-"Remind people to read the errors --- many developers have gotten used to "
-"ignore lengthy compiler output. The Rust compiler is significantly more "
-"talkative than other compilers. It will often provide you with _actionable_ "
-"feedback, ready to copy-paste into your code."
-msgstr ""
-"エラーをちゃんと確認するよう注意してください。多くの開発者は、長いコンパイラ"
-"出力を無視することに慣れてしまっています。Rustのコンパイラは他のコンパイラよ"
-"りもわかりやすく実用的なフィードバックを提供してくれます。そして多くの場合、"
-"コードにそのままコピペできるようなフィードバックが提供されます。"
-
-#: src/why-rust/modern.md:37
-msgid ""
-"The Rust standard library is small compared to languages like Java, Python, "
-"and Go. Rust does not come with several things you might consider standard "
-"and essential:"
-msgstr ""
-"Rustの標準ライブラリは、Java、Python、Goなどのそれと比べると小規模です。Rust"
-"には標準的かつ必須と思われるいくつかの機能が含まれていません："
-
-#: src/why-rust/modern.md:41
-msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
-msgstr "乱数生成器。[rand](https://docs.rs/rand/)を確認してください。"
-
-#: src/why-rust/modern.md:42
-msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
-msgstr ""
-"SSLやTLSのサポート。[rusttls](https://docs.rs/rustls/)を確認してください。"
-
-#: src/why-rust/modern.md:43
-msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
-msgstr ""
-"JSONのサポート。[serde_json](https://docs.rs/serde_json/)を確認してくださ"
-"い。 "
-
-#: src/why-rust/modern.md:45
-msgid ""
-"The reasoning behind this is that functionality in the standard library "
-"cannot go away, so it has to be very stable. For the examples above, the "
-"Rust community is still working on finding the best solution --- and perhaps "
-"there isn't a single \"best solution\" for some of these things."
-msgstr ""
-"この理由は、標準ライブラリの機能は消えることがなく、非常に安定したものでなけ"
-"ればならないからです。上記の例については、Rustコミュニティが未だに最適な解決"
-"策を探し続けています。そもそも、これらに対する「最適解」は一つであるとは限ら"
-"ないのです。"
-
-#: src/why-rust/modern.md:50
-msgid ""
-"Rust comes with a built-in package manager in the form of Cargo and this "
-"makes it trivial to download and compile third-party crates. A consequence "
-"of this is that the standard library can be smaller."
-msgstr ""
-"Rustには、Cargoという外部クレートのダウンロードからコンパイルまでを簡単に行っ"
-"てくれるパッケージマネージャが組み込まれています。これにより、標準ライブラリ"
-"を小規模に保つことができています。"
-
-#: src/why-rust/modern.md:54
-msgid ""
-"Discovering good third-party crates can be a problem. Sites like <https://"
-"lib.rs/> help with this by letting you compare health metrics for crates to "
-"find a good and trusted one."
-msgstr ""
-"良い外部クレートを見つけるのは難しいときがあります。<https://lib.rs/>のような"
-"サイトを使うことで、クレートの評価基準を参考にしながら比較を行うことができま"
-"す。"
-
-#: src/why-rust/modern.md:58
-msgid ""
-"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
-"implementation used in major IDEs and text editors."
-msgstr ""
-"[rust-analyzer](https://rust-analyzer.github.io/)は、主要IDEやテキストエディ"
-"タで使用できる、サポートが充実しているLSPの実装です。"
-
-#: src/basic-syntax.md:3
-msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
-msgstr ""
-
-#: src/basic-syntax.md:5
-msgid "Blocks and scopes are delimited by curly braces."
-msgstr ""
-
-#: src/basic-syntax.md:6
-msgid ""
-"Line comments are started with `//`, block comments are delimited by `/* ... "
-"*/`."
-msgstr ""
-
-#: src/basic-syntax.md:8
-msgid "Keywords like `if` and `while` work the same."
-msgstr ""
-
-#: src/basic-syntax.md:9
-msgid "Variable assignment is done with `=`, comparison is done with `==`."
-msgstr ""
-
-#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
-#: src/exercises/day-3/safe-ffi-wrapper.md:16
+#: src/types-and-values/values.md:6
+#: src/tuples-and-arrays/tuples-and-arrays.md:7 src/unsafe-rust/exercise.md:16
 msgid "Types"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/types-and-values/values.md:6
+#: src/tuples-and-arrays/tuples-and-arrays.md:7
 msgid "Literals"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:5
+#: src/types-and-values/values.md:8
 msgid "Signed integers"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:5
+#: src/types-and-values/values.md:8
 msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:5
+#: src/types-and-values/values.md:8
 msgid "`-10`, `0`, `1_000`, `123_i64`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:6
+#: src/types-and-values/values.md:9
 msgid "Unsigned integers"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:6
+#: src/types-and-values/values.md:9
 msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:6
+#: src/types-and-values/values.md:9
 msgid "`0`, `123`, `10_u16`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:7
+#: src/types-and-values/values.md:10
 msgid "Floating point numbers"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:7
+#: src/types-and-values/values.md:10
 msgid "`f32`, `f64`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:7
+#: src/types-and-values/values.md:10
 msgid "`3.14`, `-10.0e20`, `2_f32`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:8
-msgid "Strings"
-msgstr ""
-
-#: src/basic-syntax/scalar-types.md:8
-msgid "`&str`"
-msgstr ""
-
-#: src/basic-syntax/scalar-types.md:8
-msgid "`\"foo\"`, `\"two\\nlines\"`"
-msgstr ""
-
-#: src/basic-syntax/scalar-types.md:9
+#: src/types-and-values/values.md:11
 msgid "Unicode scalar values"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:9
+#: src/types-and-values/values.md:11
 msgid "`char`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:9
+#: src/types-and-values/values.md:11
 msgid "`'a'`, `'α'`, `'∞'`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:10
+#: src/types-and-values/values.md:12
 msgid "Booleans"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:10
+#: src/types-and-values/values.md:12
 msgid "`bool`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:10
+#: src/types-and-values/values.md:12
 msgid "`true`, `false`"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:12
+#: src/types-and-values/values.md:14
 msgid "The types have widths as follows:"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:14
+#: src/types-and-values/values.md:16
 msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:15
+#: src/types-and-values/values.md:17
 msgid "`isize` and `usize` are the width of a pointer,"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:16
+#: src/types-and-values/values.md:18
 msgid "`char` is 32 bits wide,"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:17
+#: src/types-and-values/values.md:19
 msgid "`bool` is 8 bits wide."
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:21
+#: src/types-and-values/values.md:24
 msgid "There are a few syntaxes which are not shown above:"
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:23
-msgid ""
-"Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
-"amount of `#` on either side of the quotes:"
-msgstr ""
-
-#: src/basic-syntax/scalar-types.md:35
-msgid "Byte strings allow you to create a `&[u8]` value directly:"
-msgstr ""
-
-#: src/basic-syntax/scalar-types.md:45
+#: src/types-and-values/values.md:26
 msgid ""
 "All underscores in numbers can be left out, they are for legibility only. So "
 "`1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written "
 "as `123i64`."
 msgstr ""
 
-#: src/basic-syntax/compound-types.md:5
-msgid "Arrays"
+#: src/types-and-values/arithmetic.md:9
+msgid "\"result: {}\""
 msgstr ""
 
-#: src/basic-syntax/compound-types.md:5
-msgid "`[T; N]`"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:5
-msgid "`[20, 30, 40]`, `[0; 3]`"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:6
-msgid "Tuples"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:6
-msgid "`()`, `(T,)`, `(T1, T2)`, ..."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:6
-msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:8
-msgid "Array assignment and access:"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:19
-msgid "Tuple assignment and access:"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:34
-msgid "Arrays:"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:36
-msgid ""
-"A value of the array type `[T; N]` holds `N` (a compile-time constant) "
-"elements of the same type `T`. Note that the length of the array is _part of "
-"its type_, which means that `[u8; 3]` and `[u8; 4]` are considered two "
-"different types."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:40
-msgid "We can use literals to assign values to arrays."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:42
-msgid ""
-"In the main function, the print statement asks for the debug implementation "
-"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
-"the debug output. We could also have used `{a}` and `{a:?}` without "
-"specifying the value after the format string."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:47
-msgid ""
-"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
-"easier to read."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:49
-msgid "Tuples:"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:51
-msgid "Like arrays, tuples have a fixed length."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:53
-msgid "Tuples group together values of different types into a compound type."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:55
-msgid ""
-"Fields of a tuple can be accessed by the period and the index of the value, "
-"e.g. `t.0`, `t.1`."
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:57
-msgid ""
-"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
-"and the only valid value of that type - that is to say both the type and its "
-"value are expressed as `()`. It is used to indicate, for example, that a "
-"function or expression has no return value, as we'll see in a future slide. "
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:61
-msgid ""
-"You can think of it as `void` that can be familiar to you from other  "
-"programming languages."
-msgstr ""
-
-#: src/basic-syntax/references.md:3
-msgid "Like C++, Rust has references:"
-msgstr ""
-
-#: src/basic-syntax/references.md:15
-msgid "Some notes:"
-msgstr ""
-
-#: src/basic-syntax/references.md:17
-msgid ""
-"We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers."
-msgstr ""
-
-#: src/basic-syntax/references.md:18
-msgid ""
-"Rust will auto-dereference in some cases, in particular when invoking "
-"methods (try `ref_x.count_ones()`)."
-msgstr ""
-
-#: src/basic-syntax/references.md:20
-msgid ""
-"References that are declared as `mut` can be bound to different values over "
-"their lifetime."
-msgstr ""
-
-#: src/basic-syntax/references.md:26
-msgid ""
-"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
-"&mut i32`. The first one represents a mutable reference which can be bound "
-"to different values, while the second represents a reference to a mutable "
-"value."
-msgstr ""
-
-#: src/basic-syntax/references-dangling.md:3
-msgid "Rust will statically forbid dangling references:"
-msgstr ""
-
-#: src/basic-syntax/references-dangling.md:17
-msgid "A reference is said to \"borrow\" the value it refers to."
-msgstr ""
-
-#: src/basic-syntax/references-dangling.md:18
-msgid ""
-"Rust is tracking the lifetimes of all references to ensure they live long "
-"enough."
-msgstr ""
-
-#: src/basic-syntax/references-dangling.md:20
-msgid "We will talk more about borrowing when we get to ownership."
-msgstr ""
-
-#: src/basic-syntax/slices.md:3
-msgid "A slice gives you a view into a larger collection:"
-msgstr ""
-
-#: src/basic-syntax/slices.md:17
-msgid "Slices borrow data from the sliced type."
-msgstr ""
-
-#: src/basic-syntax/slices.md:18
-msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
-msgstr ""
-
-#: src/basic-syntax/slices.md:22
-msgid ""
-"We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets."
-msgstr ""
-
-#: src/basic-syntax/slices.md:24
-msgid ""
-"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
-"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical."
-msgstr ""
-
-#: src/basic-syntax/slices.md:26
-msgid ""
-"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical."
-msgstr ""
-
-#: src/basic-syntax/slices.md:28
-msgid ""
-"To easily create a slice of the full array, we can therefore use `&a[..]`."
-msgstr ""
-
-#: src/basic-syntax/slices.md:30
-msgid ""
-"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
-"(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes."
-msgstr ""
-
-#: src/basic-syntax/slices.md:32
-msgid ""
-"Slices always borrow from another object. In this example, `a` has to remain "
-"'alive' (in scope) for at least as long as our slice. "
-msgstr ""
-
-#: src/basic-syntax/slices.md:34
-msgid ""
-"The question about modifying `a[3]` can spark an interesting discussion, but "
-"the answer is that for memory safety reasons you cannot do it through `a` at "
-"this point in the execution, but you can read the data from both `a` and `s` "
-"safely. It works before you created the slice, and again after the "
-"`println`, when the slice is no longer used. More details will be explained "
-"in the borrow checker section."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:1
-msgid "`String` vs `str`"
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:3
-msgid "We can now understand the two string types in Rust:"
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:7 src/traits/read-write.md:36
-#: src/testing/test-modules.md:12
-msgid "\"World\""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:8
-msgid "\"s1: {s1}\""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:10 src/memory-management/scope-based.md:16
-#: src/memory-management/garbage-collection.md:15
-msgid "\"Hello \""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:11 src/basic-syntax/string-slices.md:13
-#: src/ownership/move-semantics.md:9
-msgid "\"s2: {s2}\""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:16
-msgid "\"s3: {s3}\""
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:20
-msgid "Rust terminology:"
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:22
-msgid "`&str` an immutable reference to a string slice."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:23
-msgid "`String` a mutable string buffer."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:27
-msgid ""
-"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data  stored in a block of memory. String literals "
-"(`”Hello”`), are stored in the program’s binary."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:30
-msgid ""
-"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:32
-msgid ""
-"As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()`  creates a new empty string, to which string data "
-"can be added using the `push()` and `push_str()` methods."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:35
-msgid ""
-"The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It  accepts the same format specification as `println!()`."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:38
-msgid ""
-"You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection."
-msgstr ""
-
-#: src/basic-syntax/string-slices.md:40
-msgid ""
-"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
-"that always points  to a valid string in memory. Rust `String` is a rough "
-"equivalent of `std::string` from C++  (main difference: it can only contain "
-"UTF-8 encoded bytes and will never use a small-string optimization)."
-msgstr ""
-
-#: src/basic-syntax/functions.md:3
-msgid ""
-"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
-"Fizz_buzz) interview question:"
-msgstr ""
-
-#: src/basic-syntax/functions.md:36
-msgid ""
-"We refer in `main` to a function written below. Neither forward declarations "
-"nor headers are necessary. "
-msgstr ""
-
-#: src/basic-syntax/functions.md:37
-msgid ""
-"Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type."
-msgstr ""
-
-#: src/basic-syntax/functions.md:38
-msgid ""
-"The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression."
-msgstr ""
-
-#: src/basic-syntax/functions.md:39
-msgid ""
-"Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted."
-msgstr ""
-
-#: src/basic-syntax/functions.md:40
+#: src/types-and-values/arithmetic.md:16
 msgid ""
-"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
-"`=n`, which causes it to include the upper bound."
+"This is the first time we've seen a function other than `main`, but the "
+"meaning should be clear: it takes three integers, and returns an integer. "
+"Functions will be covered in more detail later."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:3
-msgid ""
-"All language items in Rust can be documented using special `///` syntax."
+#: src/types-and-values/arithmetic.md:20
+msgid "Arithmetic is very similar to other languages, with similar precedence."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:6
+#: src/types-and-values/arithmetic.md:22
 msgid ""
-"/// Determine whether the first argument is divisible by the second "
-"argument.\n"
-"///\n"
-"/// If the second argument is zero, the result is false.\n"
-"///\n"
-"/// # Example\n"
-"/// ```\n"
-"/// assert!(is_divisible_by(42, 2));\n"
-"/// ```\n"
-msgstr ""
-
-#: src/basic-syntax/rustdoc.md:16
-msgid "// Corner case, early return\n"
+"What about integer overflow? In C and C++ overflow of _signed_ integers is "
+"actually undefined, and might do different things on different platforms or "
+"compilers. In Rust, it's defined."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:18
-msgid "// The last expression in a block is the return value\n"
-msgstr ""
-
-#: src/basic-syntax/rustdoc.md:22
+#: src/types-and-values/arithmetic.md:26
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are "
-"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
-"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
-"idiomatic to document all public items in an API using this pattern. Code "
-"snippets can document usage and will be used as unit tests."
+"Change the `i32`'s to `i16` to see an integer overflow, which panics "
+"(checked) in a debug build and wraps in a release build. There are other "
+"options, such as overflowing, saturating, and carrying. These are accessed "
+"with method syntax, e.g., `(a * b).saturating_add(b * c).saturating_add(c * "
+"a)`."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:30
+#: src/types-and-values/arithmetic.md:31
 msgid ""
-"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
-"(https://docs.rs/rand)."
+"In fact, the compiler will detect overflow of constant expressions, which is "
+"why the example requires a separate function."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:33
+#: src/types-and-values/strings.md:3
 msgid ""
-"This course does not include rustdoc on slides, just to save space, but in "
-"real code they should be present."
+"Rust has two types to represent strings, both of which will be covered in "
+"more depth later. Both _always_ store UTF-8 encoded strings."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:36
-msgid ""
-"Inner doc comments are discussed later (in the page on modules) and need not "
-"be addressed here."
+#: src/types-and-values/strings.md:6
+msgid "`String` - a modifiable, owned string."
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:39
-msgid ""
-"Rustdoc comments can contain code snippets that we can run and test using "
-"`cargo test`. We will discuss these tests in the [Testing section](../"
-"testing/doc-tests.html)."
+#: src/types-and-values/strings.md:7
+msgid "`&str` - a read-only string. String literals have this type."
 msgstr ""
 
-#: src/basic-syntax/methods.md:3
-msgid ""
-"Methods are functions associated with a type. The `self` argument of a "
-"method is an instance of the type it is associated with:"
+#: src/types-and-values/strings.md:11
+msgid "\"Greetings\""
 msgstr ""
 
-#: src/basic-syntax/methods.md:24
-msgid "\"old area: {}\""
+#: src/types-and-values/strings.md:12
+msgid "\"🪐\""
 msgstr ""
 
-#: src/basic-syntax/methods.md:26
-msgid "\"new area: {}\""
+#: src/types-and-values/strings.md:15
+msgid "\", \""
 msgstr ""
 
-#: src/basic-syntax/methods.md:30
-msgid ""
-"We will look much more at methods in today's exercise and in tomorrow's "
-"class."
+#: src/types-and-values/strings.md:17
+msgid "\"final sentence: {}\""
 msgstr ""
 
-#: src/basic-syntax/methods.md:34
-msgid "Add a static method called `Rectangle::new` and call this from `main`:"
+#: src/types-and-values/strings.md:18 src/async/control-flow/join.md:30
+msgid "\"{:?}\""
 msgstr ""
 
-#: src/basic-syntax/methods.md:42
-msgid ""
-"While _technically_, Rust does not have custom constructors, static methods "
-"are commonly used to initialize structs (but don't have to). The actual "
-"constructor, `Rectangle { width, height }`, could be called directly. See "
-"the [Rustnomicon](https://doc.rust-lang.org/nomicon/constructors.html)."
+#: src/types-and-values/strings.md:19
+msgid "//println!(\"{:?}\", &sentence[12..13]);\n"
 msgstr ""
 
-#: src/basic-syntax/methods.md:45
+#: src/types-and-values/strings.md:26
 msgid ""
-"Add a `Rectangle::square(width: u32)` constructor to illustrate that such "
-"static methods can take arbitrary parameters."
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:1
-msgid "Function Overloading"
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:3
-msgid "Overloading is not supported:"
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:5
-msgid "Each function has a single implementation:"
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:6
-msgid "Always takes a fixed number of parameters."
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:7
-msgid "Always takes a single set of parameter types."
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:8
-msgid "Default values are not supported:"
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:9
-msgid "All call sites have the same number of arguments."
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:10
-msgid "Macros are sometimes used as an alternative."
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:12
-msgid "However, function parameters can be generic:"
+"This slide introduces strings. Everything here will be covered in more depth "
+"later, but this is enough for subsequent slides and exercises to use strings."
 msgstr ""
 
-#: src/basic-syntax/functions-interlude.md:20
-msgid "\"coin toss: {}\""
+#: src/types-and-values/strings.md:29
+msgid "Invalid UTF-8 in a string is UB, and this not allowed in safe Rust."
 msgstr ""
 
-#: src/basic-syntax/functions-interlude.md:20
-msgid "\"heads\""
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:20
-msgid "\"tails\""
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:21
-msgid "\"cash prize: {}\""
-msgstr ""
-
-#: src/basic-syntax/functions-interlude.md:27
+#: src/types-and-values/strings.md:31
 msgid ""
-"When using generics, the standard library's `Into<T>` can provide a kind of "
-"limited polymorphism on argument types. We will see more details in a later "
-"section."
-msgstr ""
-
-#: src/exercises/day-1/morning.md:1
-msgid "Day 1: Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-1/morning.md:3
-msgid "In these exercises, we will explore two parts of Rust:"
-msgstr ""
-
-#: src/exercises/day-1/morning.md:5
-msgid "Implicit conversions between types."
-msgstr ""
-
-#: src/exercises/day-1/morning.md:7
-msgid "Arrays and `for` loops."
+"`String` is a user-defined type with a constructor (`::new()`) and methods "
+"like `s.push_str(..)`."
 msgstr ""
 
-#: src/exercises/day-1/morning.md:11
-msgid "A few things to consider while solving the exercises:"
-msgstr ""
-
-#: src/exercises/day-1/morning.md:13
+#: src/types-and-values/strings.md:34
 msgid ""
-"Use a local Rust installation, if possible. This way you can get auto-"
-"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
-"for details on installing Rust."
-msgstr ""
-
-#: src/exercises/day-1/morning.md:17
-msgid "Alternatively, use the Rust Playground."
+"The `&` in `&str` indicates that this is a reference. We will cover "
+"references later, so for now just think of `&str` as a unit meaning \"a read-"
+"only string\"."
 msgstr ""
 
-#: src/exercises/day-1/morning.md:19
+#: src/types-and-values/strings.md:37
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets lose "
-"their state if you navigate away from the page."
+"The commented-out line is indexing into the string by byte position. "
+"`12..13` does not end on a character boundary, so the program panics. Adjust "
+"it to a range that does, based on the error message."
 msgstr ""
 
-#: src/exercises/day-1/morning.md:22 src/exercises/day-2/morning.md:11
-#: src/exercises/day-3/morning.md:9 src/exercises/bare-metal/morning.md:7
-#: src/exercises/concurrency/morning.md:12
+#: src/types-and-values/strings.md:41
 msgid ""
-"After looking at the exercises, you can look at the [solutions](solutions-"
-"morning.md) provided."
+"Raw strings allow you to create a `&str` value with escapes disabled: `r\"\\n"
+"\" == \"\\\\n\"`. You can embed double-quotes by using an equal amount of "
+"`#` on either side of the quotes:"
 msgstr ""
-"練習問題に取り組んだあとは、 [解答](solutions-morning.md)をみても構いません。"
 
-#: src/exercises/day-1/implicit-conversions.md:3
-msgid ""
-"Rust will not automatically apply _implicit conversions_ between types "
-"([unlike C++](https://en.cppreference.com/w/cpp/language/"
-"implicit_conversion)). You can see this in a program like this:"
+#: src/types-and-values/inference.md:3
+msgid "Rust will look at how the variable is _used_ to determine the type:"
 msgstr ""
 
-#: src/exercises/day-1/implicit-conversions.md:20
+#: src/types-and-values/inference.md:29
 msgid ""
-"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
-"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
-"std/convert/trait.Into.html) traits to let us convert between them. The "
-"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
-"trait has a single `into()` method. Implementing these traits is how a type "
-"expresses that it can be converted into another type."
-msgstr ""
-
-#: src/exercises/day-1/implicit-conversions.md:26
-msgid ""
-"The standard library has an implementation of `From<i8> for i16`, which "
-"means that we can convert a variable `x` of type `i8` to an `i16` by "
-"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
-"i16` implementation automatically create an implementation of `Into<i16> for "
-"i8`."
+"This slide demonstrates how the Rust compiler infers types based on "
+"constraints given by variable declarations and usages."
 msgstr ""
 
-#: src/exercises/day-1/implicit-conversions.md:31
+#: src/types-and-values/inference.md:32
 msgid ""
-"The same applies for your own `From` implementations for your own types, so "
-"it is sufficient to only implement `From` to get a respective `Into` "
-"implementation automatically."
-msgstr ""
-
-#: src/exercises/day-1/implicit-conversions.md:34
-msgid "Execute the above program and look at the compiler error."
-msgstr ""
-
-#: src/exercises/day-1/implicit-conversions.md:36
-msgid "Update the code above to use `into()` to do the conversion."
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 
-#: src/exercises/day-1/implicit-conversions.md:38
+#: src/types-and-values/inference.md:37
 msgid ""
-"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
-"`i128`) to see which types you can convert to which other types. Try "
-"converting small types to big types and the other way around. Check the "
-"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
-"From.html) to see if `From<T>` is implemented for the pairs you check."
+"When nothing constrains the type of an integer literal, Rust defaults to "
+"`i32`. This sometimes appears as `{integer}` in error messages. Similarly, "
+"floating-point literals default to `f64`."
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:1
-#: src/exercises/day-1/solutions-morning.md:3
-msgid "Arrays and `for` Loops"
+#: src/types-and-values/inference.md:46
+msgid "// ERROR: no implementation for `{float} == {integer}`\n"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:3
-msgid "We saw that an array can be declared like this:"
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:9
+#: src/types-and-values/exercise.md:3
 msgid ""
-"You can print such an array by asking for its debug representation with `{:?}"
-"`:"
+"The first and second Fibonacci numbers are both `1`. For n>2, the n'th "
+"Fibonacci number is calculated recursively as the sum of the n-1'th and "
+"n-2'th Fibonacci numbers."
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:19
+#: src/types-and-values/exercise.md:7
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for` "
-"keyword:"
+"Write a function `fib(n)` that calculates the n'th Fibonacci number. When "
+"will this function panic?"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:25
-msgid "\"Iterating over array:\""
+#: src/types-and-values/exercise.md:13
+msgid "// The base case.\n"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:27
-msgid "\" {n}\""
-msgstr ""
+#: src/types-and-values/exercise.md:14 src/types-and-values/exercise.md:17
+#: src/control-flow-basics/exercise.md:27
+#: src/control-flow-basics/exercise.md:31
+#, fuzzy
+msgid "\"Implement this\""
+msgstr "実装"
 
-#: src/exercises/day-1/for-loops.md:31
-msgid "\"Iterating over range:\""
+#: src/types-and-values/exercise.md:16
+msgid "// The recursive case.\n"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:33
-msgid "\" {}\""
+#: src/types-and-values/exercise.md:23 src/types-and-values/solution.md:14
+msgid "\"fib(n) = {}\""
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:39
-msgid ""
-"Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and a function `transpose` which will transpose a matrix (turn rows into "
-"columns):"
+#: src/control-flow-basics.md:4
+msgid "[Conditionals](./control-flow-basics/conditionals.md) (5 minutes)"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:49
-msgid "Hard-code both functions to operate on 3 × 3 matrices."
+#: src/control-flow-basics.md:5
+msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:51
+#: src/control-flow-basics.md:6
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the "
-"functions:"
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:55 src/exercises/day-1/luhn.md:26
-#: src/exercises/day-2/health-statistics.md:14
-#: src/exercises/day-2/strings-iterators.md:13
-#: src/exercises/day-3/simple-gui.md:20
-#: src/exercises/day-3/points-polygons.md:8
-#: src/exercises/day-3/safe-ffi-wrapper.md:49
-msgid "// TODO: remove this when you're done with your implementation.\n"
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:68
-#: src/exercises/day-1/solutions-morning.md:44
-msgid "// <-- the comment makes rustfmt add a newline\n"
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:73
-#: src/exercises/day-1/solutions-morning.md:49
-msgid "\"matrix:\""
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:77
-#: src/exercises/day-1/solutions-morning.md:53
-msgid "\"transposed:\""
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:82
-msgid "Bonus Question"
+"[break and continue](./control-flow-basics/break-continue.md) (5 minutes)"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:84
+#: src/control-flow-basics.md:7
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
-"slice-of-slices. Why or why not?"
+"[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (10 minutes)"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:89
-msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
-"implementation."
+#: src/control-flow-basics.md:8
+msgid "[Functions](./control-flow-basics/functions.md) (3 minutes)"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:94
-msgid ""
-"The solution and the answer to the bonus section are available in the  "
-"[Solution](solutions-morning.md#arrays-and-for-loops) section."
+#: src/control-flow-basics.md:9
+msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:97
+#: src/control-flow-basics.md:10
 msgid ""
-"The use of the reference `&array` within `for n in &array` is a subtle "
-"preview of issues of ownership that will come later in the afternoon."
-msgstr ""
-
-#: src/exercises/day-1/for-loops.md:100
-msgid "Without the `&`..."
+"[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (30 minutes)"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:101
-msgid ""
-"The loop would have been one that consumes the array.  This is a change "
-"[introduced in the 2021 Edition](https://doc.rust-lang.org/edition-guide/"
-"rust-2021/IntoIterator-for-arrays.html)."
+#: src/control-flow-basics.md:12 src/tuples-and-arrays.md:10 src/borrowing.md:9
+msgid "This segment should take about 1 hour"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:104
-msgid ""
-"An implicit array copy would have occurred.  Since `i32` is a copy type, "
-"then `[i32; 3]` is also a copy type."
+#: src/control-flow-basics/conditionals.md:3
+msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr ""
 
-#: src/control-flow.md:3
-msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally "
-"evaluate one of two blocks, but the blocks can have a value which then "
-"becomes the value of the `if` expression. Other control flow expressions "
-"work similarly in Rust."
-msgstr ""
-"今まで見てきたように、Rust において `if` は式です。`if` 式のブロックは値を"
-"持っており、条件判定の結果に応じて評価されたブロックの値が `if` 式の値となり"
-"ます。Rust では他の制御フローの式も同様の動作をします。"
-
-#: src/control-flow/blocks.md:3
-msgid ""
-"A block in Rust contains a sequence of expressions. Each block has a value "
-"and a type, which are those of the last expression of the block:"
-msgstr ""
-"Rust におけるブロックの中にはいくつかの式が存在します。それぞれのブロックは値"
-"と型を持っており、ブロックの値や型はそのブロック内にある最後の式の値や型と一"
-"致します。"
+#: src/control-flow-basics/conditionals.md:5
+#, fuzzy
+msgid "Blocks are delimited by curly braces."
+msgstr "CやC++と同様に、ブロックは波括弧で囲みます。"
 
-#: src/control-flow/blocks.md:27
+#: src/control-flow-basics/conditionals.md:6
 msgid ""
-"If the last expression ends with `;`, then the resulting value and type is "
-"`()`."
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"最後の式が `;` で終了した場合、ブロック全体の値と型は `()` になります。"
 
-#: src/control-flow/blocks.md:29
-msgid ""
-"The same rule is used for functions: the value of the function body is the "
-"return value:"
-msgstr ""
-"同じルールが関数についても適用されます。関数の body ブロックの値が、その関数"
-"の返り値となります。"
-
-#: src/control-flow/blocks.md:45 src/enums.md:34 src/enums/sizes.md:28
-#: src/pattern-matching.md:25 src/pattern-matching/match-guards.md:22
-#: src/structs.md:31 src/methods.md:30 src/methods/example.md:46
-msgid "Key Points:"
-msgstr "キーポイント: "
-
-#: src/control-flow/blocks.md:46
-msgid ""
-"The point of this slide is to show that blocks have a type and value in "
-"Rust. "
+#: src/control-flow-basics/conditionals.md:8
+msgid "Keywords like `if` and `while` work the same."
 msgstr ""
-"このスライドのポイントは、Rust におけるブロックは型と値を持つということです。"
 
-#: src/control-flow/blocks.md:47
-msgid ""
-"You can show how the value of the block changes by changing the last line in "
-"the block. For instance, adding/removing a semicolon or using a `return`."
+#: src/control-flow-basics/conditionals.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
 msgstr ""
-"ブロック内にある最後の行を変更することによって、ブロック全体の値が変わること"
-"が分かります。例えば、行末のセミコロンを追加/削除したり、`return` を使用した"
-"りすることで、ブロックの値は変化します。"
 
-#: src/control-flow/if-expressions.md:1
+#: src/control-flow-basics/conditionals.md:11
 msgid "`if` expressions"
 msgstr "`if` 式"
 
-#: src/control-flow/if-expressions.md:3
+#: src/control-flow-basics/conditionals.md:13
 msgid ""
 "You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
 "if-expr.html#if-expressions) exactly like `if` statements in other languages:"
@@ -3758,7 +3237,20 @@ msgstr ""
 "Rust の [`if` 式](https://doc.rust-lang.org/reference/expressions/if-expr."
 "html#if-expressions) は、他の言語における `if` 文と全く同じように使えます。"
 
-#: src/control-flow/if-expressions.md:18
+#: src/control-flow-basics/conditionals.md:21
+#: src/control-flow-basics/conditionals.md:36
+msgid "\"small\""
+msgstr ""
+
+#: src/control-flow-basics/conditionals.md:23
+msgid "\"biggish\""
+msgstr ""
+
+#: src/control-flow-basics/conditionals.md:25
+msgid "\"huge\""
+msgstr ""
+
+#: src/control-flow-basics/conditionals.md:30
 msgid ""
 "In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
@@ -3766,88 +3258,105 @@ msgstr ""
 "さらに、`if` を式としても用いることができます。それぞれのブロックにある最後の"
 "式が、`if` 式の値となります。"
 
-#: src/control-flow/if-expressions.md:35
+#: src/control-flow-basics/conditionals.md:36
+msgid "\"large\""
+msgstr ""
+
+#: src/control-flow-basics/conditionals.md:37
+msgid "\"number size: {}\""
+msgstr ""
+
+#: src/control-flow-basics/conditionals.md:44
+#, fuzzy
 msgid ""
 "Because `if` is an expression and must have a particular type, both of its "
-"branch blocks must have the same type. Consider showing what happens if you "
-"add `;` after `x / 2` in the second example."
+"branch blocks must have the same type. Show what happens if you add `;` "
+"after `\"small\"` in the second example."
 msgstr ""
 "`if` は式であるため、1 つの決まった型を持たなくてはなりません。したがって、"
 "`if` 式の分岐ブロックは同一の型を持つ必要があります。2 つ目の例において、"
 "`x / 2` のあとに `;` を付け加えると何が起こるでしょうか。"
 
-#: src/control-flow/for-expressions.md:1
-msgid "`for` loops"
-msgstr "`for` ループ"
-
-#: src/control-flow/for-expressions.md:3
+#: src/control-flow-basics/conditionals.md:48
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
-"related to the [`while let` loop](while-let-expressions.md). It will "
-"automatically call `into_iter()` on the expression and then iterate over it:"
+"When `if` is used in an expression, the expression must have a `;` to "
+"separate it from the next statement. Remove the `;` before `println!` to see "
+"the compiler error."
 msgstr ""
-"[`for` loop](https://doc.rust-lang.org/std/keyword.for.html) は、[`while "
-"let` loop](while-let-expressions.md) とよく似ています。`for` ループは `in` "
-"キーワードの右側にある式に対して自動的に `into_iter()` を呼び出し、その結果生"
-"成されたイテレータを用いて走査を行います。"
 
-#: src/control-flow/for-expressions.md:22
-msgid "You can use `break` and `continue` here as usual."
+#: src/control-flow-basics/loops.md:3
+msgid "There are three looping keywords in Rust: `while`, `loop`, and `for`:"
 msgstr ""
-"`for` ループの中では、いつも通り `break` や `continue` を使うことができます。"
 
-#: src/control-flow/for-expressions.md:26
-msgid "Index iteration is not a special syntax in Rust for just that case."
-msgstr ""
-"Rust では、インデックスによる反復処理のために特別な構文は提供されていません。"
-
-#: src/control-flow/for-expressions.md:27
-msgid "`(0..10)` is a range that implements an `Iterator` trait. "
-msgstr "`(0..10)` は Range 型であり、`Iterator` トレイトを実装しています。"
-
-#: src/control-flow/for-expressions.md:28
-msgid ""
-"`step_by` is a method that returns another `Iterator` that skips every other "
-"element. "
-msgstr ""
-"`step_by` は、元のイテレータとは別の、各要素をスキップする `Iterator` を返す"
-"メソッドです。"
-
-#: src/control-flow/for-expressions.md:29
-msgid ""
-"Modify the elements in the vector and explain the compiler errors. Change "
-"vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
-msgstr ""
-"ベクタ内の要素を変更してみて、その結果生じるコンパイルエラーについて説明して"
-"ください。また、ベクタ `v` をミュータブルに、for ループを `for x in v."
-"iter_mut()` に変更してみましょう。"
-
-#: src/control-flow/while-expressions.md:1
-msgid "`while` loops"
+#: src/control-flow-basics/loops.md:5
+#, fuzzy
+msgid "`while`"
 msgstr "`while` ループ"
 
-#: src/control-flow/while-expressions.md:3
+#: src/control-flow-basics/loops.md:7
+#, fuzzy
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops) works very similar to other languages:"
+"expr.html#predicate-loops) works much like in other languages, executing the "
+"loop body as long as the condition is true."
 msgstr ""
 "[`while` キーワード](https://doc.rust-lang.org/reference/expressions/loop-"
 "expr.html#predicate-loops) は、他の言語における `while` と非常によく似た働き"
 "をします。"
 
-#: src/control-flow/break-continue.md:1
-msgid "`break` and `continue`"
-msgstr "`break` と `continue`"
+#: src/control-flow-basics/loops.md:18
+#, fuzzy
+msgid "\"Final x: {x}\""
+msgstr "\" -> {x}\""
 
-#: src/control-flow/break-continue.md:3
+#: src/control-flow-basics/loops.md:22
+#, fuzzy
+msgid "`for`"
+msgstr "`for` ループ"
+
+#: src/control-flow-basics/loops.md:24
 msgid ""
-"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) iterates "
+"over ranges of values:"
+msgstr ""
+
+#: src/control-flow-basics/loops.md:35
+msgid "`loop`"
+msgstr ""
+
+#: src/control-flow-basics/loops.md:37
+msgid ""
+"The [`loop` statement](https://doc.rust-lang.org/std/keyword.loop.html) just "
+"loops forever, until a `break`."
+msgstr ""
+
+#: src/control-flow-basics/loops.md:45
+msgid "\"{i}\""
+msgstr ""
+
+#: src/control-flow-basics/loops.md:56
+msgid ""
+"We will discuss iteration later; for now, just stick to range expressions."
+msgstr ""
+
+#: src/control-flow-basics/loops.md:57
+msgid ""
+"Note that the `for` loop only iterates to `4`. Show the `1..=5` syntax for "
+"an inclusive range."
+msgstr ""
+
+#: src/control-flow-basics/break-continue.md:3
+#, fuzzy
+msgid ""
+"If you want to exit any kind of loop early, use [`break`](https://doc.rust-"
+"lang.org/reference/expressions/loop-expr.html#break-expressions). For "
+"`loop`, this can take an optional expression that becomes the value of the "
+"`loop` expression."
 msgstr ""
 "ループから早く抜け出したい場合は [`break`](https://doc.rust-lang.org/"
 "reference/expressions/loop-expr.html#break-expressions) を使用してください。"
 
-#: src/control-flow/break-continue.md:4
+#: src/control-flow-basics/break-continue.md:8
 msgid ""
 "If you want to immediately start the next iteration use [`continue`](https://"
 "doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
@@ -3856,7 +3365,11 @@ msgstr ""
 "lang.org/reference/expressions/loop-expr.html#continue-expressions) を使用し"
 "てください。"
 
-#: src/control-flow/break-continue.md:7
+#: src/control-flow-basics/break-continue.md:24
+msgid "\"{result}\""
+msgstr ""
+
+#: src/control-flow-basics/break-continue.md:28
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
 "used to break out of nested loops:"
@@ -3864,37 +3377,18 @@ msgstr ""
 "`continue` と `break` はオプションでラベル引数を取ることができます。ラベルは"
 "ネストしたループから抜け出すために使われます。"
 
-#: src/control-flow/break-continue.md:29
+#: src/control-flow-basics/break-continue.md:37
+msgid "\"x: {x}, i: {i}\""
+msgstr ""
+
+#: src/control-flow-basics/break-continue.md:47
 msgid ""
 "In this case we break the outer loop after 3 iterations of the inner loop."
 msgstr ""
 "上の例では、内側のループを 3 回イテレーションしたのちに外側のループを抜けるこ"
 "とになります。"
 
-#: src/control-flow/loop-expressions.md:1
-msgid "`loop` expressions"
-msgstr "`loop` 式"
-
-#: src/control-flow/loop-expressions.md:3
-msgid ""
-"Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
-msgstr ""
-"最後に、無限ループを作る [`loop` キーワード](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#infinite-loops) について説明します。"
-
-#: src/control-flow/loop-expressions.md:6
-msgid "Here you must either `break` or `return` to stop the loop:"
-msgstr ""
-"下の例で、ループから抜けるためには `break` あるいは `return` を使う必要があり"
-"ます。"
-
-#: src/control-flow/loop-expressions.md:28
-msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
-msgstr ""
-"例えば `break 8` のようにループを値と共に抜け、それを print してみましょう。"
-
-#: src/control-flow/loop-expressions.md:29
+#: src/control-flow-basics/break-continue.md:52
 msgid ""
 "Note that `loop` is the only looping construct which returns a non-trivial "
 "value. This is because it's guaranteed to be entered at least once (unlike "
@@ -3905,910 +3399,663 @@ msgstr ""
 "いるからです（これに対して、while や for ループは必ずしも実行されるわけではあ"
 "りません）。"
 
-#: src/basic-syntax/variables.md:3
+#: src/control-flow-basics/blocks-and-scopes.md:3
+msgid "Blocks"
+msgstr "コードブロック"
+
+#: src/control-flow-basics/blocks-and-scopes.md:5
 msgid ""
-"Rust provides type safety via static typing. Variable bindings are immutable "
-"by default:"
+"A block in Rust contains a sequence of expressions. Each block has a value "
+"and a type, which are those of the last expression of the block:"
+msgstr ""
+"Rust におけるブロックの中にはいくつかの式が存在します。それぞれのブロックは値"
+"と型を持っており、ブロックの値や型はそのブロック内にある最後の式の値や型と一"
+"致します。"
+
+#: src/control-flow-basics/blocks-and-scopes.md:13
+msgid "\"y: {y}\""
 msgstr ""
 
-#: src/basic-syntax/variables.md:18
+#: src/control-flow-basics/blocks-and-scopes.md:20
 msgid ""
-"Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses."
+"If the last expression ends with `;`, then the resulting value and type is "
+"`()`."
+msgstr ""
+"最後の式が `;` で終了した場合、ブロック全体の値と型は `()` になります。"
+
+#: src/control-flow-basics/blocks-and-scopes.md:22
+msgid "Scopes and Shadowing"
+msgstr "スコープとシャドーイング"
+
+#: src/control-flow-basics/blocks-and-scopes.md:24
+msgid "A variable's scope is limited to the enclosing block."
 msgstr ""
 
-#: src/basic-syntax/type-inference.md:3
-msgid "Rust will look at how the variable is _used_ to determine the type:"
-msgstr ""
-
-#: src/basic-syntax/type-inference.md:27
-msgid ""
-"This slide demonstrates how the Rust compiler infers types based on "
-"constraints given by variable declarations and usages."
-msgstr ""
-
-#: src/basic-syntax/type-inference.md:29
-msgid ""
-"It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can hold any data. The machine "
-"code generated by such declaration is identical to the explicit declaration "
-"of a type. The compiler does the job for us and helps us write more concise "
-"code."
-msgstr ""
-
-#: src/basic-syntax/type-inference.md:33
-msgid ""
-"The following code tells the compiler to copy into a certain generic "
-"container without the code ever explicitly specifying the contained type, "
-"using `_` as a placeholder:"
-msgstr ""
-
-#: src/basic-syntax/type-inference.md:48
-msgid ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
-"html#method.collect) relies on [`FromIterator`](https://doc.rust-lang.org/"
-"std/iter/trait.FromIterator.html), which [`HashSet`](https://doc.rust-lang."
-"org/std/collections/struct.HashSet.html#impl-FromIterator%3CT%3E-for-"
-"HashSet%3CT,+S%3E) implements."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:1
-msgid "Static and Constant Variables"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:3
-msgid ""
-"Static and constant variables are two different ways to create globally-"
-"scoped values that cannot be moved or reallocated during the execution of "
-"the program. "
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:6
-msgid "`const`"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:8
-msgid ""
-"Constant variables are evaluated at compile time and their values are "
-"inlined wherever they are used:"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:30
-msgid ""
-"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
-"vs-static.html) these are inlined upon use."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:32
-msgid ""
-"Only functions marked `const` can be called at compile time to generate "
-"`const` values. `const` functions can however be called at runtime."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:34
-msgid "`static`"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:36
-msgid ""
-"Static variables will live during the whole execution of the program, and "
-"therefore will not move:"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:39
-msgid "\"Welcome to RustOS 3.14\""
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:42
-msgid "\"{BANNER}\""
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:46
-msgid ""
-"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
-"vs-static.html), these are not inlined upon use and have an actual "
-"associated memory location.  This is useful for unsafe and  embedded code, "
-"and the variable lives through the entirety of the program execution. When a "
-"globally-scoped value does not have a reason to need object identity, "
-"`const` is generally preferred."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:50
-msgid ""
-"Because `static` variables are accessible from any thread, they must be "
-"`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
-"lang.org/std/sync/struct.Mutex.html), atomic or similar. It is also possible "
-"to have mutable statics, but they require manual synchronisation so any "
-"access to them requires `unsafe` code. We will look at [mutable statics](../"
-"unsafe/mutable-static-variables.md) in the chapter on Unsafe Rust."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:58
-msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:59
-msgid ""
-"`static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:60
-msgid ""
-"`static` provides object identity: an address in memory and state as "
-"required by types with interior mutability such as `Mutex<T>`."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:61
-msgid ""
-"It isn't super common that one would need a runtime evaluated constant, but "
-"it is helpful and safer than using a static."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:62
-msgid "`thread_local` data can be created with the macro `std::thread_local`."
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:64
-msgid "Properties table:"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:66
-msgid "Property"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:66
-msgid "Static"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:66
-msgid "Constant"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:68
-msgid "Has an address in memory"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:68
-#: src/basic-syntax/static-and-const.md:69
-#: src/basic-syntax/static-and-const.md:71
-#: src/basic-syntax/static-and-const.md:72
-msgid "Yes"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:68
-msgid "No (inlined)"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:69
-#, fuzzy
-msgid "Lives for the entire duration of the program"
-msgstr "`main`関数はプログラムのエントリーポイントになります。"
-
-#: src/basic-syntax/static-and-const.md:69
-#: src/basic-syntax/static-and-const.md:70
-#: src/basic-syntax/static-and-const.md:72
-msgid "No"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:70
-msgid "Can be mutable"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:70
-msgid "Yes (unsafe)"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:71
-msgid "Evaluated at compile time"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:71
-msgid "Yes (initialised at compile time)"
-msgstr ""
-
-#: src/basic-syntax/static-and-const.md:72
-msgid "Inlined wherever it is used"
-msgstr ""
-
-#: src/basic-syntax/scopes-shadowing.md:3
+#: src/control-flow-basics/blocks-and-scopes.md:26
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
 "the same scope:"
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:9
+#: src/control-flow-basics/blocks-and-scopes.md:32
 msgid "\"before: {a}\""
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:12 src/traits/from-into.md:7
-#: src/traits/from-into.md:19
+#: src/control-flow-basics/blocks-and-scopes.md:34
+#: src/std-traits/from-and-into.md:7 src/std-traits/from-and-into.md:19
+#: src/slices-and-lifetimes/solution.md:225
 msgid "\"hello\""
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:13
+#: src/control-flow-basics/blocks-and-scopes.md:35
 msgid "\"inner scope: {a}\""
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:16
+#: src/control-flow-basics/blocks-and-scopes.md:38
 msgid "\"shadowed in inner scope: {a}\""
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:19
+#: src/control-flow-basics/blocks-and-scopes.md:41
 msgid "\"after: {a}\""
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:25
+#: src/control-flow-basics/blocks-and-scopes.md:48
 msgid ""
-"Definition: Shadowing is different from mutation, because after shadowing "
-"both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. "
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
+msgstr ""
+"ブロック内にある最後の行を変更することによって、ブロック全体の値が変わること"
+"が分かります。例えば、行末のセミコロンを追加/削除したり、`return` を使用した"
+"りすることで、ブロックの値は変化します。"
+
+#: src/control-flow-basics/blocks-and-scopes.md:50
+msgid ""
+"Show that a variable's scope is limited by adding a `b` in the inner block "
+"in the last example, and then trying to access it outside that block."
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:26
-msgid "A shadowing variable can have a different type. "
+#: src/control-flow-basics/blocks-and-scopes.md:52
+msgid ""
+"Shadowing is different from mutation, because after shadowing both "
+"variable's memory locations exist at the same time. Both are available under "
+"the same name, depending where you use it in the code."
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:27
+#: src/control-flow-basics/blocks-and-scopes.md:55
+msgid "A shadowing variable can have a different type."
+msgstr ""
+
+#: src/control-flow-basics/blocks-and-scopes.md:56
 msgid ""
 "Shadowing looks obscure at first, but is convenient for holding on to values "
 "after `.unwrap()`."
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:28
+#: src/control-flow-basics/functions.md:22
 msgid ""
-"The following code demonstrates why the compiler can't simply reuse memory "
-"locations when shadowing an immutable variable in a scope, even if the type "
-"does not change."
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
 msgstr ""
 
-#: src/enums.md:3
+#: src/control-flow-basics/functions.md:24
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few different "
-"variants:"
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression. The `return` "
+"keyword can be used for early return, but the \"bare value\" form is "
+"idiomatic at the end of a function (refactor `gcd` to use a `return`)."
 msgstr ""
 
-#: src/enums.md:8
-msgid "// Implementation based on https://xkcd.com/221/\n"
-msgstr ""
-
-#: src/enums.md:9
-msgid "// Chosen by fair dice roll. Guaranteed to be random.\n"
-msgstr ""
-
-#: src/enums.md:28
-msgid "\"You got: {:?}\""
-msgstr ""
-
-#: src/enums.md:36
-msgid "Enumerations allow you to collect a set of values under one type"
-msgstr ""
-
-#: src/enums.md:37
+#: src/control-flow-basics/functions.md:28
 msgid ""
-"This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tails`. You might note the namespace when using variants."
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
 msgstr ""
 
-#: src/enums.md:38
-msgid "This might be a good time to compare Structs and Enums:"
-msgstr ""
-
-#: src/enums.md:39
+#: src/control-flow-basics/functions.md:30
 msgid ""
-"In both, you can have a simple version without fields (unit struct) or one "
-"with different types of fields (variant payloads). "
+"Overloading is not supported -- each function has a single implementation."
 msgstr ""
 
-#: src/enums.md:40
-msgid "In both, associated functions are defined within an `impl` block."
-msgstr ""
-
-#: src/enums.md:41
+#: src/control-flow-basics/functions.md:31
 msgid ""
-"You could even implement the different variants of an enum with separate "
-"structs but then they wouldn’t be the same type as they would if they were "
-"all defined in an enum. "
+"Always takes a fixed number of parameters. Default arguments are not "
+"supported. Macros can be used to support variadic functions."
 msgstr ""
 
-#: src/enums/variant-payloads.md:3
+#: src/control-flow-basics/functions.md:33
 msgid ""
-"You can define richer enums where the variants carry data. You can then use "
-"the `match` statement to extract the data from each variant:"
+"Always takes a single set of parameter types. These types can be generic, "
+"which will be covered later."
 msgstr ""
 
-#: src/enums/variant-payloads.md:8
-msgid "// Variant without payload\n"
-msgstr ""
-
-#: src/enums/variant-payloads.md:9
-msgid "// Tuple struct variant\n"
-msgstr ""
-
-#: src/enums/variant-payloads.md:10
-msgid "// Full struct variant\n"
-msgstr ""
-
-#: src/enums/variant-payloads.md:16
-msgid "\"page loaded\""
-msgstr ""
-
-#: src/enums/variant-payloads.md:17
-msgid "\"pressed '{c}'\""
-msgstr ""
-
-#: src/enums/variant-payloads.md:18
-msgid "\"clicked at x={x}, y={y}\""
-msgstr ""
-
-#: src/enums/variant-payloads.md:24 src/pattern-matching.md:10
-msgid "'x'"
-msgstr ""
-
-#: src/enums/variant-payloads.md:35
+#: src/control-flow-basics/macros.md:3
 msgid ""
-"The values in the enum variants can only be accessed after being pattern "
-"matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`."
+"Macros are expanded into Rust code during compilation, and can take a "
+"variable number of arguments. They are distinguished by a `!` at the end. "
+"The Rust standard library includes an assortment of useful macros."
 msgstr ""
 
-#: src/enums/variant-payloads.md:36
+#: src/control-flow-basics/macros.md:7
 msgid ""
-"The expression is matched against the patterns from top to bottom. There is "
-"no fall-through like in C or C++."
+"`println!(format, ..)` prints a line to standard output, applying formatting "
+"described in [`std::fmt`](https://doc.rust-lang.org/std/fmt/index.html)."
 msgstr ""
 
-#: src/enums/variant-payloads.md:37
+#: src/control-flow-basics/macros.md:9
 msgid ""
-"The match expression has a value. The value is the last expression in the "
-"match arm which was executed."
+"`format!(format, ..)` works just like `println!` but returns the result as a "
+"string."
 msgstr ""
 
-#: src/enums/variant-payloads.md:38
+#: src/control-flow-basics/macros.md:11
+msgid "`dbg!(expression)` logs the value of the expression and returns it."
+msgstr ""
+
+#: src/control-flow-basics/macros.md:12
 msgid ""
-"Starting from the top we look for what pattern matches the value then run "
-"the code following the arrow. Once we find a match, we stop. "
+"`todo!()` marks a bit of code as not-yet-implemented. If executed, it will "
+"panic."
 msgstr ""
 
-#: src/enums/variant-payloads.md:39
+#: src/control-flow-basics/macros.md:14
 msgid ""
-"Demonstrate what happens when the search is inexhaustive. Note the advantage "
-"the Rust compiler provides by confirming when all cases are handled. "
+"`unreachable!()` marks a bit of code as unreachable. If executed, it will "
+"panic."
 msgstr ""
 
-#: src/enums/variant-payloads.md:40
-msgid "`match` inspects a hidden discriminant field in the `enum`."
+#: src/control-flow-basics/macros.md:32
+msgid "\"{n}! = {}\""
 msgstr ""
 
-#: src/enums/variant-payloads.md:41
+#: src/control-flow-basics/macros.md:39
 msgid ""
-"It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`"
+"The takeaway from this section is that these common conveniences exist, and "
+"how to use them. Why they are defined as macros, and what they expand to, is "
+"not especially critical."
 msgstr ""
 
-#: src/enums/variant-payloads.md:42
+#: src/control-flow-basics/macros.md:43
 msgid ""
-"This is useful, for example, if implementing `PartialEq` for structs where "
-"comparing field values doesn't affect equality."
+"The course does not cover defining macros, but a later section will describe "
+"use of derive macros."
 msgstr ""
 
-#: src/enums/variant-payloads.md:43
+#: src/control-flow-basics/exercise.md:3
 msgid ""
-"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example."
+"The [Collatz Sequence](https://en.wikipedia.org/wiki/Collatz_conjecture) is "
+"defined as follows, for an arbitrary n"
 msgstr ""
 
-#: src/enums/sizes.md:3
+#: src/control-flow-basics/exercise.md:4 src/control-flow-basics/exercise.md:10
+msgid "1"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:4
+msgid " greater than zero:"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:6 src/control-flow-basics/exercise.md:7
+#: src/control-flow-basics/exercise.md:8
+msgid "If _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:6 src/control-flow-basics/exercise.md:7
+#: src/control-flow-basics/exercise.md:8
+msgid "i"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:6
+msgid "_ is 1, then the sequence terminates at _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:6
+msgid "_."
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:7
+msgid "_ is even, then _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:7 src/control-flow-basics/exercise.md:8
+msgid "i+1"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:7
+msgid " = n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:7
+msgid " / 2_."
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:8
+msgid "_ is odd, then _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:8
+msgid " = 3 * n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:8
+msgid " + 1_."
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:10
+msgid "For example, beginning with _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:10
+msgid "_ = 3:"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:12
+msgid "3 is odd, so _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:12
+msgid "2"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:12
+msgid "_ = 3 * 3 + 1 = 10;"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:13
+msgid "10 is even, so _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:13 src/bare-metal/aps/better-uart.md:22
+msgid "3"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:13
+msgid "_ = 10 / 2 = 5;"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:14
+msgid "5 is odd, so _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:14 src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:14
+msgid "_ = 3 * 15 + 1 = 16;"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:15
+msgid "16 is even, so _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:15
+msgid "5"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:15
+msgid "_ = 16 / 2 = 8;"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:16
+msgid "8 is even, so _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:16 src/bare-metal/aps/better-uart.md:14
+#: src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:16
+msgid "_ = 8 / 2 = 4;"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:17
+msgid "4 is even, so _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:17
+msgid "7"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:17
+msgid "_ = 4 / 2 = 2;"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:18
+msgid "2 is even, so _n"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:18 src/bare-metal/aps/better-uart.md:12
+#: src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:18
+msgid "_ = 1; and"
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:19
+msgid "the sequence terminates."
+msgstr ""
+
+#: src/control-flow-basics/exercise.md:21
 msgid ""
-"Rust enums are packed tightly, taking constraints due to alignment into "
-"account:"
+"Write a function to calculate the length of the collatz sequence for a given "
+"initial `n`."
 msgstr ""
 
-#: src/enums/sizes.md:10
-msgid "\"{}: size {} bytes, align: {} bytes\""
+#: src/control-flow-basics/exercise.md:25 src/control-flow-basics/solution.md:4
+msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/enums/sizes.md:24
-msgid ""
-"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
-"html)."
+#: src/control-flow-basics/solution.md:20 src/concurrency/scoped-threads.md:11
+#: src/concurrency/scoped-threads.md:30
+msgid "\"Length: {}\""
 msgstr ""
 
-#: src/enums/sizes.md:30
-msgid ""
-"Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant."
-msgstr ""
-
-#: src/enums/sizes.md:32
-msgid ""
-"You can control the discriminant if needed (e.g., for compatibility with C):"
-msgstr ""
-
-#: src/enums/sizes.md:50
-msgid ""
-"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
-"bytes."
-msgstr ""
-
-#: src/enums/sizes.md:54
-msgid "Try out other types such as"
-msgstr ""
-
-#: src/enums/sizes.md:56
-msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
-msgstr ""
-
-#: src/enums/sizes.md:57
-msgid ""
-"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
-"see below),"
-msgstr ""
-
-#: src/enums/sizes.md:58
-msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
-msgstr ""
-
-#: src/enums/sizes.md:59
-msgid ""
-"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below)."
-msgstr ""
-
-#: src/enums/sizes.md:61
-msgid ""
-"Niche optimization: Rust will merge unused bit patterns for the enum "
-"discriminant."
-msgstr ""
-
-#: src/enums/sizes.md:64
-msgid ""
-"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
-"option/#representation), Rust guarantees that `size_of::<T>()` equals "
-"`size_of::<Option<T>>()`."
-msgstr ""
-
-#: src/enums/sizes.md:68
-msgid ""
-"Example code if you want to show how the bitwise representation _may_ look "
-"like in practice. It's important to note that the compiler provides no "
-"guarantees regarding this representation, therefore this is totally unsafe."
-msgstr ""
-
-#: src/enums/sizes.md:105
-msgid ""
-"More complex example if you want to discuss what happens when we chain more "
-"than 256 `Option`s together."
-msgstr ""
-
-#: src/control-flow/novel.md:3
-msgid ""
-"Rust has a few control flow constructs which differ from other languages. "
-"They are used for pattern matching:"
-msgstr ""
-
-#: src/control-flow/novel.md:6 src/control-flow/if-let-expressions.md:1
-msgid "`if let` expressions"
-msgstr ""
-
-#: src/control-flow/novel.md:7
+#: src/welcome-day-1-afternoon.md:1 src/welcome-day-2-afternoon.md:1
+#: src/welcome-day-3-afternoon.md:1 src/welcome-day-4-afternoon.md:1
 #, fuzzy
-msgid "`while let` expressions"
-msgstr "while let式"
+msgid "Welcome Back"
+msgstr "Welcome"
 
-#: src/control-flow/novel.md:8 src/control-flow/match-expressions.md:1
-msgid "`match` expressions"
+#: src/welcome-day-1-afternoon.md:4
+msgid "[Tuples and Arrays](./tuples-and-arrays.md) (1 hour)"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:3
+#: src/welcome-day-1-afternoon.md:5
+msgid "[References](./references.md) (50 minutes)"
+msgstr ""
+
+#: src/welcome-day-1-afternoon.md:6
+msgid "[User-Defined Types](./user-defined-types.md) (50 minutes)"
+msgstr ""
+
+#: src/welcome-day-1-afternoon.md:8
 msgid ""
-"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
-"expr.html#if-let-expressions) lets you execute different code depending on "
-"whether a value matches a pattern:"
+"Including 10 minute breaks, this session should take about 2 hours and 55 "
+"minutes"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:11
-msgid "\"Program name: {value}\""
-msgstr ""
-
-#: src/control-flow/if-let-expressions.md:13
-msgid "\"Missing name?\""
-msgstr ""
-
-#: src/control-flow/if-let-expressions.md:18
-#: src/control-flow/while-let-expressions.md:22
-#: src/control-flow/match-expressions.md:23
+#: src/tuples-and-arrays.md:4
 msgid ""
-"See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in Rust."
+"[Tuples and Arrays](./tuples-and-arrays/tuples-and-arrays.md) (10 minutes)"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:23
+#: src/tuples-and-arrays.md:5
+msgid "[Array Iteration](./tuples-and-arrays/iteration.md) (3 minutes)"
+msgstr ""
+
+#: src/tuples-and-arrays.md:6
+msgid "[Pattern Matching](./tuples-and-arrays/match.md) (10 minutes)"
+msgstr ""
+
+#: src/tuples-and-arrays.md:7
+msgid "[Destructuring](./tuples-and-arrays/destructuring.md) (5 minutes)"
+msgstr ""
+
+#: src/tuples-and-arrays.md:8
+msgid "[Exercise: Nested Arrays](./tuples-and-arrays/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:3
 msgid ""
-"Unlike `match`, `if let` does not have to cover all branches. This can make "
-"it more concise than `match`."
+"Tuples and arrays are the first \"compound\" types we have seen. All "
+"elements of an array have the same type, while tuples can accommodate "
+"different types. Both types have a size fixed at compile time."
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:24
-msgid "A common usage is handling `Some` values when working with `Option`."
+#: src/tuples-and-arrays/tuples-and-arrays.md:9
+#: src/tuples-and-arrays/destructuring.md:27
+msgid "Arrays"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:25
+#: src/tuples-and-arrays/tuples-and-arrays.md:9
+msgid "`[T; N]`"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:9
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:10
+#: src/tuples-and-arrays/destructuring.md:9
+msgid "Tuples"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:10
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:10
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:12
+msgid "Array assignment and access:"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:24
+msgid "Tuple assignment and access:"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:41
+msgid "Arrays:"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:43
 msgid ""
-"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+"A value of the array type `[T; N]` holds `N` (a compile-time constant) "
+"elements of the same type `T`. Note that the length of the array is _part of "
+"its type_, which means that `[u8; 3]` and `[u8; 4]` are considered two "
+"different types. Slices, which have a size determined at runtime, are "
+"covered later."
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:26
+#: src/tuples-and-arrays/tuples-and-arrays.md:49
 msgid ""
-"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
-"flow_control/let_else.html) construct allows to do a destructuring "
-"assignment, or if it fails, execute a block which is required to abort "
-"normal control flow (with `panic`/`return`/`break`/`continue`):"
+"Try accessing an out-of-bounds array element. Array accesses are checked at "
+"runtime. Rust can usually optimize these checks away, and they can be "
+"avoided using unsafe Rust."
 msgstr ""
 
-#: src/control-flow/while-let-expressions.md:1
-msgid "`while let` loops"
+#: src/tuples-and-arrays/tuples-and-arrays.md:53
+msgid "We can use literals to assign values to arrays."
 msgstr ""
 
-#: src/control-flow/while-let-expressions.md:3
+#: src/tuples-and-arrays/tuples-and-arrays.md:55
 msgid ""
-"Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
-"repeatedly tests a value against a pattern:"
+"The `println!` macro asks for the debug implementation with the `?` format "
+"parameter: `{}` gives the default output, `{:?}` gives the debug output. "
+"Types such as integers and strings implement the default output, but arrays "
+"only implement the debug output. This means that we must use debug output "
+"here."
 msgstr ""
 
-#: src/control-flow/while-let-expressions.md:18
+#: src/tuples-and-arrays/tuples-and-arrays.md:60
 msgid ""
-"Here the iterator returned by `v.into_iter()` will return a `Option<i32>` on "
-"every call to `next()`. It returns `Some(x)` until it is done, after which "
-"it will return `None`. The `while let` lets us keep iterating through all "
-"items."
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
 msgstr ""
 
-#: src/control-flow/while-let-expressions.md:27
+#: src/tuples-and-arrays/tuples-and-arrays.md:63
+msgid "Tuples:"
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:65
+msgid "Like arrays, tuples have a fixed length."
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:67
+msgid "Tuples group together values of different types into a compound type."
+msgstr ""
+
+#: src/tuples-and-arrays/tuples-and-arrays.md:69
 msgid ""
-"Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern."
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
 msgstr ""
 
-#: src/control-flow/while-let-expressions.md:28
+#: src/tuples-and-arrays/tuples-and-arrays.md:72
 msgid ""
-"You could rewrite the `while let` loop as an infinite loop with an if "
-"statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario."
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type --- that is to say both the type and "
+"its value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide."
 msgstr ""
 
-#: src/control-flow/match-expressions.md:3
+#: src/tuples-and-arrays/tuples-and-arrays.md:76
 msgid ""
-"The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
-"expr.html) is used to match a value against one or more patterns. In that "
-"sense, it works like a series of `if let` expressions:"
+"You can think of it as `void` that can be familiar to you from other "
+"programming languages."
 msgstr ""
 
-#: src/control-flow/match-expressions.md:10
-msgid "\"cat\""
+#: src/tuples-and-arrays/iteration.md:3
+msgid "The `for` statement supports iterating over arrays (but not tuples)."
 msgstr ""
 
-#: src/control-flow/match-expressions.md:10
-msgid "\"Will do cat things\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:11
-msgid "\"ls\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:11
-msgid "\"Will ls some files\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:12
-msgid "\"mv\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:12
-msgid "\"Let's move some files\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:13
-msgid "\"rm\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:13
-msgid "\"Uh, dangerous!\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:14
-msgid "\"Hmm, no program name?\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:15
-msgid "\"Unknown program name!\""
-msgstr ""
-
-#: src/control-flow/match-expressions.md:20
+#: src/tuples-and-arrays/iteration.md:19
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last "
-"expression of the block, if any. In the example above, the type is `()`."
+"This functionality uses the `IntoIterator` trait, but we haven't covered "
+"that yet."
 msgstr ""
 
-#: src/control-flow/match-expressions.md:28
-msgid "Save the match expression to a variable and print it out."
-msgstr ""
-
-#: src/control-flow/match-expressions.md:29
-msgid "Remove `.as_deref()` and explain the error."
-msgstr ""
-
-#: src/control-flow/match-expressions.md:30
+#: src/tuples-and-arrays/iteration.md:22
 msgid ""
-"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
-"against `String`."
+"The `assert_ne!` macro is new here. There are also `assert_eq!` and `assert!"
+"` macros. These are always checked while, debug-only variants like "
+"`debug_assert!` compile to nothing in release builds."
 msgstr ""
 
-#: src/control-flow/match-expressions.md:31
+#: src/tuples-and-arrays/match.md:3
 msgid ""
-"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
-"this turns `Option<String>` into `Option<&str>`."
-msgstr ""
-
-#: src/control-flow/match-expressions.md:32
-msgid ""
-"We can now use pattern matching to match against the `&str` inside `Option`."
-msgstr ""
-
-#: src/pattern-matching.md:3
-msgid ""
-"The `match` keyword let you match a value against one or more _patterns_. "
+"The `match` keyword lets you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
-#: src/pattern-matching.md:6
+#: src/tuples-and-arrays/match.md:6
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
 msgstr ""
 
-#: src/pattern-matching.md:13
+#: src/tuples-and-arrays/match.md:11
+msgid "'x'"
+msgstr ""
+
+#: src/tuples-and-arrays/match.md:13
 msgid "'q'"
 msgstr ""
 
-#: src/pattern-matching.md:13
+#: src/tuples-and-arrays/match.md:13
 msgid "\"Quitting\""
 msgstr ""
 
-#: src/pattern-matching.md:14
+#: src/tuples-and-arrays/match.md:14 src/std-traits/solution.md:16
+#: src/error-handling/exercise.md:62 src/error-handling/exercise.md:64
+#: src/error-handling/solution.md:62 src/error-handling/solution.md:64
 msgid "'a'"
 msgstr ""
 
-#: src/pattern-matching.md:14
+#: src/tuples-and-arrays/match.md:14
 msgid "'s'"
 msgstr ""
 
-#: src/pattern-matching.md:14
+#: src/tuples-and-arrays/match.md:14
 msgid "'w'"
 msgstr ""
 
-#: src/pattern-matching.md:14
+#: src/tuples-and-arrays/match.md:14
 msgid "'d'"
 msgstr ""
 
-#: src/pattern-matching.md:14
+#: src/tuples-and-arrays/match.md:14
 msgid "\"Moving around\""
 msgstr ""
 
-#: src/pattern-matching.md:15
+#: src/tuples-and-arrays/match.md:15 src/error-handling/exercise.md:54
+#: src/error-handling/exercise.md:56 src/error-handling/exercise.md:64
+#: src/error-handling/solution.md:54 src/error-handling/solution.md:56
+#: src/error-handling/solution.md:64
 msgid "'0'"
 msgstr ""
 
-#: src/pattern-matching.md:15
+#: src/tuples-and-arrays/match.md:15 src/error-handling/exercise.md:54
+#: src/error-handling/exercise.md:56 src/error-handling/exercise.md:64
+#: src/error-handling/solution.md:54 src/error-handling/solution.md:56
+#: src/error-handling/solution.md:64
 msgid "'9'"
 msgstr ""
 
-#: src/pattern-matching.md:15
+#: src/tuples-and-arrays/match.md:15
 msgid "\"Number input\""
 msgstr ""
 
-#: src/pattern-matching.md:16
+#: src/tuples-and-arrays/match.md:16
+msgid "\"Lowercase: {key}\""
+msgstr ""
+
+#: src/tuples-and-arrays/match.md:17
 msgid "\"Something else\""
 msgstr ""
 
-#: src/pattern-matching.md:21
-msgid "The `_` pattern is a wildcard pattern which matches any value."
+#: src/tuples-and-arrays/match.md:22
+msgid ""
+"The `_` pattern is a wildcard pattern which matches any value. The "
+"expressions _must_ be irrefutable, meaning that it covers every possibility, "
+"so `_` is often used as the final catch-all case."
 msgstr ""
 
-#: src/pattern-matching.md:26
+#: src/tuples-and-arrays/match.md:26
+msgid ""
+"Match can be used as an expression. Just like `if`, each match arm must have "
+"the same type. The type is the last expression of the block, if any. In the "
+"example above, the type is `()`."
+msgstr ""
+
+#: src/tuples-and-arrays/match.md:30
+msgid ""
+"A variable in the pattern (`key` in this example) will create a binding that "
+"can be used within the match arm."
+msgstr ""
+
+#: src/tuples-and-arrays/match.md:33
+msgid "A match guard causes the arm to match only if the condition is true."
+msgstr ""
+
+#: src/tuples-and-arrays/match.md:38 src/user-defined-types/named-structs.md:35
+#: src/user-defined-types/enums.md:29 src/methods-and-traits/methods.md:69
+msgid "Key Points:"
+msgstr "キーポイント: "
+
+#: src/tuples-and-arrays/match.md:40
 msgid ""
 "You might point out how some specific characters are being used when in a "
 "pattern"
 msgstr ""
 
-#: src/pattern-matching.md:27
+#: src/tuples-and-arrays/match.md:42
 msgid "`|` as an `or`"
 msgstr ""
 
-#: src/pattern-matching.md:28
+#: src/tuples-and-arrays/match.md:43
 msgid "`..` can expand as much as it needs to be"
 msgstr ""
 
-#: src/pattern-matching.md:29
+#: src/tuples-and-arrays/match.md:44
 msgid "`1..=5` represents an inclusive range"
 msgstr ""
 
-#: src/pattern-matching.md:30
+#: src/tuples-and-arrays/match.md:45
 msgid "`_` is a wild card"
 msgstr ""
 
-#: src/pattern-matching.md:31
-msgid ""
-"It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`."
-msgstr ""
-
-#: src/pattern-matching.md:32
-msgid "You can demonstrate matching on a reference."
-msgstr ""
-
-#: src/pattern-matching.md:33
-msgid ""
-"This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages."
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:3
-msgid ""
-"Patterns can also be used to bind variables to parts of your values. This is "
-"how you inspect the structure of your types. Let us start with a simple "
-"`enum` type:"
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:16
-msgid "\"cannot divide {n} into two equal parts\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:23
-msgid "\"{n} divided in two is {half}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:24
-msgid "\"sorry, an error happened: {msg}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:29
-msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the first "
-"arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm, `msg` is bound to the error message."
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:36
-msgid ""
-"The `if`/`else` expression is returning an enum that is later unpacked with "
-"a `match`."
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:37
-msgid ""
-"You can try adding a third variant to the enum definition and displaying the "
-"errors when running the code. Point out the places where your code is now "
-"inexhaustive and how the compiler tries to give you hints."
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:3
-msgid "You can also destructure `structs`:"
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:15
-msgid "\"x.0 = 1, b = {b}, y = {y}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:16
-msgid "\"y = 2, x = {i:?}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:17
-msgid "\"y = {y}, other fields were ignored\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:23
-msgid "Change the literal values in `foo` to match with the other patterns."
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:24
-msgid "Add a new field to `Foo` and make changes to the pattern as needed."
-msgstr ""
-
-#: src/pattern-matching/destructuring-structs.md:25
-msgid ""
-"The distinction between a capture and a constant expression can be hard to "
-"spot. Try changing the `2` in the second arm to a variable, and see that it "
-"subtly doesn't work. Change it to a `const` and see it working again."
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:3
-msgid ""
-"You can destructure arrays, tuples, and slices by matching on their elements:"
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:9
-msgid "\"Tell me about {triple:?}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:11
-#: src/pattern-matching/destructuring-arrays.md:34
-msgid "\"First is 0, y = {y}, and z = {z}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:12
-#: src/pattern-matching/destructuring-arrays.md:35
-msgid "\"First is 1 and the rest were ignored\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:13
-#: src/pattern-matching/destructuring-arrays.md:36
-msgid "\"All elements were ignored\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:21
-msgid ""
-"Destructuring of slices of unknown length also works with patterns of fixed "
-"length."
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:32
-msgid "\"Tell me about {slice:?}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:41
-msgid "Create a new pattern using `_` to represent an element. "
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:42
-msgid "Add more values to the array."
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:43
-msgid ""
-"Point out that how `..` will expand to account for different number of "
-"elements."
-msgstr ""
-
-#: src/pattern-matching/destructuring-arrays.md:44
-msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:3
-msgid ""
-"When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean expression which will be executed if the pattern matches:"
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:10
-msgid "\"Tell me about {pair:?}\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:12
-msgid "\"These are twins\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:13
-msgid "\"Antimatter, kaboom!\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:14
-msgid "\"The first one is odd\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:15
-msgid "\"No correlation...\""
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:23
+#: src/tuples-and-arrays/match.md:47
 msgid ""
 "Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
 "allow."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:24
+#: src/tuples-and-arrays/match.md:49
 msgid ""
 "They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
@@ -4816,233 +4063,823 @@ msgid ""
 "result in other arms of the original `match` expression being considered."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:26
-msgid "You can use the variables defined in the pattern in your if expression."
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:27
+#: src/tuples-and-arrays/match.md:53
 msgid ""
 "The condition defined in the guard applies to every expression in a pattern "
 "with an `|`."
 msgstr ""
 
-#: src/exercises/day-1/afternoon.md:1
-msgid "Day 1: Afternoon Exercises"
+#: src/tuples-and-arrays/destructuring.md:3
+msgid ""
+"Destructuring is a way of extracting data from a data structure by writing a "
+"pattern that is matched up to the data structure, binding variables to "
+"subcomponents of the data structure."
 msgstr ""
 
-#: src/exercises/day-1/afternoon.md:3
-msgid "We will look at two things:"
+#: src/tuples-and-arrays/destructuring.md:7
+msgid "You can destructure tuples and arrays by matching on their elements:"
 msgstr ""
 
-#: src/exercises/day-1/afternoon.md:5
+#: src/tuples-and-arrays/destructuring.md:18
+msgid "\"on Y axis\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:19
+msgid "\"on X axis\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:20
+msgid "\"left of Y axis\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:21
+msgid "\"below X axis\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:22
+msgid "\"first quadrant\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:33
+msgid "\"Tell me about {triple:?}\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:35
+msgid "\"First is 0, y = {y}, and z = {z}\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:36
+msgid "\"First is 1 and the rest were ignored\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:37
+msgid "\"All elements were ignored\""
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:45
+msgid "Create a new array pattern using `_` to represent an element."
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:46
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:47
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/tuples-and-arrays/destructuring.md:49
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr ""
+
+#: src/tuples-and-arrays/exercise.md:3
+msgid "Arrays can contain other arrays:"
+msgstr ""
+
+#: src/tuples-and-arrays/exercise.md:9
 #, fuzzy
-msgid "The Luhn algorithm,"
-msgstr "Luhnアルゴリズム"
+msgid "What is the type of this variable?"
+msgstr "非同期の呼び出しの返り値の型は？"
 
-#: src/exercises/day-1/afternoon.md:7
-#, fuzzy
-msgid "An exercise on pattern matching."
-msgstr "列挙型とパターンマッチング"
-
-#: src/exercises/day-1/afternoon.md:11 src/exercises/day-2/afternoon.md:7
-#: src/exercises/bare-metal/afternoon.md:7
-#: src/exercises/concurrency/afternoon.md:13
+#: src/tuples-and-arrays/exercise.md:11
 msgid ""
-"After looking at the exercises, you can look at the [solutions](solutions-"
-"afternoon.md) provided."
+"Use an array such as the above to write a function `transpose` which will "
+"transpose a matrix (turn rows into columns):"
 msgstr ""
 
-#: src/exercises/day-1/luhn.md:3
-msgid ""
-"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to validate credit card numbers. The algorithm takes a string as input and "
-"does the following to validate the credit card number:"
+#: src/tuples-and-arrays/exercise.md:22
+msgid "Hard-code both functions to operate on 3 × 3 matrices."
 msgstr ""
 
-#: src/exercises/day-1/luhn.md:7
-msgid "Ignore all spaces. Reject number with less than two digits."
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:9
-msgid ""
-"Moving from **right to left**, double every second digit: for the number "
-"`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:12
-msgid ""
-"After doubling a digit, sum the digits if the result is greater than 9. So "
-"doubling `7` becomes `14` which becomes `1 + 4 = 5`."
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:15
-msgid "Sum all the undoubled and doubled digits."
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:17
-msgid "The credit card number is valid if the sum ends with `0`."
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:19
+#: src/tuples-and-arrays/exercise.md:24
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and implement the "
-"function."
+"functions:"
 msgstr ""
 
-#: src/exercises/day-1/luhn.md:21
+#: src/tuples-and-arrays/exercise.md:28 src/methods-and-traits/exercise.md:20
+#: src/borrowing/exercise.md:14 src/unsafe-rust/exercise.md:51
+msgid "// TODO: remove this when you're done with your implementation.\n"
+msgstr ""
+
+#: src/tuples-and-arrays/exercise.md:37 src/tuples-and-arrays/solution.md:34
+msgid "// <-- the comment makes rustfmt add a newline\n"
+msgstr ""
+
+#: src/tuples-and-arrays/exercise.md:42 src/tuples-and-arrays/solution.md:39
+msgid "\"matrix: {:#?}\""
+msgstr ""
+
+#: src/tuples-and-arrays/exercise.md:44 src/tuples-and-arrays/solution.md:41
+msgid "\"transposed: {:#?}\""
+msgstr ""
+
+#: src/tuples-and-arrays/solution.md:17 src/tuples-and-arrays/solution.md:25
+msgid "//\n"
+msgstr ""
+
+#: src/references.md:4
+msgid "[Shared References](./references/shared.md) (10 minutes)"
+msgstr ""
+
+#: src/references.md:5
+msgid "[Exclusive References](./references/exclusive.md) (10 minutes)"
+msgstr ""
+
+#: src/references.md:6
+msgid "[Exercise: Geometry](./references/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/references.md:8 src/user-defined-types.md:11 src/pattern-matching.md:8
+msgid "This segment should take about 50 minutes"
+msgstr ""
+
+#: src/references/shared.md:3
 msgid ""
-"Try to solve the problem the \"simple\" way first, using `for` loops and "
-"integers. Then, revisit the solution and try to implement it with iterators."
+"A reference provides a way to access another value without taking "
+"responsibility for the value, and is also called \"borrowing\". Shared "
+"references are read-only, and the referenced data cannot change."
 msgstr ""
 
-#: src/exercises/day-1/luhn.md:35
-#: src/exercises/day-2/iterators-and-ownership.md:75
-#: src/exercises/day-2/iterators-and-ownership.md:91
-#: src/traits/trait-bounds.md:22 src/traits/impl-trait.md:14
-#: src/exercises/day-3/simple-gui.md:148 src/exercises/day-3/simple-gui.md:149
-#: src/exercises/day-3/simple-gui.md:150 src/testing/test-modules.md:21
-#: src/exercises/day-1/solutions-afternoon.md:43
-msgid "\"foo\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:36 src/exercises/day-1/solutions-afternoon.md:44
-msgid "\"foo 0 0\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:41 src/testing/unit-tests.md:15
-#: src/exercises/day-1/solutions-afternoon.md:49
-#: src/exercises/day-3/solutions-morning.md:90
-#: src/exercises/day-3/solutions-morning.md:92
-#: src/exercises/day-3/solutions-morning.md:96
-#: src/exercises/day-3/solutions-morning.md:110
-#: src/exercises/day-3/solutions-morning.md:114
-msgid "\"\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:42 src/exercises/day-1/solutions-afternoon.md:50
-msgid "\" \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:43 src/exercises/day-1/solutions-afternoon.md:51
-msgid "\"  \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:44 src/exercises/day-1/solutions-afternoon.md:52
-msgid "\"    \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:49 src/exercises/day-1/solutions-afternoon.md:57
-msgid "\"0\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:54 src/exercises/day-1/solutions-afternoon.md:62
-msgid "\" 0 0 \""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:59 src/exercises/day-1/solutions-afternoon.md:67
-msgid "\"4263 9826 4026 9299\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:60 src/exercises/day-1/solutions-afternoon.md:68
-msgid "\"4539 3195 0343 6467\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:61 src/exercises/day-1/solutions-afternoon.md:69
-msgid "\"7992 7398 713\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:66 src/exercises/day-1/solutions-afternoon.md:74
-msgid "\"4223 9826 4026 9299\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:67 src/exercises/day-1/solutions-afternoon.md:75
-msgid "\"4539 3195 0343 6476\""
-msgstr ""
-
-#: src/exercises/day-1/luhn.md:68 src/exercises/day-1/solutions-afternoon.md:76
-msgid "\"8273 1232 7352 0569\""
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:1
-msgid "Exercise: Expression Evaluation"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:3
-msgid "Let's write a simple recursive evaluator for arithmetic expressions. "
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:6
-#: src/exercises/day-1/solutions-afternoon.md:83
-msgid "/// An operation to perform on two subexpressions.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:14
-#: src/exercises/day-1/solutions-afternoon.md:91
-msgid "/// An expression, in tree form.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:18
-#: src/exercises/day-1/solutions-afternoon.md:95
-msgid "/// An operation on two subexpressions.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:25
-#: src/exercises/day-1/solutions-afternoon.md:102
-msgid "/// A literal value\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:28
-#: src/exercises/day-1/solutions-afternoon.md:105
-msgid "/// The result of evaluating an expression.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:32
-#: src/exercises/day-1/solutions-afternoon.md:109
-msgid "/// Evaluation was successful, with the given result.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:34
-#: src/exercises/day-1/solutions-afternoon.md:111
-msgid "/// Evaluation failed, with the given error message.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:36
-#: src/exercises/day-1/solutions-afternoon.md:113
-msgid "// Allow `Ok` and `Err` as shorthands for `Res::Ok` and `Res::Err`.\n"
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:95
-#: src/exercises/day-1/solutions-afternoon.md:134
-#: src/exercises/day-1/solutions-afternoon.md:196
-msgid "\"division by zero\""
-msgstr ""
-
-#: src/exercises/day-1/pattern-matching.md:100
+#: src/references/shared.md:20
 msgid ""
-"The `Box` type here is a smart pointer, and will be covered in detail later "
-"in the course. An expression can be \"boxed\" with `Box::new` as seen in the "
-"tests. To evaluate a boxed expression, use the deref operator to \"unbox\" "
-"it: `eval(*boxed_expr)`."
+"A shared reference to a type `T` has type `&T`. A reference value is made "
+"with the `&` operator. The `*` operator \"dereferences\" a reference, "
+"yielding its value."
 msgstr ""
 
-#: src/exercises/day-1/pattern-matching.md:105
-msgid ""
-"Some expressions cannot be evaluated and will return an error. The `Res` "
-"type represents either a successful value or an error with a message. This "
-"is very similar to the standard-library `Result` which we will see later."
+#: src/references/shared.md:24
+msgid "Rust will statically forbid dangling references:"
 msgstr ""
 
-#: src/exercises/day-1/pattern-matching.md:109
+#: src/references/shared.md:38
 msgid ""
-"Copy and paste the code into the Rust playground, and begin implementing "
-"`eval`. The final product should pass the tests. It may be helpful to use "
-"`todo!()` and get the tests to pass one-by-one."
+"A reference is said to \"borrow\" the value it refers to, and this is a good "
+"model for students not familiar with pointers: code can use the reference to "
+"access the value, but is still \"owned\" by the original variable. The "
+"course will get into more detail on ownership in day 3."
 msgstr ""
 
-#: src/exercises/day-1/pattern-matching.md:113
+#: src/references/shared.md:43
 msgid ""
-"If you finish early, try writing a test that results in an integer overflow. "
-"How could you handle this with `Res::Err` instead of a panic?"
+"References are implemented as pointers, and a key advantage is that they can "
+"be much smaller than the thing they point to. Students familiar with C or C+"
+"+ will recognize references as pointers. Later parts of the course will "
+"cover how Rust prevents the memory-safety bugs that come from using raw "
+"pointers."
+msgstr ""
+
+#: src/references/shared.md:48
+msgid ""
+"Rust does not automatically create references for you - the `&` is always "
+"required."
+msgstr ""
+
+#: src/references/shared.md:51
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `r.count_ones()`). There is no need for an `->` operator like "
+"in C++."
+msgstr ""
+
+#: src/references/shared.md:54
+msgid ""
+"In this example, `r` is mutable so that it can be reassigned (`r = &b`). "
+"Note that this re-binds `r`, so that it refers to something else. This is "
+"different from C++, where assignment to a reference changes the referenced "
+"value."
+msgstr ""
+
+#: src/references/shared.md:58
+msgid ""
+"A shared reference does not allow modifying the value it refers to, even if "
+"that value was mutable. Try `*r = 'X'`."
+msgstr ""
+
+#: src/references/shared.md:61
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough. Dangling references cannot occur in safe Rust. `x_axis` would return "
+"a reference to `point`, but `point` will be deallocated when the function "
+"returns, so this will not compile."
+msgstr ""
+
+#: src/references/shared.md:66
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr ""
+
+#: src/references/exclusive.md:3
+msgid ""
+"Exclusive references, also known as mutable references, allow changing the "
+"value they refer to. They have type `&mut T`."
+msgstr ""
+
+#: src/references/exclusive.md:22
+msgid ""
+"\"Exclusive\" means that only this reference can be used to access the "
+"value. No other references (shared or exclusive) can exist at the same time, "
+"and the referenced value cannot be accessed while the exclusive reference "
+"exists. Try making an `&point.0` or changing `point.0` while `x_coord` is "
+"alive."
+msgstr ""
+
+#: src/references/exclusive.md:27
+msgid ""
+"Be sure to note the difference between `let mut x_coord: &i32` and `let "
+"x_coord: &mut i32`. The first one represents a shared reference which can be "
+"bound to different values, while the second represents an exclusive "
+"reference to a mutable value."
+msgstr ""
+
+#: src/references/exercise.md:3
+msgid ""
+"We will create a few utility functions for 3-dimensional geometry, "
+"representing a point as `[f64;3]`. It is up to you to determine the function "
+"signatures."
+msgstr ""
+
+#: src/references/exercise.md:7
+msgid ""
+"// Calculate the magnitude of a vector by summing the squares of its "
+"coordinates\n"
+"// and taking the square root. Use the `sqrt()` method to calculate the "
+"square\n"
+"// root, like `v.sqrt()`.\n"
+msgstr ""
+
+#: src/references/exercise.md:15
+msgid ""
+"// Normalize a vector by calculating its magnitude and dividing all of its\n"
+"// coordinates by that magnitude.\n"
+msgstr ""
+
+#: src/references/exercise.md:23
+msgid "// Use the following `main` to test your work.\n"
+msgstr ""
+
+#: src/references/exercise.md:27 src/references/solution.md:22
+msgid "\"Magnitude of a unit vector: {}\""
+msgstr ""
+
+#: src/references/exercise.md:30 src/references/solution.md:25
+msgid "\"Magnitude of {v:?}: {}\""
+msgstr ""
+
+#: src/references/exercise.md:32 src/references/solution.md:27
+msgid "\"Magnitude of {v:?} after normalization: {}\""
+msgstr ""
+
+#: src/references/solution.md:4
+msgid "/// Calculate the magnitude of the given vector.\n"
+msgstr ""
+
+#: src/references/solution.md:12
+msgid ""
+"/// Change the magnitude of the vector to 1.0 without changing its "
+"direction.\n"
+msgstr ""
+
+#: src/user-defined-types.md:4
+msgid "[Named Structs](./user-defined-types/named-structs.md) (10 minutes)"
+msgstr ""
+
+#: src/user-defined-types.md:5
+msgid "[Tuple Structs](./user-defined-types/tuple-structs.md) (10 minutes)"
+msgstr ""
+
+#: src/user-defined-types.md:6
+msgid "[Enums](./user-defined-types/enums.md) (5 minutes)"
+msgstr ""
+
+#: src/user-defined-types.md:7
+msgid ""
+"[Static and Const](./user-defined-types/static-and-const.md) (5 minutes)"
+msgstr ""
+
+#: src/user-defined-types.md:8
+msgid "[Type Aliases](./user-defined-types/aliases.md) (2 minutes)"
+msgstr ""
+
+#: src/user-defined-types.md:9
+msgid ""
+"[Exercise: Elevator Events](./user-defined-types/exercise.md) (15 minutes)"
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:3
+msgid "Like C and C++, Rust has support for custom structs:"
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:12
+msgid "\"{} is {} years old\""
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:16
+#: src/android/interoperability/with-c/bindgen.md:87
+msgid "\"Peter\""
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:22
+msgid "\"Avery\""
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:27
+msgid "\"Jackie\""
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:37
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:38
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:39
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:40
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs."
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:42
+msgid ""
+"Zero-sized structs (e.g. `struct Foo;`) might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself."
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:45
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:47
+msgid ""
+"If you already have variables with the right names, then you can create the "
+"struct using a shorthand."
+msgstr ""
+
+#: src/user-defined-types/named-structs.md:49
+msgid ""
+"The syntax `..avery` allows us to copy the majority of the fields from the "
+"old struct without having to explicitly type it all out. It must always be "
+"the last element."
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:7
+msgid "If the field names are unimportant, you can use a tuple struct:"
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:14
+msgid "\"({}, {})\""
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:18
+msgid "This is often used for single-field wrappers (called newtypes):"
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:25
+msgid "\"Ask a rocket scientist at NASA\""
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:29
+#: src/android/interoperability/cpp/cpp-bridge.md:50
+#: src/bare-metal/microcontrollers/type-state.md:14
+#: src/async/pitfalls/cancellation.md:98 src/async/pitfalls/cancellation.md:101
+msgid "// ...\n"
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:41
+msgid ""
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:43
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:44
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: `PhoneNumber(String)` or `OddNumber(u32)`."
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:47
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:49
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:51
+msgid "Operator overloading is discussed on Day 3 (generics)."
+msgstr ""
+
+#: src/user-defined-types/tuple-structs.md:52
+msgid ""
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
+msgstr ""
+
+#: src/user-defined-types/enums.md:3
+msgid ""
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
+msgstr ""
+
+#: src/user-defined-types/enums.md:15
+msgid "// Simple variant\n"
+msgstr ""
+
+#: src/user-defined-types/enums.md:16
+#, fuzzy
+msgid "// Tuple variant\n"
+msgstr "// 可変変数のバインディング\n"
+
+#: src/user-defined-types/enums.md:17
+msgid "// Struct variant\n"
+msgstr ""
+
+#: src/user-defined-types/enums.md:22
+msgid "\"On this turn: {:?}\""
+msgstr ""
+
+#: src/user-defined-types/enums.md:31
+msgid "Enumerations allow you to collect a set of values under one type."
+msgstr ""
+
+#: src/user-defined-types/enums.md:32
+msgid ""
+"`Direction` is a type with variants. There are two values of `Direction`: "
+"`Direction::Left` and `Direction::Right`."
+msgstr ""
+
+#: src/user-defined-types/enums.md:34
+msgid ""
+"`PlayerMove` is a type with three variants. In addition to the payloads, "
+"Rust will store a discriminant so that it knows at runtime which variant is "
+"in a `PlayerMove` value."
+msgstr ""
+
+#: src/user-defined-types/enums.md:37
+msgid "This might be a good time to compare structs and enums:"
+msgstr ""
+
+#: src/user-defined-types/enums.md:38
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads)."
+msgstr ""
+
+#: src/user-defined-types/enums.md:40
+msgid ""
+"You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum."
+msgstr ""
+
+#: src/user-defined-types/enums.md:43
+msgid "Rust uses minimal space to store the discriminant."
+msgstr ""
+
+#: src/user-defined-types/enums.md:44
+msgid "If necessary, it stores an integer of the smallest required size"
+msgstr ""
+
+#: src/user-defined-types/enums.md:45
+msgid ""
+"If the allowed variant values do not cover all bit patterns, it will use "
+"invalid bit patterns to encode the discriminant (the \"niche optimization"
+"\"). For example, `Option<&u8>` stores either a pointer to an integer or "
+"`NULL` for the `None` variant."
+msgstr ""
+
+#: src/user-defined-types/enums.md:49
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr ""
+
+#: src/user-defined-types/enums.md:67
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+
+#: src/user-defined-types/enums.md:70
+#: src/user-defined-types/static-and-const.md:76
+#: src/memory-management/review.md:51 src/memory-management/move.md:100
+#: src/smart-pointers/box.md:84 src/borrowing/shared.md:33
+msgid "More to Explore"
+msgstr ""
+
+#: src/user-defined-types/enums.md:72
+msgid ""
+"Rust has several optimizations it can employ to make enums take up less "
+"space."
+msgstr ""
+
+#: src/user-defined-types/enums.md:74
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/user-defined-types/enums.md:78
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:3
+msgid ""
+"Static and constant variables are two different ways to create globally-"
+"scoped values that cannot be moved or reallocated during the execution of "
+"the program."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:6
+msgid "`const`"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:8
+msgid ""
+"Constant variables are evaluated at compile time and their values are "
+"inlined wherever they are used:"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:31
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:33
+msgid ""
+"Only functions marked `const` can be called at compile time to generate "
+"`const` values. `const` functions can however be called at runtime."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:36
+msgid "`static`"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:38
+msgid ""
+"Static variables will live during the whole execution of the program, and "
+"therefore will not move:"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:42
+msgid "\"Welcome to RustOS 3.14\""
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:45
+msgid "\"{BANNER}\""
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:49
+msgid ""
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location. This is useful for unsafe and embedded code, and "
+"the variable lives through the entirety of the program execution. When a "
+"globally-scoped value does not have a reason to need object identity, "
+"`const` is generally preferred."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:58
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:59
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:61
+msgid ""
+"`static` provides object identity: an address in memory and state as "
+"required by types with interior mutability such as `Mutex<T>`."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:63
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:66
+msgid "Properties table:"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:68
+#: src/chromium/adding-third-party-crates.md:6
+msgid "Property"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:68
+msgid "Static"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:68
+msgid "Constant"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:70
+msgid "Has an address in memory"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:70
+#: src/user-defined-types/static-and-const.md:71
+#: src/user-defined-types/static-and-const.md:73
+#: src/user-defined-types/static-and-const.md:74
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
+msgid "Yes"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:70
+msgid "No (inlined)"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:71
+#, fuzzy
+msgid "Lives for the entire duration of the program"
+msgstr "`main`関数はプログラムのエントリーポイントになります。"
+
+#: src/user-defined-types/static-and-const.md:71
+#: src/user-defined-types/static-and-const.md:72
+#: src/user-defined-types/static-and-const.md:74
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
+msgid "No"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:72
+msgid "Can be mutable"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:72
+msgid "Yes (unsafe)"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:73
+msgid "Evaluated at compile time"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:73
+msgid "Yes (initialised at compile time)"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:74
+msgid "Inlined wherever it is used"
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:78
+msgid ""
+"Because `static` variables are accessible from any thread, they must be "
+"`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html), atomic or similar."
+msgstr ""
+
+#: src/user-defined-types/static-and-const.md:83
+msgid "Thread-local data can be created with the macro `std::thread_local`."
+msgstr ""
+
+#: src/user-defined-types/aliases.md:3
+msgid ""
+"A type alias creates a name for another type. The two types can be used "
+"interchangeably."
+msgstr ""
+
+#: src/user-defined-types/aliases.md:13
+msgid "// Aliases are more useful with long, complex types:\n"
+msgstr ""
+
+#: src/user-defined-types/aliases.md:23
+msgid "C programmers will recognize this as similar to a `typedef`."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:3
+msgid ""
+"We will create a data structure to represent an event in an elevator control "
+"system. It is up to you to define the types and functions to construct "
+"various events. Use `#[derive(Debug)]` to allow the types to be formatted "
+"with `{:?}`."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:7
+msgid ""
+"This exercise only requires creating and populating data structures so that "
+"`main` runs without errors. The next part of the course will cover getting "
+"data out of these structures."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:12 src/user-defined-types/solution.md:4
+msgid ""
+"/// An event in the elevator system that the controller must react to.\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:15
+msgid "// TODO: add required variants\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:17 src/user-defined-types/solution.md:22
+msgid "/// A direction of travel.\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:24 src/user-defined-types/solution.md:39
+msgid "/// The car has arrived on the given floor.\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:29 src/user-defined-types/solution.md:44
+msgid "/// The car doors have opened.\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:34 src/user-defined-types/solution.md:49
+msgid "/// The car doors have closed.\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:39 src/user-defined-types/solution.md:54
+msgid ""
+"/// A directional button was pressed in an elevator lobby on the given "
+"floor.\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:44 src/user-defined-types/solution.md:59
+msgid "/// A floor button was pressed in the elevator car.\n"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:52 src/user-defined-types/solution.md:67
+msgid "\"A ground floor passenger has pressed the up button: {:?}\""
+msgstr ""
+
+#: src/user-defined-types/exercise.md:55 src/user-defined-types/solution.md:70
+msgid "\"The car has arrived on the ground floor: {:?}\""
+msgstr ""
+
+#: src/user-defined-types/exercise.md:56 src/user-defined-types/solution.md:71
+msgid "\"The car door opened: {:?}\""
+msgstr ""
+
+#: src/user-defined-types/exercise.md:58 src/user-defined-types/solution.md:73
+msgid "\"A passenger has pressed the 3rd floor button: {:?}\""
+msgstr ""
+
+#: src/user-defined-types/exercise.md:61 src/user-defined-types/solution.md:76
+msgid "\"The car door closed: {:?}\""
+msgstr ""
+
+#: src/user-defined-types/exercise.md:62 src/user-defined-types/solution.md:77
+msgid "\"The car has arrived on the 3rd floor: {:?}\""
+msgstr ""
+
+#: src/user-defined-types/solution.md:7
+msgid "/// A button was pressed.\n"
+msgstr ""
+
+#: src/user-defined-types/solution.md:10
+msgid "/// The car has arrived at the given floor.\n"
+msgstr ""
+
+#: src/user-defined-types/solution.md:13
+msgid "/// The car's doors have opened.\n"
+msgstr ""
+
+#: src/user-defined-types/solution.md:16
+msgid "/// The car's doors have closed.\n"
+msgstr ""
+
+#: src/user-defined-types/solution.md:19
+msgid "/// A floor is represented as an integer.\n"
+msgstr ""
+
+#: src/user-defined-types/solution.md:29
+msgid "/// A user-accessible button.\n"
+msgstr ""
+
+#: src/user-defined-types/solution.md:33
+msgid "/// A button in the elevator lobby on the given floor.\n"
+msgstr ""
+
+#: src/user-defined-types/solution.md:36
+msgid "/// A floor button within the car.\n"
 msgstr ""
 
 #: src/welcome-day-2.md:1
@@ -5050,1067 +4887,437 @@ msgid "Welcome to Day 2"
 msgstr ""
 
 #: src/welcome-day-2.md:3
-msgid "Now that we have seen a fair amount of Rust, we will continue with:"
+msgid ""
+"Now that we have seen a fair amount of Rust, today will focus on Rust's type "
+"system:"
 msgstr ""
 
-#: src/welcome-day-2.md:5
-msgid ""
-"Memory management: stack vs heap, manual memory management, scope-based "
-"memory management, and garbage collection."
+#: src/welcome-day-2.md:6
+msgid "Pattern matching: extracting data from structures."
 msgstr ""
-"メモリ管理： スタック vs ヒープ、手動でのメモリ管理、スコープに基づくメモリ管"
-"理、ガベージコレクション。"
+
+#: src/welcome-day-2.md:7
+msgid "Methods: associating functions with types."
+msgstr ""
 
 #: src/welcome-day-2.md:8
-msgid ""
-"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
-msgstr "所有権： ムーブセマンティクス、コピーとクローン、借用、ライフタイム。"
+msgid "Traits: behaviors shared by multiple types."
+msgstr ""
+
+#: src/welcome-day-2.md:9
+msgid "Generics: parameterizing types on other types."
+msgstr ""
 
 #: src/welcome-day-2.md:10
-#, fuzzy
-msgid "Structs and methods."
-msgstr "文字列とイテレータ"
-
-#: src/welcome-day-2.md:12
 msgid ""
-"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc` and `Arc`."
+"Standard library types and traits: a tour of Rust's rich standard library."
 msgstr ""
 
 #: src/welcome-day-2.md:15
-msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgid "[Welcome](./welcome-day-2.md) (3 minutes)"
 msgstr ""
 
-#: src/memory-management.md:3
-msgid "Traditionally, languages have fallen into two broad categories:"
+#: src/welcome-day-2.md:16
+msgid "[Pattern Matching](./pattern-matching.md) (50 minutes)"
 msgstr ""
 
-#: src/memory-management.md:5
-msgid "Full control via manual memory management: C, C++, Pascal, ..."
+#: src/welcome-day-2.md:17
+msgid "[Methods and Traits](./methods-and-traits.md) (1 hour and 5 minutes)"
 msgstr ""
 
-#: src/memory-management.md:6
+#: src/welcome-day-2.md:18
+msgid "[Generics](./generics.md) (45 minutes)"
+msgstr ""
+
+#: src/welcome-day-2.md:20
 msgid ""
-"Full safety via automatic memory management at runtime: Java, Python, Go, "
-"Haskell, ..."
+"Including 10 minute breaks, this session should take about 3 hours and 15 "
+"minutes"
 msgstr ""
 
-#: src/memory-management.md:8
-msgid "Rust offers a new mix:"
+#: src/pattern-matching.md:4
+msgid "[Destructuring](./pattern-matching/destructuring.md) (10 minutes)"
 msgstr ""
 
-#: src/memory-management.md:10
+#: src/pattern-matching.md:5
+msgid "[Let Control Flow](./pattern-matching/let-control-flow.md) (10 minutes)"
+msgstr ""
+
+#: src/pattern-matching.md:6
 msgid ""
-"Full control _and_ safety via compile time enforcement of correct memory "
-"management."
+"[Exercise: Expression Evaluation](./pattern-matching/exercise.md) (30 "
+"minutes)"
 msgstr ""
 
-#: src/memory-management.md:13
-msgid "It does this with an explicit ownership concept."
+#: src/pattern-matching/destructuring.md:3
+msgid "Like tuples, structs and enums can also be destructured by matching:"
 msgstr ""
 
-#: src/memory-management.md:15
-msgid "First, let's refresh how memory management works."
+#: src/pattern-matching/destructuring.md:5
+#: src/pattern-matching/destructuring.md:59
+msgid "Structs"
+msgstr "構造体（structs）"
+
+#: src/pattern-matching/destructuring.md:17
+msgid "\"x.0 = 1, b = {b}, y = {y}\""
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:1
-msgid "The Stack vs The Heap"
+#: src/pattern-matching/destructuring.md:18
+msgid "\"y = 2, x = {i:?}\""
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:3
-msgid "Stack: Continuous area of memory for local variables."
+#: src/pattern-matching/destructuring.md:19
+msgid "\"y = {y}, other fields were ignored\""
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:4
-msgid "Values have fixed sizes known at compile time."
+#: src/pattern-matching/destructuring.md:26
+msgid ""
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:5
-msgid "Extremely fast: just move a stack pointer."
+#: src/pattern-matching/destructuring.md:39
+msgid "\"cannot divide {n} into two equal parts\""
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:6
-msgid "Easy to manage: follows function calls."
+#: src/pattern-matching/destructuring.md:46
+msgid "\"{n} divided in two is {half}\""
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:7
-msgid "Great memory locality."
+#: src/pattern-matching/destructuring.md:47
+msgid "\"sorry, an error happened: {msg}\""
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:9
-msgid "Heap: Storage of values outside of function calls."
+#: src/pattern-matching/destructuring.md:52
+msgid ""
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm, `msg` is bound to the error message."
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:10
-msgid "Values have dynamic sizes determined at runtime."
+#: src/pattern-matching/destructuring.md:61
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:11
-msgid "Slightly slower than the stack: some book-keeping needed."
+#: src/pattern-matching/destructuring.md:62
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
 msgstr ""
 
-#: src/memory-management/stack-vs-heap.md:12
-msgid "No guarantee of memory locality."
+#: src/pattern-matching/destructuring.md:63
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
 
-#: src/memory-management/stack.md:1
+#: src/pattern-matching/destructuring.md:71
+msgid ""
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
+msgstr ""
+
+#: src/pattern-matching/destructuring.md:73
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
+msgstr ""
+
+#: src/pattern-matching/destructuring.md:76
+msgid ""
+"The values in the enum variants can only be accessed after being pattern "
+"matched. The pattern binds references to the fields in the \"match arm\" "
+"after the `=>`."
+msgstr ""
+
+#: src/pattern-matching/destructuring.md:79
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled."
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:3
+msgid ""
+"Rust has a few control flow constructs which differ from other languages. "
+"They are used for pattern matching:"
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:6
+#: src/pattern-matching/let-control-flow.md:10
+msgid "`if let` expressions"
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:7
 #, fuzzy
-msgid "Stack and Heap Example"
-msgstr "スタック vs ヒープ"
+msgid "`while let` expressions"
+msgstr "while let式"
 
-#: src/memory-management/stack.md:3
+#: src/pattern-matching/let-control-flow.md:8
+msgid "`match` expressions"
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:12
 msgid ""
-"Creating a `String` puts fixed-sized metadata on the stack and dynamically "
-"sized data, the actual string, on the heap:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
 
-#: src/memory-management/stack.md:8 src/memory-management/stack.md:36
-#: src/std/string.md:8 src/traits/read-write.md:35 src/testing/unit-tests.md:20
-#: src/testing/unit-tests.md:25 src/testing/test-modules.md:12
-#: src/concurrency/scoped-threads.md:9 src/concurrency/scoped-threads.md:26
-msgid "\"Hello\""
+#: src/pattern-matching/let-control-flow.md:24
+msgid "\"slept for {:?}\""
 msgstr ""
 
-#: src/memory-management/stack.md:28
-msgid ""
-"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap."
-msgstr ""
-
-#: src/memory-management/stack.md:30
-msgid ""
-"If students ask about it, you can mention that the underlying memory is heap "
-"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
-"struct.System.html) and custom allocators can be implemented using the "
-"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
-msgstr ""
-
-#: src/memory-management/stack.md:32
-msgid ""
-"We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!"
-msgstr ""
-
-#: src/memory-management/stack.md:37 src/testing/unit-tests.md:7
-#: src/exercises/day-1/solutions-afternoon.md:11
-msgid "' '"
-msgstr ""
-
-#: src/memory-management/stack.md:38
-msgid "\"world\""
-msgstr ""
-
-#: src/memory-management/stack.md:39
-msgid ""
-"// DON'T DO THIS AT HOME! For educational purposes only.\n"
-"    // String provides no guarantees about its layout, so this could lead "
-"to\n"
-"    // undefined behavior.\n"
-msgstr ""
-
-#: src/memory-management/stack.md:44
-msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
-msgstr ""
-
-#: src/memory-management/manual.md:3
-msgid "You allocate and deallocate heap memory yourself."
-msgstr ""
-
-#: src/memory-management/manual.md:5
-msgid ""
-"If not done with care, this can lead to crashes, bugs, security "
-"vulnerabilities, and memory leaks."
-msgstr ""
-
-#: src/memory-management/manual.md:7
-msgid "C Example"
-msgstr ""
-
-#: src/memory-management/manual.md:9
-msgid "You must call `free` on every pointer you allocate with `malloc`:"
-msgstr ""
-
-#: src/memory-management/manual.md:14
-msgid ""
-"//\n"
-"    // ... lots of code\n"
-"    //\n"
-msgstr ""
-
-#: src/memory-management/manual.md:21
-msgid ""
-"Memory is leaked if the function returns early between `malloc` and `free`: "
-"the pointer is lost and we cannot deallocate the memory. Worse, freeing the "
-"pointer twice, or accessing a freed pointer can lead to exploitable security "
-"vulnerabilities."
-msgstr ""
-
-#: src/memory-management/scope-based.md:3
-msgid ""
-"Constructors and destructors let you hook into the lifetime of an object."
-msgstr ""
-
-#: src/memory-management/scope-based.md:5
-msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is "
-"destroyed. The compiler guarantees that this happens, even if an exception "
-"is raised."
-msgstr ""
-
-#: src/memory-management/scope-based.md:9
-msgid ""
-"This is often called _resource acquisition is initialization_ (RAII) and "
-"gives you smart pointers."
-msgstr ""
-
-#: src/memory-management/scope-based.md:12
-msgid "C++ Example"
-msgstr ""
-
-#: src/memory-management/scope-based.md:20
-msgid ""
-"The `std::unique_ptr` object is allocated on the stack, and points to memory "
-"allocated on the heap."
-msgstr ""
-
-#: src/memory-management/scope-based.md:22
-msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
-msgstr ""
-
-#: src/memory-management/scope-based.md:23
-msgid "The destructor frees the `Person` object it points to."
-msgstr ""
-
-#: src/memory-management/scope-based.md:25
-msgid ""
-"Special move constructors are used when passing ownership to a function:"
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:1
-msgid "Automatic Memory Management"
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:3
-msgid ""
-"An alternative to manual and scope-based memory management is automatic "
-"memory management:"
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:6
-msgid "The programmer never allocates or deallocates memory explicitly."
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:7
-msgid ""
-"A garbage collector finds unused memory and deallocates it for the "
-"programmer."
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:9
-msgid "Java Example"
-msgstr ""
-
-#: src/memory-management/garbage-collection.md:11
-msgid "The `person` object is not deallocated after `sayHello` returns:"
-msgstr ""
-
-#: src/memory-management/rust.md:1
-msgid "Memory Management in Rust"
-msgstr ""
-
-#: src/memory-management/rust.md:3
-msgid "Memory management in Rust is a mix:"
-msgstr ""
-
-#: src/memory-management/rust.md:5
-msgid "Safe and correct like Java, but without a garbage collector."
-msgstr ""
-
-#: src/memory-management/rust.md:6
-msgid "Scope-based like C++, but the compiler enforces full adherence."
-msgstr ""
-
-#: src/memory-management/rust.md:7
-msgid ""
-"A Rust user can choose the right abstraction for the situation, some even "
-"have no cost at runtime like C."
-msgstr ""
-
-#: src/memory-management/rust.md:9
-msgid "Rust achieves this by modeling _ownership_ explicitly."
-msgstr ""
-
-#: src/memory-management/rust.md:13
-msgid ""
-"If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
-"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
-"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
-"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
-"ownership and memory allocation via various means, and prevent the potential "
-"errors in C."
-msgstr ""
-
-#: src/memory-management/rust.md:15
-msgid ""
-"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
-"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
-msgstr ""
-
-#: src/ownership.md:3
-msgid ""
-"All variable bindings have a _scope_ where they are valid and it is an error "
-"to use a variable outside its scope:"
-msgstr ""
-
-#: src/ownership.md:19
-msgid ""
-"At the end of the scope, the variable is _dropped_ and the data is freed."
-msgstr ""
-
-#: src/ownership.md:20
-msgid "A destructor can run here to free up resources."
-msgstr ""
-
-#: src/ownership.md:21
-msgid "We say that the variable _owns_ the value."
-msgstr ""
-
-#: src/ownership/move-semantics.md:3
-msgid "An assignment will transfer _ownership_ between variables:"
-msgstr ""
-
-#: src/ownership/move-semantics.md:7
-msgid "\"Hello!\""
-msgstr ""
-
-#: src/ownership/move-semantics.md:10
-msgid "// println!(\"s1: {s1}\");\n"
-msgstr ""
-
-#: src/ownership/move-semantics.md:14
-msgid "The assignment of `s1` to `s2` transfers ownership."
-msgstr ""
-
-#: src/ownership/move-semantics.md:15
-msgid "When `s1` goes out of scope, nothing happens: it does not own anything."
-msgstr ""
-
-#: src/ownership/move-semantics.md:16
-msgid "When `s2` goes out of scope, the string data is freed."
-msgstr ""
-
-#: src/ownership/move-semantics.md:17
-msgid "There is always _exactly_ one variable binding which owns a value."
-msgstr ""
-
-#: src/ownership/move-semantics.md:21
-msgid ""
-"Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!)."
-msgstr ""
-
-#: src/ownership/move-semantics.md:23
-msgid ""
-"It is only the ownership that moves. Whether any machine code is generated "
-"to manipulate the data itself is a matter of optimization, and such copies "
-"are aggressively optimized away."
-msgstr ""
-
-#: src/ownership/move-semantics.md:25
-msgid ""
-"Simple values (such as integers) can be marked `Copy` (see later slides)."
-msgstr ""
-
-#: src/ownership/move-semantics.md:27
-msgid "In Rust, clones are explicit (by using `clone`)."
-msgstr ""
-
-#: src/ownership/moved-strings-rust.md:11
-msgid "The heap data from `s1` is reused for `s2`."
-msgstr ""
-
-#: src/ownership/moved-strings-rust.md:12
-msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
-msgstr ""
-
-#: src/ownership/moved-strings-rust.md:14
-msgid "Before move to `s2`:"
-msgstr ""
-
-#: src/ownership/moved-strings-rust.md:31
-msgid "After move to `s2`:"
-msgstr ""
-
-#: src/ownership/moved-strings-rust.md:33
-msgid ""
-"```bob\n"
-" Stack                             Heap\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
-":                           :     :                           :\n"
-":    s1 \"(inaccessible)\"    :     :                           :\n"
-":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
-":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
-":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
-":   | capacity  |     4 |   :  |  :                           :\n"
-":   +-----------+-------+   :  |  :                           :\n"
-":                           :  |  `- - - - - - - - - - - - - -'\n"
-":    s2                     :  |\n"
-":   +-----------+-------+   :  |\n"
-":   | ptr       |   o---+---+--'\n"
-":   | len       |     4 |   :\n"
-":   | capacity  |     4 |   :\n"
-":   +-----------+-------+   :\n"
-":                           :\n"
-"`- - - - - - - - - - - - - -'\n"
-"```"
-msgstr ""
-
-#: src/ownership/double-free-modern-cpp.md:1
+#: src/pattern-matching/let-control-flow.md:33
 #, fuzzy
-msgid "Defensive Copies in Modern C++"
-msgstr "現代C++の二重解放"
+msgid "`let else` expressions"
+msgstr "while let式"
 
-#: src/ownership/double-free-modern-cpp.md:3
-msgid "Modern C++ solves this differently:"
-msgstr ""
-
-#: src/ownership/double-free-modern-cpp.md:6
-msgid "\"Cpp\""
-msgstr ""
-
-#: src/ownership/double-free-modern-cpp.md:7
-msgid "// Duplicate the data in s1.\n"
-msgstr ""
-
-#: src/ownership/double-free-modern-cpp.md:10
+#: src/pattern-matching/let-control-flow.md:35
 msgid ""
-"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+"For the common case of matching a pattern and returning from the function, "
+"use [`let else`](https://doc.rust-lang.org/rust-by-example/flow_control/"
+"let_else.html). The \"else\" case must diverge (`return`, `break`, or panic "
+"- anything but falling off the end of the block)."
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:11
-msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+#: src/pattern-matching/let-control-flow.md:45
+#: src/pattern-matching/let-control-flow.md:108
+msgid "\"got None\""
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:13
-msgid "Before copy-assignment:"
+#: src/pattern-matching/let-control-flow.md:51
+#: src/pattern-matching/let-control-flow.md:112
+msgid "\"got empty string\""
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:30
-msgid "After copy-assignment:"
+#: src/pattern-matching/let-control-flow.md:57
+#: src/pattern-matching/let-control-flow.md:116
+msgid "\"not a hex digit\""
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:57
+#: src/pattern-matching/let-control-flow.md:62
+#: src/pattern-matching/solution.md:113
+msgid "\"result: {:?}\""
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:62
+#: src/methods-and-traits/exercise.md:114
+#: src/methods-and-traits/exercise.md:115
+#: src/methods-and-traits/exercise.md:116 src/generics/trait-bounds.md:16
+#: src/smart-pointers/solution.md:87 src/smart-pointers/solution.md:90
+#: src/testing/googletest.md:11 src/testing/googletest.md:12
+#: src/testing/solution.md:83
+msgid "\"foo\""
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:66
 msgid ""
-"C++ has made a slightly different choice than Rust. Because `=` copies data, "
-"the string data has to be cloned. Otherwise we would get a double-free when "
-"either string goes out of scope."
+"Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:61
+#: src/pattern-matching/let-control-flow.md:82
 msgid ""
-"C++ also has [`std::move`](https://en.cppreference.com/w/cpp/utility/move), "
-"which is used to indicate when a value may be moved from. If the example had "
-"been `s2 = std::move(s1)`, no heap allocation would take place. After the "
-"move, `s1` would be in a valid but unspecified state. Unlike Rust, the "
-"programmer is allowed to keep using `s1`."
+"Here [`String::pop`](https://doc.rust-lang.org/stable/std/string/struct."
+"String.html#method.pop) returns `Some(c)` until the string is empty, after "
+"which it will return `None`. The `while let` lets us keep iterating through "
+"all items."
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:66
+#: src/pattern-matching/let-control-flow.md:90
+msgid "if-let"
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:92
 msgid ""
-"Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
-"which is being copied or moved."
+"Unlike `match`, `if let` does not have to cover all branches. This can make "
+"it more concise than `match`."
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:3
+#: src/pattern-matching/let-control-flow.md:94
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:95
 msgid ""
-"When you pass a value to a function, the value is assigned to the function "
-"parameter. This transfers ownership:"
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:8 src/traits/impl-trait.md:10
-msgid "\"Hello {name}\""
+#: src/pattern-matching/let-control-flow.md:97
+msgid "let-else"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:12
-#: src/android/interoperability/java.md:56
-msgid "\"Alice\""
-msgstr ""
-
-#: src/ownership/moves-function-calls.md:14
-msgid "// say_hello(name);\n"
-msgstr ""
-
-#: src/ownership/moves-function-calls.md:20
+#: src/pattern-matching/let-control-flow.md:99
 msgid ""
-"With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`."
+"`if-let`s can pile up, as shown. The `let-else` construct supports "
+"flattening this nested code. Rewrite the awkward version for students, so "
+"they can see the transformation."
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:21
+#: src/pattern-matching/let-control-flow.md:103
+msgid "The rewritten version is:"
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:123
+msgid "while-let"
+msgstr ""
+
+#: src/pattern-matching/let-control-flow.md:125
 msgid ""
-"The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function."
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:22
+#: src/pattern-matching/let-control-flow.md:127
 msgid ""
-"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
-"if `say_hello` accepts a reference as a parameter."
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `name.pop()`. The "
+"`while let` provides syntactic sugar for the above scenario."
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:23
+#: src/pattern-matching/exercise.md:3
+msgid "Let's write a simple recursive evaluator for arithmetic expressions."
+msgstr ""
+
+#: src/pattern-matching/exercise.md:5
 msgid ""
-"Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`)."
+"The `Box` type here is a smart pointer, and will be covered in detail later "
+"in the course. An expression can be \"boxed\" with `Box::new` as seen in the "
+"tests. To evaluate a boxed expression, use the deref operator (`*`) to "
+"\"unbox\" it: `eval(*boxed_expr)`."
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:24
+#: src/pattern-matching/exercise.md:10
 msgid ""
-"Rust makes it harder than C++ to inadvertently create copies by making move "
-"semantics the default, and by forcing programmers to make clones explicit."
+"Some expressions cannot be evaluated and will return an error. The standard "
+"[`Result<Value, String>`](https://doc.rust-lang.org/std/result/enum.Result."
+"html) type is an enum that represents either a successful value "
+"(`Ok(Value)`) or an error (`Err(String)`). We will cover this type in detail "
+"later."
 msgstr ""
 
-#: src/ownership/copy-clone.md:3
+#: src/pattern-matching/exercise.md:15
 msgid ""
-"While move semantics are the default, certain types are copied by default:"
+"Copy and paste the code into the Rust playground, and begin implementing "
+"`eval`. The final product should pass the tests. It may be helpful to use "
+"`todo!()` and get the tests to pass one-by-one. You can also skip a test "
+"temporarily with `#[ignore]`:"
 msgstr ""
 
-#: src/ownership/copy-clone.md:15
-msgid "These types implement the `Copy` trait."
-msgstr ""
-
-#: src/ownership/copy-clone.md:17
-msgid "You can opt-in your own types to use copy semantics:"
-msgstr ""
-
-#: src/ownership/copy-clone.md:32
-msgid "After the assignment, both `p1` and `p2` own their own data."
-msgstr ""
-
-#: src/ownership/copy-clone.md:33
-msgid "We can also use `p1.clone()` to explicitly copy the data."
-msgstr ""
-
-#: src/ownership/copy-clone.md:37
-msgid "Copying and cloning are not the same thing:"
-msgstr ""
-
-#: src/ownership/copy-clone.md:39
+#: src/pattern-matching/exercise.md:26
 msgid ""
-"Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects."
+"If you finish early, try writing a test that results in division by zero or "
+"integer overflow. How could you handle this with `Result` instead of a panic?"
 msgstr ""
 
-#: src/ownership/copy-clone.md:40
-msgid ""
-"Copying does not allow for custom logic (unlike copy constructors in C++)."
+#: src/pattern-matching/exercise.md:30 src/pattern-matching/solution.md:4
+msgid "/// An operation to perform on two subexpressions.\n"
 msgstr ""
 
-#: src/ownership/copy-clone.md:41
-msgid ""
-"Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait."
+#: src/pattern-matching/exercise.md:38 src/pattern-matching/solution.md:12
+msgid "/// An expression, in tree form.\n"
 msgstr ""
 
-#: src/ownership/copy-clone.md:42
-msgid "Copying does not work on types that implement the `Drop` trait."
+#: src/pattern-matching/exercise.md:42 src/pattern-matching/solution.md:16
+msgid "/// An operation on two subexpressions.\n"
 msgstr ""
 
-#: src/ownership/copy-clone.md:44 src/ownership/lifetimes-function-calls.md:30
-msgid "In the above example, try the following:"
+#: src/pattern-matching/exercise.md:45 src/pattern-matching/solution.md:19
+msgid "/// A literal value\n"
 msgstr ""
 
-#: src/ownership/copy-clone.md:46
-msgid ""
-"Add a `String` field to `struct Point`. It will not compile because `String` "
-"is not a `Copy` type."
+#: src/pattern-matching/exercise.md:104 src/pattern-matching/solution.md:40
+#: src/pattern-matching/solution.md:102
+msgid "\"division by zero\""
 msgstr ""
 
-#: src/ownership/copy-clone.md:47
-msgid ""
-"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
-"`println!` for  `p1`."
+#: src/pattern-matching/solution.md:112
+msgid "\"expr: {:?}\""
 msgstr ""
 
-#: src/ownership/copy-clone.md:48
-msgid "Show that it works if you clone `p1` instead."
+#: src/methods-and-traits.md:4
+msgid "[Methods](./methods-and-traits/methods.md) (10 minutes)"
 msgstr ""
 
-#: src/ownership/copy-clone.md:50
-msgid ""
-"If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust at compile time. In this case the default "
-"implementations of `Copy` and `Clone` traits are generated."
+#: src/methods-and-traits.md:5
+msgid "[Traits](./methods-and-traits/traits.md) (10 minutes)"
 msgstr ""
 
-#: src/ownership/borrowing.md:3
-msgid ""
-"Instead of transferring ownership when calling a function, you can let a "
-"function _borrow_ the value:"
+#: src/methods-and-traits.md:6
+msgid "[Deriving](./methods-and-traits/deriving.md) (5 minutes)"
 msgstr ""
 
-#: src/ownership/borrowing.md:23
-msgid "The `add` function _borrows_ two points and returns a new point."
+#: src/methods-and-traits.md:7
+msgid "[Trait Objects](./methods-and-traits/trait-objects.md) (10 minutes)"
 msgstr ""
 
-#: src/ownership/borrowing.md:24
-msgid "The caller retains ownership of the inputs."
+#: src/methods-and-traits.md:8
+msgid "[Exercise: GUI Library](./methods-and-traits/exercise.md) (30 minutes)"
 msgstr ""
 
-#: src/ownership/borrowing.md:28
-msgid "Notes on stack returns:"
-msgstr ""
-
-#: src/ownership/borrowing.md:29
-msgid ""
-"Demonstrate that the return from `add` is cheap because the compiler can "
-"eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground](https://play.rust-lang.org/) or look at the "
-"assembly in [Godbolt](https://rust.godbolt.org/). In the \"DEBUG\" "
-"optimization level, the addresses should change, while they stay the same "
-"when changing to the \"RELEASE\" setting:"
-msgstr ""
-
-#: src/ownership/borrowing.md:50
-msgid "The Rust compiler can do return value optimization (RVO)."
-msgstr ""
-
-#: src/ownership/borrowing.md:51
-msgid ""
-"In C++, copy elision has to be defined in the language specification because "
-"constructors can have side effects. In Rust, this is not an issue at all. If "
-"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
-"copy."
-msgstr ""
-
-#: src/ownership/shared-unique-borrows.md:3
-msgid "Rust puts constraints on the ways you can borrow values:"
-msgstr ""
-
-#: src/ownership/shared-unique-borrows.md:5
-msgid "You can have one or more `&T` values at any given time, _or_"
-msgstr ""
-
-#: src/ownership/shared-unique-borrows.md:6
-msgid "You can have exactly one `&mut T` value."
-msgstr ""
-
-#: src/ownership/shared-unique-borrows.md:26
-msgid ""
-"The above code does not compile because `a` is borrowed as mutable (through "
-"`c`) and as immutable (through `b`) at the same time."
-msgstr ""
-
-#: src/ownership/shared-unique-borrows.md:27
-msgid ""
-"Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile."
-msgstr ""
-
-#: src/ownership/shared-unique-borrows.md:28
-msgid ""
-"After that change, the compiler realizes that `b` is only ever used before "
-"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
-"checker called \"non-lexical lifetimes\"."
-msgstr ""
-
-#: src/ownership/lifetimes.md:3
-msgid "A borrowed value has a _lifetime_:"
-msgstr ""
-
-#: src/ownership/lifetimes.md:5
-msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
-msgstr ""
-
-#: src/ownership/lifetimes.md:6
-msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
-msgstr ""
-
-#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:24
-msgid ""
-"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
-"lifetime `a`\"."
-msgstr ""
-
-#: src/ownership/lifetimes.md:9
-msgid ""
-"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
-"yourself."
-msgstr ""
-
-#: src/ownership/lifetimes.md:11
-msgid ""
-"Lifetime annotations create constraints; the compiler verifies that there is "
-"a valid solution."
-msgstr ""
-
-#: src/ownership/lifetimes.md:13
-msgid ""
-"Lifetimes for function arguments and return values must be fully specified, "
-"but Rust allows lifetimes to be elided in most cases with [a few simple "
-"rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:3
-msgid ""
-"In addition to borrowing its arguments, a function can return a borrowed "
-"value:"
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:22
-msgid "`'a` is a generic parameter, it is inferred by the compiler."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:23
-msgid "Lifetimes start with `'` and `'a` is a typical default name."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:26
-msgid ""
-"The _at least_ part is important when parameters are in different scopes."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:32
-msgid ""
-"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
-"resulting in the following code:"
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:52
-msgid "Note how this does not compile since `p3` outlives `p2`."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:54
-msgid ""
-"Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:55
-msgid "Another way to explain it:"
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:56
-msgid ""
-"Two references to two values are borrowed by a function and the function "
-"returns another reference."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:58
-msgid ""
-"It must have come from one of those two inputs (or from a global variable)."
-msgstr ""
-
-#: src/ownership/lifetimes-function-calls.md:59
-msgid ""
-"Which one is it? The compiler needs to know, so at the call site the "
-"returned reference is not used for longer than a variable from where the "
-"reference came from."
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:3
-msgid ""
-"If a data type stores borrowed data, it must be annotated with a lifetime:"
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:10
-msgid "\"Bye {text}!\""
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:14
-msgid "\"The quick brown fox jumps over the lazy dog.\""
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:17
-msgid "// erase(text);\n"
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:18
-msgid "\"{fox:?}\""
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:19
-msgid "\"{dog:?}\""
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:25
-msgid ""
-"In the above example, the annotation on `Highlight` enforces that the data "
-"underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data."
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:26
-msgid ""
-"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error."
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:27
-msgid ""
-"Types with borrowed data force users to hold on to the original data. This "
-"can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use."
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:28
-msgid "When possible, make data structures own their data directly."
-msgstr ""
-
-#: src/ownership/lifetimes-data-structures.md:29
-msgid ""
-"Some structs with multiple references inside can have more than one lifetime "
-"annotation. This can be necessary if there is a need to describe lifetime "
-"relationships between the references themselves, in addition to the lifetime "
-"of the struct itself. Those are very advanced use cases."
-msgstr ""
-
-#: src/structs.md:3
-msgid "Like C and C++, Rust has support for custom structs:"
-msgstr ""
-
-#: src/structs.md:13 src/structs/field-shorthand.md:20 src/methods.md:21
-#: src/android/interoperability/with-c/bindgen.md:87
-msgid "\"Peter\""
-msgstr ""
-
-#: src/structs.md:16 src/structs.md:19 src/structs.md:25
-msgid "\"{} is {} years old\""
-msgstr ""
-
-#: src/structs.md:22
-msgid "\"Jackie\""
-msgstr ""
-
-#: src/structs.md:33
-msgid "Structs work like in C or C++."
-msgstr ""
-
-#: src/structs.md:34
-msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
-msgstr ""
-
-#: src/structs.md:35
-msgid "Unlike in C++, there is no inheritance between structs."
-msgstr ""
-
-#: src/structs.md:36
-msgid ""
-"Methods are defined in an `impl` block, which we will see in following "
-"slides."
-msgstr ""
-
-#: src/structs.md:37
-msgid ""
-"This may be a good time to let people know there are different types of "
-"structs. "
-msgstr ""
-
-#: src/structs.md:38
-msgid ""
-"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
-"trait on some type but don’t have any data that you want to store in the "
-"value itself. "
-msgstr ""
-
-#: src/structs.md:39
-msgid ""
-"The next slide will introduce Tuple structs, used when the field names are "
-"not important."
-msgstr ""
-
-#: src/structs.md:40
-msgid ""
-"The syntax `..peter` allows us to copy the majority of the fields from the "
-"old struct without having to explicitly type it all out. It must always be "
-"the last element."
-msgstr ""
-
-#: src/structs/tuple-structs.md:3
-msgid "If the field names are unimportant, you can use a tuple struct:"
-msgstr ""
-
-#: src/structs/tuple-structs.md:10
-msgid "\"({}, {})\""
-msgstr ""
-
-#: src/structs/tuple-structs.md:14
-msgid "This is often used for single-field wrappers (called newtypes):"
-msgstr ""
-
-#: src/structs/tuple-structs.md:21
-msgid "\"Ask a rocket scientist at NASA\""
-msgstr ""
-
-#: src/structs/tuple-structs.md:25
-#: src/bare-metal/microcontrollers/type-state.md:14
-#: src/async/pitfalls/cancellation.md:99
-msgid "// ...\n"
-msgstr ""
-
-#: src/structs/tuple-structs.md:37
-msgid ""
-"Newtypes are a great way to encode additional information about the value in "
-"a primitive type, for example:"
-msgstr ""
-
-#: src/structs/tuple-structs.md:38
-msgid "The number is measured in some units: `Newtons` in the example above."
-msgstr ""
-
-#: src/structs/tuple-structs.md:39
-msgid ""
-"The value passed some validation when it was created, so you no longer have "
-"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
-msgstr ""
-
-#: src/structs/tuple-structs.md:40
-msgid ""
-"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype."
-msgstr ""
-
-#: src/structs/tuple-structs.md:41
-msgid ""
-"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
-"for instance using booleans as integers."
-msgstr ""
-
-#: src/structs/tuple-structs.md:42
-msgid "Operator overloading is discussed on Day 3 (generics)."
-msgstr ""
-
-#: src/structs/tuple-structs.md:43
-msgid ""
-"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
-"wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
-msgstr ""
-
-#: src/structs/field-shorthand.md:3
-msgid ""
-"If you already have variables with the right names, then you can create the "
-"struct using a shorthand:"
-msgstr ""
-
-#: src/structs/field-shorthand.md:21
-msgid "\"{peter:?}\""
-msgstr ""
-
-#: src/structs/field-shorthand.md:27
-msgid ""
-"The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name"
-msgstr ""
-
-#: src/structs/field-shorthand.md:41
-msgid ""
-"Implement the `Default` trait for the struct. Define some fields and use the "
-"default values for the other fields."
-msgstr ""
-
-#: src/structs/field-shorthand.md:52
-msgid "\"Bot\""
-msgstr ""
-
-#: src/structs/field-shorthand.md:62
-msgid "\"Sam\""
-msgstr ""
-
-#: src/structs/field-shorthand.md:68
-msgid "Methods are defined in the `impl` block."
-msgstr ""
-
-#: src/structs/field-shorthand.md:69
-msgid ""
-"Use struct update syntax to define a new structure using `peter`. Note that "
-"the variable `peter` will no longer be accessible afterwards."
-msgstr ""
-
-#: src/structs/field-shorthand.md:70
-msgid ""
-"Use `{:#?}` when printing structs to request the `Debug` representation."
-msgstr ""
-
-#: src/methods.md:3
+#: src/methods-and-traits/methods.md:3
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
 "an `impl` block:"
 msgstr ""
 
-#: src/methods.md:15
-msgid "\"Hello, my name is {}\""
+#: src/methods-and-traits/methods.md:14
+msgid "// No receiver, a static method\n"
 msgstr ""
 
-#: src/methods.md:31
-msgid "It can be helpful to introduce methods by comparing them to functions."
+#: src/methods-and-traits/methods.md:19
+msgid "// Exclusive borrowed read-write access to self\n"
 msgstr ""
 
-#: src/methods.md:32
+#: src/methods-and-traits/methods.md:24
+msgid "// Shared and read-only borrowed access to self\n"
+msgstr ""
+
+#: src/methods-and-traits/methods.md:26
+msgid "\"Recorded {} laps for {}:\""
+msgstr ""
+
+#: src/methods-and-traits/methods.md:28
+msgid "\"Lap {idx}: {lap} sec\""
+msgstr ""
+
+#: src/methods-and-traits/methods.md:32
+msgid "// Exclusive ownership of self\n"
+msgstr ""
+
+#: src/methods-and-traits/methods.md:35
+msgid "\"Race {} is finished, total lap time: {}\""
+msgstr ""
+
+#: src/methods-and-traits/methods.md:40
+msgid "\"Monaco Grand Prix\""
+msgstr ""
+
+#: src/methods-and-traits/methods.md:47
+msgid "// race.add_lap(42);\n"
+msgstr ""
+
+#: src/methods-and-traits/methods.md:51
 msgid ""
-"Methods are called on an instance of a type (such as a struct or enum), the "
-"first parameter represents the instance as `self`."
+"The `self` arguments specify the \"receiver\" - the object the method acts "
+"on. There are several common receivers for a method:"
 msgstr ""
 
-#: src/methods.md:33
-msgid ""
-"Developers may choose to use methods to take advantage of method receiver "
-"syntax and to help keep them more organized. By using methods we can keep "
-"all the implementation code in one predictable place."
-msgstr ""
-
-#: src/methods.md:34
-msgid "Point out the use of the keyword `self`, a method receiver."
-msgstr ""
-
-#: src/methods.md:35
-msgid ""
-"Show that it is an abbreviated term for `self: Self` and perhaps show how "
-"the struct name could also be used."
-msgstr ""
-
-#: src/methods.md:36
-msgid ""
-"Explain that `Self` is a type alias for the type the `impl` block is in and "
-"can be used elsewhere in the block."
-msgstr ""
-
-#: src/methods.md:37
-msgid ""
-"Note how `self` is used like other structs and dot notation can be used to "
-"refer to individual fields."
-msgstr ""
-
-#: src/methods.md:38
-msgid ""
-"This might be a good time to demonstrate how the `&self` differs from `self` "
-"by modifying the code and trying to run say_hello twice."
-msgstr ""
-
-#: src/methods.md:39
-msgid "We describe the distinction between method receivers next."
-msgstr ""
-
-#: src/methods/receiver.md:3
-msgid ""
-"The `&self` above indicates that the method borrows the object immutably. "
-"There are other possible receivers for a method:"
-msgstr ""
-
-#: src/methods/receiver.md:6
+#: src/methods-and-traits/methods.md:54
 msgid ""
 "`&self`: borrows the object from the caller using a shared and immutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods/receiver.md:8
+#: src/methods-and-traits/methods.md:56
 msgid ""
 "`&mut self`: borrows the object from the caller using a unique and mutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods/receiver.md:10
+#: src/methods-and-traits/methods.md:58
 msgid ""
 "`self`: takes ownership of the object and moves it away from the caller. The "
 "method becomes the owner of the object. The object will be dropped "
@@ -6118,1523 +5325,149 @@ msgid ""
 "transmitted. Complete ownership does not automatically mean mutability."
 msgstr ""
 
-#: src/methods/receiver.md:14
-msgid "`mut self`: same as above, but the method can mutate the object. "
+#: src/methods-and-traits/methods.md:62
+msgid "`mut self`: same as above, but the method can mutate the object."
 msgstr ""
 
-#: src/methods/receiver.md:15
+#: src/methods-and-traits/methods.md:63
 msgid ""
 "No receiver: this becomes a static method on the struct. Typically used to "
 "create constructors which are called `new` by convention."
 msgstr ""
 
-#: src/methods/receiver.md:18
+#: src/methods-and-traits/methods.md:71
+msgid "It can be helpful to introduce methods by comparing them to functions."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:72
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:74
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:77
+msgid "Point out the use of the keyword `self`, a method receiver."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:78
+msgid ""
+"Show that it is an abbreviated term for `self: Self` and perhaps show how "
+"the struct name could also be used."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:80
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:82
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:84
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by trying to run `finish` twice."
+msgstr ""
+
+#: src/methods-and-traits/methods.md:86
 msgid ""
 "Beyond variants on `self`, there are also [special wrapper types](https://"
 "doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
 "receiver types, such as `Box<Self>`."
 msgstr ""
 
-#: src/methods/receiver.md:24
-msgid ""
-"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come together in Rust due to borrow checker rules, "
-"and `self` is no exception. It isn't possible to reference a struct from "
-"multiple locations and call a mutating (`&mut self`) method on it."
-msgstr ""
-
-#: src/methods/example.md:11
-msgid "// No receiver, a static method\n"
-msgstr ""
-
-#: src/methods/example.md:15
-msgid "// Exclusive borrowed read-write access to self\n"
-msgstr ""
-
-#: src/methods/example.md:19
-msgid "// Shared and read-only borrowed access to self\n"
-msgstr ""
-
-#: src/methods/example.md:20
-msgid "\"Recorded {} laps for {}:\""
-msgstr ""
-
-#: src/methods/example.md:22
-msgid "\"Lap {idx}: {lap} sec\""
-msgstr ""
-
-#: src/methods/example.md:26
-msgid "// Exclusive ownership of self\n"
-msgstr ""
-
-#: src/methods/example.md:28
-msgid "\"Race {} is finished, total lap time: {}\""
-msgstr ""
-
-#: src/methods/example.md:33
-msgid "\"Monaco Grand Prix\""
-msgstr ""
-
-#: src/methods/example.md:40
-msgid "// race.add_lap(42);\n"
-msgstr ""
-
-#: src/methods/example.md:47
-msgid "All four methods here use a different method receiver."
-msgstr ""
-
-#: src/methods/example.md:48
-msgid ""
-"You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`."
-msgstr ""
-
-#: src/methods/example.md:49
-msgid ""
-"You can showcase the error that appears when trying to call `finish` twice."
-msgstr ""
-
-#: src/methods/example.md:50
-msgid ""
-"Note that although the method receivers are different, the non-static "
-"functions are called the same way in the main body. Rust enables automatic "
-"referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature."
-msgstr ""
-
-#: src/methods/example.md:51
-msgid ""
-"You might point out that `print_laps` is using a vector that is iterated "
-"over. We describe vectors in more detail in the afternoon. "
-msgstr ""
-
-#: src/exercises/day-2/morning.md:1
-msgid "Day 2: Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-2/morning.md:3
-msgid "We will look at implementing methods in two contexts:"
-msgstr ""
-
-#: src/exercises/day-2/morning.md:5
-msgid "Storing books and querying the collection"
-msgstr ""
-
-#: src/exercises/day-2/morning.md:7
-msgid "Keeping track of health statistics for patients"
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:3
-msgid ""
-"We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now, you just need to know part of its API:"
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:11
-msgid "\"middle value: {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:13
-msgid "\"item: {item}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:18
-msgid ""
-"Use this to model a library's book collection. Copy the code below to "
-"<https://play.rust-lang.org/> and update the types to make it compile:"
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:32
-#: src/exercises/day-2/solutions-morning.md:18
-msgid "// This is a constructor, used below.\n"
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:40
-#: src/exercises/day-2/solutions-morning.md:26
-msgid ""
-"// Implement the methods below. Notice how the `self` parameter\n"
-"// changes type to indicate the method's required level of ownership\n"
-"// over the object:\n"
-"//\n"
-"// - `&self` for shared read-only access,\n"
-"// - `&mut self` for unique and mutable access,\n"
-"// - `self` for unique access by value.\n"
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:50
-msgid "\"Initialize and return a `Library` value\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:54
-msgid "\"Return the length of `self.books`\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:58
-msgid "\"Return `true` if `self.books` is empty\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:62
-msgid "\"Add a new book to `self.books`\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:66
-msgid "\"Iterate over `self.books` and print each book's title and year\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:70
-msgid "\"Return a reference to the oldest book (if any)\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:78
-#: src/exercises/day-2/solutions-morning.md:78
-msgid "\"The library is empty: library.is_empty() -> {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:82
-#: src/exercises/day-2/solutions-morning.md:82
-#: src/exercises/day-2/solutions-morning.md:107
-#: src/exercises/day-2/solutions-morning.md:118
-#: src/exercises/day-2/solutions-morning.md:125
-#: src/exercises/day-2/solutions-morning.md:137
-#: src/exercises/day-2/solutions-morning.md:140
-msgid "\"Lord of the Rings\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:83
-#: src/exercises/day-2/solutions-morning.md:83
-#: src/exercises/day-2/solutions-morning.md:108
-#: src/exercises/day-2/solutions-morning.md:126
-#: src/exercises/day-2/solutions-morning.md:143
-#: src/exercises/day-2/solutions-morning.md:146
-msgid "\"Alice's Adventures in Wonderland\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:86
-#: src/exercises/day-2/solutions-morning.md:86
-msgid "\"The library is no longer empty: library.is_empty() -> {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:93
-#: src/exercises/day-2/solutions-morning.md:93
-msgid "\"The oldest book is {}\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:94
-#: src/exercises/day-2/solutions-morning.md:94
-msgid "\"The library is empty!\""
-msgstr ""
-
-#: src/exercises/day-2/book-library.md:97
-#: src/exercises/day-2/solutions-morning.md:97
-msgid "\"The library has {} books\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:3
-msgid ""
-"You're working on implementing a health-monitoring system. As part of that, "
-"you need to keep track of users' health statistics."
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:6
-msgid ""
-"You'll start with some stubbed functions in an `impl` block as well as a "
-"`User` struct definition. Your goal is to implement the stubbed out methods "
-"on the `User` `struct` defined in the `impl` block."
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:10
-msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
-"methods:"
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:39
-msgid "\"Create a new User instance\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:43
-msgid "\"Return the user's name\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:47
-msgid "\"Return the user's age\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:51
-msgid "\"Return the user's height\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:55
-msgid "\"Return the number of time the user has visited the doctor\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:59
-msgid "\"Set the user's age\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:63
-msgid "\"Set the user's height\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:67
-msgid ""
-"\"Update a user's statistics based on measurements from a visit to the "
-"doctor\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:72
-#: src/exercises/day-2/health-statistics.md:78
-#: src/exercises/day-2/health-statistics.md:84
-#: src/exercises/day-2/health-statistics.md:92
-#: src/exercises/day-2/health-statistics.md:98
-#: src/android/build-rules/library.md:44 src/android/aidl/client.md:23
-#: src/exercises/day-2/solutions-morning.md:233
-#: src/exercises/day-2/solutions-morning.md:239
-#: src/exercises/day-2/solutions-morning.md:245
-#: src/exercises/day-2/solutions-morning.md:253
-#: src/exercises/day-2/solutions-morning.md:259
-msgid "\"Bob\""
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:73
-#: src/exercises/day-2/solutions-morning.md:234
-msgid "\"I'm {} and my age is {}\""
-msgstr ""
-
-#: src/std.md:3
-msgid ""
-"Rust comes with a standard library which helps establish a set of common "
-"types used by Rust library and programs. This way, two libraries can work "
-"together smoothly because they both use the same `String` type."
-msgstr ""
-
-#: src/std.md:7
-msgid "The common vocabulary types include:"
-msgstr ""
-
-#: src/std.md:9
-msgid ""
-"[`Option` and `Result`](std/option-result.md) types: used for optional "
-"values and [error handling](error-handling.md)."
-msgstr ""
-
-#: src/std.md:12
-msgid "[`String`](std/string.md): the default string type used for owned data."
-msgstr ""
-
-#: src/std.md:14
-msgid "[`Vec`](std/vec.md): a standard extensible vector."
-msgstr ""
-
-#: src/std.md:16
-msgid ""
-"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
-"algorithm."
-msgstr ""
-
-#: src/std.md:19
-msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
-msgstr ""
-
-#: src/std.md:21
-msgid ""
-"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
-"data."
-msgstr ""
-
-#: src/std.md:25
-msgid ""
-"In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. "
-msgstr ""
-
-#: src/std.md:26
-msgid ""
-"`core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or even the presence of an operating system. "
-msgstr ""
-
-#: src/std.md:28
-msgid ""
-"`alloc` includes types which require a global heap allocator, such as `Vec`, "
-"`Box` and `Arc`."
-msgstr ""
-
-#: src/std.md:29
-msgid ""
-"Embedded Rust applications often only use `core`, and sometimes `alloc`."
-msgstr ""
-
-#: src/std/option-result.md:1
-msgid "`Option` and `Result`"
-msgstr ""
-
-#: src/std/option-result.md:3
-msgid "The types represent optional data:"
-msgstr ""
-
-#: src/std/option-result.md:9
-msgid "\"first: {first:?}\""
-msgstr ""
-
-#: src/std/option-result.md:12
-msgid "\"arr: {arr:?}\""
-msgstr ""
-
-#: src/std/option-result.md:18
-msgid "`Option` and `Result` are widely used not just in the standard library."
-msgstr ""
-
-#: src/std/option-result.md:19
-msgid "`Option<&T>` has zero space overhead compared to `&T`."
-msgstr ""
-
-#: src/std/option-result.md:20
-msgid ""
-"`Result` is the standard type to implement error handling as we will see on "
-"Day 3."
-msgstr ""
-
-#: src/std/option-result.md:21
-msgid ""
-"`try_into` attempts to convert the vector into a fixed-sized array. This can "
-"fail:"
-msgstr ""
-
-#: src/std/option-result.md:22
-msgid ""
-"If the vector has the right size, `Result::Ok` is returned with the array."
-msgstr ""
-
-#: src/std/option-result.md:23
-msgid "Otherwise, `Result::Err` is returned with the original vector."
-msgstr ""
-
-#: src/std/string.md:3
-msgid ""
-"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
-"standard heap-allocated growable UTF-8 string buffer:"
-msgstr ""
-
-#: src/std/string.md:9
-msgid "\"s1: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/string.md:13
-msgid "'!'"
-msgstr ""
-
-#: src/std/string.md:14
-msgid "\"s2: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/string.md:16
-msgid "\"🇨🇭\""
-msgstr ""
-
-#: src/std/string.md:17
-msgid "\"s3: len = {}, number of chars = {}\""
-msgstr ""
-
-#: src/std/string.md:22
-msgid ""
-"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
-"string/struct.String.html#deref-methods-str), which means that you can call "
-"all `str` methods on a `String`."
-msgstr ""
-
-#: src/std/string.md:30
-msgid ""
-"`String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string."
-msgstr ""
-
-#: src/std/string.md:31
-msgid ""
-"`String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters)."
-msgstr ""
-
-#: src/std/string.md:32
-msgid ""
-"`String::chars` returns an iterator over the actual characters. Note that a "
-"`char` can be different from what a human will consider a \"character\" due "
-"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html)."
-msgstr ""
-
-#: src/std/string.md:33
-msgid ""
-"When people refer to strings they could either be talking about `&str` or "
-"`String`."
-msgstr ""
-
-#: src/std/string.md:34
-msgid ""
-"When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`."
-msgstr ""
-
-#: src/std/string.md:35
-msgid ""
-"`String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods."
-msgstr ""
-
-#: src/std/string.md:36
-msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1;`."
-msgstr ""
-
-#: src/std/string.md:37
-msgid ""
-"`String` is implemented as a wrapper around a vector of bytes, many of the "
-"operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees."
-msgstr ""
-
-#: src/std/string.md:38
-msgid "Compare the different ways to index a `String`:"
-msgstr ""
-
-#: src/std/string.md:39
-msgid ""
-"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
-"out-of-bounds."
-msgstr ""
-
-#: src/std/string.md:40
-msgid ""
-"To a substring by using `s3[0..4]`, where that slice is on character "
-"boundaries or not."
-msgstr ""
-
-#: src/std/vec.md:1
-msgid "`Vec`"
-msgstr ""
-
-#: src/std/vec.md:3
-msgid ""
-"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
-"resizable heap-allocated buffer:"
-msgstr ""
-
-#: src/std/vec.md:9
-msgid "\"v1: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/vec.md:14
-msgid "\"v2: len = {}, capacity = {}\""
-msgstr ""
-
-#: src/std/vec.md:16
-msgid "// Canonical macro to initialize a vector with elements.\n"
-msgstr ""
-
-#: src/std/vec.md:19
-msgid "// Retain only the even elements.\n"
-msgstr ""
-
-#: src/std/vec.md:21 src/std/vec.md:25
-msgid "\"{v3:?}\""
-msgstr ""
-
-#: src/std/vec.md:23
-msgid "// Remove consecutive duplicates.\n"
-msgstr ""
-
-#: src/std/vec.md:29
-msgid ""
-"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
-"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
-"methods on a `Vec`."
-msgstr ""
-
-#: src/std/vec.md:37
-msgid ""
-"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored on the heap. This means the amount of data doesn't "
-"need to be  known at compile time. It can grow or shrink at runtime."
-msgstr ""
-
-#: src/std/vec.md:40
-msgid ""
-"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
-"explicitly. As always with Rust type inference, the `T` was established "
-"during the first `push` call."
-msgstr ""
-
-#: src/std/vec.md:42
-msgid ""
-"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial elements to the vector."
-msgstr ""
-
-#: src/std/vec.md:44
-msgid ""
-"To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using `get` will return an `Option`. The `pop` function will "
-"remove the last element."
-msgstr ""
-
-#: src/std/vec.md:46
-msgid ""
-"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
-"+= 50; }`"
-msgstr ""
-
-#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
-msgid "`HashMap`"
-msgstr ""
-
-#: src/std/hashmap.md:3
-msgid "Standard hash map with protection against HashDoS attacks:"
-msgstr ""
-
-#: src/std/hashmap.md:10
-msgid "\"Adventures of Huckleberry Finn\""
-msgstr ""
-
-#: src/std/hashmap.md:11
-msgid "\"Grimms' Fairy Tales\""
-msgstr ""
-
-#: src/std/hashmap.md:12 src/std/hashmap.md:19 src/std/hashmap.md:27
-msgid "\"Pride and Prejudice\""
-msgstr ""
-
-#: src/std/hashmap.md:14
-msgid "\"Les Misérables\""
-msgstr ""
-
-#: src/std/hashmap.md:15
-msgid "\"We know about {} books, but not Les Misérables.\""
-msgstr ""
-
-#: src/std/hashmap.md:19 src/std/hashmap.md:27
-msgid "\"Alice's Adventure in Wonderland\""
-msgstr ""
-
-#: src/std/hashmap.md:21
-msgid "\"{book}: {count} pages\""
-msgstr ""
-
-#: src/std/hashmap.md:22
-msgid "\"{book} is unknown.\""
-msgstr ""
-
-#: src/std/hashmap.md:26
-msgid "// Use the .entry() method to insert a value if nothing is found.\n"
-msgstr ""
-
-#: src/std/hashmap.md:32
-msgid "\"{page_counts:#?}\""
-msgstr ""
-
-#: src/std/hashmap.md:38
-msgid ""
-"`HashMap` is not defined in the prelude and needs to be brought into scope."
-msgstr ""
-
-#: src/std/hashmap.md:39
-msgid ""
-"Try the following lines of code. The first line will see if a book is in the "
-"hashmap and if not return an alternative value. The second line will insert "
-"the alternative value in the hashmap if the book is not found."
-msgstr ""
-
-#: src/std/hashmap.md:43
-msgid "\"Harry Potter and the Sorcerer's Stone \""
-msgstr ""
-
-#: src/std/hashmap.md:46 src/std/hashmap.md:55
-msgid "\"The Hunger Games\""
-msgstr ""
-
-#: src/std/hashmap.md:49
-msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
-msgstr ""
-
-#: src/std/hashmap.md:50
-msgid ""
-"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
-"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
-"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
-"us to easily initialize a hash map from a literal array:"
-msgstr ""
-
-#: src/std/hashmap.md:54
-msgid "\"Harry Potter and the Sorcerer's Stone\""
-msgstr ""
-
-#: src/std/hashmap.md:59
-msgid ""
-"Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples."
-msgstr ""
-
-#: src/std/hashmap.md:60
-msgid ""
-"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
-"examples easier. Using references in collections can, of course, be done, "
-"but it can lead into complications with the borrow checker."
-msgstr ""
-
-#: src/std/hashmap.md:62
-msgid ""
-"Try removing `to_string()` from the example above and see if it still "
-"compiles. Where do you think we might run into issues?"
-msgstr ""
-
-#: src/std/hashmap.md:64
-msgid ""
-"This type has several \"method-specific\" return types, such as `std::"
-"collections::hash_map::Keys`. These types often appear in searches of the "
-"Rust docs. Show students the docs for this type, and the helpful link back "
-"to the `keys` method."
-msgstr ""
-
-#: src/std/box.md:1
-msgid "`Box`"
-msgstr ""
-
-#: src/std/box.md:3
-msgid ""
-"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
-"pointer to data on the heap:"
-msgstr ""
-
-#: src/std/box.md:8
-msgid "\"five: {}\""
-msgstr ""
-
-#: src/std/box.md:26
-msgid ""
-"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
-"trait.Deref.html#more-on-deref-coercion)."
-msgstr ""
-
-#: src/std/box.md:34
-msgid ""
-"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. "
-msgstr ""
-
-#: src/std/box.md:35
-msgid ""
-"In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. "
-msgstr ""
-
-#: src/std/box.md:36
-msgid "A `Box` can be useful when you:"
-msgstr ""
-
-#: src/std/box.md:37
-msgid ""
-"have a type whose size that can't be known at compile time, but the Rust "
-"compiler wants to know an exact size."
-msgstr ""
-
-#: src/std/box.md:38
-msgid ""
-"want to transfer ownership of a large amount of data. To avoid copying large "
-"amounts of data on the stack, instead store the data on the heap in a `Box` "
-"so only the pointer is moved."
-msgstr ""
-
-#: src/std/box-recursive.md:1
-msgid "Box with Recursive Data Structures"
-msgstr ""
-
-#: src/std/box-recursive.md:3
-msgid ""
-"Recursive data types or data types with dynamic sizes need to use a `Box`:"
-msgstr ""
-
-#: src/std/box-recursive.md:14 src/std/box-niche.md:12
-msgid "\"{list:?}\""
-msgstr ""
-
-#: src/std/box-recursive.md:18
-msgid ""
-"```bob\n"
-" Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
-"- -.\n"
-":                         :     :                                               :\n"
-":    "
-"list                 :     :                                               :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
-"+   :\n"
-":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
-"|   :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
-"+   :\n"
-":                         :     :                                               :\n"
-":                         :     :                                               :\n"
-"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
-"- -'\n"
-"```"
-msgstr ""
-
-#: src/std/box-recursive.md:33
-msgid ""
-"If `Box` was not used and we attempted to embed a `List` directly into the "
-"`List`, the compiler would not compute a fixed size of the struct in memory "
-"(`List` would be of infinite size)."
-msgstr ""
-
-#: src/std/box-recursive.md:36
-msgid ""
-"`Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next element of the `List` in the heap."
-msgstr ""
-
-#: src/std/box-recursive.md:39
-msgid ""
-"Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly."
-msgstr ""
-
-#: src/std/box-niche.md:16
-msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
-"allows the compiler to optimize the memory layout:"
-msgstr ""
-
-#: src/std/box-niche.md:19
-msgid ""
-"```bob\n"
-" Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
-"-.\n"
-":                         :     :                                             :\n"
-":    "
-"list                 :     :                                             :\n"
-":   +----+----+           :     :    +----+----+    +----+------"
-"+             :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
-"|             :\n"
-":   +----+----+           :     :    +----+----+    +----+------"
-"+             :\n"
-":                         :     :                                             :\n"
-":                         :     :                                             :\n"
-"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
-"-'\n"
-"```"
-msgstr ""
-
-#: src/std/rc.md:1
-msgid "`Rc`"
-msgstr ""
-
-#: src/std/rc.md:3
-msgid ""
-"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
-"counted shared pointer. Use this when you need to refer to the same data "
-"from multiple places:"
-msgstr ""
-
-#: src/std/rc.md:13
-msgid "\"a: {a}\""
-msgstr ""
-
-#: src/std/rc.md:14
-msgid "\"b: {b}\""
-msgstr ""
-
-#: src/std/rc.md:18
-msgid ""
-"See [`Arc`](../concurrency/shared_state/arc.md) and [`Mutex`](https://doc."
-"rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
-"context."
-msgstr ""
-
-#: src/std/rc.md:19
-msgid ""
-"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
-"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
-msgstr ""
-
-#: src/std/rc.md:29
-msgid ""
-"`Rc`'s count ensures that its contained value is valid for as long as there "
-"are references."
-msgstr ""
-
-#: src/std/rc.md:30
-msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
-msgstr ""
-
-#: src/std/rc.md:31
-msgid ""
-"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
-"increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code."
-msgstr ""
-
-#: src/std/rc.md:32
-msgid ""
-"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
-"and returns a mutable reference."
-msgstr ""
-
-#: src/std/rc.md:33
-msgid "Use `Rc::strong_count` to check the reference count."
-msgstr ""
-
-#: src/std/rc.md:34
-msgid ""
-"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
-"cycles that will be dropped properly (likely in combination with `RefCell`, "
-"on the next slide)."
-msgstr ""
-
-#: src/std/cell.md:1
-msgid "`Cell` and `RefCell`"
-msgstr ""
-
-#: src/std/cell.md:3
-msgid ""
-"[`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and [`RefCell`]"
-"(https://doc.rust-lang.org/std/cell/struct.RefCell.html) implement what Rust "
-"calls _interior mutability:_ mutation of values in an immutable context."
-msgstr ""
-
-#: src/std/cell.md:8
-msgid ""
-"`Cell` is typically used for simple types, as it requires copying or moving "
-"values. More complex interior types typically use `RefCell`, which tracks "
-"shared and exclusive references at runtime and panics if they are misused."
-msgstr ""
-
-#: src/std/cell.md:40
-msgid "\"graph: {root:#?}\""
-msgstr ""
-
-#: src/std/cell.md:41
-msgid "\"graph sum: {}\""
-msgstr ""
-
-#: src/std/cell.md:47
-msgid ""
-"If we were using `Cell` instead of `RefCell` in this example, we would have "
-"to move the `Node` out of the `Rc` to push children, then move it back in. "
-"This is safe because there's always one, un-referenced value in the cell, "
-"but it's not ergonomic."
-msgstr ""
-
-#: src/std/cell.md:48
-msgid ""
-"To do anything with a Node, you must call a `RefCell` method, usually "
-"`borrow` or `borrow_mut`."
-msgstr ""
-
-#: src/std/cell.md:49
-msgid ""
-"Demonstrate that reference loops can be created by adding `root` to `subtree."
-"children` (don't try to print it!)."
-msgstr ""
-
-#: src/std/cell.md:50
-msgid ""
-"To demonstrate a runtime panic, add a `fn inc(&mut self)` that increments "
-"`self.value` and calls the same method on its children. This will panic in "
-"the presence of the reference loop, with `thread 'main' panicked at 'already "
-"borrowed: BorrowMutError'`."
-msgstr ""
-
-#: src/modules.md:3
-msgid "We have seen how `impl` blocks let us namespace functions to a type."
-msgstr ""
-
-#: src/modules.md:5
-msgid "Similarly, `mod` lets us namespace types and functions:"
-msgstr ""
-
-#: src/modules.md:10
-msgid "\"In the foo module\""
-msgstr ""
-
-#: src/modules.md:16
-msgid "\"In the bar module\""
-msgstr ""
-
-#: src/modules.md:28
-msgid ""
-"Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates."
-msgstr ""
-
-#: src/modules.md:29
-msgid ""
-"Crates are a tree of modules, where a binary crate creates an executable and "
-"a library crate compiles to a library."
-msgstr ""
-
-#: src/modules.md:30
-msgid "Modules define organization, scope, and are the focus of this section."
-msgstr ""
-
-#: src/modules/visibility.md:3
-msgid "Modules are a privacy boundary:"
-msgstr ""
-
-#: src/modules/visibility.md:5
-msgid "Module items are private by default (hides implementation details)."
-msgstr ""
-
-#: src/modules/visibility.md:6
-msgid "Parent and sibling items are always visible."
-msgstr ""
-
-#: src/modules/visibility.md:7
-msgid ""
-"In other words, if an item is visible in module `foo`, it's visible in all "
-"the descendants of `foo`."
-msgstr ""
-
-#: src/modules/visibility.md:13
-msgid "\"outer::private\""
-msgstr ""
-
-#: src/modules/visibility.md:17
-msgid "\"outer::public\""
-msgstr ""
-
-#: src/modules/visibility.md:22
-msgid "\"outer::inner::private\""
-msgstr ""
-
-#: src/modules/visibility.md:26
-msgid "\"outer::inner::public\""
-msgstr ""
-
-#: src/modules/visibility.md:39
-msgid "Use the `pub` keyword to make modules public."
-msgstr ""
-
-#: src/modules/visibility.md:41
-msgid ""
-"Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
-"of public visibility."
-msgstr ""
-
-#: src/modules/visibility.md:43
-msgid ""
-"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
-"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
-msgstr ""
-
-#: src/modules/visibility.md:44
-msgid "Configuring `pub(crate)` visibility is a common pattern."
-msgstr ""
-
-#: src/modules/visibility.md:45
-msgid "Less commonly, you can give visibility to a specific path."
-msgstr ""
-
-#: src/modules/visibility.md:46
-msgid ""
-"In any case, visibility must be granted to an ancestor module (and all of "
-"its descendants)."
-msgstr ""
-
-#: src/modules/paths.md:3
-msgid "Paths are resolved as follows:"
-msgstr ""
-
-#: src/modules/paths.md:5
-msgid "As a relative path:"
-msgstr ""
-
-#: src/modules/paths.md:6
-msgid "`foo` or `self::foo` refers to `foo` in the current module,"
-msgstr ""
-
-#: src/modules/paths.md:7
-msgid "`super::foo` refers to `foo` in the parent module."
-msgstr ""
-
-#: src/modules/paths.md:9
-msgid "As an absolute path:"
-msgstr ""
-
-#: src/modules/paths.md:10
-msgid "`crate::foo` refers to `foo` in the root of the current crate,"
-msgstr ""
-
-#: src/modules/paths.md:11
-msgid "`bar::foo` refers to `foo` in the `bar` crate."
-msgstr ""
-
-#: src/modules/paths.md:13
-msgid ""
-"A module can bring symbols from another module into scope with `use`. You "
-"will typically see something like this at the top of each module:"
-msgstr ""
-
-#: src/modules/filesystem.md:3
-msgid ""
-"Omitting the module content will tell Rust to look for it in another file:"
-msgstr ""
-
-#: src/modules/filesystem.md:9
-msgid ""
-"This tells rust that the `garden` module content is found at `src/garden."
-"rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
-"vegetables.rs`."
-msgstr ""
-
-#: src/modules/filesystem.md:12
-msgid "The `crate` root is in:"
-msgstr ""
-
-#: src/modules/filesystem.md:14
-msgid "`src/lib.rs` (for a library crate)"
-msgstr ""
-
-#: src/modules/filesystem.md:15
-msgid "`src/main.rs` (for a binary crate)"
-msgstr ""
-
-#: src/modules/filesystem.md:17
-msgid ""
-"Modules defined in files can be documented, too, using \"inner doc "
-"comments\". These document the item that contains them -- in this case, a "
-"module."
-msgstr ""
-
-#: src/modules/filesystem.md:21
-msgid ""
-"//! This module implements the garden, including a highly performant "
-"germination\n"
-"//! implementation.\n"
-msgstr ""
-
-#: src/modules/filesystem.md:23
-msgid "// Re-export types from this module.\n"
-msgstr ""
-
-#: src/modules/filesystem.md:27
-msgid "/// Sow the given seed packets.\n"
-msgstr ""
-
-#: src/modules/filesystem.md:30
-msgid "/// Harvest the produce in the garden that is ready.\n"
-msgstr ""
-
-#: src/modules/filesystem.md:37
-msgid ""
-"Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
-"`module.rs`, and this is still a working alternative for editions after 2018."
-msgstr ""
-
-#: src/modules/filesystem.md:39
-msgid ""
-"The main reason to introduce `filename.rs` as alternative to `filename/mod."
-"rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
-msgstr ""
-
-#: src/modules/filesystem.md:42
-msgid "Deeper nesting can use folders, even if the main module is a file:"
-msgstr ""
-
-#: src/modules/filesystem.md:52
-msgid ""
-"The place rust will look for modules can be changed with a compiler "
-"directive:"
-msgstr ""
-
-#: src/modules/filesystem.md:55
-msgid "\"some/path.rs\""
-msgstr ""
-
-#: src/modules/filesystem.md:59
-msgid ""
-"This is useful, for example, if you would like to place tests for a module "
-"in a file named `some_module_test.rs`, similar to the convention in Go."
-msgstr ""
-
-#: src/exercises/day-2/afternoon.md:1
-msgid "Day 2: Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-2/afternoon.md:3
-msgid "The exercises for this afternoon will focus on strings and iterators."
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:3
-msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the "
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
-"traits."
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
-msgid "`Iterator`"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:10
-msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. The "
-"`Iterator` trait simply says that you can call `next` until you get `None` "
-"back:"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:20
-msgid "You use this trait like this:"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:27
-msgid "\"v[0]: {:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:28
-msgid "\"v[1]: {:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:29
-msgid "\"v[2]: {:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:30
-msgid "\"No more items: {:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:34
-msgid "What is the type returned by the iterator? Test your answer here:"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:42
-#: src/exercises/day-2/iterators-and-ownership.md:79
-msgid "\"v0: {v0:?}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:46
-msgid "Why is this type used?"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:48
-msgid "`IntoIterator`"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:50
-msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an "
-"iterator. The related trait `IntoIterator` tells you how to create the "
-"iterator:"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:62
-msgid ""
-"The syntax here means that every implementation of `IntoIterator` must "
-"declare two types:"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:65
-msgid "`Item`: the type we iterate over, such as `i8`,"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:66
-msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:68
-msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
-"`Item` type, which means that it returns `Option<Item>`"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:71
-msgid "Like before, what  is the type returned by the iterator?"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:75
-#: src/exercises/day-2/iterators-and-ownership.md:91
-#: src/testing/test-modules.md:21
-msgid "\"bar\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:83
-msgid "`for` Loops"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:85
-msgid ""
-"Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops. They call `into_iter()` on an expression and iterates over the "
-"resulting iterator:"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:94
-#: src/exercises/day-2/iterators-and-ownership.md:98
-msgid "\"word: {word}\""
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:103
-msgid "What is the type of `word` in each loop?"
-msgstr ""
-
-#: src/exercises/day-2/iterators-and-ownership.md:105
-msgid ""
-"Experiment with the code above and then consult the documentation for [`impl "
-"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
-"html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E) and [`impl IntoIterator for "
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT,+A%3E) to check your answers."
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:3
-msgid ""
-"In this exercise, you are implementing a routing component of a web server. "
-"The server is configured with a number of _path prefixes_ which are matched "
-"against _request paths_. The path prefixes can contain a wildcard character "
-"which matches a full segment. See the unit tests below."
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:8
-msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests "
-"pass. Try avoiding allocating a `Vec` for your intermediate results:"
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:22
-#: src/exercises/day-2/strings-iterators.md:23
-#: src/exercises/day-2/strings-iterators.md:24
-#: src/exercises/day-2/strings-iterators.md:26
-#: src/exercises/day-2/strings-iterators.md:27
-#: src/exercises/day-2/strings-iterators.md:28
-#: src/exercises/day-2/strings-iterators.md:46
-#: src/exercises/day-2/solutions-afternoon.md:32
-#: src/exercises/day-2/solutions-afternoon.md:33
-#: src/exercises/day-2/solutions-afternoon.md:34
-#: src/exercises/day-2/solutions-afternoon.md:36
-#: src/exercises/day-2/solutions-afternoon.md:37
-#: src/exercises/day-2/solutions-afternoon.md:38
-#: src/exercises/day-2/solutions-afternoon.md:56
-msgid "\"/v1/publishers\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:23
-#: src/exercises/day-2/solutions-afternoon.md:33
-msgid "\"/v1/publishers/abc-123\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:24
-#: src/exercises/day-2/solutions-afternoon.md:34
-msgid "\"/v1/publishers/abc/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:26
-#: src/exercises/day-2/solutions-afternoon.md:36
-msgid "\"/v1\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:27
-#: src/exercises/day-2/solutions-afternoon.md:37
-msgid "\"/v1/publishersBooks\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:28
-#: src/exercises/day-2/solutions-afternoon.md:38
-msgid "\"/v1/parent/publishers\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:34
-#: src/exercises/day-2/strings-iterators.md:38
-#: src/exercises/day-2/strings-iterators.md:42
-#: src/exercises/day-2/strings-iterators.md:46
-#: src/exercises/day-2/strings-iterators.md:48
-#: src/exercises/day-2/solutions-afternoon.md:44
-#: src/exercises/day-2/solutions-afternoon.md:48
-#: src/exercises/day-2/solutions-afternoon.md:52
-#: src/exercises/day-2/solutions-afternoon.md:56
-#: src/exercises/day-2/solutions-afternoon.md:58
-msgid "\"/v1/publishers/*/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:35
-#: src/exercises/day-2/solutions-afternoon.md:45
-msgid "\"/v1/publishers/foo/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:39
-#: src/exercises/day-2/solutions-afternoon.md:49
-msgid "\"/v1/publishers/bar/books\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:43
-#: src/exercises/day-2/solutions-afternoon.md:53
-msgid "\"/v1/publishers/foo/books/book1\""
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:49
-#: src/exercises/day-2/solutions-afternoon.md:59
-msgid "\"/v1/publishers/foo/booksByAuthor\""
-msgstr ""
-
-#: src/welcome-day-3.md:1
-msgid "Welcome to Day 3"
-msgstr ""
-
-#: src/welcome-day-3.md:3
-msgid "Today, we will cover some more advanced topics of Rust:"
-msgstr ""
-
-#: src/welcome-day-3.md:5
-msgid ""
-"Traits: deriving traits, default methods, and important standard library "
-"traits."
-msgstr ""
-
-#: src/welcome-day-3.md:8
-msgid ""
-"Generics: generic data types, generic methods, monomorphization, and trait "
-"objects."
-msgstr ""
-
-#: src/welcome-day-3.md:11
-msgid "Error handling: panics, `Result`, and the try operator `?`."
-msgstr ""
-
-#: src/welcome-day-3.md:13
-msgid "Testing: unit tests, documentation tests, and integration tests."
-msgstr ""
-
-#: src/welcome-day-3.md:15
-msgid ""
-"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
-"functions."
-msgstr ""
-
-#: src/generics.md:3
-msgid ""
-"Rust support generics, which lets you abstract algorithms or data structures "
-"(such as sorting or a binary tree) over the types used or stored."
-msgstr ""
-"Rustはジェネリクス（generics）をサポートします。これにより、使用または保存す"
-"る型に関してアルゴリズムやデータ構造（ソートアルゴリズムや、二分木など）を抽"
-"象化することができます。"
-
-#: src/generics/data-types.md:3
-msgid "You can use generics to abstract over the concrete field type:"
-msgstr ""
-"ジェネリクスを使って、具体的なフィールドの型を抽象化することができます："
-
-#: src/generics/data-types.md:15
-msgid "\"{integer:?} and {float:?}\""
-msgstr ""
-
-#: src/generics/data-types.md:21
-msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
-msgstr ""
-"次のような新しい変数を宣言してみてください `let p = Point { x: 5, y: 10.0 };"
-"`."
-
-#: src/generics/data-types.md:23
-msgid "Fix the code to allow points that have elements of different types."
-msgstr "異なる型の要素を持つ点を許容するように、コードを修正してください。"
-
-#: src/generics/methods.md:3
-msgid "You can declare a generic type on your `impl` block:"
-msgstr "`impl`に対して、ジェネリックな型を宣言することもできます："
-
-#: src/generics/methods.md:11
-msgid "// + 10\n"
-msgstr ""
-
-#: src/generics/methods.md:14
-msgid "// fn set_x(&mut self, x: T)\n"
-msgstr ""
-
-#: src/generics/methods.md:19
-msgid "\"p.x = {}\""
-msgstr ""
-
-#: src/generics/methods.md:25
-msgid ""
-"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?"
-msgstr ""
-"_Q:_ なぜ`T`は２回も `impl<T> Point<T> {}` において指定されたのでしょうか？冗"
-"長ではありませんか？"
-
-#: src/generics/methods.md:26
-msgid ""
-"This is because it is a generic implementation section for generic type. "
-"They are independently generic."
-msgstr ""
-"なぜなら、これはジェネリクスに対してのジェネリックな実装の箇所だからです。そ"
-"れらは独立してジェネリックです。"
-
-#: src/generics/methods.md:27
-msgid "It means these methods are defined for any `T`."
-msgstr ""
-"つまり、そのようなメソッドは任意の`T`に対して定義されるということです。"
-
-#: src/generics/methods.md:28
-msgid "It is possible to write `impl Point<u32> { .. }`. "
-msgstr "`impl Point<u32> { .. }`のように書くことも可能です。 "
-
-#: src/generics/methods.md:29
-msgid ""
-"`Point` is still generic and you can use `Point<f64>`, but methods in this "
-"block will only be available for `Point<u32>`."
-msgstr ""
-"`Point`はそれでもなおジェネリックであり、 `Point<f64>`を使うことができます。"
-"しかし、このブロックでのメソッドは`Point<u32>`に対してのみ利用可能となりま"
-"す。"
-
-#: src/generics/monomorphization.md:3
-msgid "Generic code is turned into non-generic code based on the call sites:"
-msgstr ""
-"ジェネリクスのコードは呼び出し箇所に基づいて、ジェネリックでないコードに変換"
-"されます："
-
-#: src/generics/monomorphization.md:12
-msgid "behaves as if you wrote"
-msgstr "上のコードは、次のように書いた時と同じように動作します"
-
-#: src/generics/monomorphization.md:31
-msgid ""
-"This is a zero-cost abstraction: you get exactly the same result as if you "
-"had hand-coded the data structures without the abstraction."
-msgstr ""
-"これはゼロコスト抽象化です：抽象化なしに手作業でデータ構造を書いたときと、全"
-"く同じ結果を得ることができます。"
-
-#: src/traits.md:3
+#: src/methods-and-traits/traits.md:3
 msgid ""
 "Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 "Rustでは、型に関しての抽象化をトレイトを用いて行うことができます。トレイトは"
 "インターフェースに似ています："
 
-#: src/traits.md:7 src/traits/trait-objects.md:7
-msgid "// No name needed, cats won't respond anyway.\n"
-msgstr ""
-
-#: src/traits.md:14 src/traits/trait-objects.md:14
-msgid "\"Woof, my name is {}!\""
-msgstr ""
-
-#: src/traits.md:18 src/traits/trait-objects.md:18
-msgid "\"Miau!\""
-msgstr ""
-
-#: src/traits.md:22
+#: src/methods-and-traits/traits.md:18
 msgid "\"Oh you're a cutie! What's your name? {}\""
 msgstr ""
 
-#: src/traits.md:27 src/traits/trait-objects.md:24
+#: src/methods-and-traits/traits.md:24
+#: src/methods-and-traits/trait-objects.md:20
+msgid "\"Woof, my name is {}!\""
+msgstr ""
+
+#: src/methods-and-traits/traits.md:30
+#: src/methods-and-traits/trait-objects.md:26
+msgid "\"Miau!\""
+msgstr ""
+
+#: src/methods-and-traits/traits.md:36
+#: src/methods-and-traits/trait-objects.md:33
 msgid "\"Fido\""
 msgstr ""
 
-#: src/traits/trait-objects.md:3
+#: src/methods-and-traits/traits.md:46
+msgid ""
+"A trait defines a number of methods that types must have in order to "
+"implement the trait."
+msgstr ""
+
+#: src/methods-and-traits/traits.md:49
+msgid "Traits are implemented in an `impl <trait> for <type> { .. }` block."
+msgstr ""
+
+#: src/methods-and-traits/traits.md:51
+#, fuzzy
+msgid ""
+"Traits may specify pre-implemented (provided) methods and methods that users "
+"are required to implement themselves. Provided methods can rely on required "
+"methods. In this case, `greet` is provided, and relies on `talk`."
+msgstr ""
+"トレイトは予め実装された（デフォルトの）メソッドと、ユーザが自身で実装する必"
+"要のあるメソッドを指定することができます。デフォルトの実装のあるメソッドは、"
+"その定義を実装必須のメソットに依存することができます。"
+
+#: src/methods-and-traits/deriving.md:3
+msgid ""
+"Supported traits can be automatically implemented for your custom types, as "
+"follows:"
+msgstr ""
+
+#: src/methods-and-traits/deriving.md:15
+msgid "// Default trait adds `default` constructor.\n"
+msgstr ""
+
+#: src/methods-and-traits/deriving.md:16
+msgid "// Clone trait adds `clone` method.\n"
+msgstr ""
+
+#: src/methods-and-traits/deriving.md:17
+msgid "\"EldurScrollz\""
+msgstr ""
+
+#: src/methods-and-traits/deriving.md:18
+msgid "// Debug trait adds support for printing with `{:?}`.\n"
+msgstr ""
+
+#: src/methods-and-traits/deriving.md:19
+msgid "\"{:?} vs. {:?}\""
+msgstr ""
+
+#: src/methods-and-traits/deriving.md:26
+msgid ""
+"Derivation is implemented with macros, and many crates provide useful derive "
+"macros to add useful functionality. For example, `serde` can derive "
+"serialization support for a struct using `#[derive(Serialize)]`."
+msgstr ""
+
+#: src/methods-and-traits/trait-objects.md:3
 msgid ""
 "Trait objects allow for values of different types, for instance in a "
 "collection:"
@@ -7642,15 +5475,15 @@ msgstr ""
 "トレイトオブジェクトは異なる型の値をひとつのコレクションにまとめることを可能"
 "にします："
 
-#: src/traits/trait-objects.md:27
+#: src/methods-and-traits/trait-objects.md:36
 msgid "\"Hello, who are you? {}\""
 msgstr ""
 
-#: src/traits/trait-objects.md:32
+#: src/methods-and-traits/trait-objects.md:41
 msgid "Memory layout after allocating `pets`:"
 msgstr "`pets`を割り当てた後のメモリレイアウト："
 
-#: src/traits/trait-objects.md:34
+#: src/methods-and-traits/trait-objects.md:43
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -7711,7 +5544,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/traits/trait-objects.md:68
+#: src/methods-and-traits/trait-objects.md:78
 msgid ""
 "Types that implement a given trait may be of different sizes. This makes it "
 "impossible to have things like `Vec<dyn Pet>` in the example above."
@@ -7719,7 +5552,7 @@ msgstr ""
 "同じトレイトを実装する型であってもそのサイズは異なることがあります。そのた"
 "め、上の例でVec<dyn Pet>と書くことはできません。"
 
-#: src/traits/trait-objects.md:70
+#: src/methods-and-traits/trait-objects.md:80
 msgid ""
 "`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
 "implements `Pet`."
@@ -7727,7 +5560,7 @@ msgstr ""
 "`dyn Pet` はコンパイラに、この型が`Pet`トレイトを実装する動的なサイズの型であ"
 "ることを伝えます。"
 
-#: src/traits/trait-objects.md:72
+#: src/methods-and-traits/trait-objects.md:82
 msgid ""
 "In the example, `pets` is allocated on the stack and the vector data is on "
 "the heap. The two vector elements are _fat pointers_:"
@@ -7735,7 +5568,7 @@ msgstr ""
 "上の例では `pets` はスタックに確保され、ベクターのデータはヒープ上にありま"
 "す。二つのベクターの要素は _ファットポインタ_ です："
 
-#: src/traits/trait-objects.md:74
+#: src/methods-and-traits/trait-objects.md:84
 msgid ""
 "A fat pointer is a double-width pointer. It has two components: a pointer to "
 "the actual object and a pointer to the [virtual method table](https://en."
@@ -7744,11 +5577,11 @@ msgid ""
 msgstr ""
 "ファットポインタはdouble-widthポインタです。これは二つの要素からなります：実"
 "際のオブジェクトへのポインタと、そのオブジェクトの`Pet`の実装のための[仮想関"
-"数テーブル](https://ja.wikipedia.org/wiki/"
-"%E4%BB%AE%E6%83%B3%E9%96%A2%E6%95%B0%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB) "
-"(vtable)です。"
+"数テーブル](https://ja.wikipedia.org/wiki/%E4%BB%AE"
+"%E6%83%B3%E9%96%A2%E6%95%B0%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB) (vtable)で"
+"す。"
 
-#: src/traits/trait-objects.md:77
+#: src/methods-and-traits/trait-objects.md:87
 msgid ""
 "The data for the `Dog` named Fido is the `name` and `age` fields. The `Cat` "
 "has a `lives` field."
@@ -7759,93 +5592,327 @@ msgstr ""
 "`lives`というフィールドを持ち、9で初期化しているのは\"A cat has nine lives\" "
 "—猫は９つの命を持つ—ということわざに由来します。）"
 
-#: src/traits/trait-objects.md:79
+#: src/methods-and-traits/trait-objects.md:89
 msgid "Compare these outputs in the above example:"
 msgstr "上の例において、下のコードによる出力結果を比べてみましょう："
 
-#: src/traits/trait-objects.md:81 src/traits/trait-objects.md:82
-#: src/traits/closures.md:54
+#: src/methods-and-traits/trait-objects.md:91
+#: src/methods-and-traits/trait-objects.md:92 src/std-traits/closures.md:63
 msgid "\"{} {}\""
 msgstr ""
 
-#: src/traits/trait-objects.md:83 src/traits/trait-objects.md:84
-#: src/testing/test-modules.md:12 src/android/build-rules/library.md:44
+#: src/methods-and-traits/trait-objects.md:93
+#: src/methods-and-traits/trait-objects.md:94
+#: src/methods-and-traits/solution.md:112 src/std-traits/exercise.md:23
+#: src/std-traits/solution.md:29 src/modules/solution.md:78
+#: src/android/build-rules/library.md:44
+#: src/android/interoperability/cpp/rust-bridge.md:17
 #: src/async/pitfalls/cancellation.md:59
-#: src/exercises/day-3/solutions-morning.md:128
 msgid "\"{}\""
 msgstr ""
 
-#: src/traits/deriving-traits.md:3
+#: src/methods-and-traits/exercise.md:3
 msgid ""
-"Rust derive macros work by automatically generating code that implements the "
-"specified traits for a data structure."
-msgstr ""
-"Rustのderiveマクロは、データ構造体に対して、指定されたトレイトを実装するコー"
-"ドを自動的に生成します。"
-
-#: src/traits/deriving-traits.md:5
-msgid "You can let the compiler derive a number of traits as follows:"
-msgstr "コンパイラには、以下のような多くのトレイトを導出させることができます："
-
-#: src/traits/deriving-traits.md:18
-msgid "\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\""
+"Let us design a classical GUI library using our new knowledge of traits and "
+"trait objects. We'll only implement the drawing of it (as text) for "
+"simplicity."
 msgstr ""
 
-#: src/traits/deriving-traits.md:19
-#: src/exercises/day-1/solutions-afternoon.md:37
-msgid "\"yes\""
+#: src/methods-and-traits/exercise.md:6
+msgid "We will have a number of widgets in our library:"
 msgstr ""
 
-#: src/traits/deriving-traits.md:19
-#: src/exercises/day-1/solutions-afternoon.md:37
-msgid "\"no\""
+#: src/methods-and-traits/exercise.md:8
+msgid "`Window`: has a `title` and contains other widgets."
 msgstr ""
 
-#: src/traits/default-methods.md:3
-msgid "Traits can implement behavior in terms of other trait methods:"
-msgstr ""
-"トレイトでは、別のトレイトメソッドを用いて挙動を定義することが可能です："
-
-#: src/traits/default-methods.md:25
-msgid "\"{a:?} equals {b:?}: {}\""
-msgstr ""
-
-#: src/traits/default-methods.md:26
-msgid "\"{a:?} not_equals {b:?}: {}\""
-msgstr ""
-
-#: src/traits/default-methods.md:32
+#: src/methods-and-traits/exercise.md:9
 msgid ""
-"Traits may specify pre-implemented (default) methods and methods that users "
-"are required to implement themselves. Methods with default implementations "
-"can rely on required methods."
+"`Button`: has a `label`. In reality, it would also take a callback function "
+"to allow the program to do something when the button is clicked but we won't "
+"include that since we're only drawing the GUI."
 msgstr ""
-"トレイトは予め実装された（デフォルトの）メソッドと、ユーザが自身で実装する必"
-"要のあるメソッドを指定することができます。デフォルトの実装のあるメソッドは、"
-"その定義を実装必須のメソットに依存することができます。"
 
-#: src/traits/default-methods.md:35
-msgid "Move method `not_equals` to a new trait `NotEquals`."
+#: src/methods-and-traits/exercise.md:12
+msgid "`Label`: has a `label`."
 msgstr ""
-"メソッド `not_equals` を新しいトレイト `NotEquals` に移してみましょう。"
 
-#: src/traits/default-methods.md:37
-msgid "Make `Equals` a super trait for `NotEquals`."
-msgstr "`Equals` を `NotEquals` のスーパートレイトにしてみましょう。"
+#: src/methods-and-traits/exercise.md:14
+msgid "The widgets will implement a `Widget` trait, see below."
+msgstr ""
 
-#: src/traits/default-methods.md:46
-msgid "Provide a blanket implementation of `NotEquals` for `Equals`."
-msgstr "`Equals`に対する`NotEquals`のブランケット実装を示してみましょう。"
-
-#: src/traits/default-methods.md:58
+#: src/methods-and-traits/exercise.md:16
 msgid ""
-"With the blanket implementation, you no longer need `Equals` as a super "
-"trait for `NotEqual`."
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
+"`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
-"ブランケット実装を用いれば、`Equals` を`NotEqual`のスーパートレイトとする必要"
-"はなくなります。"
 
-#: src/traits/trait-bounds.md:3
+#: src/methods-and-traits/exercise.md:24 src/methods-and-traits/solution.md:5
+#: src/modules/solution.md:36
+msgid "/// Natural width of `self`.\n"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:27 src/methods-and-traits/solution.md:8
+#: src/modules/solution.md:39
+msgid "/// Draw the widget into a buffer.\n"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:30 src/methods-and-traits/solution.md:11
+#: src/modules/solution.md:42
+msgid "/// Draw the widget on standard output.\n"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:34 src/methods-and-traits/solution.md:15
+#: src/modules/solution.md:46
+msgid "\"{buffer}\""
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:79
+msgid "// TODO: Implement `Widget` for `Label`.\n"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:81
+msgid "// TODO: Implement `Widget` for `Button`.\n"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:83
+msgid "// TODO: Implement `Widget` for `Window`.\n"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:87 src/methods-and-traits/solution.md:117
+#: src/modules/solution.md:183
+msgid "\"Rust GUI Demo 1.23\""
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:88 src/methods-and-traits/solution.md:118
+#: src/modules/solution.md:185
+msgid "\"This is a small text GUI demo.\""
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:89 src/methods-and-traits/solution.md:119
+#: src/modules/solution.md:186
+msgid "\"Click me!\""
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:94
+msgid "The output of the above program can be something simple like this:"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:106
+msgid ""
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:114
+msgid "\"left aligned:  |{:/<width$}|\""
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:115
+msgid "\"centered:      |{:/^width$}|\""
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:116
+msgid "\"right aligned: |{:/>width$}|\""
+msgstr ""
+
+#: src/methods-and-traits/exercise.md:120
+msgid ""
+"Using such alignment tricks, you can for example produce output like this:"
+msgstr ""
+
+#: src/methods-and-traits/solution.md:63
+msgid "// Add 4 paddings for borders\n"
+msgstr ""
+
+#: src/methods-and-traits/solution.md:75 src/modules/solution.md:162
+msgid ""
+"// TODO: after learning about error handling, you can change\n"
+"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
+"        // the ?-operator here instead of .unwrap().\n"
+msgstr ""
+
+#: src/methods-and-traits/solution.md:78 src/methods-and-traits/solution.md:84
+#: src/modules/solution.md:165 src/modules/solution.md:171
+msgid "\"+-{:-<inner_width$}-+\""
+msgstr ""
+
+#: src/methods-and-traits/solution.md:78 src/methods-and-traits/solution.md:80
+#: src/methods-and-traits/solution.md:84 src/methods-and-traits/solution.md:98
+#: src/methods-and-traits/solution.md:102 src/modules/solution.md:110
+#: src/modules/solution.md:114 src/modules/solution.md:165
+#: src/modules/solution.md:167 src/modules/solution.md:171
+#: src/testing/unit-tests.md:27 src/testing/solution.md:89
+msgid "\"\""
+msgstr ""
+
+#: src/methods-and-traits/solution.md:79 src/modules/solution.md:166
+msgid "\"| {:^inner_width$} |\""
+msgstr ""
+
+#: src/methods-and-traits/solution.md:80 src/modules/solution.md:167
+msgid "\"+={:=<inner_width$}=+\""
+msgstr ""
+
+#: src/methods-and-traits/solution.md:82 src/modules/solution.md:169
+msgid "\"| {:inner_width$} |\""
+msgstr ""
+
+#: src/methods-and-traits/solution.md:90 src/modules/solution.md:100
+msgid "// add a bit of padding\n"
+msgstr ""
+
+#: src/methods-and-traits/solution.md:98 src/methods-and-traits/solution.md:102
+#: src/modules/solution.md:110 src/modules/solution.md:114
+msgid "\"+{:-<width$}+\""
+msgstr ""
+
+#: src/methods-and-traits/solution.md:100 src/modules/solution.md:112
+msgid "\"|{:^width$}|\""
+msgstr ""
+
+#: src/generics.md:4
+msgid "[Generic Functions](./generics/generic-functions.md) (5 minutes)"
+msgstr ""
+
+#: src/generics.md:5
+msgid "[Generic Data Types](./generics/generic-data.md) (15 minutes)"
+msgstr ""
+
+#: src/generics.md:6
+msgid "[Trait Bounds](./generics/trait-bounds.md) (10 minutes)"
+msgstr ""
+
+#: src/generics.md:7
+msgid "[impl Trait](./generics/impl-trait.md) (5 minutes)"
+msgstr ""
+
+#: src/generics.md:8
+msgid "[Exercise: Generic min](./generics/exercise.md) (10 minutes)"
+msgstr ""
+
+#: src/generics.md:10 src/smart-pointers.md:8 src/iterators.md:9
+#: src/modules.md:10 src/error-handling.md:11
+msgid "This segment should take about 45 minutes"
+msgstr ""
+
+#: src/generics/generic-functions.md:3
+#, fuzzy
+msgid ""
+"Rust supports generics, which lets you abstract algorithms or data "
+"structures (such as sorting or a binary tree) over the types used or stored."
+msgstr ""
+"Rustはジェネリクス（generics）をサポートします。これにより、使用または保存す"
+"る型に関してアルゴリズムやデータ構造（ソートアルゴリズムや、二分木など）を抽"
+"象化することができます。"
+
+#: src/generics/generic-functions.md:7
+msgid "/// Pick `even` or `odd` depending on the value of `n`.\n"
+msgstr ""
+
+#: src/generics/generic-functions.md:17
+msgid "\"picked a number: {:?}\""
+msgstr ""
+
+#: src/generics/generic-functions.md:18
+msgid "\"picked a tuple: {:?}\""
+msgstr ""
+
+#: src/generics/generic-functions.md:18
+msgid "\"dog\""
+msgstr ""
+
+#: src/generics/generic-functions.md:18
+msgid "\"cat\""
+msgstr ""
+
+#: src/generics/generic-functions.md:25
+msgid ""
+"Rust infers a type for T based on the types of the arguments and return "
+"value."
+msgstr ""
+
+#: src/generics/generic-functions.md:27
+msgid ""
+"This is similar to C++ templates, but Rust partially compiles the generic "
+"function immediately, so that function must be valid for all types matching "
+"the constraints. For example, try modifying `pick` to return `even + odd` if "
+"`n == 0`. Even if only the `pick` instantiation with integers is used, Rust "
+"still considers it invalid. C++ would let you do this."
+msgstr ""
+
+#: src/generics/generic-functions.md:33
+#, fuzzy
+msgid ""
+"Generic code is turned into non-generic code based on the call sites. This "
+"is a zero-cost abstraction: you get exactly the same result as if you had "
+"hand-coded the data structures without the abstraction."
+msgstr ""
+"これはゼロコスト抽象化です：抽象化なしに手作業でデータ構造を書いたときと、全"
+"く同じ結果を得ることができます。"
+
+#: src/generics/generic-data.md:3
+msgid "You can use generics to abstract over the concrete field type:"
+msgstr ""
+"ジェネリクスを使って、具体的なフィールドの型を抽象化することができます："
+
+#: src/generics/generic-data.md:17
+msgid "// fn set_x(&mut self, x: T)\n"
+msgstr ""
+
+#: src/generics/generic-data.md:23
+msgid "\"{integer:?} and {float:?}\""
+msgstr ""
+
+#: src/generics/generic-data.md:24
+msgid "\"coords: {:?}\""
+msgstr ""
+
+#: src/generics/generic-data.md:31
+msgid ""
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
+msgstr ""
+"_Q:_ なぜ`T`は２回も `impl<T> Point<T> {}` において指定されたのでしょうか？冗"
+"長ではありませんか？"
+
+#: src/generics/generic-data.md:33
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"なぜなら、これはジェネリクスに対してのジェネリックな実装の箇所だからです。そ"
+"れらは独立してジェネリックです。"
+
+#: src/generics/generic-data.md:35
+msgid "It means these methods are defined for any `T`."
+msgstr ""
+"つまり、そのようなメソッドは任意の`T`に対して定義されるということです。"
+
+#: src/generics/generic-data.md:36
+#, fuzzy
+msgid "It is possible to write `impl Point<u32> { .. }`."
+msgstr "`impl Point<u32> { .. }`のように書くことも可能です。 "
+
+#: src/generics/generic-data.md:37
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"`Point`はそれでもなおジェネリックであり、 `Point<f64>`を使うことができます。"
+"しかし、このブロックでのメソッドは`Point<u32>`に対してのみ利用可能となりま"
+"す。"
+
+#: src/generics/generic-data.md:40
+msgid ""
+"Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`. Update the "
+"code to allow points that have elements of different types, by using two "
+"type variables, e.g., `T` and `U`."
+msgstr ""
+
+#: src/generics/trait-bounds.md:3
 msgid ""
 "When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
@@ -7857,49 +5924,43 @@ msgstr ""
 "[議論がなされています](https://github.com/rust-lang-ja/book-ja/"
 "issues/172)。）"
 
-#: src/traits/trait-bounds.md:6
+#: src/generics/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
 msgstr "そうしたことは`T: Trait` や `impl Trait`を用いて行えます："
 
-#: src/traits/trait-bounds.md:12
-msgid ""
-"// Syntactic sugar for:\n"
-"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
-msgstr ""
-
-#: src/traits/trait-bounds.md:18
+#: src/generics/trait-bounds.md:12
 msgid "// struct NotClonable;\n"
 msgstr ""
 
-#: src/traits/trait-bounds.md:24
+#: src/generics/trait-bounds.md:18
 msgid "\"{pair:?}\""
 msgstr ""
 
-#: src/traits/trait-bounds.md:27
-msgid "\"{many}\""
+#: src/generics/trait-bounds.md:25
+msgid "Try making a `NonClonable` and passing it to `duplicate`."
 msgstr ""
 
-#: src/traits/trait-bounds.md:29
-msgid "\"{many_more}\""
+#: src/generics/trait-bounds.md:27
+msgid "When multiple traits are necessary, use `+` to join them."
 msgstr ""
 
-#: src/traits/trait-bounds.md:35
+#: src/generics/trait-bounds.md:29
 msgid "Show a `where` clause, students will encounter it when reading code."
 msgstr ""
 "`where` 節の使い方を示しましょう。受講生はコードを読んでいるときに、この"
 "`where`節に遭遇します。"
 
-#: src/traits/trait-bounds.md:46
+#: src/generics/trait-bounds.md:40
 msgid "It declutters the function signature if you have many parameters."
 msgstr ""
 "たくさんのパラメタがある場合に、`where`節は関数のシグネチャを整理整頓してくれ"
 "ます。"
 
-#: src/traits/trait-bounds.md:47
+#: src/generics/trait-bounds.md:41
 msgid "It has additional features making it more powerful."
 msgstr "`where`節には更に強力な機能があります。"
 
-#: src/traits/trait-bounds.md:48
+#: src/generics/trait-bounds.md:42
 msgid ""
 "If someone asks, the extra feature is that the type on the left of \":\" can "
 "be arbitrary, like `Option<T>`."
@@ -7907,11 +5968,13 @@ msgstr ""
 "誰かに聞かれた場合で良いですが、その機能というのは、\":\" の左側には "
 "`Option<T>` のように任意の型を表現できるというものです。"
 
-#: src/traits/impl-trait.md:1
-msgid "`impl Trait`"
+#: src/generics/trait-bounds.md:45
+msgid ""
+"Note that Rust does not (yet) support specialization. For example, given the "
+"original `duplicate`, it is invalid to add a specialized `duplicate(a: u32)`."
 msgstr ""
 
-#: src/traits/impl-trait.md:3
+#: src/generics/impl-trait.md:3
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
@@ -7919,16 +5982,32 @@ msgstr ""
 "トレイト境界と似たように、構文 `impl Trait`は関数の引数と返り値においてのみ利"
 "用可能です："
 
-#: src/traits/impl-trait.md:19
-msgid "`impl Trait` allows you to work with types which you cannot name."
-msgstr "`impl Trait`を用いれば、型名を明示せずに型を限定することができます。"
-
-#: src/traits/impl-trait.md:23
+#: src/generics/impl-trait.md:7
 msgid ""
-"The meaning of `impl Trait` is a bit different in the different positions."
+"// Syntactic sugar for:\n"
+"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
+msgstr ""
+
+#: src/generics/impl-trait.md:19
+msgid "\"{many}\""
+msgstr ""
+
+#: src/generics/impl-trait.md:21
+msgid "\"{many_more}\""
+msgstr ""
+
+#: src/generics/impl-trait.md:23
+msgid "\"debuggable: {debuggable:?}\""
+msgstr ""
+
+#: src/generics/impl-trait.md:30
+#, fuzzy
+msgid ""
+"`impl Trait` allows you to work with types which you cannot name. The "
+"meaning of `impl Trait` is a bit different in the different positions."
 msgstr "`impl Trait`の意味は、位置によって少し異なります。"
 
-#: src/traits/impl-trait.md:25
+#: src/generics/impl-trait.md:33
 msgid ""
 "For a parameter, `impl Trait` is like an anonymous generic parameter with a "
 "trait bound."
@@ -7936,7 +6015,7 @@ msgstr ""
 "パラメタに対しては、`impl Trait`は、トレイト境界を持つ匿名のジェネリックパラ"
 "メタのようなものです。"
 
-#: src/traits/impl-trait.md:27
+#: src/generics/impl-trait.md:36
 msgid ""
 "For a return type, it means that the return type is some concrete type that "
 "implements the trait, without naming the type. This can be useful when you "
@@ -7946,7 +6025,7 @@ msgstr ""
 "体的な型名は明示しないということを意味します。このことは公開されるAPIに具象型"
 "を晒したくない場合に便利です。"
 
-#: src/traits/impl-trait.md:31
+#: src/generics/impl-trait.md:40
 msgid ""
 "Inference is hard in return position. A function returning `impl Foo` picks "
 "the concrete type it returns, without writing it out in the source. A "
@@ -7962,732 +6041,270 @@ msgstr ""
 "ん。 それは、 `let x: Vec<_> = foo.collect()`としたり、turbofishを用いて`foo."
 "collect::<Vec<_>>()`とすることで行えます。"
 
-#: src/traits/impl-trait.md:37
+#: src/generics/impl-trait.md:47
 msgid ""
-"This example is great, because it uses `impl Display` twice. It helps to "
-"explain that nothing here enforces that it is _the same_ `impl Display` "
-"type. If we used a single  `T: Display`, it would enforce the constraint "
-"that input `T` and return `T` type are the same type. It would not work for "
-"this particular function, as the type we expect as input is likely not what "
-"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
-"need two independent generic parameters."
+"What is the type of `debuggable`? Try `let debuggable: () = ..` to see what "
+"the error message shows."
 msgstr ""
-"この例は素晴らしい例です。なぜなら、 `impl Display`を２回用いているからで"
-"す。 ここでは `impl Display` の型が同一になることを強制するものはない、という"
-"説明をするのに役立ちます。もし単一の`T: Display`を用いた場合、入力の`T`と返り"
-"値の`T`が同一の型であることが強制されてしまいます。例で示した関数ではうまくい"
-"かないでしょう。なぜなら、我々が期待する入力の型は、`format!`が返すものではお"
-"そらくないからです。もしも同じことを`: Display`の構文で行いたい場合、２つの独"
-"立したジェネリックなパラメタが必要となるでしょう。"
 
-#: src/traits/important-traits.md:3
+#: src/generics/exercise.md:3
 msgid ""
-"We will now look at some of the most common traits of the Rust standard "
-"library:"
+"In this short exercise, you will implement a generic `min` function that "
+"determines the minimum of two values, using a `LessThan` trait."
 msgstr ""
 
-#: src/traits/important-traits.md:5
+#: src/generics/exercise.md:8 src/generics/solution.md:5
+msgid "/// Return true if self is less than other.\n"
+msgstr ""
+
+#: src/generics/exercise.md:29
+msgid "// TODO: implement the `min` function used in `main`.\n"
+msgstr ""
+
+#: src/generics/exercise.md:33 src/generics/solution.md:36
+msgid "\"Shapiro\""
+msgstr ""
+
+#: src/generics/exercise.md:34 src/generics/exercise.md:35
+#: src/generics/solution.md:37 src/generics/solution.md:38
+msgid "\"Baumann\""
+msgstr ""
+
+#: src/welcome-day-2-afternoon.md:4
+msgid "[Standard Library Types](./std-types.md) (1 hour and 10 minutes)"
+msgstr ""
+
+#: src/welcome-day-2-afternoon.md:5
+msgid "[Standard Library Traits](./std-traits.md) (1 hour and 40 minutes)"
+msgstr ""
+
+#: src/std-types.md:4
+msgid "[Standard Library](./std-types/std.md) (3 minutes)"
+msgstr ""
+
+#: src/std-types.md:5
+msgid "[Documentation](./std-types/docs.md) (5 minutes)"
+msgstr ""
+
+#: src/std-types.md:6
+msgid "[Option](./std-types/option.md) (10 minutes)"
+msgstr ""
+
+#: src/std-types.md:7
+msgid "[Result](./std-types/result.md) (10 minutes)"
+msgstr ""
+
+#: src/std-types.md:8
+msgid "[String](./std-types/string.md) (10 minutes)"
+msgstr ""
+
+#: src/std-types.md:9
+msgid "[Vec](./std-types/vec.md) (10 minutes)"
+msgstr ""
+
+#: src/std-types.md:10
+msgid "[HashMap](./std-types/hashmap.md) (10 minutes)"
+msgstr ""
+
+#: src/std-types.md:11
+msgid "[Exercise: Counter](./std-types/exercise.md) (10 minutes)"
+msgstr ""
+
+#: src/std-types.md:13 src/memory-management.md:13
+#: src/slices-and-lifetimes.md:11
+msgid "This segment should take about 1 hour and 10 minutes"
+msgstr ""
+
+#: src/std-types.md:18
 msgid ""
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
-"used in `for` loops,"
+"For each of the slides in this section, spend some time reviewing the "
+"documentation pages, highlighting some of the more common methods."
 msgstr ""
 
-#: src/traits/important-traits.md:6
+#: src/std-types/std.md:3
 msgid ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
-"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
-"values,"
+"Rust comes with a standard library which helps establish a set of common "
+"types used by Rust libraries and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 
-#: src/traits/important-traits.md:7
+#: src/std-types/std.md:7
 msgid ""
-"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
-"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`."
 msgstr ""
 
-#: src/traits/important-traits.md:8
+#: src/std-types/std.md:10
 msgid ""
-"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
-"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
-"overloading, and"
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system."
 msgstr ""
 
-#: src/traits/important-traits.md:9
+#: src/std-types/std.md:12
 msgid ""
-"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
-"defining destructors."
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
 msgstr ""
 
-#: src/traits/important-traits.md:10
+#: src/std-types/std.md:14
 msgid ""
-"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
-"to construct a default instance of a type."
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
 
-#: src/traits/iterator.md:1
-msgid "Iterators"
+#: src/std-types/docs.md:3
+msgid "Rust comes with extensive documentation. For example:"
 msgstr ""
 
-#: src/traits/iterator.md:3
-msgid ""
-"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
-"Iterator.html) trait on your own types:"
-msgstr ""
-
-#: src/traits/iterator.md:25
-msgid "\"fib({i}): {n}\""
-msgstr ""
-
-#: src/traits/iterator.md:32
-msgid ""
-"The `Iterator` trait implements many common functional programming "
-"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
-"the trait where you can find all the documentation about them. In Rust these "
-"functions should produce the code as efficient as equivalent imperative "
-"implementations."
-msgstr ""
-
-#: src/traits/iterator.md:37
-msgid ""
-"`IntoIterator` is the trait that makes for loops work. It is implemented by "
-"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
-"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
-"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
-msgstr ""
-
-#: src/traits/from-iterator.md:3
-msgid ""
-"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
-"std/iter/trait.Iterator.html)."
-msgstr ""
-
-#: src/traits/from-iterator.md:12
-msgid "\"prime_squares: {prime_squares:?}\""
-msgstr ""
-
-#: src/traits/from-iterator.md:18
-msgid ""
-"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
-"Item>, Self: Sized`"
-msgstr ""
-
-#: src/traits/from-iterator.md:24
-msgid ""
-"There are also implementations which let you do cool things like convert an "
-"`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
-msgstr ""
-
-#: src/traits/from-into.md:1
-msgid "`From` and `Into`"
-msgstr ""
-
-#: src/traits/from-into.md:3
-msgid ""
-"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
-"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
-"facilitate type conversions:"
-msgstr ""
-
-#: src/traits/from-into.md:11 src/traits/from-into.md:23
-msgid "\"{s}, {addr}, {one}, {bigger}\""
-msgstr ""
-
-#: src/traits/from-into.md:15
-msgid ""
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
-"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
-"convert/trait.From.html) is implemented:"
-msgstr ""
-
-#: src/traits/from-into.md:29
-msgid ""
-"That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too."
-msgstr ""
-
-#: src/traits/from-into.md:30
-msgid ""
-"When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`. "
-"Your function will accept types that implement `From` and those that _only_ "
-"implement `Into`."
-msgstr ""
-
-#: src/traits/read-write.md:1
-msgid "`Read` and `Write`"
-msgstr ""
-
-#: src/traits/read-write.md:3
-msgid ""
-"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
-"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
-"abstract over `u8` sources:"
-msgstr ""
-
-#: src/traits/read-write.md:14
-msgid "b\"foo\\nbar\\nbaz\\n\""
-msgstr ""
-
-#: src/traits/read-write.md:15
-msgid "\"lines in slice: {}\""
-msgstr ""
-
-#: src/traits/read-write.md:18
-msgid "\"lines in file: {}\""
-msgstr ""
-
-#: src/traits/read-write.md:23
-msgid ""
-"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
-"you abstract over `u8` sinks:"
-msgstr ""
-
-#: src/traits/read-write.md:30
-msgid "\"\\n\""
-msgstr ""
-
-#: src/traits/read-write.md:37
-msgid "\"Logged: {:?}\""
-msgstr ""
-
-#: src/traits/drop.md:1
-msgid "The `Drop` Trait"
-msgstr ""
-
-#: src/traits/drop.md:3
-msgid ""
-"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
-"html) can specify code to run when they go out of scope:"
-msgstr ""
-
-#: src/traits/drop.md:12
-msgid "\"Dropping {}\""
-msgstr ""
-
-#: src/traits/drop.md:17 src/exercises/concurrency/link-checker.md:92
-#: src/exercises/day-1/solutions-morning.md:86
-#: src/exercises/concurrency/solutions-morning.md:123
-msgid "\"a\""
-msgstr ""
-
-#: src/traits/drop.md:19 src/exercises/day-1/solutions-morning.md:86
-msgid "\"b\""
-msgstr ""
-
-#: src/traits/drop.md:21 src/exercises/day-1/solutions-morning.md:86
-msgid "\"c\""
-msgstr ""
-
-#: src/traits/drop.md:22 src/exercises/day-1/solutions-morning.md:86
-msgid "\"d\""
-msgstr ""
-
-#: src/traits/drop.md:23
-msgid "\"Exiting block B\""
-msgstr ""
-
-#: src/traits/drop.md:25
-msgid "\"Exiting block A\""
-msgstr ""
-
-#: src/traits/drop.md:28
-msgid "\"Exiting main\""
-msgstr ""
-
-#: src/traits/drop.md:34
-msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
-msgstr ""
-
-#: src/traits/drop.md:35
-msgid "Values are automatically dropped when they go out of scope."
-msgstr ""
-
-#: src/traits/drop.md:36
-msgid ""
-"When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
-"drop` implementation will be called."
-msgstr ""
-
-#: src/traits/drop.md:38
-msgid ""
-"All its fields will then be dropped too, whether or not it implements `Drop`."
-msgstr ""
-
-#: src/traits/drop.md:39
-msgid ""
-"`std::mem::drop` is just an empty function that takes any value. The "
-"significance is that it takes ownership of the value, so at the end of its "
-"scope it gets dropped. This makes it a convenient way to explicitly drop "
-"values earlier than they would otherwise go out of scope."
-msgstr ""
-
-#: src/traits/drop.md:42
-msgid ""
-"This can be useful for objects that do some work on `drop`: releasing locks, "
-"closing files, etc."
-msgstr ""
-
-#: src/traits/drop.md:45 src/traits/operators.md:26
-msgid "Discussion points:"
-msgstr ""
-
-#: src/traits/drop.md:47
-msgid "Why doesn't `Drop::drop` take `self`?"
-msgstr ""
-
-#: src/traits/drop.md:48
-msgid ""
-"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
-"block, resulting in another call to `Drop::drop`, and a stack overflow!"
-msgstr ""
-
-#: src/traits/drop.md:51
-msgid "Try replacing `drop(a)` with `a.drop()`."
-msgstr ""
-
-#: src/traits/default.md:1
-msgid "The `Default` Trait"
-msgstr ""
-
-#: src/traits/default.md:3
-msgid ""
-"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
-"produces a default value for a type."
-msgstr ""
-
-#: src/traits/default.md:18
-msgid "\"John Smith\""
-msgstr ""
-
-#: src/traits/default.md:24
-msgid "\"{default_struct:#?}\""
-msgstr ""
-
-#: src/traits/default.md:27
-msgid "\"Y is set!\""
-msgstr ""
-
-#: src/traits/default.md:30
-msgid "\"{almost_default_struct:#?}\""
-msgstr ""
-
-#: src/traits/default.md:33
-msgid "\"{:#?}\""
-msgstr ""
-
-#: src/traits/default.md:40
-msgid ""
-"It can be implemented directly or it can be derived via `#[derive(Default)]`."
-msgstr ""
-
-#: src/traits/default.md:41
-msgid ""
-"A derived implementation will produce a value where all fields are set to "
-"their default values."
-msgstr ""
-
-#: src/traits/default.md:42
-msgid "This means all types in the struct must implement `Default` too."
-msgstr ""
-
-#: src/traits/default.md:43
-msgid ""
-"Standard Rust types often implement `Default` with reasonable values (e.g. "
-"`0`, `\"\"`, etc)."
-msgstr ""
-
-#: src/traits/default.md:44
-msgid "The partial struct copy works nicely with default."
-msgstr ""
-
-#: src/traits/default.md:45
-msgid ""
-"Rust standard library is aware that types can implement `Default` and "
-"provides convenience methods that use it."
-msgstr ""
-
-#: src/traits/default.md:46
-msgid ""
-"the `..` syntax is called [struct update syntax](https://doc.rust-lang.org/"
-"book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
-"with-struct-update-syntax)"
-msgstr ""
-
-#: src/traits/operators.md:1
-msgid "`Add`, `Mul`, ..."
-msgstr ""
-
-#: src/traits/operators.md:3
-msgid ""
-"Operator overloading is implemented via traits in [`std::ops`](https://doc."
-"rust-lang.org/std/ops/index.html):"
-msgstr ""
-
-#: src/traits/operators.md:20
-msgid "\"{:?} + {:?} = {:?}\""
-msgstr ""
-
-#: src/traits/operators.md:28
-msgid ""
-"You could implement `Add` for `&Point`. In which situations is that useful? "
-msgstr ""
-
-#: src/traits/operators.md:29
-msgid ""
-"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
-"the operator is not `Copy`, you should consider overloading the operator for "
-"`&T` as well. This avoids unnecessary cloning on the call site."
-msgstr ""
-
-#: src/traits/operators.md:33
-msgid ""
-"Why is `Output` an associated type? Could it be made a type parameter of the "
-"method?"
-msgstr ""
-
-#: src/traits/operators.md:34
-msgid ""
-"Short answer: Function type parameters are controlled by the caller, but "
-"associated types (like `Output`) are controlled by the implementor of a "
-"trait."
-msgstr ""
-
-#: src/traits/operators.md:37
-msgid ""
-"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
-"i32)> for Point` would add a tuple to a `Point`."
-msgstr ""
-
-#: src/traits/closures.md:1
-msgid "Closures"
-msgstr ""
-
-#: src/traits/closures.md:3
-msgid ""
-"Closures or lambda expressions have types which cannot be named. However, "
-"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
-"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
-msgstr ""
-
-#: src/traits/closures.md:10
-msgid "\"Calling function on {input}\""
-msgstr ""
-
-#: src/traits/closures.md:16 src/traits/closures.md:17
-msgid "\"add_3: {}\""
-msgstr ""
-
-#: src/traits/closures.md:24 src/traits/closures.md:25
-msgid "\"accumulate: {}\""
-msgstr ""
-
-#: src/traits/closures.md:28
-msgid "\"multiply_sum: {}\""
-msgstr ""
-
-#: src/traits/closures.md:34
-msgid ""
-"An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
-"perhaps captures nothing at all. It can be called multiple times "
-"concurrently."
-msgstr ""
-
-#: src/traits/closures.md:37
-msgid ""
-"An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
-"multiple times, but not concurrently."
-msgstr ""
-
-#: src/traits/closures.md:40
-msgid ""
-"If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
-"might consume captured values."
-msgstr ""
-
-#: src/traits/closures.md:43
-msgid ""
-"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
-"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
-msgstr ""
-
-#: src/traits/closures.md:47
-msgid ""
-"The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
-"`multiply_sum`), depending on what the closure captures."
-msgstr ""
-
-#: src/traits/closures.md:50
-msgid ""
-"By default, closures will capture by reference if they can. The `move` "
-"keyword makes them capture by value."
-msgstr ""
-
-#: src/traits/closures.md:58
-msgid "\"Hi\""
-msgstr ""
-
-#: src/traits/closures.md:59
-msgid "\"there\""
-msgstr ""
-
-#: src/exercises/day-3/morning.md:1
-msgid "Day 3: Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-3/morning.md:3
-msgid "We will design a classical GUI library using traits and trait objects."
-msgstr ""
-
-#: src/exercises/day-3/morning.md:5
-msgid ""
-"We will also look at enum dispatch with an exercise involving points and "
-"polygons."
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:1
-#: src/exercises/day-3/solutions-morning.md:3
+#: src/std-types/docs.md:5
 #, fuzzy
-msgid "Drawing A Simple GUI"
-msgstr "GUIライブラリ"
-
-#: src/exercises/day-3/simple-gui.md:3
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and "
-"trait objects. We'll only implement the drawing of it (as text) for "
-"simplicity."
+"All of the details about [loops](https://doc.rust-lang.org/stable/reference/"
+"expressions/loop-expr.html)."
 msgstr ""
+"ループから早く抜け出したい場合は [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions) を使用してください。"
 
-#: src/exercises/day-3/simple-gui.md:6
-msgid "We will have a number of widgets in our library:"
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:8
-msgid "`Window`: has a `title` and contains other widgets."
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:9
+#: src/std-types/docs.md:7
 msgid ""
-"`Button`: has a `label`. In reality, it would also take a callback function "
-"to allow the program to do something when the button is clicked but we won't "
-"include that since we're only drawing the GUI."
+"Primitive types like [`u8`](https://doc.rust-lang.org/stable/std/primitive."
+"u8.html)."
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:12
-msgid "`Label`: has a `label`."
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:14
-msgid "The widgets will implement a `Widget` trait, see below."
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:16
+#: src/std-types/docs.md:9
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
-"`draw_into` methods so that you implement the `Widget` trait:"
+"Standard library types like [`Option`](https://doc.rust-lang.org/stable/std/"
+"option/enum.Option.html) or [`BinaryHeap`](https://doc.rust-lang.org/stable/"
+"std/collections/struct.BinaryHeap.html)."
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:24
-#: src/exercises/day-3/solutions-morning.md:9
-msgid "/// Natural width of `self`.\n"
+#: src/std-types/docs.md:13
+msgid "In fact, you can document your own code:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:27
-#: src/exercises/day-3/solutions-morning.md:12
-msgid "/// Draw the widget into a buffer.\n"
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:30
-#: src/exercises/day-3/solutions-morning.md:15
-msgid "/// Draw the widget on standard output.\n"
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:34
-#: src/exercises/day-3/solutions-morning.md:19
-msgid "\"{buffer}\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:119
-#: src/exercises/day-3/solutions-morning.md:133
-msgid "\"Rust GUI Demo 1.23\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:120
-#: src/exercises/day-3/solutions-morning.md:134
-msgid "\"This is a small text GUI demo.\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:122
-#: src/exercises/day-3/solutions-morning.md:136
-msgid "\"Click me!\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:128
-msgid "The output of the above program can be something simple like this:"
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:140
+#: src/std-types/docs.md:16
 msgid ""
-"If you want to draw aligned text, you can use the [fill/alignment](https://"
-"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
-"particular, notice how you can pad with different characters (here a `'/'`) "
-"and how you can control alignment:"
+"/// Determine whether the first argument is divisible by the second "
+"argument.\n"
+"///\n"
+"/// If the second argument is zero, the result is false.\n"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:148
-msgid "\"left aligned:  |{:/<width$}|\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:149
-msgid "\"centered:      |{:/^width$}|\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:150
-msgid "\"right aligned: |{:/>width$}|\""
-msgstr ""
-
-#: src/exercises/day-3/simple-gui.md:154
+#: src/std-types/docs.md:27
 msgid ""
-"Using such alignment tricks, you can for example produce output like this:"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
+"idiomatic to document all public items in an API using this pattern."
 msgstr ""
 
-#: src/exercises/day-3/points-polygons.md:1
-msgid "Polygon Struct"
-msgstr ""
-
-#: src/exercises/day-3/points-polygons.md:3
+#: src/std-types/docs.md:32
 msgid ""
-"We will create a `Polygon` struct which contain some points. Copy the code "
-"below to <https://play.rust-lang.org/> and fill in the missing methods to "
-"make the tests pass:"
+"To document an item from inside the item (such as inside a module), use `//!"
+"` or `/*! .. */`, called \"inner doc comments\":"
 msgstr ""
 
-#: src/exercises/day-3/points-polygons.md:12
-#: src/exercises/day-3/points-polygons.md:20
-#: src/exercises/day-3/points-polygons.md:28
-msgid "// add fields\n"
-msgstr ""
-
-#: src/exercises/day-3/points-polygons.md:16
-#: src/exercises/day-3/points-polygons.md:24
-#: src/exercises/day-3/points-polygons.md:32
-msgid "// add methods\n"
-msgstr ""
-
-#: src/exercises/day-3/points-polygons.md:117
+#: src/std-types/docs.md:36
 msgid ""
-"Since the method signatures are missing from the problem statements, the key "
-"part of the exercise is to specify those correctly. You don't have to modify "
-"the tests."
+"//! This module contains functionality relating to divisibility of "
+"integers.\n"
 msgstr ""
 
-#: src/exercises/day-3/points-polygons.md:120
-msgid "Other interesting parts of the exercise:"
-msgstr ""
-
-#: src/exercises/day-3/points-polygons.md:122
+#: src/std-types/docs.md:42
 msgid ""
-"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments."
+"Show students the generated docs for the `rand` crate at <https://docs.rs/"
+"rand>."
 msgstr ""
 
-#: src/exercises/day-3/points-polygons.md:123
+#: src/std-types/option.md:1
+#, fuzzy
+msgid "Option"
+msgstr "例外"
+
+#: src/std-types/option.md:3
 msgid ""
-"Discover that `Add` trait must be implemented for two objects to be addable "
-"via \"+\". Note that we do not discuss generics until Day 3."
+"We have already seen some use of `Option<T>`. It stores either a value of "
+"type `T` or nothing. For example, [`String::find`](https://doc.rust-lang.org/"
+"stable/std/string/struct.String.html#method.find) returns an `Option<usize>`."
 msgstr ""
 
-#: src/error-handling.md:3
-msgid "Error handling in Rust is done using explicit control flow:"
+#: src/std-types/option.md:10
+msgid "\"Löwe 老虎 Léopard Gepardi\""
 msgstr ""
 
-#: src/error-handling.md:5
-msgid "Functions that can have errors list this in their return type,"
+#: src/std-types/option.md:11
+msgid "'é'"
 msgstr ""
 
-#: src/error-handling.md:6
-msgid "There are no exceptions."
+#: src/std-types/option.md:12 src/std-types/option.md:15
+msgid "\"find returned {position:?}\""
 msgstr ""
 
-#: src/error-handling/panics.md:3
-msgid "Rust will trigger a panic if a fatal error happens at runtime:"
+#: src/std-types/option.md:14
+msgid "'Z'"
 msgstr ""
 
-#: src/error-handling/panics.md:8
-msgid "\"v[100]: {}\""
+#: src/std-types/option.md:16
+msgid "\"Character not found\""
 msgstr ""
 
-#: src/error-handling/panics.md:12
-msgid "Panics are for unrecoverable and unexpected errors."
-msgstr ""
+#: src/std-types/option.md:23
+#, fuzzy
+msgid "`Option` is widely used, not just in the standard library."
+msgstr "標準ライブラリの非同期バージョン。"
 
-#: src/error-handling/panics.md:13
-msgid "Panics are symptoms of bugs in the program."
-msgstr ""
-
-#: src/error-handling/panics.md:14
+#: src/std-types/option.md:24
 msgid ""
-"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"`unwrap` will return the value in an `Option`, or panic. `expect` is similar "
+"but takes an error message."
 msgstr ""
 
-#: src/error-handling/panic-unwind.md:1
-msgid "Catching the Stack Unwinding"
-msgstr ""
-
-#: src/error-handling/panic-unwind.md:3
+#: src/std-types/option.md:26
 msgid ""
-"By default, a panic will cause the stack to unwind. The unwinding can be "
-"caught:"
+"You can panic on None, but you can't \"accidentally\" forget to check for "
+"None."
 msgstr ""
 
-#: src/error-handling/panic-unwind.md:10
-msgid "\"No problem here!\""
-msgstr ""
-
-#: src/error-handling/panic-unwind.md:12 src/error-handling/panic-unwind.md:17
-msgid "\"{result:?}\""
-msgstr ""
-
-#: src/error-handling/panic-unwind.md:15
-msgid "\"oh no!\""
-msgstr ""
-
-#: src/error-handling/panic-unwind.md:21
+#: src/std-types/option.md:28
 msgid ""
-"This can be useful in servers which should keep running even if a single "
-"request crashes."
+"It's common to `unwrap`/`expect` all over the place when hacking something "
+"together, but production code typically handles `None` in a nicer fashion."
 msgstr ""
 
-#: src/error-handling/panic-unwind.md:23
-msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
-msgstr ""
-
-#: src/error-handling/result.md:1
-msgid "Structured Error Handling with `Result`"
-msgstr ""
-
-#: src/error-handling/result.md:3
+#: src/std-types/option.md:30
 msgid ""
-"We have already seen the `Result` enum. This is used pervasively when errors "
-"are expected as part of normal operation:"
+"The niche optimization means that `Option<T>` often has the same size in "
+"memory as `T`."
 msgstr ""
 
-#: src/error-handling/result.md:11
+#: src/std-types/result.md:1
+msgid "Result"
+msgstr ""
+
+#: src/std-types/result.md:3
+msgid ""
+"`Result` is similar to `Option`, but indicates the success or failure of an "
+"operation, each with a different type. This is similar to the `Res` defined "
+"in the expression exercise, but generic: `Result<T, E>` where `T` is used in "
+"the `Ok` variant and `E` appears in the `Err` variant."
+msgstr ""
+
+#: src/std-types/result.md:13
 msgid "\"diary.txt\""
 msgstr ""
 
-#: src/error-handling/result.md:16
-msgid "\"Dear diary: {contents}\""
+#: src/std-types/result.md:18
+msgid "\"Dear diary: {contents} ({bytes} bytes)\""
 msgstr ""
 
-#: src/error-handling/result.md:19
+#: src/std-types/result.md:20
+msgid "\"Could not read file content\""
+msgstr ""
+
+#: src/std-types/result.md:24
 msgid "\"The diary could not be opened: {err}\""
 msgstr ""
 
-#: src/error-handling/result.md:27
+#: src/std-types/result.md:33
 msgid ""
 "As with `Option`, the successful value sits inside of `Result`, forcing the "
 "developer to explicitly extract it. This encourages error checking. In the "
@@ -8695,274 +6312,3253 @@ msgid ""
 "called, and this is a signal of the developer intent too."
 msgstr ""
 
-#: src/error-handling/result.md:30
+#: src/std-types/result.md:37
 msgid ""
 "`Result` documentation is a recommended read. Not during the course, but it "
-"is worth mentioning.  It contains a lot of convenience methods and functions "
-"that help functional-style programming. "
+"is worth mentioning. It contains a lot of convenience methods and functions "
+"that help functional-style programming."
 msgstr ""
 
-#: src/error-handling/try-operator.md:1
-msgid "Propagating Errors with `?`"
-msgstr ""
-
-#: src/error-handling/try-operator.md:3
+#: src/std-types/result.md:40
 msgid ""
-"The try-operator `?` is used to return errors to the caller. It lets you "
-"turn the common"
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
 msgstr ""
 
-#: src/error-handling/try-operator.md:13
-msgid "into the much simpler"
-msgstr ""
+#: src/std-types/string.md:1
+msgid "String"
+msgstr "文字列（String）"
 
-#: src/error-handling/try-operator.md:19
-msgid "We can use this to simplify our error handling code:"
-msgstr ""
-
-#: src/error-handling/try-operator.md:40
-msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
-msgstr ""
-
-#: src/error-handling/try-operator.md:41
-#: src/error-handling/converting-error-types-example.md:43
-#: src/error-handling/deriving-error-enums.md:30
-#: src/error-handling/dynamic-errors.md:27
-#: src/error-handling/error-contexts.md:26
-msgid "\"config.dat\""
-msgstr ""
-
-#: src/error-handling/try-operator.md:42
-#: src/error-handling/converting-error-types-example.md:44
-msgid "\"username or error: {username:?}\""
-msgstr ""
-
-#: src/error-handling/try-operator.md:50
-#: src/error-handling/converting-error-types-example.md:52
-msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
-msgstr ""
-
-#: src/error-handling/try-operator.md:51
-#: src/error-handling/converting-error-types-example.md:53
+#: src/std-types/string.md:3
 msgid ""
-"Use the `fs::write` call to test out the different scenarios: no file, empty "
-"file, file with username."
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
 
-#: src/error-handling/try-operator.md:52
+#: src/std-types/string.md:8 src/std-traits/read-and-write.md:35
+#: src/memory-management/review.md:23 src/memory-management/review.md:58
+#: src/testing/unit-tests.md:32 src/testing/unit-tests.md:37
+#: src/concurrency/scoped-threads.md:9 src/concurrency/scoped-threads.md:26
+msgid "\"Hello\""
+msgstr ""
+
+#: src/std-types/string.md:9
+msgid "\"s1: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std-types/string.md:13
+msgid "'!'"
+msgstr ""
+
+#: src/std-types/string.md:14
+msgid "\"s2: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std-types/string.md:16
+msgid "\"🇨🇭\""
+msgstr ""
+
+#: src/std-types/string.md:17
+msgid "\"s3: len = {}, number of chars = {}\""
+msgstr ""
+
+#: src/std-types/string.md:21
 msgid ""
-"The return type of the function has to be compatible with the nested "
-"functions it calls. For instance, a function returning a `Result<T, Err>` "
-"can only apply the `?` operator on a function returning a  `Result<AnyT, "
-"Err>`. It cannot apply the `?` operator on a function returning an "
-"`Option<AnyT>` or `Result<T, OtherErr>` unless `OtherErr` implements "
-"`From<Err>`. Reciprocally, a function returning an `Option<T>` can only "
-"apply the `?` operator  on a function returning an `Option<AnyT>`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
 
-#: src/error-handling/try-operator.md:57
+#: src/std-types/string.md:30
 msgid ""
-"You can convert incompatible types into one another with the different "
-"`Option` and `Result` methods  such as `Option::ok_or`, `Result::ok`, "
-"`Result::err`."
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
 msgstr ""
 
-#: src/error-handling/converting-error-types.md:3
+#: src/std-types/string.md:32
 msgid ""
-"The effective expansion of `?` is a little more complicated than previously "
-"indicated:"
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
 msgstr ""
 
-#: src/error-handling/converting-error-types.md:9
-msgid "works the same as"
-msgstr ""
-
-#: src/error-handling/converting-error-types.md:18
+#: src/std-types/string.md:34
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to the "
-"type returned by the function:"
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
 msgstr ""
 
-#: src/error-handling/converting-error-types-example.md:20
-msgid "\"IO error: {e}\""
-msgstr ""
-
-#: src/error-handling/converting-error-types-example.md:21
-msgid "\"Found no username in {filename}\""
-msgstr ""
-
-#: src/error-handling/converting-error-types-example.md:42
-#: src/error-handling/deriving-error-enums.md:29
-#: src/error-handling/dynamic-errors.md:26
-#: src/error-handling/error-contexts.md:25
-msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
-msgstr ""
-
-#: src/error-handling/converting-error-types-example.md:55
+#: src/std-types/string.md:37
 msgid ""
-"It is good practice for all error types that don't need to be `no_std` to "
-"implement `std::error::Error`, which requires `Debug` and `Display`. The "
-"`Error` crate for `core` is only available in [nightly](https://github.com/"
-"rust-lang/rust/issues/103765), so not fully `no_std` compatible yet."
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
 msgstr ""
 
-#: src/error-handling/converting-error-types-example.md:57
+#: src/std-types/string.md:39
 msgid ""
-"It's generally helpful for them to implement `Clone` and `Eq` too where "
-"possible, to make life easier for tests and consumers of your library. In "
-"this case we can't easily do so, because `io::Error` doesn't implement them."
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:3
+#: src/std-types/string.md:41
 msgid ""
-"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an error enum like we did on the previous page:"
+"We haven't discussed the `Deref` trait yet, so at this point this mostly "
+"explains the structure of the sidebar in the documentation."
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:13
-msgid "\"Could not read: {0}\""
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:15
-#: src/error-handling/dynamic-errors.md:13
-msgid "\"Found no username in {0}\""
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:31
-#: src/error-handling/dynamic-errors.md:28
-#: src/error-handling/error-contexts.md:27
-msgid "\"Username: {username}\""
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:32
-#: src/error-handling/dynamic-errors.md:29
-msgid "\"Error: {err}\""
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:39
+#: src/std-types/string.md:43
 msgid ""
-"`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
-"`From` (if the `#[from]` attribute is added). It also works for structs."
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:43
-msgid "It doesn't affect your public API, which makes it good for libraries."
+#: src/std-types/string.md:45
+msgid "Write and compare `let s3 = s1.deref();` and `let s3 = &*s1;`."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:3
+#: src/std-types/string.md:46
 msgid ""
-"Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering all the different possibilities. `std::error::Error` "
-"makes this easy."
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
+"operations you see supported on vectors are also supported on `String`, but "
+"with some extra guarantees."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:36
+#: src/std-types/string.md:49
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std-types/string.md:50
 msgid ""
-"This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in the program. As such it's generally not a good "
-"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
-"good option in a program where you just want to display the error message "
-"somewhere."
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
 msgstr ""
 
-#: src/error-handling/error-contexts.md:3
+#: src/std-types/string.md:52
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
-"contextual information to your errors and allows you to have fewer custom "
-"error types:"
+"To a substring by using `s3[0..4]`, where that slice is on character "
+"boundaries or not."
 msgstr ""
 
-#: src/error-handling/error-contexts.md:15
-msgid "\"Failed to open {path}\""
-msgstr ""
-
-#: src/error-handling/error-contexts.md:17
-msgid "\"Failed to read\""
-msgstr ""
-
-#: src/error-handling/error-contexts.md:19
-msgid "\"Found no username in {path}\""
-msgstr ""
-
-#: src/error-handling/error-contexts.md:28
-msgid "\"Error: {err:?}\""
-msgstr ""
-
-#: src/error-handling/error-contexts.md:35
-msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
-msgstr ""
-
-#: src/error-handling/error-contexts.md:36
+#: src/std-types/vec.md:3
 msgid ""
-"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not a good choice for the public API of a library, but "
-"is widely used in applications."
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
 msgstr ""
 
-#: src/error-handling/error-contexts.md:38
+#: src/std-types/vec.md:9
+msgid "\"v1: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std-types/vec.md:14
+msgid "\"v2: len = {}, capacity = {}\""
+msgstr ""
+
+#: src/std-types/vec.md:16
+msgid "// Canonical macro to initialize a vector with elements.\n"
+msgstr ""
+
+#: src/std-types/vec.md:19
+msgid "// Retain only the even elements.\n"
+msgstr ""
+
+#: src/std-types/vec.md:21 src/std-types/vec.md:25
+msgid "\"{v3:?}\""
+msgstr ""
+
+#: src/std-types/vec.md:23
+msgid "// Remove consecutive duplicates.\n"
+msgstr ""
+
+#: src/std-types/vec.md:29
 msgid ""
-"Actual error type inside of it can be extracted for examination if necessary."
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
+"methods on a `Vec`."
 msgstr ""
 
-#: src/error-handling/error-contexts.md:39
+#: src/std-types/vec.md:38
 msgid ""
-"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides similar usage patterns and ergonomics to `(T, "
-"error)` from Go."
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/testing.md:3
-msgid "Rust and Cargo come with a simple unit test framework:"
+#: src/std-types/vec.md:41
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std-types/vec.md:44
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std-types/vec.md:46
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std-types/vec.md:49
+msgid ""
+"Slices are covered on day 3. For now, students only need to know that a "
+"value of type `Vec` gives access to all of the documented slice methods, too."
+msgstr ""
+
+#: src/std-types/hashmap.md:3
+msgid "Standard hash map with protection against HashDoS attacks:"
+msgstr ""
+
+#: src/std-types/hashmap.md:10
+msgid "\"Adventures of Huckleberry Finn\""
+msgstr ""
+
+#: src/std-types/hashmap.md:11
+msgid "\"Grimms' Fairy Tales\""
+msgstr ""
+
+#: src/std-types/hashmap.md:12 src/std-types/hashmap.md:21
+#: src/std-types/hashmap.md:29
+msgid "\"Pride and Prejudice\""
+msgstr ""
+
+#: src/std-types/hashmap.md:14
+msgid "\"Les Misérables\""
+msgstr ""
+
+#: src/std-types/hashmap.md:16
+msgid "\"We know about {} books, but not Les Misérables.\""
+msgstr ""
+
+#: src/std-types/hashmap.md:21 src/std-types/hashmap.md:29
+msgid "\"Alice's Adventure in Wonderland\""
+msgstr ""
+
+#: src/std-types/hashmap.md:23
+msgid "\"{book}: {count} pages\""
+msgstr ""
+
+#: src/std-types/hashmap.md:24
+msgid "\"{book} is unknown.\""
+msgstr ""
+
+#: src/std-types/hashmap.md:28
+msgid "// Use the .entry() method to insert a value if nothing is found.\n"
+msgstr ""
+
+#: src/std-types/hashmap.md:34
+msgid "\"{page_counts:#?}\""
+msgstr ""
+
+#: src/std-types/hashmap.md:41
+msgid ""
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std-types/hashmap.md:42
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std-types/hashmap.md:48 src/std-types/hashmap.md:60
+msgid "\"Harry Potter and the Sorcerer's Stone\""
+msgstr ""
+
+#: src/std-types/hashmap.md:51 src/std-types/hashmap.md:61
+msgid "\"The Hunger Games\""
+msgstr ""
+
+#: src/std-types/hashmap.md:54
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std-types/hashmap.md:55
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C"
+"%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows us to "
+"easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std-types/hashmap.md:65
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std-types/hashmap.md:67
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std-types/hashmap.md:70
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
+"compiles. Where do you think we might run into issues?"
+msgstr ""
+
+#: src/std-types/hashmap.md:73
+msgid ""
+"This type has several \"method-specific\" return types, such as `std::"
+"collections::hash_map::Keys`. These types often appear in searches of the "
+"Rust docs. Show students the docs for this type, and the helpful link back "
+"to the `keys` method."
+msgstr ""
+
+#: src/std-types/exercise.md:3
+msgid ""
+"In this exercise you will take a very simple data structure and make it "
+"generic. It uses a [`std::collections::HashMap`](https://doc.rust-lang.org/"
+"stable/std/collections/struct.HashMap.html) to keep track of which values "
+"have been seen and how many times each one has appeared."
+msgstr ""
+
+#: src/std-types/exercise.md:9
+msgid ""
+"The initial version of `Counter` is hard coded to only work for `u32` "
+"values. Make the struct and its methods generic over the type of value being "
+"tracked, that way `Counter` can track any type of value."
+msgstr ""
+
+#: src/std-types/exercise.md:13
+msgid ""
+"If you finish early, try using the [`entry`](https://doc.rust-lang.org/"
+"stable/std/collections/struct.HashMap.html#method.entry) method to halve the "
+"number of hash lookups required to implement the `count` method."
+msgstr ""
+
+#: src/std-types/exercise.md:20 src/std-types/solution.md:6
+msgid ""
+"/// Counter counts the number of times each value of type T has been seen.\n"
+msgstr ""
+
+#: src/std-types/exercise.md:27 src/std-types/solution.md:13
+msgid "/// Create a new Counter.\n"
+msgstr ""
+
+#: src/std-types/exercise.md:34 src/std-types/solution.md:18
+msgid "/// Count an occurrence of the given value.\n"
+msgstr ""
+
+#: src/std-types/exercise.md:43 src/std-types/solution.md:23
+msgid "/// Return the number of times the given value has been seen.\n"
+msgstr ""
+
+#: src/std-types/exercise.md:59 src/std-types/solution.md:39
+msgid "\"saw {} values equal to {}\""
+msgstr ""
+
+#: src/std-types/exercise.md:63 src/std-types/exercise.md:65
+#: src/std-types/exercise.md:66 src/std-types/solution.md:43
+#: src/std-types/solution.md:45 src/std-types/solution.md:46
+msgid "\"apple\""
+msgstr ""
+
+#: src/std-types/exercise.md:64 src/std-types/solution.md:44
+msgid "\"orange\""
+msgstr ""
+
+#: src/std-types/exercise.md:66 src/std-types/solution.md:46
+msgid "\"got {} apples\""
+msgstr ""
+
+#: src/std-traits.md:4
+msgid "[Comparisons](./std-traits/comparisons.md) (10 minutes)"
+msgstr ""
+
+#: src/std-traits.md:5
+msgid "[Operators](./std-traits/operators.md) (10 minutes)"
+msgstr ""
+
+#: src/std-traits.md:6
+msgid "[From and Into](./std-traits/from-and-into.md) (10 minutes)"
+msgstr ""
+
+#: src/std-traits.md:7
+msgid "[Casting](./std-traits/casting.md) (5 minutes)"
+msgstr ""
+
+#: src/std-traits.md:8
+msgid "[Read and Write](./std-traits/read-and-write.md) (10 minutes)"
+msgstr ""
+
+#: src/std-traits.md:9
+msgid "[Default, struct update syntax](./std-traits/default.md) (5 minutes)"
+msgstr ""
+
+#: src/std-traits.md:10
+msgid "[Closures](./std-traits/closures.md) (20 minutes)"
+msgstr ""
+
+#: src/std-traits.md:11
+msgid "[Exercise: ROT13](./std-traits/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/std-traits.md:13
+msgid "This segment should take about 1 hour and 40 minutes"
+msgstr ""
+
+#: src/std-traits.md:18
+msgid ""
+"As with the standard-library types, spend time reviewing the documentation "
+"for each trait."
+msgstr ""
+
+#: src/std-traits.md:21
+msgid "This section is long. Take a break midway through."
+msgstr ""
+
+#: src/std-traits/comparisons.md:3
+msgid ""
+"These traits support comparisons between values. All traits can be derived "
+"for types containing fields that implement these traits."
+msgstr ""
+
+#: src/std-traits/comparisons.md:6
+msgid "`PartialEq` and `Eq`"
+msgstr ""
+
+#: src/std-traits/comparisons.md:8
+msgid ""
+"`PartialEq` is a partial equivalence relation, with required method `eq` and "
+"provided method `ne`. The `==` and `!=` operators will call these methods."
+msgstr ""
+
+#: src/std-traits/comparisons.md:23
+msgid ""
+"`Eq` is a full equivalence relation (reflexive, symmetric, and transitive) "
+"and implies `PartialEq`. Functions that require full equivalence will use "
+"`Eq` as a trait bound."
+msgstr ""
+
+#: src/std-traits/comparisons.md:27
+msgid "`PartialOrd` and `Ord`"
+msgstr ""
+
+#: src/std-traits/comparisons.md:29
+msgid ""
+"`PartialOrd` defines a partial ordering, with a `partial_cmp` method. It is "
+"used to implement the `<`, `<=`, `>=`, and `>` operators."
+msgstr ""
+
+#: src/std-traits/comparisons.md:49
+msgid "`Ord` is a total ordering, with `cmp` returning `Ordering`."
+msgstr ""
+
+#: src/std-traits/comparisons.md:54
+msgid ""
+"`PartialEq` can be implemented between different types, but `Eq` cannot, "
+"because it is reflexive:"
+msgstr ""
+
+#: src/std-traits/comparisons.md:69
+msgid ""
+"In practice, it's common to derive these traits, but uncommon to implement "
+"them."
+msgstr ""
+
+#: src/std-traits/operators.md:3
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
+msgstr ""
+
+#: src/std-traits/operators.md:23
+msgid "\"{:?} + {:?} = {:?}\""
+msgstr ""
+
+#: src/std-traits/operators.md:30 src/memory-management/drop.md:48
+msgid "Discussion points:"
+msgstr ""
+
+#: src/std-traits/operators.md:32
+msgid ""
+"You could implement `Add` for `&Point`. In which situations is that useful?"
+msgstr ""
+
+#: src/std-traits/operators.md:33
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+
+#: src/std-traits/operators.md:36
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr ""
+
+#: src/std-traits/operators.md:38
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementer of a "
+"trait."
+msgstr ""
+
+#: src/std-traits/operators.md:41
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
+msgstr ""
+
+#: src/std-traits/from-and-into.md:3
+msgid ""
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
+msgstr ""
+
+#: src/std-traits/from-and-into.md:11 src/std-traits/from-and-into.md:23
+msgid "\"{s}, {addr}, {one}, {bigger}\""
+msgstr ""
+
+#: src/std-traits/from-and-into.md:15
+msgid ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
+msgstr ""
+
+#: src/std-traits/from-and-into.md:30
+msgid ""
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
+msgstr ""
+
+#: src/std-traits/from-and-into.md:32
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
+msgstr ""
+
+#: src/std-traits/casting.md:3
+msgid ""
+"Rust has no _implicit_ type conversions, but does support explicit casts "
+"with `as`. These generally follow C semantics where those are defined."
+msgstr ""
+
+#: src/std-traits/casting.md:9
+msgid "\"as u16: {}\""
+msgstr ""
+
+#: src/std-traits/casting.md:10
+msgid "\"as i16: {}\""
+msgstr ""
+
+#: src/std-traits/casting.md:11
+msgid "\"as u8: {}\""
+msgstr ""
+
+#: src/std-traits/casting.md:15
+msgid ""
+"The results of `as` are _always_ defined in Rust and consistent across "
+"platforms. This might not match your intuition for changing sign or casting "
+"to a smaller type -- check the docs, and comment for clarity."
+msgstr ""
+
+#: src/std-traits/casting.md:19
+msgid ""
+"Casting with `as` is a relatively sharp tool that is easy to use "
+"incorrectly, and can be a source of subtle bugs as future maintenance work "
+"changes the types that are used or the ranges of values in types. Casts are "
+"best used only when the intent is to indicate unconditional truncation (e.g. "
+"selecting the bottom 32 bits of a `u64` with `as u32`, regardless of what "
+"was in the high bits)."
+msgstr ""
+
+#: src/std-traits/casting.md:25
+msgid ""
+"For infallible casts (e.g. `u32` to `u64`), prefer using `From` or `Into` "
+"over `as` to confirm that the cast is in fact infallible. For fallible "
+"casts, `TryFrom` and `TryInto` are available when you want to handle casts "
+"that fit differently from those that don't."
+msgstr ""
+
+#: src/std-traits/casting.md:33
+msgid "Consider taking a break after this slide."
+msgstr ""
+
+#: src/std-traits/casting.md:35
+msgid ""
+"`as` is similar to a C++ static cast. Use of `as` in cases where data might "
+"be lost is generally discouraged, or at least deserves an explanatory "
+"comment."
+msgstr ""
+
+#: src/std-traits/casting.md:38
+msgid "This is common in casting integers to `usize` for use as an index."
+msgstr ""
+
+#: src/std-traits/read-and-write.md:3
+msgid ""
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr ""
+
+#: src/std-traits/read-and-write.md:14
+msgid "b\"foo\\nbar\\nbaz\\n\""
+msgstr ""
+
+#: src/std-traits/read-and-write.md:15
+msgid "\"lines in slice: {}\""
+msgstr ""
+
+#: src/std-traits/read-and-write.md:18
+msgid "\"lines in file: {}\""
+msgstr ""
+
+#: src/std-traits/read-and-write.md:23
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
+msgstr ""
+
+#: src/std-traits/read-and-write.md:30
+msgid "\"\\n\""
+msgstr ""
+
+#: src/std-traits/read-and-write.md:36 src/slices-and-lifetimes/str.md:12
+msgid "\"World\""
+msgstr ""
+
+#: src/std-traits/read-and-write.md:37
+msgid "\"Logged: {:?}\""
+msgstr ""
+
+#: src/std-traits/default.md:1
+msgid "The `Default` Trait"
+msgstr ""
+
+#: src/std-traits/default.md:3
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
+msgstr ""
+
+#: src/std-traits/default.md:18
+msgid "\"John Smith\""
+msgstr ""
+
+#: src/std-traits/default.md:24
+msgid "\"{default_struct:#?}\""
+msgstr ""
+
+#: src/std-traits/default.md:27
+msgid "\"Y is set!\""
+msgstr ""
+
+#: src/std-traits/default.md:28
+msgid "\"{almost_default_struct:#?}\""
+msgstr ""
+
+#: src/std-traits/default.md:31 src/slices-and-lifetimes/exercise.md:211
+#: src/slices-and-lifetimes/solution.md:214
+msgid "\"{:#?}\""
+msgstr ""
+
+#: src/std-traits/default.md:38
+msgid ""
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr ""
+
+#: src/std-traits/default.md:39
+msgid ""
+"A derived implementation will produce a value where all fields are set to "
+"their default values."
+msgstr ""
+
+#: src/std-traits/default.md:41
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+
+#: src/std-traits/default.md:42
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+
+#: src/std-traits/default.md:44
+msgid "The partial struct initialization works nicely with default."
+msgstr ""
+
+#: src/std-traits/default.md:45
+msgid ""
+"The Rust standard library is aware that types can implement `Default` and "
+"provides convenience methods that use it."
+msgstr ""
+
+#: src/std-traits/default.md:47
+msgid ""
+"The `..` syntax is called [struct update syntax](https://doc.rust-lang.org/"
+"book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
+"with-struct-update-syntax)."
+msgstr ""
+
+#: src/std-traits/closures.md:3
+msgid ""
+"Closures or lambda expressions have types which cannot be named. However, "
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
+"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
+msgstr ""
+
+#: src/std-traits/closures.md:10
+msgid "\"Calling function on {input}\""
+msgstr ""
+
+#: src/std-traits/closures.md:16 src/std-traits/closures.md:17
+msgid "\"add_3: {}\""
+msgstr ""
+
+#: src/std-traits/closures.md:24 src/std-traits/closures.md:25
+msgid "\"accumulate: {}\""
+msgstr ""
+
+#: src/std-traits/closures.md:28
+msgid "\"multiply_sum: {}\""
+msgstr ""
+
+#: src/std-traits/closures.md:35
+msgid ""
+"An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
+"perhaps captures nothing at all. It can be called multiple times "
+"concurrently."
+msgstr ""
+
+#: src/std-traits/closures.md:38
+msgid ""
+"An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
+"multiple times, but not concurrently."
+msgstr ""
+
+#: src/std-traits/closures.md:41
+msgid ""
+"If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
+"might consume captured values."
+msgstr ""
+
+#: src/std-traits/closures.md:44
+msgid ""
+"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
+msgstr ""
+
+#: src/std-traits/closures.md:48
+msgid ""
+"When you define a function that takes a closure, you should take `FnOnce` if "
+"you can (i.e. you call it once), or `FnMut` else, and last `Fn`. This allows "
+"the most flexibility for the caller."
+msgstr ""
+
+#: src/std-traits/closures.md:52
+msgid ""
+"In contrast, when you have a closure, the most flexible you can have is `Fn` "
+"(it can be passed everywhere), then `FnMut`, and lastly `FnOnce`."
+msgstr ""
+
+#: src/std-traits/closures.md:55
+msgid ""
+"The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
+"`multiply_sum`), depending on what the closure captures."
+msgstr ""
+
+#: src/std-traits/closures.md:58
+msgid ""
+"By default, closures will capture by reference if they can. The `move` "
+"keyword makes them capture by value."
+msgstr ""
+
+#: src/std-traits/closures.md:67
+msgid "\"Hi\""
+msgstr ""
+
+#: src/std-traits/closures.md:68
+msgid "\"there\""
+msgstr ""
+
+#: src/std-traits/exercise.md:3
+msgid ""
+"In this example, you will implement the classic [\"ROT13\" cipher](https://"
+"en.wikipedia.org/wiki/ROT13). Copy this code to the playground, and "
+"implement the missing bits. Only rotate ASCII alphabetic characters, to "
+"ensure the result is still valid UTF-8."
+msgstr ""
+
+#: src/std-traits/exercise.md:15
+msgid "// Implement the `Read` trait for `RotDecoder`.\n"
+msgstr ""
+
+#: src/std-traits/exercise.md:20 src/std-traits/exercise.md:33
+#: src/std-traits/solution.md:26 src/std-traits/solution.md:39
+msgid "\"Gb trg gb gur bgure fvqr!\""
+msgstr ""
+
+#: src/std-traits/exercise.md:36 src/std-traits/solution.md:42
+msgid "\"To get to the other side!\""
+msgstr ""
+
+#: src/std-traits/exercise.md:55
+msgid ""
+"What happens if you chain two `RotDecoder` instances together, each rotating "
+"by 13 characters?"
+msgstr ""
+
+#: src/std-traits/solution.md:16
+msgid "'A'"
+msgstr ""
+
+#: src/welcome-day-3.md:1
+msgid "Welcome to Day 3"
+msgstr ""
+
+#: src/welcome-day-3.md:3
+msgid "Today, we will cover:"
+msgstr ""
+
+#: src/welcome-day-3.md:5
+msgid ""
+"Memory management, lifetimes, and the borrow checker: how Rust ensures "
+"memory safety."
+msgstr ""
+
+#: src/welcome-day-3.md:7
+msgid "Smart pointers: standard library pointer types."
+msgstr ""
+
+#: src/welcome-day-3.md:12
+msgid "[Welcome](./welcome-day-3.md) (3 minutes)"
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "[Memory Management](./memory-management.md) (1 hour and 10 minutes)"
+msgstr ""
+
+#: src/welcome-day-3.md:14
+msgid "[Smart Pointers](./smart-pointers.md) (45 minutes)"
+msgstr ""
+
+#: src/welcome-day-3.md:16
+msgid ""
+"Including 10 minute breaks, this session should take about 2 hours and 15 "
+"minutes"
+msgstr ""
+
+#: src/memory-management.md:4
+msgid "[Review of Program Memory](./memory-management/review.md) (5 minutes)"
+msgstr ""
+
+#: src/memory-management.md:5
+msgid ""
+"[Approaches to Memory Management](./memory-management/approaches.md) (10 "
+"minutes)"
+msgstr ""
+
+#: src/memory-management.md:6
+msgid "[Ownership](./memory-management/ownership.md) (5 minutes)"
+msgstr ""
+
+#: src/memory-management.md:7
+msgid "[Move Semantics](./memory-management/move.md) (10 minutes)"
+msgstr ""
+
+#: src/memory-management.md:8
+msgid "[Clone](./memory-management/clone.md) (2 minutes)"
+msgstr ""
+
+#: src/memory-management.md:9
+msgid "[Copy Types](./memory-management/copy-types.md) (5 minutes)"
+msgstr ""
+
+#: src/memory-management.md:10
+msgid "[Drop](./memory-management/drop.md) (10 minutes)"
+msgstr ""
+
+#: src/memory-management.md:11
+msgid "[Exercise: Builder Type](./memory-management/exercise.md) (20 minutes)"
+msgstr ""
+
+#: src/memory-management/review.md:3
+msgid "Programs allocate memory in two ways:"
+msgstr ""
+
+#: src/memory-management/review.md:5
+msgid "Stack: Continuous area of memory for local variables."
+msgstr ""
+
+#: src/memory-management/review.md:6
+msgid "Values have fixed sizes known at compile time."
+msgstr ""
+
+#: src/memory-management/review.md:7
+msgid "Extremely fast: just move a stack pointer."
+msgstr ""
+
+#: src/memory-management/review.md:8
+msgid "Easy to manage: follows function calls."
+msgstr ""
+
+#: src/memory-management/review.md:9
+msgid "Great memory locality."
+msgstr ""
+
+#: src/memory-management/review.md:11
+msgid "Heap: Storage of values outside of function calls."
+msgstr ""
+
+#: src/memory-management/review.md:12
+msgid "Values have dynamic sizes determined at runtime."
+msgstr ""
+
+#: src/memory-management/review.md:13
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr ""
+
+#: src/memory-management/review.md:14
+msgid "No guarantee of memory locality."
+msgstr ""
+
+#: src/memory-management/review.md:18
+msgid ""
+"Creating a `String` puts fixed-sized metadata on the stack and dynamically "
+"sized data, the actual string, on the heap:"
+msgstr ""
+
+#: src/memory-management/review.md:44
+msgid ""
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
+msgstr ""
+
+#: src/memory-management/review.md:47
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+
+#: src/memory-management/review.md:53
+msgid ""
+"We can inspect the memory layout with `unsafe` Rust. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+
+#: src/memory-management/review.md:59 src/testing/unit-tests.md:15
+msgid "' '"
+msgstr ""
+
+#: src/memory-management/review.md:60
+msgid "\"world\""
+msgstr ""
+
+#: src/memory-management/review.md:61
+msgid ""
+"// DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+msgstr ""
+
+#: src/memory-management/review.md:66
+msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
+msgstr ""
+
+#: src/memory-management/approaches.md:3
+msgid "Traditionally, languages have fallen into two broad categories:"
+msgstr ""
+
+#: src/memory-management/approaches.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr ""
+
+#: src/memory-management/approaches.md:6
+msgid "Programmer decides when to allocate or free heap memory."
+msgstr ""
+
+#: src/memory-management/approaches.md:7
+msgid ""
+"Programmer must determine whether a pointer still points to valid memory."
+msgstr ""
+
+#: src/memory-management/approaches.md:8
+msgid "Studies show, programmers make mistakes."
+msgstr ""
+
+#: src/memory-management/approaches.md:9
+msgid ""
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Haskell, ..."
+msgstr ""
+
+#: src/memory-management/approaches.md:11
+msgid ""
+"A runtime system ensures that memory is not freed until it can no longer be "
+"referenced."
+msgstr ""
+
+#: src/memory-management/approaches.md:13
+msgid ""
+"Typically implemented with reference counting, garbage collection, or RAII."
+msgstr ""
+
+#: src/memory-management/approaches.md:15
+msgid "Rust offers a new mix:"
+msgstr ""
+
+#: src/memory-management/approaches.md:17
+msgid ""
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
+msgstr ""
+
+#: src/memory-management/approaches.md:20
+msgid "It does this with an explicit ownership concept."
+msgstr ""
+
+#: src/memory-management/approaches.md:25
+msgid ""
+"This slide is intended to help students coming from other languages to put "
+"Rust in context."
+msgstr ""
+
+#: src/memory-management/approaches.md:28
+msgid ""
+"C must manage heap manually with `malloc` and `free`. Common errors include "
+"forgetting to call `free`, calling it multiple times for the same pointer, "
+"or dereferencing a pointer after the memory it points to has been freed."
+msgstr ""
+
+#: src/memory-management/approaches.md:32
+msgid ""
+"C++ has tools like smart pointers (`unique_ptr`, `shared_ptr`) that take "
+"advantage of language guarantees about calling destructors to ensure memory "
+"is freed when a function returns. It is still quite easy to mis-use these "
+"tools and create similar bugs to C."
+msgstr ""
+
+#: src/memory-management/approaches.md:37
+msgid ""
+"Java, Go, and Python rely on the garbage collector to identify memory that "
+"is no longer reachable and discard it. This guarantees that any pointer can "
+"be dereferenced, eliminating use-after-free and other classes of bugs. But, "
+"GC has a runtime cost and is difficult to tune properly."
+msgstr ""
+
+#: src/memory-management/approaches.md:42
+msgid ""
+"Rust's ownership and borrowing model can, in many cases, get the performance "
+"of C, with alloc and free operations precisely where they are required -- "
+"zero cost. It also provides tools similar to C++'s smart pointers. When "
+"required, other options such as reference counting are available, and there "
+"are even third-party crates available to support runtime garbage collection "
+"(not covered in this class)."
+msgstr ""
+
+#: src/memory-management/ownership.md:3
+msgid ""
+"All variable bindings have a _scope_ where they are valid and it is an error "
+"to use a variable outside its scope:"
+msgstr ""
+
+#: src/memory-management/ownership.md:20
+msgid ""
+"We say that the variable _owns_ the value. Every Rust value has precisely "
+"one owner at all times."
+msgstr ""
+
+#: src/memory-management/ownership.md:23
+msgid ""
+"At the end of the scope, the variable is _dropped_ and the data is freed. A "
+"destructor can run here to free up resources."
+msgstr ""
+
+#: src/memory-management/ownership.md:29
+msgid ""
+"Students familiar with garbage-collection implementations will know that a "
+"garbage collector starts with a set of \"roots\" to find all reachable "
+"memory. Rust's \"single owner\" principle is a similar idea."
+msgstr ""
+
+#: src/memory-management/move.md:3
+msgid "An assignment will transfer _ownership_ between variables:"
+msgstr ""
+
+#: src/memory-management/move.md:7
+msgid "\"Hello!\""
+msgstr ""
+
+#: src/memory-management/move.md:9 src/slices-and-lifetimes/str.md:16
+#: src/slices-and-lifetimes/str.md:18
+msgid "\"s2: {s2}\""
+msgstr ""
+
+#: src/memory-management/move.md:10
+msgid "// println!(\"s1: {s1}\");\n"
+msgstr ""
+
+#: src/memory-management/move.md:14
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr ""
+
+#: src/memory-management/move.md:15
+msgid "When `s1` goes out of scope, nothing happens: it does not own anything."
+msgstr ""
+
+#: src/memory-management/move.md:16
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr ""
+
+#: src/memory-management/move.md:18
+msgid "Before move to `s2`:"
+msgstr ""
+
+#: src/memory-management/move.md:35
+msgid "After move to `s2`:"
+msgstr ""
+
+#: src/memory-management/move.md:37
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1 \"(inaccessible)\"    :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :  |  :                           :\n"
+":   +-----------+-------+   :  |  :                           :\n"
+":                           :  |  `- - - - - - - - - - - - - -'\n"
+":    s2                     :  |\n"
+":   +-----------+-------+   :  |\n"
+":   | ptr       |   o---+---+--'\n"
+":   | len       |     4 |   :\n"
+":   | capacity  |     4 |   :\n"
+":   +-----------+-------+   :\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/memory-management/move.md:58
+msgid ""
+"When you pass a value to a function, the value is assigned to the function "
+"parameter. This transfers ownership:"
+msgstr ""
+
+#: src/memory-management/move.md:63
+msgid "\"Hello {name}\""
+msgstr ""
+
+#: src/memory-management/move.md:67 src/android/interoperability/java.md:57
+msgid "\"Alice\""
+msgstr ""
+
+#: src/memory-management/move.md:69
+msgid "// say_hello(name);\n"
+msgstr ""
+
+#: src/memory-management/move.md:76
+msgid ""
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
+msgstr ""
+
+#: src/memory-management/move.md:79
+msgid ""
+"It is only the ownership that moves. Whether any machine code is generated "
+"to manipulate the data itself is a matter of optimization, and such copies "
+"are aggressively optimized away."
+msgstr ""
+
+#: src/memory-management/move.md:83
+msgid ""
+"Simple values (such as integers) can be marked `Copy` (see later slides)."
+msgstr ""
+
+#: src/memory-management/move.md:85
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr ""
+
+#: src/memory-management/move.md:87
+msgid "In the `say_hello` example:"
+msgstr ""
+
+#: src/memory-management/move.md:89
+msgid ""
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
+msgstr ""
+
+#: src/memory-management/move.md:91
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+
+#: src/memory-management/move.md:93
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+
+#: src/memory-management/move.md:95
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+
+#: src/memory-management/move.md:97
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+
+#: src/memory-management/move.md:102
+#, fuzzy
+msgid "Defensive Copies in Modern C++"
+msgstr "現代C++の二重解放"
+
+#: src/memory-management/move.md:104
+msgid "Modern C++ solves this differently:"
+msgstr ""
+
+#: src/memory-management/move.md:107
+msgid "\"Cpp\""
+msgstr ""
+
+#: src/memory-management/move.md:108
+msgid "// Duplicate the data in s1.\n"
+msgstr ""
+
+#: src/memory-management/move.md:111
+msgid ""
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+msgstr ""
+
+#: src/memory-management/move.md:112
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+
+#: src/memory-management/move.md:114
+msgid "Before copy-assignment:"
+msgstr ""
+
+#: src/memory-management/move.md:130
+msgid "After copy-assignment:"
+msgstr ""
+
+#: src/memory-management/move.md:155
+msgid ""
+"C++ has made a slightly different choice than Rust. Because `=` copies data, "
+"the string data has to be cloned. Otherwise we would get a double-free when "
+"either string goes out of scope."
+msgstr ""
+
+#: src/memory-management/move.md:159
+msgid ""
+"C++ also has [`std::move`](https://en.cppreference.com/w/cpp/utility/move), "
+"which is used to indicate when a value may be moved from. If the example had "
+"been `s2 = std::move(s1)`, no heap allocation would take place. After the "
+"move, `s1` would be in a valid but unspecified state. Unlike Rust, the "
+"programmer is allowed to keep using `s1`."
+msgstr ""
+
+#: src/memory-management/move.md:164
+msgid ""
+"Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
+"which is being copied or moved."
+msgstr ""
+
+#: src/memory-management/clone.md:1
+msgid "Clone"
+msgstr ""
+
+#: src/memory-management/clone.md:3
+msgid ""
+"Sometimes you _want_ to make a copy of a value. The `Clone` trait "
+"accomplishes this."
+msgstr ""
+
+#: src/memory-management/clone.md:24
+msgid ""
+"The idea of `Clone` is to make it easy to spot where heap allocations are "
+"occurring. Look for `.clone()` and a few others like `Vec::new` or `Box::"
+"new`."
+msgstr ""
+
+#: src/memory-management/clone.md:27
+msgid ""
+"It's common to \"clone your way out\" of problems with the borrow checker, "
+"and return later to try to optimize those clones away."
+msgstr ""
+
+#: src/memory-management/copy-types.md:7
+msgid ""
+"While move semantics are the default, certain types are copied by default:"
+msgstr ""
+
+#: src/memory-management/copy-types.md:20
+msgid "These types implement the `Copy` trait."
+msgstr ""
+
+#: src/memory-management/copy-types.md:22
+msgid "You can opt-in your own types to use copy semantics:"
+msgstr ""
+
+#: src/memory-management/copy-types.md:38
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr ""
+
+#: src/memory-management/copy-types.md:39
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr ""
+
+#: src/memory-management/copy-types.md:44
+msgid "Copying and cloning are not the same thing:"
+msgstr ""
+
+#: src/memory-management/copy-types.md:46
+msgid ""
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
+msgstr ""
+
+#: src/memory-management/copy-types.md:48
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+
+#: src/memory-management/copy-types.md:49
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+
+#: src/memory-management/copy-types.md:51
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr ""
+
+#: src/memory-management/copy-types.md:53
+msgid "In the above example, try the following:"
+msgstr ""
+
+#: src/memory-management/copy-types.md:55
+msgid ""
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
+msgstr ""
+
+#: src/memory-management/copy-types.md:57
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for `p1`."
+msgstr ""
+
+#: src/memory-management/copy-types.md:59
+msgid "Show that it works if you clone `p1` instead."
+msgstr ""
+
+#: src/memory-management/drop.md:1
+msgid "The `Drop` Trait"
+msgstr ""
+
+#: src/memory-management/drop.md:3
+msgid ""
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
+msgstr ""
+
+#: src/memory-management/drop.md:13
+msgid "\"Dropping {}\""
+msgstr ""
+
+#: src/memory-management/drop.md:18
+#: src/exercises/concurrency/link-checker.md:93
+#: src/exercises/concurrency/solutions-morning.md:125
+msgid "\"a\""
+msgstr ""
+
+#: src/memory-management/drop.md:20 src/testing/googletest.md:12
+msgid "\"b\""
+msgstr ""
+
+#: src/memory-management/drop.md:22
+msgid "\"c\""
+msgstr ""
+
+#: src/memory-management/drop.md:23
+msgid "\"d\""
+msgstr ""
+
+#: src/memory-management/drop.md:24
+msgid "\"Exiting block B\""
+msgstr ""
+
+#: src/memory-management/drop.md:26
+msgid "\"Exiting block A\""
+msgstr ""
+
+#: src/memory-management/drop.md:29
+msgid "\"Exiting main\""
+msgstr ""
+
+#: src/memory-management/drop.md:36
+msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
+msgstr ""
+
+#: src/memory-management/drop.md:37
+msgid "Values are automatically dropped when they go out of scope."
+msgstr ""
+
+#: src/memory-management/drop.md:38
+msgid ""
+"When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
+"drop` implementation will be called."
+msgstr ""
+
+#: src/memory-management/drop.md:40
+msgid ""
+"All its fields will then be dropped too, whether or not it implements `Drop`."
+msgstr ""
+
+#: src/memory-management/drop.md:41
+msgid ""
+"`std::mem::drop` is just an empty function that takes any value. The "
+"significance is that it takes ownership of the value, so at the end of its "
+"scope it gets dropped. This makes it a convenient way to explicitly drop "
+"values earlier than they would otherwise go out of scope."
+msgstr ""
+
+#: src/memory-management/drop.md:45
+msgid ""
+"This can be useful for objects that do some work on `drop`: releasing locks, "
+"closing files, etc."
+msgstr ""
+
+#: src/memory-management/drop.md:50
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr ""
+
+#: src/memory-management/drop.md:51
+msgid ""
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
+msgstr ""
+
+#: src/memory-management/drop.md:53
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr ""
+
+#: src/memory-management/exercise.md:3
+msgid ""
+"In this example, we will implement a complex data type that owns all of its "
+"data. We will use the \"builder pattern\" to support building a new value "
+"piece-by-piece, using convenience functions."
+msgstr ""
+
+#: src/memory-management/exercise.md:7
+msgid "Fill in the missing pieces."
+msgstr ""
+
+#: src/memory-management/exercise.md:22 src/memory-management/solution.md:16
+msgid "/// A representation of a software package.\n"
+msgstr ""
+
+#: src/memory-management/exercise.md:34 src/memory-management/solution.md:28
+msgid ""
+"/// Return a representation of this package as a dependency, for use in\n"
+"    /// building other packages.\n"
+msgstr ""
+
+#: src/memory-management/exercise.md:37
+msgid "\"1\""
+msgstr ""
+
+#: src/memory-management/exercise.md:40 src/memory-management/solution.md:37
+msgid ""
+"/// A builder for a Package. Use `build()` to create the `Package` itself.\n"
+msgstr ""
+
+#: src/memory-management/exercise.md:46
+msgid "\"2\""
+msgstr ""
+
+#: src/memory-management/exercise.md:49 src/memory-management/solution.md:52
+msgid "/// Set the package version.\n"
+msgstr ""
+
+#: src/memory-management/exercise.md:55 src/memory-management/solution.md:58
+msgid "/// Set the package authors.\n"
+msgstr ""
+
+#: src/memory-management/exercise.md:57
+msgid "\"3\""
+msgstr ""
+
+#: src/memory-management/exercise.md:60 src/memory-management/solution.md:64
+msgid "/// Add an additional dependency.\n"
+msgstr ""
+
+#: src/memory-management/exercise.md:62
+msgid "\"4\""
+msgstr ""
+
+#: src/memory-management/exercise.md:65 src/memory-management/solution.md:70
+msgid "/// Set the language. If not set, language defaults to None.\n"
+msgstr ""
+
+#: src/memory-management/exercise.md:67
+msgid "\"5\""
+msgstr ""
+
+#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
+msgid "\"base64\""
+msgstr ""
+
+#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
+msgid "\"0.13\""
+msgstr ""
+
+#: src/memory-management/exercise.md:77 src/memory-management/solution.md:83
+msgid "\"base64: {base64:?}\""
+msgstr ""
+
+#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
+msgid "\"log\""
+msgstr ""
+
+#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
+msgid "\"0.4\""
+msgstr ""
+
+#: src/memory-management/exercise.md:80 src/memory-management/solution.md:86
+msgid "\"log: {log:?}\""
+msgstr ""
+
+#: src/memory-management/exercise.md:81 src/memory-management/solution.md:87
+msgid "\"serde\""
+msgstr ""
+
+#: src/memory-management/exercise.md:82 src/memory-management/solution.md:88
+msgid "\"djmitche\""
+msgstr ""
+
+#: src/memory-management/exercise.md:83 src/memory-management/solution.md:89
+msgid "\"4.0\""
+msgstr ""
+
+#: src/memory-management/exercise.md:87 src/memory-management/solution.md:93
+msgid "\"serde: {serde:?}\""
+msgstr ""
+
+#: src/memory-management/solution.md:45
+msgid "\"0.1\""
+msgstr ""
+
+#: src/smart-pointers.md:4
+msgid "[Box"
+msgstr ""
+
+#: src/smart-pointers.md:4
+msgid "](./smart-pointers/box.md) (10 minutes)"
+msgstr ""
+
+#: src/smart-pointers.md:5
+msgid "[Rc](./smart-pointers/rc.md) (5 minutes)"
+msgstr ""
+
+#: src/smart-pointers.md:6
+msgid "[Exercise: Binary Tree](./smart-pointers/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/smart-pointers/box.md:3
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+
+#: src/smart-pointers/box.md:9
+msgid "\"five: {}\""
+msgstr ""
+
+#: src/smart-pointers/box.md:26
+msgid ""
+"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
+msgstr ""
+
+#: src/smart-pointers/box.md:30
+msgid ""
+"Recursive data types or data types with dynamic sizes need to use a `Box`:"
+msgstr ""
+
+#: src/smart-pointers/box.md:35
+msgid "/// A non-empty list: first element and the rest of the list.\n"
+msgstr ""
+
+#: src/smart-pointers/box.md:37
+msgid "/// An empty list.\n"
+msgstr ""
+
+#: src/smart-pointers/box.md:44 src/smart-pointers/box.md:98
+msgid "\"{list:?}\""
+msgstr ""
+
+#: src/smart-pointers/box.md:48
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - - - .     .- - - - - - - - - - - - - - - - - - - - "
+"- - - - -.\n"
+":                            :     :                                                 :\n"
+":    "
+"list                    :     :                                                 :\n"
+":   +---------+----+----+    :     :    +---------+----+----+    +------+----"
+"+----+  :\n"
+":   | Element | 1  | o--+----+-----+--->| Element | 2  | o--+--->| Nil  | // "
+"| // |  :\n"
+":   +---------+----+----+    :     :    +---------+----+----+    +------+----"
+"+----+  :\n"
+":                            :     :                                                 :\n"
+":                            :     :                                                 :\n"
+"'- - - - - - - - - - - - - - '     '- - - - - - - - - - - - - - - - - - - - "
+"- - - - -'\n"
+"```"
+msgstr ""
+
+#: src/smart-pointers/box.md:64
+msgid ""
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null."
+msgstr ""
+
+#: src/smart-pointers/box.md:66
+msgid "A `Box` can be useful when you:"
+msgstr ""
+
+#: src/smart-pointers/box.md:67
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+
+#: src/smart-pointers/box.md:69
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr ""
+
+#: src/smart-pointers/box.md:73
+msgid ""
+"If `Box` was not used and we attempted to embed a `List` directly into the "
+"`List`, the compiler would not compute a fixed size of the struct in memory "
+"(`List` would be of infinite size)."
+msgstr ""
+
+#: src/smart-pointers/box.md:77
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+
+#: src/smart-pointers/box.md:80
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
+
+#: src/smart-pointers/box.md:86
+msgid "Niche Optimization"
+msgstr "Niche最適化"
+
+#: src/smart-pointers/box.md:102
+msgid ""
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
+"allows the compiler to optimize the memory layout:"
+msgstr ""
+
+#: src/smart-pointers/box.md:105
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - - - .     .- - - - - - - - - - - - - -.\n"
+":                            :     :                           :\n"
+":    list                    :     :                           :\n"
+":   +---------+----+----+    :     :    +---------+----+----+  :\n"
+":   | Element | 1  | o--+----+-----+--->| Element | 2  | // |  :\n"
+":   +---------+----+----+    :     :    +---------+----+----+  :\n"
+":                            :     :                           :\n"
+":                            :     :                           :\n"
+"'- - - - - - - - - - - - - - '     '- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/smart-pointers/rc.md:3
+msgid ""
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
+msgstr ""
+
+#: src/smart-pointers/rc.md:13
+msgid "\"a: {a}\""
+msgstr ""
+
+#: src/smart-pointers/rc.md:14
+msgid "\"b: {b}\""
+msgstr ""
+
+#: src/smart-pointers/rc.md:18
+msgid ""
+"See [`Arc`](../concurrency/shared_state/arc.md) and [`Mutex`](https://doc."
+"rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
+"context."
+msgstr ""
+
+#: src/smart-pointers/rc.md:19
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
+
+#: src/smart-pointers/rc.md:30
+msgid ""
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr ""
+
+#: src/smart-pointers/rc.md:32
+msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
+msgstr ""
+
+#: src/smart-pointers/rc.md:33
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"increases the reference count. Does not make a deep clone and can generally "
+"be ignored when looking for performance issues in code."
+msgstr ""
+
+#: src/smart-pointers/rc.md:36
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+
+#: src/smart-pointers/rc.md:38
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr ""
+
+#: src/smart-pointers/rc.md:39
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
+msgstr ""
+
+#: src/smart-pointers/exercise.md:3
+msgid ""
+"A binary tree is a tree-type data structure where every node has two "
+"children (left and right). We will create a tree where each node stores a "
+"value. For a given node N, all nodes in a N's left subtree contain smaller "
+"values, and all nodes in N's right subtree will contain larger values."
+msgstr ""
+
+#: src/smart-pointers/exercise.md:8
+msgid "Implement the following types, so that the given tests pass."
+msgstr ""
+
+#: src/smart-pointers/exercise.md:10
+msgid ""
+"Extra Credit: implement an iterator over a binary tree that returns the "
+"values in order."
+msgstr ""
+
+#: src/smart-pointers/exercise.md:14 src/smart-pointers/solution.md:5
+msgid "/// A node in the binary tree.\n"
+msgstr ""
+
+#: src/smart-pointers/exercise.md:21 src/smart-pointers/solution.md:13
+msgid "/// A possibly-empty subtree.\n"
+msgstr ""
+
+#: src/smart-pointers/exercise.md:25 src/smart-pointers/solution.md:17
+msgid ""
+"/// A container storing a set of values, using a binary tree.\n"
+"///\n"
+"/// If the same value is added multiple times, it is only stored once.\n"
+msgstr ""
+
+#: src/smart-pointers/exercise.md:33
+msgid "// Implement `new`, `insert`, `len`, and `has`.\n"
+msgstr ""
+
+#: src/smart-pointers/exercise.md:48 src/smart-pointers/solution.md:105
+msgid "// not a unique item\n"
+msgstr ""
+
+#: src/smart-pointers/solution.md:89 src/testing/googletest.md:11
+msgid "\"bar\""
+msgstr ""
+
+#: src/welcome-day-3-afternoon.md:4
+msgid "[Borrowing](./borrowing.md) (1 hour)"
+msgstr ""
+
+#: src/welcome-day-3-afternoon.md:5
+msgid ""
+"[Slices and Lifetimes](./slices-and-lifetimes.md) (1 hour and 10 minutes)"
+msgstr ""
+
+#: src/welcome-day-3-afternoon.md:7
+msgid ""
+"Including 10 minute breaks, this session should take about 2 hours and 20 "
+"minutes"
+msgstr ""
+
+#: src/borrowing.md:4
+msgid "[Borrowing a Value](./borrowing/shared.md) (10 minutes)"
+msgstr ""
+
+#: src/borrowing.md:5
+msgid "[Borrow Checking](./borrowing/borrowck.md) (10 minutes)"
+msgstr ""
+
+#: src/borrowing.md:6
+msgid "[Interior Mutability](./borrowing/interior-mutability.md) (10 minutes)"
+msgstr ""
+
+#: src/borrowing.md:7
+msgid "[Exercise: Health Statistics](./borrowing/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/borrowing/shared.md:3
+msgid ""
+"As we saw before, instead of transferring ownership when calling a function, "
+"you can let a function _borrow_ the value:"
+msgstr ""
+
+#: src/borrowing/shared.md:24
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr ""
+
+#: src/borrowing/shared.md:25
+msgid "The caller retains ownership of the inputs."
+msgstr ""
+
+#: src/borrowing/shared.md:30
+msgid ""
+"This slide is a review of the material on references from day 1, expanding "
+"slightly to include function arguments and return values."
+msgstr ""
+
+#: src/borrowing/shared.md:35
+msgid "Notes on stack returns:"
+msgstr ""
+
+#: src/borrowing/shared.md:37
+msgid ""
+"Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground](https://play.rust-lang.org/?"
+"version=stable&mode=release&edition=2021&gist=0cb13be1c05d7e3446686ad9947c4671) "
+"or look at the assembly in [Godbolt](https://rust.godbolt.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
+msgstr ""
+
+#: src/borrowing/shared.md:63
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr ""
+
+#: src/borrowing/shared.md:64
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
+"copy."
+msgstr ""
+
+#: src/borrowing/borrowck.md:3
+msgid ""
+"Rust's _borrow checker_ puts constraints on the ways you can borrow values. "
+"For a given value, at any time:"
+msgstr ""
+
+#: src/borrowing/borrowck.md:6
+msgid "You can have one or more shared references to the value, _or_"
+msgstr ""
+
+#: src/borrowing/borrowck.md:7
+msgid "You can have exactly one exclusive reference to the value."
+msgstr ""
+
+#: src/borrowing/borrowck.md:29
+msgid ""
+"Note that the requirement is that conflicting references not _exist_ at the "
+"same point. It does not matter where the reference is dereferenced."
+msgstr ""
+
+#: src/borrowing/borrowck.md:31
+msgid ""
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+
+#: src/borrowing/borrowck.md:33
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+
+#: src/borrowing/borrowck.md:35
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
+msgstr ""
+
+#: src/borrowing/borrowck.md:38
+msgid ""
+"The exclusive reference constraint is quite strong. Rust uses it to ensure "
+"that data races do not occur. Rust also _relies_ on this constraint to "
+"optimize code. For example, a value behind a shared reference can be safely "
+"cached in a register for the lifetime of that reference."
+msgstr ""
+
+#: src/borrowing/borrowck.md:42
+msgid ""
+"The borrow checker is designed to accommodate many common patterns, such as "
+"taking exclusive references to different fields in a struct at the same "
+"time. But, there are some situations where it doesn't quite \"get it\" and "
+"this often results in \"fighting with the borrow checker.\""
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:7
+msgid ""
+"Rust provides a few safe means of modifying a value given only a shared "
+"reference to that value. All of these replace compile-time checks with "
+"runtime checks."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:11
+msgid "`Cell` and `RefCell`"
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:13
+msgid ""
+"[`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) and [`RefCell`]"
+"(https://doc.rust-lang.org/std/cell/struct.RefCell.html) implement what Rust "
+"calls _interior mutability:_ mutation of values in an immutable context."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:18
+msgid ""
+"`Cell` is typically used for simple types, as it requires copying or moving "
+"values. More complex interior types typically use `RefCell`, which tracks "
+"shared and exclusive references at runtime and panics if they are misused."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:50
+msgid "\"graph: {root:#?}\""
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:51
+msgid "\"graph sum: {}\""
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:58
+msgid ""
+"If we were using `Cell` instead of `RefCell` in this example, we would have "
+"to move the `Node` out of the `Rc` to push children, then move it back in. "
+"This is safe because there's always one, un-referenced value in the cell, "
+"but it's not ergonomic."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:62
+msgid ""
+"To do anything with a Node, you must call a `RefCell` method, usually "
+"`borrow` or `borrow_mut`."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:64
+msgid ""
+"Demonstrate that reference loops can be created by adding `root` to `subtree."
+"children` (don't try to print it!)."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:66
+msgid ""
+"To demonstrate a runtime panic, add a `fn inc(&mut self)` that increments "
+"`self.value` and calls the same method on its children. This will panic in "
+"the presence of the reference loop, with `thread 'main' panicked at 'already "
+"borrowed: BorrowMutError'`."
+msgstr ""
+
+#: src/borrowing/exercise.md:3
+msgid ""
+"You're working on implementing a health-monitoring system. As part of that, "
+"you need to keep track of users' health statistics."
+msgstr ""
+
+#: src/borrowing/exercise.md:6
+msgid ""
+"You'll start with a stubbed function in an `impl` block as well as a `User` "
+"struct definition. Your goal is to implement the stubbed out method on the "
+"`User` `struct` defined in the `impl` block."
+msgstr ""
+
+#: src/borrowing/exercise.md:10
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
+"method:"
+msgstr ""
+
+#: src/borrowing/exercise.md:51
+msgid ""
+"\"Update a user's statistics based on measurements from a visit to the doctor"
+"\""
+msgstr ""
+
+#: src/borrowing/exercise.md:56 src/borrowing/exercise.md:62
+#: src/borrowing/exercise.md:68 src/borrowing/solution.md:58
+#: src/borrowing/solution.md:64 src/borrowing/solution.md:70
+#: src/android/build-rules/library.md:44 src/android/aidl/client.md:22
+msgid "\"Bob\""
+msgstr ""
+
+#: src/borrowing/exercise.md:57 src/borrowing/solution.md:59
+msgid "\"I'm {} and my age is {}\""
+msgstr ""
+
+#: src/slices-and-lifetimes.md:4
+msgid "[Slices: &\\[T\\]](./slices-and-lifetimes/slices.md) (10 minutes)"
+msgstr ""
+
+#: src/slices-and-lifetimes.md:5
+msgid "[String References](./slices-and-lifetimes/str.md) (10 minutes)"
+msgstr ""
+
+#: src/slices-and-lifetimes.md:6
+msgid ""
+"[Lifetime Annotations](./slices-and-lifetimes/lifetime-annotations.md) (10 "
+"minutes)"
+msgstr ""
+
+#: src/slices-and-lifetimes.md:7
+msgid ""
+"[Lifetime Elision](./slices-and-lifetimes/lifetime-elision.md) (5 minutes)"
+msgstr ""
+
+#: src/slices-and-lifetimes.md:8
+msgid ""
+"[Struct Lifetimes](./slices-and-lifetimes/struct-lifetimes.md) (5 minutes)"
+msgstr ""
+
+#: src/slices-and-lifetimes.md:9
+msgid ""
+"[Exercise: Protobuf Parsing](./slices-and-lifetimes/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:1
+msgid "Slices"
+msgstr "スライス型"
+
+#: src/slices-and-lifetimes/slices.md:3
+msgid "A slice gives you a view into a larger collection:"
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:18
+msgid "Slices borrow data from the sliced type."
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:19
+msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:24
+msgid ""
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:27
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:31
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:34
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:36
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:40
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice."
+msgstr ""
+
+#: src/slices-and-lifetimes/slices.md:43
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` at "
+"this point in the execution, but you can read the data from both `a` and `s` "
+"safely. It works before you created the slice, and again after the "
+"`println`, when the slice is no longer used."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:7
+msgid ""
+"We can now understand the two string types in Rust: `&str` is almost like "
+"`&[char]`, but with its data stored in a variable-length encoding (UTF-8)."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:13
+msgid "\"s1: {s1}\""
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:15
+msgid "\"Hello \""
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:21
+msgid "\"s3: {s3}\""
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:25
+msgid "Rust terminology:"
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:27
+msgid "`&str` an immutable reference to a string slice."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:28
+msgid "`String` a mutable string buffer."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:33
+msgid ""
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:37
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:40
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()` creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:44
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It accepts the same format specification as `println!()`."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:47
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection. If you select a byte range that is not aligned to character "
+"boundaries, the expression will panic. The `chars` iterator iterates over "
+"characters and is preferred over trying to get character boundaries right."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:52
+msgid ""
+"For C++ programmers: think of `&str` as `std::string_view` from C++, but the "
+"one that always points to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++ (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+
+#: src/slices-and-lifetimes/str.md:57
+msgid "Byte strings literals allow you to create a `&[u8]` value directly:"
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:3
+msgid ""
+"A reference has a _lifetime_, which must not \"outlive\" the value it refers "
+"to. This is verified by the borrow checker."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:6
+msgid ""
+"The lifetime can be implicit - this is what we have seen so far. Lifetimes "
+"can also be explicit: `&'a Point`, `&'document str`. Lifetimes start with "
+"`'` and `'a` is a typical default name. Read `&'a Point` as \"a borrowed "
+"`Point` which is valid for at least the lifetime `a`\"."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:11
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself. Explicit lifetime annotations create constraints where there is "
+"ambiguity; the compiler verifies that there is a valid solution."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:15
+msgid ""
+"Lifetimes become more complicated when considering passing values to and "
+"returning values from functions."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:36
+msgid "// What is the lifetime of p3?\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:37
+msgid "\"p3: {p3:?}\""
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:44
+msgid ""
+"In this example, the the compiler does not know what lifetime to infer for "
+"`p3`. Looking inside the function body shows that it can only safely assume "
+"that `p3`'s lifetime is the shorter of `p1` and `p2`. But just like types, "
+"Rust requires explicit annotations of lifetimes on function arguments and "
+"return values."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:50
+msgid "Add `'a` appropriately to `left_most`:"
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:56
+msgid ""
+"This says, \"given p1 and p2 which both outlive `'a`, the return value lives "
+"for at least `'a`."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-annotations.md:59
+msgid ""
+"In common cases, lifetimes can be elided, as described on the next slide."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:1
+msgid "Lifetimes in Function Calls"
+msgstr "関数とライフタイム"
+
+#: src/slices-and-lifetimes/lifetime-elision.md:3
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows lifetimes to be elided in most cases with [a few simple "
+"rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html). This is not "
+"inference -- it is just a syntactic shorthand."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:8
+msgid "Each argument which does not have a lifetime annotation is given one."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:9
+msgid ""
+"If there is only one argument lifetime, it is given to all un-annotated "
+"return values."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:11
+msgid ""
+"If there are multiple argument lifetimes, but the first one is for `self`, "
+"that lifetime is given to all un-annotated return values."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:53
+msgid "In this example, `cab_distance` is trivially elided."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:55
+msgid ""
+"The `nearest` function provides another example of a function with multiple "
+"references in its arguments that requires explicit annotation."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:58
+msgid "Try adjusting the signature to \"lie\" about the lifetimes returned:"
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:64
+msgid ""
+"This won't compile, demonstrating that the annotations are checked for "
+"validity by the compiler. Note that this is not the case for raw pointers "
+"(unsafe), and this is a common source of errors with unsafe Rust."
+msgstr ""
+
+#: src/slices-and-lifetimes/lifetime-elision.md:68
+msgid ""
+"Students may ask when to use lifetimes. Rust borrows _always_ have "
+"lifetimes. Most of the time, elision and type inference mean these don't "
+"need to be written out. In more complicated cases, lifetime annotations can "
+"help resolve ambiguity. Often, especially when prototyping, it's easier to "
+"just work with owned data by cloning values where necessary."
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:1
+msgid "Lifetimes in Data Structures"
+msgstr "データ構造とライフタイム"
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:3
+msgid ""
+"If a data type stores borrowed data, it must be annotated with a lifetime:"
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:10
+msgid "\"Bye {text}!\""
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:14
+msgid "\"The quick brown fox jumps over the lazy dog.\""
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:17
+msgid "// erase(text);\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:18
+msgid "\"{fox:?}\""
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:19
+msgid "\"{dog:?}\""
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:26
+msgid ""
+"In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data."
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:29
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:31
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:34
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+
+#: src/slices-and-lifetimes/struct-lifetimes.md:35
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:3
+msgid ""
+"In this exercise, you will build a parser for the [protobuf binary encoding]"
+"(https://protobuf.dev/programming-guides/encoding/). Don't worry, it's "
+"simpler than it seems! This illustrates a common parsing pattern, passing "
+"slices of data. The underlying data itself is never copied."
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:8
+msgid ""
+"Fully parsing a protobuf message requires knowing the types of the fields, "
+"indexed by their field numbers. That is typically provided in a `proto` "
+"file. In this exercise, we'll encode that information into `match` "
+"statements in functions that get called for each field."
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:13
+msgid "We'll use the following proto:"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:28
+msgid ""
+"A proto message is encoded as a series of fields, one after the next. Each "
+"is implemented as a \"tag\" followed by the value. The tag contains a field "
+"number (e.g., `2` for the `id` field of a `Person` message) and a wire type "
+"defining how the payload should be determined from the byte stream."
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:33
+msgid ""
+"Integers, including the tag, are represented with a variable-length encoding "
+"called VARINT. Luckily, `parse_varint` is defined for you below. The given "
+"code also defines callbacks to handle `Person` and `PhoneNumber` fields, and "
+"to parse a message into a series of calls to those callbacks."
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:38
+msgid ""
+"What remains for you is to implement the `parse_field` function and the "
+"`ProtoMessage` trait for `Person` and `PhoneNumber`."
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:49
+#: src/slices-and-lifetimes/solution.md:11
+msgid "\"Invalid varint\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:51
+#: src/slices-and-lifetimes/solution.md:13
+msgid "\"Invalid wire-type\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:53
+#: src/slices-and-lifetimes/solution.md:15
+msgid "\"Unexpected EOF\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:55
+#: src/slices-and-lifetimes/solution.md:17
+msgid "\"Invalid length\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:57
+#: src/slices-and-lifetimes/solution.md:19
+msgid "\"Unexpected wire-type)\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:59
+#: src/slices-and-lifetimes/solution.md:21
+msgid "\"Invalid string (not UTF-8)\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:62
+#: src/slices-and-lifetimes/solution.md:24
+msgid "/// A wire type as seen on the wire.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:65
+#: src/slices-and-lifetimes/solution.md:27
+msgid "/// The Varint WireType indicates the value is a single VARINT.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:67
+#: src/slices-and-lifetimes/solution.md:29
+msgid ""
+"//I64,  -- not needed for this exercise\n"
+"    /// The Len WireType indicates that the value is a length represented as "
+"a\n"
+"    /// VARINT followed by exactly that number of bytes.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:71
+#: src/slices-and-lifetimes/solution.md:33
+msgid ""
+"/// The I32 WireType indicates that the value is precisely 4 bytes in\n"
+"    /// little-endian order containing a 32-bit signed integer.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:76
+#: src/slices-and-lifetimes/solution.md:38
+msgid "/// A field's value, typed based on the wire type.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:80
+#: src/slices-and-lifetimes/solution.md:42
+msgid "//I64(i64),  -- not needed for this exercise\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:85
+#: src/slices-and-lifetimes/solution.md:47
+msgid "/// A field, containing the field number and its value.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:102
+#: src/slices-and-lifetimes/solution.md:64
+msgid "//1 => WireType::I64,  -- not needed for this exercise\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:132
+#: src/slices-and-lifetimes/solution.md:94
+msgid ""
+"/// Parse a VARINT, returning the parsed value and the remaining bytes.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:140
+#: src/slices-and-lifetimes/solution.md:102
+msgid ""
+"// This is the last byte of the VARINT, so convert it to\n"
+"            // a u64 and return it.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:150
+#: src/slices-and-lifetimes/solution.md:112
+msgid "// More than 7 bytes is invalid.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:153
+#: src/slices-and-lifetimes/solution.md:115
+msgid "/// Convert a tag into a field number and a WireType.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:161
+#: src/slices-and-lifetimes/solution.md:122
+msgid "/// Parse a field, returning the remaining bytes\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:167
+msgid ""
+"\"Based on the wire type, build a Field, consuming as many bytes as "
+"necessary.\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:169
+msgid "\"Return the field, and any un-consumed bytes.\""
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:171
+#: src/slices-and-lifetimes/solution.md:153
+msgid ""
+"/// Parse a message in the given data, calling `T::add_field` for each field "
+"in\n"
+"/// the message.\n"
+"///\n"
+"/// The entire input is consumed.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/exercise.md:198
+msgid "// TODO: Implement ProtoMessage for Person and PhoneNumber.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/solution.md:146
+msgid "// Unwrap error because `value` is definitely 4 bytes long.\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/solution.md:187
+#: src/slices-and-lifetimes/solution.md:198
+msgid "// skip everything else\n"
+msgstr ""
+
+#: src/slices-and-lifetimes/solution.md:225
+#: src/slices-and-lifetimes/solution.md:232
+#: src/slices-and-lifetimes/solution.md:239
+msgid "b\"hello\""
+msgstr ""
+
+#: src/welcome-day-4.md:1
+#, fuzzy
+msgid "Welcome to Day 4"
+msgstr "Day 1へようこそ"
+
+#: src/welcome-day-4.md:3
+msgid ""
+"Today we will cover topics relating to building large-scale software in Rust:"
+msgstr ""
+
+#: src/welcome-day-4.md:5
+msgid "Iterators: a deep dive on the `Iterator` trait."
+msgstr ""
+
+#: src/welcome-day-4.md:6
+msgid "Modules and visibility."
+msgstr ""
+
+#: src/welcome-day-4.md:7
+#, fuzzy
+msgid "Testing."
+msgstr "テスト"
+
+#: src/welcome-day-4.md:8
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-4.md:9
+msgid ""
+"Unsafe Rust: the escape hatch when you can't express yourself in safe Rust."
+msgstr ""
+
+#: src/welcome-day-4.md:14
+msgid "[Welcome](./welcome-day-4.md) (3 minutes)"
+msgstr ""
+
+#: src/welcome-day-4.md:15
+msgid "[Iterators](./iterators.md) (45 minutes)"
+msgstr ""
+
+#: src/welcome-day-4.md:16
+msgid "[Modules](./modules.md) (45 minutes)"
+msgstr ""
+
+#: src/welcome-day-4.md:17
+msgid "[Testing](./testing.md) (1 hour and 5 minutes)"
+msgstr ""
+
+#: src/welcome-day-4.md:19
+msgid ""
+"Including 10 minute breaks, this session should take about 3 hours and 10 "
+"minutes"
+msgstr ""
+
+#: src/iterators.md:4
+msgid "[Iterator](./iterators/iterator.md) (5 minutes)"
+msgstr ""
+
+#: src/iterators.md:5
+msgid "[IntoIterator](./iterators/intoiterator.md) (5 minutes)"
+msgstr ""
+
+#: src/iterators.md:6
+msgid "[FromIterator](./iterators/fromiterator.md) (5 minutes)"
+msgstr ""
+
+#: src/iterators.md:7
+msgid ""
+"[Exercise: Iterator Method Chaining](./iterators/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/iterators/iterator.md:7
+msgid ""
+"The [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
+"trait supports iterating over values in a collection. It requires a `next` "
+"method and provides lots of methods. Many standard library types implement "
+"`Iterator`, and you can implement it yourself, too:"
+msgstr ""
+
+#: src/iterators/iterator.md:31
+msgid "\"fib({i}): {n}\""
+msgstr ""
+
+#: src/iterators/iterator.md:39
+msgid ""
+"The `Iterator` trait implements many common functional programming "
+"operations over collections (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
+msgstr ""
+
+#: src/iterators/iterator.md:44
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
+
+#: src/iterators/intoiterator.md:3
+msgid ""
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
+"iterator. The related trait [`IntoIterator`](https://doc.rust-lang.org/std/"
+"iter/trait.IntoIterator.html) defines how to create an iterator for a type. "
+"It is used automatically by the `for` loop."
+msgstr ""
+
+#: src/iterators/intoiterator.md:49
+msgid "\"point = {x}, {y}\""
+msgstr ""
+
+#: src/iterators/intoiterator.md:57
+msgid ""
+"Click through to the docs for `IntoIterator`. Every implementation of "
+"`IntoIterator` must declare two types:"
+msgstr ""
+
+#: src/iterators/intoiterator.md:60
+msgid "`Item`: the type to iterate over, such as `i8`,"
+msgstr ""
+
+#: src/iterators/intoiterator.md:61
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr ""
+
+#: src/iterators/intoiterator.md:63
+msgid ""
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
+"`Item` type, which means that it returns `Option<Item>`"
+msgstr ""
+
+#: src/iterators/intoiterator.md:66
+msgid "The example iterates over all combinations of x and y coordinates."
+msgstr ""
+
+#: src/iterators/intoiterator.md:68
+msgid ""
+"Try iterating over the grid twice in `main`. Why does this fail? Note that "
+"`IntoIterator::into_iter` takes ownership of `self`."
+msgstr ""
+
+#: src/iterators/intoiterator.md:71
+msgid ""
+"Fix this issue by implementing `IntoIterator` for `&Grid` and storing a "
+"reference to the `Grid` in `GridIter`."
+msgstr ""
+
+#: src/iterators/intoiterator.md:74
+msgid ""
+"The same problem can occur for standard library types: `for e in "
+"some_vector` will take ownership of `some_vector` and iterate over owned "
+"elements from that vector. Use `for e in &some_vector` instead, to iterate "
+"over references to elements of `some_vector`."
+msgstr ""
+
+#: src/iterators/fromiterator.md:1
+msgid "FromIterator"
+msgstr "FromIterator"
+
+#: src/iterators/fromiterator.md:3
+msgid ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
+msgstr ""
+
+#: src/iterators/fromiterator.md:9
+msgid "\"prime_squares: {prime_squares:?}\""
+msgstr ""
+
+#: src/iterators/fromiterator.md:16
+msgid "`Iterator` implements"
+msgstr ""
+
+#: src/iterators/fromiterator.md:25
+msgid "There are two ways to specify `B` for this method:"
+msgstr ""
+
+#: src/iterators/fromiterator.md:27
+msgid ""
+"With the \"turbofish\": `some_iterator.collect::<COLLECTION_TYPE>()`, as "
+"shown. The `_` shorthand used here lets Rust infer the type of the `Vec` "
+"elements."
+msgstr ""
+
+#: src/iterators/fromiterator.md:29
+msgid ""
+"With type inference: `let prime_squares: Vec<_> = some_iterator.collect()`. "
+"Rewrite the example to use this form."
+msgstr ""
+
+#: src/iterators/fromiterator.md:32
+msgid ""
+"There are basic implementations of `FromIterator` for `Vec`, `HashMap`, etc. "
+"There are also more specialized implementations which let you do cool things "
+"like convert an `Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
+msgstr ""
+
+#: src/iterators/exercise.md:3
+msgid ""
+"In this exercise, you will need to find and use some of the provided methods "
+"in the [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
+"trait to implement a complex calculation."
+msgstr ""
+
+#: src/iterators/exercise.md:6
+msgid ""
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
+"pass. Use an iterator expression and `collect` the result to construct the "
+"return value."
+msgstr ""
+
+#: src/iterators/exercise.md:11 src/iterators/solution.md:4
+msgid ""
+"/// Calculate the differences between elements of `values` offset by "
+"`offset`,\n"
+"/// wrapping around from the end of `values` to the beginning.\n"
+"///\n"
+"/// Element `n` of the result is `values[(n+offset)%len] - values[n]`.\n"
+msgstr ""
+
+#: src/modules.md:4
+msgid "[Modules](./modules/modules.md) (5 minutes)"
+msgstr ""
+
+#: src/modules.md:5
+msgid "[Filesystem Hierarchy](./modules/filesystem.md) (5 minutes)"
+msgstr ""
+
+#: src/modules.md:6
+msgid "[Visibility](./modules/visibility.md) (5 minutes)"
+msgstr ""
+
+#: src/modules.md:7
+msgid "[use, super, self](./modules/paths.md) (10 minutes)"
+msgstr ""
+
+#: src/modules.md:8
+msgid ""
+"[Exercise: Modules for the GUI Library](./modules/exercise.md) (20 minutes)"
+msgstr ""
+
+#: src/modules/modules.md:3
+msgid "We have seen how `impl` blocks let us namespace functions to a type."
+msgstr ""
+
+#: src/modules/modules.md:5
+msgid "Similarly, `mod` lets us namespace types and functions:"
+msgstr ""
+
+#: src/modules/modules.md:10
+msgid "\"In the foo module\""
+msgstr ""
+
+#: src/modules/modules.md:16
+msgid "\"In the bar module\""
+msgstr ""
+
+#: src/modules/modules.md:29
+msgid ""
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
+msgstr ""
+
+#: src/modules/modules.md:31
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules/modules.md:33
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr ""
+
+#: src/modules/filesystem.md:3
+msgid ""
+"Omitting the module content will tell Rust to look for it in another file:"
+msgstr ""
+
+#: src/modules/filesystem.md:9
+msgid ""
+"This tells rust that the `garden` module content is found at `src/garden."
+"rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
+"vegetables.rs`."
+msgstr ""
+
+#: src/modules/filesystem.md:13
+msgid "The `crate` root is in:"
+msgstr ""
+
+#: src/modules/filesystem.md:15
+msgid "`src/lib.rs` (for a library crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:16
+msgid "`src/main.rs` (for a binary crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:18
+msgid ""
+"Modules defined in files can be documented, too, using \"inner doc comments"
+"\". These document the item that contains them -- in this case, a module."
+msgstr ""
+
+#: src/modules/filesystem.md:22
+msgid ""
+"//! This module implements the garden, including a highly performant "
+"germination\n"
+"//! implementation.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:24
+msgid "// Re-export types from this module.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:28
+msgid "/// Sow the given seed packets.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:33
+msgid "/// Harvest the produce in the garden that is ready.\n"
+msgstr ""
+
+#: src/modules/filesystem.md:43
+msgid ""
+"Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
+"`module.rs`, and this is still a working alternative for editions after 2018."
+msgstr ""
+
+#: src/modules/filesystem.md:46
+msgid ""
+"The main reason to introduce `filename.rs` as alternative to `filename/mod."
+"rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid "Deeper nesting can use folders, even if the main module is a file:"
+msgstr ""
+
+#: src/modules/filesystem.md:59
+msgid ""
+"The place rust will look for modules can be changed with a compiler "
+"directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:62
+msgid "\"some/path.rs\""
+msgstr ""
+
+#: src/modules/filesystem.md:66
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
+msgstr ""
+
+#: src/modules/visibility.md:3
+msgid "Modules are a privacy boundary:"
+msgstr ""
+
+#: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr ""
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr ""
+
+#: src/modules/visibility.md:7
+msgid ""
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
+msgstr ""
+
+#: src/modules/visibility.md:13
+msgid "\"outer::private\""
+msgstr ""
+
+#: src/modules/visibility.md:17
+msgid "\"outer::public\""
+msgstr ""
+
+#: src/modules/visibility.md:22
+msgid "\"outer::inner::private\""
+msgstr ""
+
+#: src/modules/visibility.md:26
+msgid "\"outer::inner::public\""
+msgstr ""
+
+#: src/modules/visibility.md:40
+msgid "Use the `pub` keyword to make modules public."
+msgstr ""
+
+#: src/modules/visibility.md:42
+msgid ""
+"Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
+"of public visibility."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid ""
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+msgstr ""
+
+#: src/modules/visibility.md:47
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:48
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:49
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
+msgstr ""
+
+#: src/modules/paths.md:1
+msgid "use, super, self"
+msgstr ""
+
+#: src/modules/paths.md:3
+msgid ""
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "Paths"
+msgstr "パス"
+
+#: src/modules/paths.md:13
+msgid "Paths are resolved as follows:"
+msgstr ""
+
+#: src/modules/paths.md:15
+msgid "As a relative path:"
+msgstr ""
+
+#: src/modules/paths.md:16
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+
+#: src/modules/paths.md:17
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr ""
+
+#: src/modules/paths.md:19
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:20
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:21
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr ""
+
+#: src/modules/paths.md:26
+msgid ""
+"It is common to \"re-export\" symbols at a shorter path. For example, the "
+"top-level `lib.rs` in a crate might have"
+msgstr ""
+
+#: src/modules/paths.md:36
+msgid ""
+"making `DiskStorage` and `NetworkStorage` available to other crates with a "
+"convenient, short path."
+msgstr ""
+
+#: src/modules/paths.md:39
+msgid ""
+"For the most part, only items that appear in a module need to be `use`'d. "
+"However, a trait must be in scope to call any methods on that trait, even if "
+"a type implementing that trait is already in scope. For example, to use the "
+"`read_to_string` method on a type implementing the `Read` trait, you need to "
+"`use std::io::Read`."
+msgstr ""
+
+#: src/modules/paths.md:45
+msgid ""
+"The `use` statement can have a wildcard: `use std::io::*`. This is "
+"discouraged because it is not clear which items are imported, and those "
+"might change over time."
+msgstr ""
+
+#: src/modules/exercise.md:3
+msgid ""
+"In this exercise, you will reorganize the GUI Library exercise from the "
+"\"Methods and Traits\" segment of the course into a collection of modules. "
+"It is typical to put each type or set of closely-related types into its own "
+"module, so each widget type should get its own module."
+msgstr ""
+
+#: src/modules/exercise.md:8
+msgid ""
+"If you no longer have your version, that's fine - refer back to the "
+"[provided solution](../methods-and-traits/solution.html)."
+msgstr ""
+
+#: src/modules/exercise.md:11
+#, fuzzy
+msgid "Cargo Setup"
+msgstr "セットアップ"
+
+#: src/modules/exercise.md:13
+msgid ""
+"The Rust playground only supports one file, so you will need to make a Cargo "
+"project on your local filesystem:"
+msgstr ""
+
+#: src/modules/exercise.md:22
+msgid ""
+"Edit `src/main.rs` to add `mod` statements, and add additional files in the "
+"`src` directory."
+msgstr ""
+
+#: src/modules/exercise.md:28
+msgid ""
+"Encourage students to divide the code in a way that feels natural for them, "
+"and get accustomed to the required `mod`, `use`, and `pub` declarations. "
+"Afterward, discuss what organizations are most idiomatic."
+msgstr ""
+
+#: src/modules/solution.md:30
+msgid "// ---- src/widgets.rs ----\n"
+msgstr ""
+
+#: src/modules/solution.md:56
+msgid "// ---- src/widgets/label.rs ----\n"
+msgstr ""
+
+#: src/modules/solution.md:71
+msgid "// ANCHOR_END: Label-width\n"
+msgstr ""
+
+#: src/modules/solution.md:75
+msgid "// ANCHOR: Label-draw_into\n"
+msgstr ""
+
+#: src/modules/solution.md:77
+msgid "// ANCHOR_END: Label-draw_into\n"
+msgstr ""
+
+#: src/modules/solution.md:84
+msgid "// ---- src/widgets/button.rs ----\n"
+msgstr ""
+
+#: src/modules/solution.md:99
+msgid "// ANCHOR_END: Button-width\n"
+msgstr ""
+
+#: src/modules/solution.md:103
+msgid "// ANCHOR: Button-draw_into\n"
+msgstr ""
+
+#: src/modules/solution.md:105
+msgid "// ANCHOR_END: Button-draw_into\n"
+msgstr ""
+
+#: src/modules/solution.md:120
+msgid "// ---- src/widgets/window.rs ----\n"
+msgstr ""
+
+#: src/modules/solution.md:147
+msgid ""
+"// ANCHOR_END: Window-width\n"
+"        // Add 4 paddings for borders\n"
+msgstr ""
+
+#: src/modules/solution.md:152
+msgid "// ANCHOR: Window-draw_into\n"
+msgstr ""
+
+#: src/modules/solution.md:154
+msgid "// ANCHOR_END: Window-draw_into\n"
+msgstr ""
+
+#: src/modules/solution.md:177
+msgid "// ---- src/main.rs ----\n"
+msgstr ""
+
+#: src/testing.md:4
+msgid "[Test Modules](./testing/unit-tests.md) (5 minutes)"
 msgstr ""
 
 #: src/testing.md:5
-msgid "Unit tests are supported throughout your code."
+msgid "[Other Types of Tests](./testing/other.md) (10 minutes)"
+msgstr ""
+
+#: src/testing.md:6
+msgid "[Useful Crates](./testing/useful-crates.md) (3 minutes)"
 msgstr ""
 
 #: src/testing.md:7
+msgid "[GoogleTest](./testing/googletest.md) (5 minutes)"
+msgstr ""
+
+#: src/testing.md:8
+msgid "[Mocking](./testing/mocking.md) (5 minutes)"
+msgstr ""
+
+#: src/testing.md:9
+msgid "[Compiler Lints and Clippy](./testing/lints.md) (5 minutes)"
+msgstr ""
+
+#: src/testing.md:10
+msgid "[Exercise: Luhn Algorithm](./testing/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/testing/unit-tests.md:1
+msgid "Unit Tests"
+msgstr "ユニットテスト"
+
+#: src/testing/unit-tests.md:3
+msgid "Rust and Cargo come with a simple unit test framework:"
+msgstr ""
+
+#: src/testing/unit-tests.md:5
+msgid "Unit tests are supported throughout your code."
+msgstr ""
+
+#: src/testing/unit-tests.md:7
 msgid "Integration tests are supported via the `tests/` directory."
 msgstr ""
 
-#: src/testing/unit-tests.md:3
-msgid "Mark unit tests with `#[test]`:"
+#: src/testing/unit-tests.md:9
+msgid ""
+"Tests are marked with `#[test]`. Unit tests are often put in a nested "
+"`tests` module, using `#[cfg(test)]` to conditionally compile them only when "
+"building tests."
 msgstr ""
 
-#: src/testing/unit-tests.md:25
+#: src/testing/unit-tests.md:37
 msgid "\"Hello World\""
 msgstr ""
 
-#: src/testing/unit-tests.md:29
-msgid "Use `cargo test` to find and run the unit tests."
-msgstr ""
-
-#: src/testing/test-modules.md:3
-msgid ""
-"Unit tests are often put in a nested module (run tests on the [Playground]"
-"(https://play.rust-lang.org/)):"
-msgstr ""
-
-#: src/testing/test-modules.md:8
-msgid "\"{a} {b}\""
-msgstr ""
-
-#: src/testing/test-modules.md:21
-msgid "\"foo bar\""
-msgstr ""
-
-#: src/testing/test-modules.md:26
+#: src/testing/unit-tests.md:42
 msgid "This lets you unit test private helpers."
 msgstr ""
 
-#: src/testing/test-modules.md:27
+#: src/testing/unit-tests.md:43
 msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
 
-#: src/testing/doc-tests.md:3
+#: src/testing/unit-tests.md:48
+msgid "Run the tests in the playground in order to show their results."
+msgstr ""
+
+#: src/testing/other.md:3
+msgid "Integration Tests"
+msgstr "インテグレーションテスト"
+
+#: src/testing/other.md:5
+msgid "If you want to test your library as a client, use an integration test."
+msgstr ""
+
+#: src/testing/other.md:7
+msgid "Create a `.rs` file under `tests/`:"
+msgstr ""
+
+#: src/testing/other.md:10
+msgid "// tests/my_library.rs\n"
+msgstr ""
+
+#: src/testing/other.md:19
+msgid "These tests only have access to the public API of your crate."
+msgstr ""
+
+#: src/testing/other.md:21
+msgid "Documentation Tests"
+msgstr "ドキュメンテーションテスト"
+
+#: src/testing/other.md:23
 msgid "Rust has built-in support for documentation tests:"
 msgstr ""
 
-#: src/testing/doc-tests.md:6
+#: src/testing/other.md:26
 msgid ""
 "/// Shortens a string to the given length.\n"
 "///\n"
@@ -8973,40 +9569,24 @@ msgid ""
 "/// ```\n"
 msgstr ""
 
-#: src/testing/doc-tests.md:18
+#: src/testing/other.md:38
 msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
 
-#: src/testing/doc-tests.md:19
+#: src/testing/other.md:39
 msgid "The code will be compiled and executed as part of `cargo test`."
 msgstr ""
 
-#: src/testing/doc-tests.md:20
+#: src/testing/other.md:40
 msgid ""
-"Adding `# ` in the code will hide it from the docs, but will still compile/"
+"Adding `#` in the code will hide it from the docs, but will still compile/"
 "run it."
 msgstr ""
 
-#: src/testing/doc-tests.md:21
+#: src/testing/other.md:42
 msgid ""
 "Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
-msgstr ""
-
-#: src/testing/integration-tests.md:3
-msgid "If you want to test your library as a client, use an integration test."
-msgstr ""
-
-#: src/testing/integration-tests.md:5
-msgid "Create a `.rs` file under `tests/`:"
-msgstr ""
-
-#: src/testing/integration-tests.md:16
-msgid "These tests only have access to the public API of your crate."
-msgstr ""
-
-#: src/testing/useful-crates.md:1
-msgid "Useful crates for writing tests"
 msgstr ""
 
 #: src/testing/useful-crates.md:3
@@ -9023,86 +9603,866 @@ msgid ""
 "library in the tradition of GoogleTest for C++."
 msgstr ""
 
-#: src/testing/useful-crates.md:8
+#: src/testing/useful-crates.md:9
 msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
 msgstr ""
 
-#: src/testing/useful-crates.md:9
+#: src/testing/useful-crates.md:10
 msgid ""
 "[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
 "tests."
 msgstr ""
 
-#: src/unsafe.md:3
+#: src/testing/googletest.md:3
+msgid ""
+"The [GoogleTest](https://docs.rs/googletest/) crate allows for flexible test "
+"assertions using _matchers_:"
+msgstr ""
+
+#: src/testing/googletest.md:11
+msgid "\"baz\""
+msgstr ""
+
+#: src/testing/googletest.md:12
+msgid "\"xyz\""
+msgstr ""
+
+#: src/testing/googletest.md:16
+msgid ""
+"If we change the last element to `\"!\"`, the test fails with a structured "
+"error message pin-pointing the error:"
+msgstr ""
+
+#: src/testing/googletest.md:37
+msgid ""
+"GoogleTest is not part of the Rust Playground, so you need to run this "
+"example in a local environment. Use `cargo add googletest` to quickly add it "
+"to an existing Cargo project."
+msgstr ""
+
+#: src/testing/googletest.md:41
+msgid ""
+"The `use googletest::prelude::*;` line imports a number of [commonly used "
+"macros and types](https://docs.rs/googletest/latest/googletest/prelude/index."
+"html)."
+msgstr ""
+
+#: src/testing/googletest.md:44
+msgid "This just scratches the surface, there are many builtin matchers."
+msgstr ""
+
+#: src/testing/googletest.md:46
+msgid ""
+"A particularly nice feature is that mismatches in multi-line strings strings "
+"are shown as a diff:"
+msgstr ""
+
+#: src/testing/googletest.md:52
+msgid ""
+"\"Memory safety found,\\n\\\n"
+"                 Rust's strong typing guides the way,\\n\\\n"
+"                 Secure code you'll write.\""
+msgstr ""
+
+#: src/testing/googletest.md:57
+msgid ""
+"\"Memory safety found,\\n\\\n"
+"            Rust's silly humor guides the way,\\n\\\n"
+"            Secure code you'll write.\""
+msgstr ""
+
+#: src/testing/googletest.md:64
+msgid "shows a color-coded diff (colors not shown here):"
+msgstr ""
+
+#: src/testing/googletest.md:81
+msgid ""
+"The crate is a Rust port of [GoogleTest for C++](https://google.github.io/"
+"googletest/)."
+msgstr ""
+
+#: src/testing/googletest.md:86
+msgid "GoogleTest is available for use in AOSP."
+msgstr ""
+
+#: src/testing/mocking.md:3
+msgid ""
+"For mocking, [Mockall](https://docs.rs/mockall/) is a widely used library. "
+"You need to refactor your code to use traits, which you can then quickly "
+"mock:"
+msgstr ""
+
+#: src/testing/mocking.md:27
+msgid ""
+"The advice here is for Android (AOSP) where Mockall is the recommended "
+"mocking library. There are other [mocking libraries available on crates.io]"
+"(https://crates.io/keywords/mock), in particular in the area of mocking HTTP "
+"services. The other mocking libraries work in a similar fashion as Mockall, "
+"meaning that they make it easy to get a mock implementation of a given trait."
+msgstr ""
+
+#: src/testing/mocking.md:34
+msgid ""
+"Note that mocking is somewhat _controversial_: mocks allow you to completely "
+"isolate a test from its dependencies. The immediate result is faster and "
+"more stable test execution. On the other hand, the mocks can be configured "
+"wrongly and return output different from what the real dependencies would do."
+msgstr ""
+
+#: src/testing/mocking.md:39
+msgid ""
+"If at all possible, it is recommended that you use the real dependencies. As "
+"an example, many databases allow you to configure an in-memory backend. This "
+"means that you get the correct behavior in your tests, plus they are fast "
+"and will automatically clean up after themselves."
+msgstr ""
+
+#: src/testing/mocking.md:44
+msgid ""
+"Similarly, many web frameworks allow you to start an in-process server which "
+"binds to a random port on `localhost`. Always prefer this over mocking away "
+"the framework since it helps you test your code in the real environment."
+msgstr ""
+
+#: src/testing/mocking.md:48
+msgid ""
+"Mockall is not part of the Rust Playground, so you need to run this example "
+"in a local environment. Use `cargo add mockall` to quickly add Mockall to an "
+"existing Cargo project."
+msgstr ""
+
+#: src/testing/mocking.md:52
+msgid ""
+"Mockall has a lot more functionality. In particular, you can set up "
+"expectations which depend on the arguments passed. Here we use this to mock "
+"a cat which becomes hungry 3 hours after the last time it was fed:"
+msgstr ""
+
+#: src/testing/mocking.md:70
+msgid ""
+"You can use `.times(n)` to limit the number of times a mock method can be "
+"called to `n` --- the mock will automatically panic when dropped if this "
+"isn't satisfied."
+msgstr ""
+
+#: src/testing/lints.md:3
+msgid ""
+"The Rust compiler produces fantastic error messages, as well as helpful "
+"built-in lints. [Clippy](https://doc.rust-lang.org/clippy/) provides even "
+"more lints, organized into groups that can be enabled per-project."
+msgstr ""
+
+#: src/testing/lints.md:14
+msgid "\"X probably fits in a u16, right? {}\""
+msgstr ""
+
+#: src/testing/lints.md:21
+msgid ""
+"Run the code sample and examine the error message. There are also lints "
+"visible here, but those will not be shown once the code compiles. Switch to "
+"the Playground site to show those lints."
+msgstr ""
+
+#: src/testing/lints.md:25
+msgid ""
+"After resolving the lints, run `clippy` on the playground site to show "
+"clippy warnings. Clippy has extensive documentation of its lints, and adds "
+"new lints (including default-deny lints) all the time."
+msgstr ""
+
+#: src/testing/lints.md:29
+msgid ""
+"Note that errors or warnings with `help: ...` can be fixed with `cargo fix` "
+"or via your editor."
+msgstr ""
+
+#: src/testing/exercise.md:3
+msgid "Luhn Algorithm"
+msgstr "Luhnアルゴリズム"
+
+#: src/testing/exercise.md:5
+msgid ""
+"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
+msgstr ""
+
+#: src/testing/exercise.md:9
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/testing/exercise.md:11
+msgid ""
+"Moving from **right to left**, double every second digit: for the number "
+"`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
+msgstr ""
+
+#: src/testing/exercise.md:14
+msgid ""
+"After doubling a digit, sum the digits if the result is greater than 9. So "
+"doubling `7` becomes `14` which becomes `1 + 4 = 5`."
+msgstr ""
+
+#: src/testing/exercise.md:17
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/testing/exercise.md:19
+msgid "The credit card number is valid if the sum ends with `0`."
+msgstr ""
+
+#: src/testing/exercise.md:21
+msgid ""
+"The provided code provides a buggy implementation of the luhn algorithm, "
+"along with two basic unit tests that confirm that most the algorithm is "
+"implemented correctly."
+msgstr ""
+
+#: src/testing/exercise.md:25
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and write additional "
+"tests to uncover bugs in the provided implementation, fixing any bugs you "
+"find."
+msgstr ""
+
+#: src/testing/exercise.md:57 src/testing/solution.md:69
+msgid "\"4263 9826 4026 9299\""
+msgstr ""
+
+#: src/testing/exercise.md:58 src/testing/solution.md:70
+msgid "\"4539 3195 0343 6467\""
+msgstr ""
+
+#: src/testing/exercise.md:59 src/testing/solution.md:71
+msgid "\"7992 7398 713\""
+msgstr ""
+
+#: src/testing/exercise.md:64 src/testing/solution.md:76
+msgid "\"4223 9826 4026 9299\""
+msgstr ""
+
+#: src/testing/exercise.md:65 src/testing/solution.md:77
+msgid "\"4539 3195 0343 6476\""
+msgstr ""
+
+#: src/testing/exercise.md:66 src/testing/solution.md:78
+msgid "\"8273 1232 7352 0569\""
+msgstr ""
+
+#: src/testing/solution.md:4
+msgid "// This is the buggy version that appears in the problem.\n"
+msgstr ""
+
+#: src/testing/solution.md:27
+msgid "// This is the solution and passes all of the tests below.\n"
+msgstr ""
+
+#: src/testing/solution.md:56
+msgid "\"1234 5678 1234 5670\""
+msgstr ""
+
+#: src/testing/solution.md:58
+msgid "\"Is {cc_number} a valid credit card number? {}\""
+msgstr ""
+
+#: src/testing/solution.md:59
+msgid "\"yes\""
+msgstr ""
+
+#: src/testing/solution.md:59
+msgid "\"no\""
+msgstr ""
+
+#: src/testing/solution.md:84
+msgid "\"foo 0 0\""
+msgstr ""
+
+#: src/testing/solution.md:90
+msgid "\" \""
+msgstr ""
+
+#: src/testing/solution.md:91
+msgid "\"  \""
+msgstr ""
+
+#: src/testing/solution.md:92
+msgid "\"    \""
+msgstr ""
+
+#: src/testing/solution.md:97
+msgid "\"0\""
+msgstr ""
+
+#: src/testing/solution.md:102
+msgid "\" 0 0 \""
+msgstr ""
+
+#: src/welcome-day-4-afternoon.md:4
+msgid "[Error Handling](./error-handling.md) (45 minutes)"
+msgstr ""
+
+#: src/welcome-day-4-afternoon.md:5
+msgid "[Unsafe Rust](./unsafe-rust.md) (1 hour and 5 minutes)"
+msgstr ""
+
+#: src/welcome-day-4-afternoon.md:7
+msgid "Including 10 minute breaks, this session should take about 2 hours"
+msgstr ""
+
+#: src/error-handling.md:4
+msgid "[Panics](./error-handling/panics.md) (3 minutes)"
+msgstr ""
+
+#: src/error-handling.md:5
+msgid "[Try Operator](./error-handling/try.md) (5 minutes)"
+msgstr ""
+
+#: src/error-handling.md:6
+msgid "[Try Conversions](./error-handling/try-conversions.md) (5 minutes)"
+msgstr ""
+
+#: src/error-handling.md:7
+msgid "[Error Trait](./error-handling/error.md) (5 minutes)"
+msgstr ""
+
+#: src/error-handling.md:8
+msgid ""
+"[thiserror and anyhow](./error-handling/thiserror-and-anyhow.md) (5 minutes)"
+msgstr ""
+
+#: src/error-handling.md:9
+msgid ""
+"[Exercise: Rewriting with Result](./error-handling/exercise.md) (20 minutes)"
+msgstr ""
+
+#: src/error-handling/panics.md:3
+msgid "Rust handles fatal errors with a \"panic\"."
+msgstr ""
+
+#: src/error-handling/panics.md:5
+msgid "Rust will trigger a panic if a fatal error happens at runtime:"
+msgstr ""
+
+#: src/error-handling/panics.md:10
+msgid "\"v[100]: {}\""
+msgstr ""
+
+#: src/error-handling/panics.md:14
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr ""
+
+#: src/error-handling/panics.md:15
+msgid "Panics are symptoms of bugs in the program."
+msgstr ""
+
+#: src/error-handling/panics.md:16
+msgid "Runtime failures like failed bounds checks can panic"
+msgstr ""
+
+#: src/error-handling/panics.md:17
+msgid "Assertions (such as `assert!`) panic on failure"
+msgstr ""
+
+#: src/error-handling/panics.md:18
+msgid "Purpose-specific panics can use the `panic!` macro."
+msgstr ""
+
+#: src/error-handling/panics.md:19
+msgid ""
+"A panic will \"unwind\" the stack, dropping values just as if the functions "
+"had returned."
+msgstr ""
+
+#: src/error-handling/panics.md:21
+msgid ""
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+msgstr ""
+
+#: src/error-handling/panics.md:26
+msgid ""
+"By default, a panic will cause the stack to unwind. The unwinding can be "
+"caught:"
+msgstr ""
+
+#: src/error-handling/panics.md:32
+msgid "\"No problem here!\""
+msgstr ""
+
+#: src/error-handling/panics.md:33 src/error-handling/panics.md:38
+msgid "\"{result:?}\""
+msgstr ""
+
+#: src/error-handling/panics.md:36
+msgid "\"oh no!\""
+msgstr ""
+
+#: src/error-handling/panics.md:42
+msgid ""
+"Catching is unusual; do not attempt to implement exceptions with "
+"`catch_unwind`!"
+msgstr ""
+
+#: src/error-handling/panics.md:44
+msgid ""
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
+msgstr ""
+
+#: src/error-handling/panics.md:46
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+
+#: src/error-handling/try.md:3
+msgid ""
+"Runtime errors like connection-refused or file-not-found are handled with "
+"the `Result` type, but matching this type on every call can be cumbersome. "
+"The try-operator `?` is used to return errors to the caller. It lets you "
+"turn the common"
+msgstr ""
+
+#: src/error-handling/try.md:15
+msgid "into the much simpler"
+msgstr ""
+
+#: src/error-handling/try.md:21
+msgid "We can use this to simplify our error handling code:"
+msgstr ""
+
+#: src/error-handling/try.md:42
+msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
+msgstr ""
+
+#: src/error-handling/try.md:43 src/error-handling/try-conversions.md:65
+#: src/error-handling/thiserror-and-anyhow.md:33
+msgid "\"config.dat\""
+msgstr ""
+
+#: src/error-handling/try.md:44 src/error-handling/try-conversions.md:66
+msgid "\"username or error: {username:?}\""
+msgstr ""
+
+#: src/error-handling/try.md:51
+msgid "Simplify the `read_username` function to use `?`."
+msgstr ""
+
+#: src/error-handling/try.md:55
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr ""
+
+#: src/error-handling/try.md:56
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
+
+#: src/error-handling/try.md:58
+msgid ""
+"Note that `main` can return a `Result<(), E>` as long as it implements `std::"
+"process:Termination`. In practice, this means that `E` implements `Debug`. "
+"The executable will print the `Err` variant and return a nonzero exit status "
+"on error."
+msgstr ""
+
+#: src/error-handling/try-conversions.md:3
+msgid ""
+"The effective expansion of `?` is a little more complicated than previously "
+"indicated:"
+msgstr ""
+
+#: src/error-handling/try-conversions.md:10
+msgid "works the same as"
+msgstr ""
+
+#: src/error-handling/try-conversions.md:19
+msgid ""
+"The `From::from` call here means we attempt to convert the error type to the "
+"type returned by the function. This makes it easy to encapsulate errors into "
+"higher-level errors."
+msgstr ""
+
+#: src/error-handling/try-conversions.md:42
+msgid "\"IO error: {e}\""
+msgstr ""
+
+#: src/error-handling/try-conversions.md:43
+msgid "\"Found no username in {path}\""
+msgstr ""
+
+#: src/error-handling/try-conversions.md:64
+#: src/error-handling/thiserror-and-anyhow.md:32
+msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
+msgstr ""
+
+#: src/error-handling/try-conversions.md:73
+msgid ""
+"The `?` operator must return a value compatible with the return type of the "
+"function. For `Result`, it means that the error types have to be compatible. "
+"A function that returns `Result<T, ErrorOuter>` can only use `?` on a value "
+"of type `Result<U, ErrorInner>` if `ErrorOuter` and `ErrorInner` are the "
+"same type or if `ErrorOuter` implements `From<ErrorInner>`."
+msgstr ""
+
+#: src/error-handling/try-conversions.md:79
+msgid ""
+"A common alternative to a `From` implementation is `Result::map_err`, "
+"especially when the conversion only happens in one place."
+msgstr ""
+
+#: src/error-handling/try-conversions.md:82
+msgid ""
+"There is no compatibility requirement for `Option`. A function returning "
+"`Option<T>` can use the `?` operator on `Option<U>` for arbitrary `T` and "
+"`U` types."
+msgstr ""
+
+#: src/error-handling/try-conversions.md:86
+msgid ""
+"A function that returns `Result` cannot use `?` on `Option` and vice versa. "
+"However, `Option::ok_or` converts `Option` to `Result` whereas `Result::ok` "
+"turns `Result` into `Option`."
+msgstr ""
+
+#: src/error-handling/error.md:1
+msgid "Dynamic Error Types"
+msgstr "動的なエラー型"
+
+#: src/error-handling/error.md:3
+msgid ""
+"Sometimes we want to allow any type of error to be returned without writing "
+"our own enum covering all the different possibilities. The `std::error::"
+"Error` trait makes it easy to create a trait object that can contain any "
+"error."
+msgstr ""
+
+#: src/error-handling/error.md:20 src/error-handling/error.md:21
+msgid "\"count.dat\""
+msgstr ""
+
+#: src/error-handling/error.md:20
+msgid "\"1i3\""
+msgstr ""
+
+#: src/error-handling/error.md:22
+msgid "\"Count: {count}\""
+msgstr ""
+
+#: src/error-handling/error.md:23
+msgid "\"Error: {err}\""
+msgstr ""
+
+#: src/error-handling/error.md:31
+msgid ""
+"The `read_count` function can return `std::io::Error` (from file operations) "
+"or `std::num::ParseIntError` (from `String::parse`)."
+msgstr ""
+
+#: src/error-handling/error.md:34
+msgid ""
+"Boxing errors saves on code, but gives up the ability to cleanly handle "
+"different error cases differently in the program. As such it's generally not "
+"a good idea to use `Box<dyn Error>` in the public API of a library, but it "
+"can be a good option in a program where you just want to display the error "
+"message somewhere."
+msgstr ""
+
+#: src/error-handling/error.md:40
+msgid ""
+"Make sure to implement the `std::error::Error` trait when defining a custom "
+"error type so it can be boxed. But if you need to support the `no_std` "
+"attribute, keep in mind that the `std::error::Error` trait is currently "
+"compatible with `no_std` in [nightly](https://github.com/rust-lang/rust/"
+"issues/103765) only."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:3
+msgid ""
+"The [`thiserror`](https://docs.rs/thiserror/) and [`anyhow`](https://docs.rs/"
+"anyhow/) crates are widely used to simplify error handling. `thiserror` "
+"helps create custom error types that implement `From<T>`. `anyhow` helps "
+"with error handling in functions, including adding contextual information to "
+"your errors."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:16
+msgid "\"Found no username in {0}\""
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:22
+msgid "\"Failed to open {path}\""
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:24
+msgid "\"Failed to read\""
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:34
+msgid "\"Username: {username}\""
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:35
+msgid "\"Error: {err:?}\""
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:43
+msgid "`thiserror`"
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:45
+msgid ""
+"The `Error` derive macro is provided by `thiserror`, and has lots of useful "
+"attributes to help define error types in a compact way."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:47
+msgid "The `std::error::Error` trait is derived automatically."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:48
+msgid "The message from `#[error]` is used to derive the `Display` trait."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:50
+msgid "`anyhow`"
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:52
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:55
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:56
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:57
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:60
+msgid ""
+"`anyhow::Context` is a trait implemented for the standard `Result` and "
+"`Option` types. `use anyhow::Context` is necessary to enable `.context()` "
+"and `.with_context()` on those types."
+msgstr ""
+
+#: src/error-handling/exercise.md:1
+msgid "Exercise: Rewriting with Result"
+msgstr ""
+
+#: src/error-handling/exercise.md:3
+msgid ""
+"The following implements a very simple parser for an expression language. "
+"However, it handles errors by panicking. Rewrite it to instead use idiomatic "
+"error handling and propagate errors to a return from `main`. Feel free to "
+"use `thiserror` and `anyhow`."
+msgstr ""
+
+#: src/error-handling/exercise.md:8
+msgid ""
+"HINT: start by fixing error handling in the `parse` function. Once that is "
+"working correctly, update `Tokenizer` to implement "
+"`Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser."
+msgstr ""
+
+#: src/error-handling/exercise.md:15 src/error-handling/solution.md:9
+msgid "/// An arithmetic operator.\n"
+msgstr ""
+
+#: src/error-handling/exercise.md:22 src/error-handling/solution.md:16
+#, fuzzy
+msgid "/// A token in the expression language.\n"
+msgstr "// 他の言語と同様の演算\n"
+
+#: src/error-handling/exercise.md:30 src/error-handling/solution.md:24
+msgid "/// An expression in the expression language.\n"
+msgstr ""
+
+#: src/error-handling/exercise.md:34 src/error-handling/solution.md:28
+msgid "/// A reference to a variable.\n"
+msgstr ""
+
+#: src/error-handling/exercise.md:36 src/error-handling/solution.md:30
+msgid "/// A literal number.\n"
+msgstr ""
+
+#: src/error-handling/exercise.md:38 src/error-handling/solution.md:32
+msgid "/// A binary operation.\n"
+msgstr ""
+
+#: src/error-handling/exercise.md:62 src/error-handling/exercise.md:64
+#: src/error-handling/solution.md:62 src/error-handling/solution.md:64
+msgid "'z'"
+msgstr ""
+
+#: src/error-handling/exercise.md:64 src/error-handling/solution.md:64
+msgid "'_'"
+msgstr ""
+
+#: src/error-handling/exercise.md:70 src/error-handling/solution.md:70
+msgid "'+'"
+msgstr ""
+
+#: src/error-handling/exercise.md:71 src/error-handling/solution.md:71
+msgid "'-'"
+msgstr ""
+
+#: src/error-handling/exercise.md:72
+msgid "\"Unexpected character {c}\""
+msgstr ""
+
+#: src/error-handling/exercise.md:82 src/error-handling/solution.md:81
+msgid "\"Unexpected end of input\""
+msgstr ""
+
+#: src/error-handling/exercise.md:86
+msgid "\"Invalid 32-bit integer'\""
+msgstr ""
+
+#: src/error-handling/exercise.md:90 src/error-handling/exercise.md:100
+msgid "\"Unexpected token {tok:?}\""
+msgstr ""
+
+#: src/error-handling/exercise.md:92 src/error-handling/solution.md:104
+msgid "// Look ahead to parse a binary operation if present.\n"
+msgstr ""
+
+#: src/error-handling/exercise.md:108 src/error-handling/solution.md:121
+msgid "\"10+foo+20-30\""
+msgstr ""
+
+#: src/error-handling/exercise.md:109 src/error-handling/solution.md:122
+msgid "\"{expr:?}\""
+msgstr ""
+
+#: src/error-handling/solution.md:42
+msgid "\"Unexpected character '{0}' in input\""
+msgstr ""
+
+#: src/error-handling/solution.md:79
+msgid "\"Tokenizer error: {0}\""
+msgstr ""
+
+#: src/error-handling/solution.md:83
+msgid "\"Unexpected token {0:?}\""
+msgstr ""
+
+#: src/error-handling/solution.md:85
+msgid "\"Invalid number\""
+msgstr ""
+
+#: src/unsafe-rust.md:4
+msgid "[Unsafe](./unsafe-rust/unsafe.md) (5 minutes)"
+msgstr ""
+
+#: src/unsafe-rust.md:5
+msgid ""
+"[Dereferencing Raw Pointers](./unsafe-rust/dereferencing.md) (10 minutes)"
+msgstr ""
+
+#: src/unsafe-rust.md:6
+msgid "[Mutable Static Variables](./unsafe-rust/mutable-static.md) (5 minutes)"
+msgstr ""
+
+#: src/unsafe-rust.md:7
+msgid "[Unions](./unsafe-rust/unions.md) (5 minutes)"
+msgstr ""
+
+#: src/unsafe-rust.md:8
+msgid "[Unsafe Functions](./unsafe-rust/unsafe-functions.md) (5 minutes)"
+msgstr ""
+
+#: src/unsafe-rust.md:9
+msgid "[Unsafe Traits](./unsafe-rust/unsafe-traits.md) (5 minutes)"
+msgstr ""
+
+#: src/unsafe-rust.md:10
+msgid "[Exercise: FFI Wrapper](./unsafe-rust/exercise.md) (30 minutes)"
+msgstr ""
+
+#: src/unsafe-rust/unsafe.md:3
 msgid "The Rust language has two parts:"
 msgstr ""
 
-#: src/unsafe.md:5
+#: src/unsafe-rust/unsafe.md:5
 msgid "**Safe Rust:** memory safe, no undefined behavior possible."
 msgstr ""
 
-#: src/unsafe.md:6
+#: src/unsafe-rust/unsafe.md:6
 msgid ""
 "**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
 
-#: src/unsafe.md:8
+#: src/unsafe-rust/unsafe.md:8
 msgid ""
-"We will be seeing mostly safe Rust in this course, but it's important to "
-"know what Unsafe Rust is."
+"We saw mostly safe Rust in this course, but it's important to know what "
+"Unsafe Rust is."
 msgstr ""
 
-#: src/unsafe.md:11
+#: src/unsafe-rust/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
 "carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 
-#: src/unsafe.md:14
+#: src/unsafe-rust/unsafe.md:14
 msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr ""
 
-#: src/unsafe.md:16
+#: src/unsafe-rust/unsafe.md:16
 msgid "Dereference raw pointers."
 msgstr ""
 
-#: src/unsafe.md:17
+#: src/unsafe-rust/unsafe.md:17
 msgid "Access or modify mutable static variables."
 msgstr ""
 
-#: src/unsafe.md:18
+#: src/unsafe-rust/unsafe.md:18
 msgid "Access `union` fields."
 msgstr ""
 
-#: src/unsafe.md:19
+#: src/unsafe-rust/unsafe.md:19
 msgid "Call `unsafe` functions, including `extern` functions."
 msgstr ""
 
-#: src/unsafe.md:20
+#: src/unsafe-rust/unsafe.md:20
 msgid "Implement `unsafe` traits."
 msgstr ""
 
-#: src/unsafe.md:22
+#: src/unsafe-rust/unsafe.md:22
 msgid ""
 "We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
 "unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 
-#: src/unsafe.md:28
+#: src/unsafe-rust/unsafe.md:29
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have turned off the compiler safety features and have to write correct code "
+"have turned off some compiler safety features and have to write correct code "
 "by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:3
+#: src/unsafe-rust/dereferencing.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:12
+#: src/unsafe-rust/dereferencing.md:7
+msgid "\"careful!\""
+msgstr ""
+
+#: src/unsafe-rust/dereferencing.md:12
 msgid ""
 "// Safe because r1 and r2 were obtained from references and so are\n"
 "    // guaranteed to be non-null and properly aligned, the objects "
@@ -9112,83 +10472,99 @@ msgid ""
 "    // references or concurrently through any other pointers.\n"
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:18
+#: src/unsafe-rust/dereferencing.md:18
 msgid "\"r1 is: {}\""
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:20
+#: src/unsafe-rust/dereferencing.md:19
+msgid "\"uhoh\""
+msgstr ""
+
+#: src/unsafe-rust/dereferencing.md:20
 msgid "\"r2 is: {}\""
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:27
+#: src/unsafe-rust/dereferencing.md:23
+msgid ""
+"// NOT SAFE. DO NOT DO THIS.\n"
+"    /*\n"
+"    let r3: &String = unsafe { &*r1 };\n"
+"    drop(s);\n"
+"    println!(\"r3 is: {}\", *r3);\n"
+"    */"
+msgstr ""
+
+#: src/unsafe-rust/dereferencing.md:35
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
 "a comment for each `unsafe` block explaining how the code inside it "
 "satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:31
+#: src/unsafe-rust/dereferencing.md:39
 msgid ""
 "In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:34
+#: src/unsafe-rust/dereferencing.md:42
 msgid "The pointer must be non-null."
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:35
+#: src/unsafe-rust/dereferencing.md:43
 msgid ""
 "The pointer must be _dereferenceable_ (within the bounds of a single "
 "allocated object)."
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:36
+#: src/unsafe-rust/dereferencing.md:45
 msgid "The object must not have been deallocated."
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:37
+#: src/unsafe-rust/dereferencing.md:46
 msgid "There must not be concurrent accesses to the same location."
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:38
+#: src/unsafe-rust/dereferencing.md:47
 msgid ""
 "If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
 msgstr ""
 
-#: src/unsafe/raw-pointers.md:41
+#: src/unsafe-rust/dereferencing.md:50
 msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:3
+#: src/unsafe-rust/dereferencing.md:52
+msgid ""
+"The \"NOT SAFE\" section gives an example of a common kind of UB bug: `*r1` "
+"has the `'static` lifetime, so `r3` has type `&'static String`, and thus "
+"outlives `s`. Creating a reference from a pointer requires _great care_."
+msgstr ""
+
+#: src/unsafe-rust/mutable-static.md:3
 msgid "It is safe to read an immutable static variable:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:6
+#: src/unsafe-rust/mutable-static.md:6
 msgid "\"Hello, world!\""
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:9
+#: src/unsafe-rust/mutable-static.md:9
 msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:13
+#: src/unsafe-rust/mutable-static.md:13
 msgid ""
 "However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:20
-#: src/unsafe/mutable-static-variables.md:26
-msgid "// Potential data race!\n"
-msgstr ""
-
-#: src/unsafe/mutable-static-variables.md:26
+#: src/unsafe-rust/mutable-static.md:29
 msgid "\"COUNTER: {COUNTER}\""
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:32
+#: src/unsafe-rust/mutable-static.md:37
 msgid ""
 "The program here is safe because it is single-threaded. However, the Rust "
 "compiler is conservative and will assume the worst. Try removing the "
@@ -9196,36 +10572,36 @@ msgid ""
 "mutate a static from multiple threads."
 msgstr ""
 
-#: src/unsafe/mutable-static-variables.md:36
+#: src/unsafe-rust/mutable-static.md:42
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
 msgstr ""
 
-#: src/unsafe/unions.md:3
+#: src/unsafe-rust/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
 
-#: src/unsafe/unions.md:14
+#: src/unsafe-rust/unions.md:14
 msgid "\"int: {}\""
 msgstr ""
 
-#: src/unsafe/unions.md:15
+#: src/unsafe-rust/unions.md:15
 msgid "\"bool: {}\""
 msgstr ""
 
-#: src/unsafe/unions.md:15
+#: src/unsafe-rust/unions.md:15
 msgid "// Undefined behavior!\n"
 msgstr ""
 
-#: src/unsafe/unions.md:21
+#: src/unsafe-rust/unions.md:22
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
 msgstr ""
 
-#: src/unsafe/unions.md:24
+#: src/unsafe-rust/unions.md:25
 msgid ""
 "If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
@@ -9233,47 +10609,83 @@ msgid ""
 "crates/zerocopy) crate."
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:3
+#: src/unsafe-rust/unsafe-functions.md:3 src/unsafe-rust/unsafe-functions.md:75
+msgid "Calling Unsafe Functions"
+msgstr "Unsafe関数の呼び出し"
+
+#: src/unsafe-rust/unsafe-functions.md:5
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:8
+#: src/unsafe-rust/unsafe-functions.md:9 src/unsafe-rust/exercise.md:91
+#: src/unsafe-rust/solution.md:41 src/android/interoperability/with-c.md:9
+#: src/android/interoperability/with-c/rust.md:15
+#: src/android/interoperability/with-c/rust.md:30
+#: src/android/interoperability/cpp/cpp-bridge.md:29
+#: src/android/interoperability/cpp/cpp-bridge.md:38
+#: src/exercises/chromium/build-rules.md:8
+#: src/exercises/chromium/build-rules.md:21
+#: src/bare-metal/aps/inline-assembly.md:19
+#: src/bare-metal/aps/better-uart/using.md:24
+#: src/bare-metal/aps/logging/using.md:23 src/exercises/bare-metal/rtc.md:49
+#: src/exercises/bare-metal/rtc.md:104 src/exercises/bare-metal/rtc.md:110
+#: src/exercises/bare-metal/rtc.md:118 src/exercises/bare-metal/rtc.md:124
+#: src/exercises/bare-metal/rtc.md:130 src/exercises/bare-metal/rtc.md:136
+#: src/exercises/bare-metal/rtc.md:142 src/exercises/bare-metal/rtc.md:148
+#: src/exercises/bare-metal/solutions-afternoon.md:43
+msgid "\"C\""
+msgstr ""
+
+#: src/unsafe-rust/unsafe-functions.md:14
 msgid "\"🗻∈🌏\""
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:10
+#: src/unsafe-rust/unsafe-functions.md:16
 msgid ""
 "// Safe because the indices are in the correct order, within the bounds of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:13
-#: src/unsafe/calling-unsafe-functions.md:14
-#: src/unsafe/calling-unsafe-functions.md:15
+#: src/unsafe-rust/unsafe-functions.md:19
+#: src/unsafe-rust/unsafe-functions.md:20
+#: src/unsafe-rust/unsafe-functions.md:21
 msgid "\"emoji: {}\""
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:18
+#: src/unsafe-rust/unsafe-functions.md:24
 msgid "\"char count: {}\""
 msgstr ""
 
-#: src/unsafe/calling-unsafe-functions.md:20
+#: src/unsafe-rust/unsafe-functions.md:27
+msgid "// Undefined behavior if abs misbehaves.\n"
+msgstr ""
+
+#: src/unsafe-rust/unsafe-functions.md:28
+msgid "\"Absolute value of -3 according to C: {}\""
+msgstr ""
+
+#: src/unsafe-rust/unsafe-functions.md:31
 msgid ""
 "// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe { emojis."
-"get_unchecked(0..3) }));\n"
+"    // println!(\"char count: {}\", count_chars(unsafe {\n"
+"    // emojis.get_unchecked(0..3) }));\n"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:3
+#: src/unsafe-rust/unsafe-functions.md:42
+#: src/unsafe-rust/unsafe-functions.md:87
+msgid "Writing Unsafe Functions"
+msgstr "Unsafe関数の書き方"
+
+#: src/unsafe-rust/unsafe-functions.md:44
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
 "conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:7
+#: src/unsafe-rust/unsafe-functions.md:48
 msgid ""
 "/// Swaps the values pointed to by the given pointers.\n"
 "///\n"
@@ -9282,309 +10694,250 @@ msgid ""
 "/// The pointers must be valid and properly aligned.\n"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:22
+#: src/unsafe-rust/unsafe-functions.md:63
 msgid "// Safe because ...\n"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:27
+#: src/unsafe-rust/unsafe-functions.md:68
 msgid "\"a = {}, b = {}\""
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:33
+#: src/unsafe-rust/unsafe-functions.md:77
 msgid ""
-"We wouldn't actually use pointers for this because it can be done safely "
-"with references."
+"`get_unchecked`, like most `_unchecked` functions, is unsafe, because it can "
+"create UB if the range is incorrect. `abs` is incorrect for a different "
+"reason: it is an external function (FFI). Calling external functions is "
+"usually only a problem when those functions do things with pointers which "
+"might violate Rust's memory model, but in general any C function might have "
+"undefined behaviour under any arbitrary circumstances."
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:35
-msgid ""
-"Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
-"Try adding it and see what happens."
-msgstr ""
-
-#: src/unsafe/extern-functions.md:1
-msgid "Calling External Code"
-msgstr ""
-
-#: src/unsafe/extern-functions.md:3
-msgid ""
-"Functions from other languages might violate the guarantees of Rust. Calling "
-"them is thus unsafe:"
-msgstr ""
-
-#: src/unsafe/extern-functions.md:7 src/exercises/day-3/safe-ffi-wrapper.md:89
-#: src/android/interoperability/with-c.md:9
-#: src/android/interoperability/with-c/rust.md:15
-#: src/android/interoperability/with-c/rust.md:30
-#: src/bare-metal/aps/inline-assembly.md:18
-#: src/bare-metal/aps/better-uart/using.md:24
-#: src/bare-metal/aps/logging/using.md:23 src/exercises/bare-metal/rtc.md:46
-#: src/exercises/bare-metal/rtc.md:100 src/exercises/bare-metal/rtc.md:106
-#: src/exercises/bare-metal/rtc.md:113 src/exercises/bare-metal/rtc.md:119
-#: src/exercises/bare-metal/rtc.md:125 src/exercises/bare-metal/rtc.md:131
-#: src/exercises/bare-metal/rtc.md:137 src/exercises/bare-metal/rtc.md:143
-#: src/exercises/day-3/solutions-afternoon.md:45
-#: src/exercises/bare-metal/solutions-afternoon.md:43
-msgid "\"C\""
-msgstr ""
-
-#: src/unsafe/extern-functions.md:13
-msgid "// Undefined behavior if abs misbehaves.\n"
-msgstr ""
-
-#: src/unsafe/extern-functions.md:14
-msgid "\"Absolute value of -3 according to C: {}\""
-msgstr ""
-
-#: src/unsafe/extern-functions.md:21
-msgid ""
-"This is usually only a problem for extern functions which do things with "
-"pointers which might violate Rust's memory model, but in general any C "
-"function might have undefined behaviour under any arbitrary circumstances."
-msgstr ""
-
-#: src/unsafe/extern-functions.md:25
+#: src/unsafe-rust/unsafe-functions.md:84
 msgid ""
 "The `\"C\"` in this example is the ABI; [other ABIs are available too]"
 "(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:3
+#: src/unsafe-rust/unsafe-functions.md:89
+msgid ""
+"We wouldn't actually use pointers for a `swap` function - it can be done "
+"safely with references."
+msgstr ""
+
+#: src/unsafe-rust/unsafe-functions.md:92
+msgid ""
+"Note that unsafe code is allowed within an unsafe function without an "
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens. This will likely change in a future Rust "
+"edition."
+msgstr ""
+
+#: src/unsafe-rust/unsafe-traits.md:1
+msgid "Implementing Unsafe Traits"
+msgstr "Unsafeなトレイトの実装"
+
+#: src/unsafe-rust/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
 "must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:6
+#: src/unsafe-rust/unsafe-traits.md:6
 msgid ""
 "For example, the `zerocopy` crate has an unsafe trait that looks [something "
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:12
+#: src/unsafe-rust/unsafe-traits.md:12
 msgid ""
 "/// ...\n"
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:23
+#: src/unsafe-rust/unsafe-traits.md:26
 msgid "// Safe because u32 has a defined representation and no padding.\n"
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:30
+#: src/unsafe-rust/unsafe-traits.md:34
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:33
+#: src/unsafe-rust/unsafe-traits.md:37
 msgid ""
 "The actual safety section for `AsBytes` is rather longer and more "
 "complicated."
 msgstr ""
 
-#: src/unsafe/unsafe-traits.md:35
+#: src/unsafe-rust/unsafe-traits.md:39
 msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr ""
 
-#: src/exercises/day-3/afternoon.md:1
-msgid "Day 3: Afternoon Exercises"
-msgstr ""
+#: src/unsafe-rust/exercise.md:1
+msgid "Safe FFI Wrapper"
+msgstr "安全なFFIラッパ"
 
-#: src/exercises/day-3/afternoon.md:3
-msgid "Let us build a safe wrapper for reading directory content!"
-msgstr ""
-
-#: src/exercises/day-3/afternoon.md:5
-msgid ""
-"For this exercise, we suggest using a local dev environment instead of the "
-"Playground. This will allow you to run your binary on your own machine."
-msgstr ""
-
-#: src/exercises/day-3/afternoon.md:8
-msgid ""
-"To get started, follow the [running locally](../../cargo/running-locally.md) "
-"instructions."
-msgstr ""
-
-#: src/exercises/day-3/afternoon.md:14
-msgid ""
-"After looking at the exercise, you can look at the [solution](solutions-"
-"afternoon.md) provided."
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:3
+#: src/unsafe-rust/exercise.md:3
 msgid ""
 "Rust has great support for calling functions through a _foreign function "
 "interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the names of files in a directory."
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:7
+#: src/unsafe-rust/exercise.md:7
 msgid "You will want to consult the manual pages:"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:9
+#: src/unsafe-rust/exercise.md:9
 msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:10
+#: src/unsafe-rust/exercise.md:10
 msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:11
+#: src/unsafe-rust/exercise.md:11
 msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:13
+#: src/unsafe-rust/exercise.md:13
 msgid ""
 "You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
 "ffi/) module. There you find a number of string types which you need for the "
 "exercise:"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:16
+#: src/unsafe-rust/exercise.md:16
 msgid "Encoding"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:16
+#: src/unsafe-rust/exercise.md:16
 msgid "Use"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:18
+#: src/unsafe-rust/exercise.md:18
 msgid ""
 "[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
 "(https://doc.rust-lang.org/std/string/struct.String.html)"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:18
+#: src/unsafe-rust/exercise.md:18
 msgid "UTF-8"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:18
+#: src/unsafe-rust/exercise.md:18
 msgid "Text processing in Rust"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:19
+#: src/unsafe-rust/exercise.md:19
 msgid ""
 "[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
 "(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:19
+#: src/unsafe-rust/exercise.md:19
 msgid "NUL-terminated"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:19
+#: src/unsafe-rust/exercise.md:19
 msgid "Communicating with C functions"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:20
+#: src/unsafe-rust/exercise.md:20
 msgid ""
 "[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
 "[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:20
+#: src/unsafe-rust/exercise.md:20
 msgid "OS-specific"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:20
+#: src/unsafe-rust/exercise.md:20
 msgid "Communicating with the OS"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:22
+#: src/unsafe-rust/exercise.md:22
 msgid "You will convert between all these types:"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:24
+#: src/unsafe-rust/exercise.md:24
 msgid ""
 "`&str` to `CString`: you need to allocate space for a trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:25
+#: src/unsafe-rust/exercise.md:25
 msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:26
+#: src/unsafe-rust/exercise.md:26
 msgid ""
 "`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:27
+#: src/unsafe-rust/exercise.md:28
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
 "unknown data\","
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:28
+#: src/unsafe-rust/exercise.md:30
 msgid ""
 "`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
 "(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:31
+#: src/unsafe-rust/exercise.md:33
 msgid ""
 "`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
 "return it and call `readdir` again."
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:34
+#: src/unsafe-rust/exercise.md:36
 msgid ""
 "The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
 "useful chapter about FFI."
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:45
+#: src/unsafe-rust/exercise.md:47
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:54
-#: src/exercises/day-3/safe-ffi-wrapper.md:67
-#: src/exercises/day-3/safe-ffi-wrapper.md:78
-#: src/exercises/day-3/safe-ffi-wrapper.md:92
-#: src/exercises/day-3/safe-ffi-wrapper.md:100
-#: src/exercises/day-3/solutions-afternoon.md:10
-#: src/exercises/day-3/solutions-afternoon.md:23
-#: src/exercises/day-3/solutions-afternoon.md:34
-#: src/exercises/day-3/solutions-afternoon.md:48
-#: src/exercises/day-3/solutions-afternoon.md:56
+#: src/unsafe-rust/exercise.md:56 src/unsafe-rust/exercise.md:69
+#: src/unsafe-rust/exercise.md:80 src/unsafe-rust/exercise.md:94
+#: src/unsafe-rust/exercise.md:102 src/unsafe-rust/solution.md:6
+#: src/unsafe-rust/solution.md:19 src/unsafe-rust/solution.md:30
+#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
 msgid "\"macos\""
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:57
-#: src/exercises/day-3/solutions-afternoon.md:13
+#: src/unsafe-rust/exercise.md:59 src/unsafe-rust/solution.md:9
 msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:64
-#: src/exercises/day-3/solutions-afternoon.md:20
+#: src/unsafe-rust/exercise.md:66 src/unsafe-rust/solution.md:16
 msgid ""
 "// Layout according to the Linux man page for readdir(3), where ino_t and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:77
-#: src/exercises/day-3/solutions-afternoon.md:33
+#: src/unsafe-rust/exercise.md:79 src/unsafe-rust/solution.md:29
 msgid "// Layout according to the macOS man page for dir(5).\n"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:92
-#: src/exercises/day-3/safe-ffi-wrapper.md:100
-#: src/exercises/day-3/solutions-afternoon.md:48
-#: src/exercises/day-3/solutions-afternoon.md:56
+#: src/unsafe-rust/exercise.md:94 src/unsafe-rust/exercise.md:102
+#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
 msgid "\"x86_64\""
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:95
-#: src/exercises/day-3/solutions-afternoon.md:51
+#: src/unsafe-rust/exercise.md:97 src/unsafe-rust/solution.md:47
 msgid ""
 "// See https://github.com/rust-lang/libc/issues/414 and the section on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
@@ -9595,38 +10948,104 @@ msgid ""
 "PowerPC.\n"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:101
-#: src/exercises/day-3/solutions-afternoon.md:57
+#: src/unsafe-rust/exercise.md:103 src/unsafe-rust/solution.md:53
 msgid "\"readdir$INODE64\""
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:119
-#: src/exercises/day-3/solutions-afternoon.md:75
+#: src/unsafe-rust/exercise.md:121 src/unsafe-rust/solution.md:71
 msgid ""
 "// Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:128
+#: src/unsafe-rust/exercise.md:130
 msgid "// Keep calling readdir until we get a NULL pointer back.\n"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:135
-#: src/exercises/day-3/solutions-afternoon.md:108
+#: src/unsafe-rust/exercise.md:137 src/unsafe-rust/solution.md:105
 msgid "// Call closedir as needed.\n"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:141
+#: src/unsafe-rust/exercise.md:143 src/unsafe-rust/solution.md:116
+#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
 #: src/android/interoperability/with-c/rust.md:44
-#: src/exercises/day-3/solutions-afternoon.md:119
-#: src/exercises/day-3/solutions-afternoon.md:143
-#: src/exercises/day-3/solutions-afternoon.md:158
 msgid "\".\""
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:142
-#: src/exercises/day-3/solutions-afternoon.md:120
+#: src/unsafe-rust/exercise.md:144 src/unsafe-rust/solution.md:117
 msgid "\"files: {:#?}\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:74
+msgid "\"Invalid path: {err}\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:75
+msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
+msgstr ""
+
+#: src/unsafe-rust/solution.md:78
+msgid "\"Could not open {:?}\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:88
+msgid ""
+"// Keep calling readdir until we get a NULL pointer back.\n"
+"        // SAFETY: self.dir is never NULL.\n"
+msgstr ""
+
+#: src/unsafe-rust/solution.md:92
+msgid "// We have reached the end of the directory.\n"
+msgstr ""
+
+#: src/unsafe-rust/solution.md:95
+msgid ""
+"// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
+"        // terminated.\n"
+msgstr ""
+
+#: src/unsafe-rust/solution.md:107
+msgid "// SAFETY: self.dir is not NULL.\n"
+msgstr ""
+
+#: src/unsafe-rust/solution.md:109
+msgid "\"Could not close {:?}\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:128
+msgid "\"no-such-directory\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:136 src/unsafe-rust/solution.md:151
+msgid "\"Non UTF-8 character in path\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
+msgid "\"..\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:147 src/unsafe-rust/solution.md:155
+msgid "\"foo.txt\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:147
+msgid "\"The Foo Diaries\\n\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:148 src/unsafe-rust/solution.md:155
+msgid "\"bar.png\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:148
+msgid "\"<PNG>\\n\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:149 src/unsafe-rust/solution.md:155
+msgid "\"crab.rs\""
+msgstr ""
+
+#: src/unsafe-rust/solution.md:149
+msgid "\"//! Crab\\n\""
 msgstr ""
 
 #: src/android.md:1
@@ -9635,9 +11054,9 @@ msgstr ""
 
 #: src/android.md:3
 msgid ""
-"Rust is supported for native platform development on Android. This means "
-"that you can write new operating system services in Rust, as well as "
-"extending existing services."
+"Rust is supported for system software on Android. This means that you can "
+"write new services, libraries, drivers or even firmware in Rust (or improve "
+"existing code as needed)."
 msgstr ""
 
 #: src/android.md:7
@@ -9648,16 +11067,58 @@ msgid ""
 "that parses some raw bytes would be ideal."
 msgstr ""
 
+#: src/android.md:14
+msgid ""
+"The speaker may mention any of the following given the increased use of Rust "
+"in Android:"
+msgstr ""
+
+#: src/android.md:17
+msgid ""
+"Service example: [DNS over HTTP](https://security.googleblog.com/2022/07/dns-"
+"over-http3-in-android.html)"
+msgstr ""
+
+#: src/android.md:20
+msgid ""
+"Libraries: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
+"appendix/rutabaga_gfx.html)"
+msgstr ""
+
+#: src/android.md:23
+msgid ""
+"Kernel Drivers: [Binder](https://lore.kernel.org/rust-for-linux/20231101-"
+"rust-binder-v1-0-08ba9197f637@google.com/)"
+msgstr ""
+
+#: src/android.md:26
+msgid ""
+"Firmware: [pKVM firmware](https://security.googleblog.com/2023/10/bare-metal-"
+"rust-in-android.html)"
+msgstr ""
+
 #: src/android/setup.md:3
 msgid ""
-"We will be using an Android Virtual Device to test our code. Make sure you "
-"have access to one or create a new one with:"
+"We will be using a Cuttlefish Android Virtual Device to test our code. Make "
+"sure you have access to one or create a new one with:"
 msgstr ""
 
 #: src/android/setup.md:12
 msgid ""
 "Please see the [Android Developer Codelab](https://source.android.com/docs/"
 "setup/start) for details."
+msgstr ""
+
+#: src/android/setup.md:20
+msgid ""
+"Cuttlefish is a reference Android device designed to work on generic Linux "
+"desktops. MacOS support is also planned."
+msgstr ""
+
+#: src/android/setup.md:23
+msgid ""
+"The Cuttlefish system image maintains high fidelity to real devices, and is "
+"the ideal emulator to run many Rust use cases."
 msgstr ""
 
 #: src/android/build-rules.md:3
@@ -9748,6 +11209,44 @@ msgstr ""
 msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr ""
 
+#: src/android/build-rules.md:20
+msgid "Additional items speaker may mention:"
+msgstr ""
+
+#: src/android/build-rules.md:22
+msgid ""
+"Cargo is not optimized for multi-language repos, and also downloads packages "
+"from the internet."
+msgstr ""
+
+#: src/android/build-rules.md:25
+msgid ""
+"For compliance and performance, Android must have crates in-tree. It must "
+"also interop with C/C++/Java code. Soong fills that gap."
+msgstr ""
+
+#: src/android/build-rules.md:28
+msgid ""
+"Soong has many similarities to Bazel, which is the open-source variant of "
+"Blaze (used in google3)."
+msgstr ""
+
+#: src/android/build-rules.md:31
+msgid ""
+"There is a plan to transition [Android](https://source.android.com/docs/"
+"setup/build/bazel/introduction), [ChromeOS](https://chromium.googlesource."
+"com/chromiumos/bazel/), and [Fuchsia](https://source.android.com/docs/setup/"
+"build/bazel/introduction) to Bazel."
+msgstr ""
+
+#: src/android/build-rules.md:37
+msgid "Learning Bazel-like build rules is useful for all Rust OS developers."
+msgstr ""
+
+#: src/android/build-rules.md:39
+msgid "Fun fact: Data from Star Trek is a Soong-type Android."
+msgstr ""
+
 #: src/android/build-rules/binary.md:1
 msgid "Rust Binaries"
 msgstr ""
@@ -9783,7 +11282,7 @@ msgstr ""
 msgid "/// Prints a greeting to standard output.\n"
 msgstr ""
 
-#: src/android/build-rules/binary.md:23
+#: src/android/build-rules/binary.md:23 src/exercises/chromium/build-rules.md:9
 msgid "\"Hello from Rust!\""
 msgstr ""
 
@@ -9795,7 +11294,7 @@ msgstr ""
 msgid ""
 "```shell\n"
 "m hello_rust\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust /data/local/tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust\" /data/local/tmp\n"
 "adb shell /data/local/tmp/hello_rust\n"
 "```"
 msgstr ""
@@ -9835,12 +11334,16 @@ msgstr ""
 msgid "\"libtextwrap\""
 msgstr ""
 
+#: src/android/build-rules/library.md:24
+msgid "// Need this to avoid dynamic link error.\n"
+msgstr ""
+
 #: src/android/build-rules/library.md:29
 msgid "\"greetings\""
 msgstr ""
 
-#: src/android/build-rules/library.md:30 src/android/aidl/implementation.md:31
-#: src/android/interoperability/java.md:38
+#: src/android/build-rules/library.md:30 src/android/aidl/implementation.md:29
+#: src/android/interoperability/java.md:39
 msgid "\"src/lib.rs\""
 msgstr ""
 
@@ -9868,8 +11371,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep\" /data/local/"
+"tmp\n"
 "adb shell /data/local/tmp/hello_rust_with_dep\n"
 "```"
 msgstr ""
@@ -9880,11 +11383,11 @@ msgid ""
 "com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
-#: src/android/aidl.md:6
+#: src/android/aidl.md:8
 msgid "Rust code can call existing AIDL servers,"
 msgstr ""
 
-#: src/android/aidl.md:7
+#: src/android/aidl.md:9
 msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
@@ -9899,6 +11402,14 @@ msgstr ""
 #: src/android/aidl/interface.md:5
 msgid ""
 "_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
+msgstr ""
+
+#: src/android/aidl/interface.md:9 src/android/aidl/changing.md:8
+msgid "/** Birthday service interface. */"
+msgstr ""
+
+#: src/android/aidl/interface.md:12 src/android/aidl/changing.md:11
+msgid "/** Generate a Happy Birthday message. */"
 msgstr ""
 
 #: src/android/aidl/interface.md:17
@@ -9943,31 +11454,31 @@ msgstr ""
 msgid "/// The `IBirthdayService` implementation.\n"
 msgstr ""
 
-#: src/android/aidl/implementation.md:20
+#: src/android/aidl/implementation.md:19
 msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
 msgstr ""
 
-#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
-#: src/android/aidl/client.md:37
+#: src/android/aidl/implementation.md:24 src/android/aidl/server.md:28
+#: src/android/aidl/client.md:36
 msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md:30 src/android/aidl/server.md:38
+#: src/android/aidl/implementation.md:28 src/android/aidl/server.md:38
 msgid "\"libbirthdayservice\""
 msgstr ""
 
-#: src/android/aidl/implementation.md:32 src/android/aidl/server.md:13
+#: src/android/aidl/implementation.md:30 src/android/aidl/server.md:13
 #: src/android/aidl/client.md:12
 msgid "\"birthdayservice\""
 msgstr ""
 
-#: src/android/aidl/implementation.md:34 src/android/aidl/server.md:36
-#: src/android/aidl/client.md:45
+#: src/android/aidl/implementation.md:32 src/android/aidl/server.md:36
+#: src/android/aidl/client.md:44
 msgid "\"com.example.birthdayservice-rust\""
 msgstr ""
 
-#: src/android/aidl/implementation.md:35 src/android/aidl/server.md:37
-#: src/android/aidl/client.md:46
+#: src/android/aidl/implementation.md:33 src/android/aidl/server.md:37
+#: src/android/aidl/client.md:45
 msgid "\"libbinder_rs\""
 msgstr ""
 
@@ -10003,6 +11514,10 @@ msgstr ""
 msgid "\"src/server.rs\""
 msgstr ""
 
+#: src/android/aidl/server.md:40 src/android/aidl/client.md:47
+msgid "// To avoid dynamic link error.\n"
+msgstr ""
+
 #: src/android/aidl/deploy.md:3
 msgid "We can now build, push, and start the service:"
 msgstr ""
@@ -10011,17 +11526,18 @@ msgstr ""
 msgid ""
 "```shell\n"
 "m birthday_server\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/"
-"tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server\" /data/local/"
+"tmp\n"
+"adb root\n"
 "adb shell /data/local/tmp/birthday_server\n"
 "```"
 msgstr ""
 
-#: src/android/aidl/deploy.md:11
+#: src/android/aidl/deploy.md:12
 msgid "In another terminal, check that the service runs:"
 msgstr ""
 
-#: src/android/aidl/deploy.md:21
+#: src/android/aidl/deploy.md:22
 msgid "You can also call the service with `service call`:"
 msgstr ""
 
@@ -10041,40 +11557,40 @@ msgstr ""
 msgid "/// Connect to the BirthdayService.\n"
 msgstr ""
 
-#: src/android/aidl/client.md:18
+#: src/android/aidl/client.md:19
 msgid "/// Call the birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/client.md:30
+#: src/android/aidl/client.md:29
 msgid "\"Failed to connect to BirthdayService\""
 msgstr ""
 
-#: src/android/aidl/client.md:32
+#: src/android/aidl/client.md:31
 msgid "\"{msg}\""
 msgstr ""
 
-#: src/android/aidl/client.md:41 src/android/aidl/client.md:42
+#: src/android/aidl/client.md:40 src/android/aidl/client.md:41
 msgid "\"birthday_client\""
 msgstr ""
 
-#: src/android/aidl/client.md:43
+#: src/android/aidl/client.md:42
 msgid "\"src/client.rs\""
 msgstr ""
 
-#: src/android/aidl/client.md:52
+#: src/android/aidl/client.md:51
 msgid "Notice that the client does not depend on `libbirthdayservice`."
 msgstr ""
 
-#: src/android/aidl/client.md:54
+#: src/android/aidl/client.md:53
 msgid "Build, push, and run the client on your device:"
 msgstr ""
 
-#: src/android/aidl/client.md:56
+#: src/android/aidl/client.md:55
 msgid ""
 "```shell\n"
 "m birthday_client\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/"
-"tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client\" /data/local/"
+"tmp\n"
 "adb shell /data/local/tmp/birthday_client Charlie 60\n"
 "```"
 msgstr ""
@@ -10107,50 +11623,50 @@ msgstr ""
 msgid "\"liblogger\""
 msgstr ""
 
-#: src/android/logging.md:22
+#: src/android/logging.md:21
 msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
-#: src/android/logging.md:25
+#: src/android/logging.md:24
 msgid "//! Rust logging demo.\n"
 msgstr ""
 
-#: src/android/logging.md:28
+#: src/android/logging.md:27
 msgid "/// Logs a greeting.\n"
 msgstr ""
 
-#: src/android/logging.md:33
+#: src/android/logging.md:32
 msgid "\"rust\""
 msgstr ""
 
-#: src/android/logging.md:36
+#: src/android/logging.md:35
 msgid "\"Starting program.\""
 msgstr ""
 
-#: src/android/logging.md:37
+#: src/android/logging.md:36
 msgid "\"Things are going fine.\""
 msgstr ""
 
-#: src/android/logging.md:38
+#: src/android/logging.md:37
 msgid "\"Something went wrong!\""
 msgstr ""
 
-#: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
-#: src/android/interoperability/with-c/rust.md:73
+#: src/android/logging.md:41 src/android/interoperability/with-c/bindgen.md:96
+#: src/android/interoperability/with-c/rust.md:72
 msgid "Build, push, and run the binary on your device:"
 msgstr ""
 
-#: src/android/logging.md:44
+#: src/android/logging.md:43
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/"
-"tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs\" /data/local/"
+"tmp\n"
 "adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 msgstr ""
 
-#: src/android/logging.md:50
+#: src/android/logging.md:49
 msgid "The logs show up in `adb logcat`:"
 msgstr ""
 
@@ -10230,6 +11746,10 @@ msgstr ""
 msgid "_interoperability/bindgen/libbirthday.c_:"
 msgstr ""
 
+#: src/android/interoperability/with-c/bindgen.md:22
+msgid "<stdio.h>"
+msgstr ""
+
 #: src/android/interoperability/with-c/bindgen.md:23
 #: src/android/interoperability/with-c/bindgen.md:50
 msgid "\"libbirthday.h\""
@@ -10255,7 +11775,7 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:35
 #: src/android/interoperability/with-c/bindgen.md:55
 #: src/android/interoperability/with-c/bindgen.md:69
-#: src/android/interoperability/with-c/bindgen.md:108
+#: src/android/interoperability/with-c/bindgen.md:106
 msgid "_interoperability/bindgen/Android.bp_:"
 msgstr ""
 
@@ -10319,39 +11839,43 @@ msgstr ""
 msgid "//! Bindgen demo.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:100
+#: src/android/interoperability/with-c/bindgen.md:89
+msgid "// SAFETY: `print_card` is safe to call with a valid `card` pointer.\n"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:98
 msgid ""
 "```shell\n"
 "m print_birthday_card\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/"
-"tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card\" /data/local/"
+"tmp\n"
 "adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:106
+#: src/android/interoperability/with-c/bindgen.md:104
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
 
+#: src/android/interoperability/with-c/bindgen.md:110
 #: src/android/interoperability/with-c/bindgen.md:112
-#: src/android/interoperability/with-c/bindgen.md:114
 msgid "\"libbirthday_bindgen_test\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:113
+#: src/android/interoperability/with-c/bindgen.md:111
 msgid "\":libbirthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:115
+#: src/android/interoperability/with-c/bindgen.md:113
 msgid "\"general-tests\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:117
-#: src/android/interoperability/with-c/bindgen.md:118
+#: src/android/interoperability/with-c/bindgen.md:115
+#: src/android/interoperability/with-c/bindgen.md:116
 msgid "\"none\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:117
+#: src/android/interoperability/with-c/bindgen.md:115
 msgid "// Generated file, skip linting\n"
 msgstr ""
 
@@ -10428,22 +11952,26 @@ msgstr ""
 msgid "\"main.c\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:75
+#: src/android/interoperability/with-c/rust.md:74
 msgid ""
 "```shell\n"
 "m analyze_numbers\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/"
-"tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers\" /data/local/"
+"tmp\n"
 "adb shell /data/local/tmp/analyze_numbers\n"
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:83
+#: src/android/interoperability/with-c/rust.md:82
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
 "will just be the name of the function. You can also use `#[export_name = "
 "\"some_name\"]` to specify whatever name you want."
 msgstr ""
+
+#: src/android/interoperability/cpp.md:1
+msgid "With C++"
+msgstr "C++"
 
 #: src/android/interoperability/cpp.md:3
 msgid ""
@@ -10455,46 +11983,445 @@ msgstr ""
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:10
+#: src/android/interoperability/cpp/bridge.md:3
 msgid ""
-"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
-"using this."
+"CXX relies on a description of the function signatures that will be exposed "
+"from each language to the other. You provide this description using extern "
+"blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:14
-msgid ""
-"At this point, the instructor should switch to the [CXX tutorial](https://"
-"cxx.rs/tutorial.html)."
+#: src/android/interoperability/cpp/bridge.md:9
+msgid "\"org::blobstore\""
 msgstr ""
 
-#: src/android/interoperability/cpp.md:16
-msgid "Walk the students through the tutorial step by step."
+#: src/android/interoperability/cpp/bridge.md:11
+msgid "// Shared structs with fields visible to both languages.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:18
-msgid ""
-"Highlight how CXX presents a clean interface without unsafe code in _both "
-"languages_."
+#: src/android/interoperability/cpp/bridge.md:17
+#: src/android/interoperability/cpp/generated-cpp.md:6
+msgid "// Rust types and signatures exposed to C++.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:20
-msgid ""
-"Show the correspondence between [Rust and C++ types](https://cxx.rs/bindings."
-"html):"
+#: src/android/interoperability/cpp/bridge.md:18
+#: src/android/interoperability/cpp/rust-bridge.md:6
+#: src/android/interoperability/cpp/generated-cpp.md:7
+#: src/android/interoperability/cpp/rust-result.md:6
+#: src/chromium/interoperability-with-cpp/example-bindings.md:9
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:10
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:9
+#, fuzzy
+msgid "\"Rust\""
+msgstr "Rustdoc"
+
+#: src/android/interoperability/cpp/bridge.md:24
+#: src/android/interoperability/cpp/cpp-bridge.md:6
+msgid "// C++ types and signatures exposed to Rust.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:22
-msgid ""
-"Explain how a Rust `String` cannot map to a C++ `std::string` (the latter "
-"does not uphold the UTF-8 invariant). Show that despite being different "
-"types, `rust::String` in C++ can be easily constructed from a C++ `std::"
-"string`, making it very ergonomic to use."
+#: src/android/interoperability/cpp/bridge.md:25
+#: src/android/interoperability/cpp/cpp-bridge.md:7
+#: src/android/interoperability/cpp/cpp-exception.md:6
+#: src/chromium/interoperability-with-cpp/example-bindings.md:15
+msgid "\"C++\""
 msgstr ""
 
-#: src/android/interoperability/cpp.md:28
+#: src/android/interoperability/cpp/bridge.md:26
+#: src/android/interoperability/cpp/cpp-bridge.md:8
+msgid "\"include/blobstore.h\""
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:40
+msgid "The bridge is generally declared in an `ffi` module within your crate."
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:41
 msgid ""
-"Explain that a Rust function returning `Result<T, E>` becomes a function "
-"which throws a `E` exception in C++ (and vice versa)."
+"From the declarations made in the bridge module, CXX will generate matching "
+"Rust and C++ type/function definitions in order to expose those items to "
+"both languages."
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:44
+msgid ""
+"To view the generated Rust code, use [cargo-expand](https://github.com/"
+"dtolnay/cargo-expand) to view the expanded proc macro. For most of the "
+"examples you would use `cargo expand ::ffi` to expand just the `ffi` module "
+"(though this doesn't apply for Android projects)."
+msgstr ""
+
+#: src/android/interoperability/cpp/bridge.md:47
+msgid "To view the generated C++ code, look in `target/cxxbridge`."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:1
+msgid "Rust Bridge Declarations"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:7
+msgid "// Opaque type\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:8
+msgid "// Method on `MyType`\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:9
+#, fuzzy
+msgid "// Free function\n"
+msgstr "関数"
+
+#: src/android/interoperability/cpp/rust-bridge.md:28
+msgid ""
+"Items declared in the `extern \"Rust\"` reference items that are in scope in "
+"the parent module."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-bridge.md:30
+msgid ""
+"The CXX code generator uses your `extern \"Rust\"` section(s) to produce a C+"
+"+ header file containing the corresponding C++ declarations. The generated "
+"header has the same path as the Rust source file containing the bridge, "
+"except with a .rs.h file extension."
+msgstr ""
+
+#: src/android/interoperability/cpp/generated-cpp.md:15
+msgid "Results in (roughly) the following C++:"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:1
+msgid "C++ Bridge Declarations"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:20
+msgid "Results in (roughly) the following Rust:"
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:30
+msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:39
+msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:56
+msgid ""
+"The programmer does not need to promise that the signatures they have typed "
+"in are accurate. CXX performs static assertions that the signatures exactly "
+"correspond with what is declared in C++."
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-bridge.md:59
+msgid ""
+"`unsafe extern` blocks allow you to declare C++ functions that are safe to "
+"call from Rust."
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-types.md:9
+msgid "// A=1, J=11, Q=12, K=13\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-types.md:23
+msgid "Only C-like (unit) enums are supported."
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-types.md:24
+msgid ""
+"A limited number of traits are supported for `#[derive()]` on shared types. "
+"Corresponding functionality is also generated for the C++ code, e.g. if you "
+"derive `Hash` also generates an implementation of `std::hash` for the "
+"corresponding C++ type."
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-enums.md:15
+#, fuzzy
+msgid "Generated Rust:"
+msgstr "Unsafe Rust"
+
+#: src/android/interoperability/cpp/shared-enums.md:33
+msgid "Generated C++:"
+msgstr ""
+
+#: src/android/interoperability/cpp/shared-enums.md:46
+msgid ""
+"On the Rust side, the code generated for shared enums is actually a struct "
+"wrapping a numeric value. This is because it is not UB in C++ for an enum "
+"class to hold a value different from all of the listed variants, and our "
+"Rust representation needs to have the same behavior."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:13
+msgid "\"fallible1 requires depth > 0\""
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:16
+msgid "\"Success!\""
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:22
+msgid ""
+"Rust functions that return `Result` are translated to exceptions on the C++ "
+"side."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:24
+msgid ""
+"The exception thrown will always be of type `rust::Error`, which primarily "
+"exposes a way to get the error message string. The error message will come "
+"from the error type's `Display` impl."
+msgstr ""
+
+#: src/android/interoperability/cpp/rust-result.md:27
+msgid ""
+"A panic unwinding from Rust to C++ will always cause the process to "
+"immediately terminate."
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:7
+msgid "\"example/include/example.h\""
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:14
+msgid "\"Error: {}\""
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:22
+msgid ""
+"C++ functions declared to return a `Result` will catch any thrown exception "
+"on the C++ side and return it as an `Err` value to the calling Rust function."
+msgstr ""
+
+#: src/android/interoperability/cpp/cpp-exception.md:24
+msgid ""
+"If an exception is thrown from an extern \"C++\" function that is not "
+"declared by the CXX bridge to return `Result`, the program calls C++'s `std::"
+"terminate`. The behavior is equivalent to the same exception being thrown "
+"through a `noexcept` C++ function."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:3
+#, fuzzy
+msgid "Rust Type"
+msgstr "再帰的データ型"
+
+#: src/android/interoperability/cpp/type-mapping.md:3
+msgid "C++ Type"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:5
+#, fuzzy
+msgid "`rust::String`"
+msgstr "文字列（String）"
+
+#: src/android/interoperability/cpp/type-mapping.md:6
+msgid "`&str`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:6
+msgid "`rust::Str`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:7
+#, fuzzy
+msgid "`CxxString`"
+msgstr "文字列（String）"
+
+#: src/android/interoperability/cpp/type-mapping.md:7
+#, fuzzy
+msgid "`std::string`"
+msgstr "文字列（String）"
+
+#: src/android/interoperability/cpp/type-mapping.md:8
+msgid "`&[T]`/`&mut [T]`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:8
+msgid "`rust::Slice`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:9
+msgid "`rust::Box<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:10
+msgid "`UniquePtr<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:10
+msgid "`std::unique_ptr<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:11
+msgid "`Vec<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:11
+msgid "`rust::Vec<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:12
+msgid "`CxxVector<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:12
+msgid "`std::vector<T>`"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:16
+msgid ""
+"These types can be used in the fields of shared structs and the arguments "
+"and returns of extern functions."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:18
+msgid ""
+"Note that Rust's `String` does not map directly to `std::string`. There are "
+"a few reasons for this:"
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:20
+msgid ""
+"`std::string` does not uphold the UTF-8 invariant that `String` requires."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:21
+msgid ""
+"The two types have different layouts in memory and so can't be passed "
+"directly between languages."
+msgstr ""
+
+#: src/android/interoperability/cpp/type-mapping.md:23
+msgid ""
+"`std::string` requires move constructors that don't match Rust's move "
+"semantics, so a `std::string` can't be passed by value to Rust."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:1
+#: src/android/interoperability/cpp/android-cpp-genrules.md:1
+#: src/android/interoperability/cpp/android-build-rust.md:1
+#, fuzzy
+msgid "Building in Android"
+msgstr "Android"
+
+#: src/android/interoperability/cpp/android-build-cpp.md:3
+msgid ""
+"Create a `cc_library_static` to build the C++ library, including the CXX "
+"generated header and source file."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:8
+#: src/android/interoperability/cpp/android-build-rust.md:10
+msgid "\"libcxx_test_cpp\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:9
+msgid "\"cxx_test.cpp\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:11
+msgid "\"cxx-bridge-header\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:12
+#: src/android/interoperability/cpp/android-cpp-genrules.md:10
+msgid "\"libcxx_test_bridge_header\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:14
+#: src/android/interoperability/cpp/android-cpp-genrules.md:19
+msgid "\"libcxx_test_bridge_code\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:20
+msgid ""
+"Point out that `libcxx_test_bridge_header` and `libcxx_test_bridge_code` are "
+"the dependencies for the CXX-generated C++ bindings. We'll show how these "
+"are setup on the next slide."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:23
+msgid ""
+"Note that you also need to depend on the `cxx-bridge-header` library in "
+"order to pull in common CXX definitions."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-cpp.md:25
+msgid ""
+"Full docs for using CXX in Android can be found in [the Android docs]"
+"(https://source.android.com/docs/setup/build/rust/building-rust-modules/"
+"android-rust-patterns#rust-cpp-interop-using-cxx). You may want to share "
+"that link with the class so that students know where they can find these "
+"instructions again in the future."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:3
+msgid ""
+"Create two genrules: One to generate the CXX header, and one to generate the "
+"CXX source file. These are then used as inputs to the `cc_library_static`."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:7
+msgid ""
+"// Generate a C++ header containing the C++ bindings\n"
+"// to the Rust exported functions in lib.rs.\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:11
+#: src/android/interoperability/cpp/android-cpp-genrules.md:20
+msgid "\"cxxbridge\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:12
+msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:13
+#: src/android/interoperability/cpp/android-cpp-genrules.md:22
+#: src/android/interoperability/cpp/android-build-rust.md:8
+msgid "\"lib.rs\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:14
+msgid "\"lib.rs.h\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:16
+msgid "// Generate the C++ code that Rust calls into.\n"
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:21
+msgid "\"$(location cxxbridge) $(in) > $(out)\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:23
+msgid "\"lib.rs.cc\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:29
+msgid ""
+"The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
+"bridge module. It is included in Android and available as a Soong tool."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-cpp-genrules.md:31
+msgid ""
+"By convention, if your Rust source file is `lib.rs` your header file will be "
+"named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
+"convention isn't enforced, though."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-rust.md:3
+msgid ""
+"Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-rust.md:7
+msgid "\"cxx_test\""
+msgstr ""
+
+#: src/android/interoperability/cpp/android-build-rust.md:9
+msgid "\"libcxx\""
 msgstr ""
 
 #: src/android/interoperability/java.md:1
@@ -10508,70 +12435,70 @@ msgid ""
 "jni/) allows you to create a compatible library."
 msgstr ""
 
-#: src/android/interoperability/java.md:7
+#: src/android/interoperability/java.md:8
 msgid "First, we create a Rust function to export to Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md:9
+#: src/android/interoperability/java.md:10
 msgid "_interoperability/java/src/lib.rs_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:12
+#: src/android/interoperability/java.md:13
 msgid "//! Rust <-> Java FFI demo.\n"
 msgstr ""
 
-#: src/android/interoperability/java.md:17
+#: src/android/interoperability/java.md:18
 msgid "/// HelloWorld::hello method implementation.\n"
 msgstr ""
 
-#: src/android/interoperability/java.md:20
+#: src/android/interoperability/java.md:21
 msgid "\"system\""
 msgstr ""
 
-#: src/android/interoperability/java.md:26
+#: src/android/interoperability/java.md:27
 msgid "\"Hello, {input}!\""
 msgstr ""
 
-#: src/android/interoperability/java.md:32
-#: src/android/interoperability/java.md:62
+#: src/android/interoperability/java.md:33
+#: src/android/interoperability/java.md:63
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:36
-#: src/android/interoperability/java.md:69
+#: src/android/interoperability/java.md:37
+#: src/android/interoperability/java.md:70
 msgid "\"libhello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:37
-#: src/android/interoperability/java.md:52
+#: src/android/interoperability/java.md:38
+#: src/android/interoperability/java.md:53
 msgid "\"hello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:39
+#: src/android/interoperability/java.md:40
 msgid "\"libjni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:43
+#: src/android/interoperability/java.md:44
 msgid "Finally, we can call this function from Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md:45
+#: src/android/interoperability/java.md:46
 msgid "_interoperability/java/HelloWorld.java_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:66
+#: src/android/interoperability/java.md:67
 msgid "\"helloworld_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:67
+#: src/android/interoperability/java.md:68
 msgid "\"HelloWorld.java\""
 msgstr ""
 
-#: src/android/interoperability/java.md:68
+#: src/android/interoperability/java.md:69
 msgid "\"HelloWorld\""
 msgstr ""
 
-#: src/android/interoperability/java.md:73
+#: src/android/interoperability/java.md:74
 msgid "Finally, you can build, sync, and run the binary:"
 msgstr ""
 
@@ -10595,6 +12522,2060 @@ msgid ""
 "in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
+#: src/chromium.md:1
+msgid "Welcome to Rust in Chromium"
+msgstr ""
+
+#: src/chromium.md:3
+msgid ""
+"Rust is supported for third-party libraries in Chromium, with first-party "
+"glue code to connect between Rust and existing Chromium C++ code."
+msgstr ""
+
+#: src/chromium.md:6
+msgid ""
+"Today, we'll call into Rust to do something silly with strings. If you've "
+"got a corner of the code where you're displaying a UTF8 string to the user, "
+"feel free to follow this recipe in your part of the codebase instead of the "
+"exact part we talk about."
+msgstr ""
+
+#: src/chromium/setup.md:3
+msgid ""
+"Make sure you can build and run Chromium. Any platform and set of build "
+"flags is OK, so long as your code is relatively recent (commit position "
+"1223636 onwards, corresponding to November 2023):"
+msgstr ""
+
+#: src/chromium/setup.md:13
+msgid ""
+"(A component, debug build is recommended for quickest iteration time. This "
+"is the default!)"
+msgstr ""
+
+#: src/chromium/setup.md:16
+msgid ""
+"See [How to build Chromium](https://www.chromium.org/developers/how-tos/get-"
+"the-code/) if you aren't already at that point. Be warned: setting up to "
+"build Chromium takes time."
+msgstr ""
+
+#: src/chromium/setup.md:21
+msgid "It's also recommended that you have Visual Studio code installed."
+msgstr ""
+
+#: src/chromium/setup.md:23
+msgid "About the exercises"
+msgstr ""
+
+#: src/chromium/setup.md:25
+msgid ""
+"This part of the course has a series of exercises which build on each other. "
+"We'll be doing them spread throughout the course instead of just at the end. "
+"If you don't have time to complete a certain part, don't worry: you can "
+"catch up in the next slot."
+msgstr ""
+
+#: src/chromium/cargo.md:3
+msgid ""
+"Rust community typically uses `cargo` and libraries from [crates.io](https://"
+"crates.io/). Chromium is built using `gn` and `ninja` and a curated set of "
+"dependencies."
+msgstr ""
+
+#: src/chromium/cargo.md:6
+msgid "When writing code in Rust, your choices are:"
+msgstr ""
+
+#: src/chromium/cargo.md:8
+msgid ""
+"Use `gn` and `ninja` with the help of the templates from `//build/rust/*."
+"gni` (e.g. `rust_static_library` that we'll meet later). This uses "
+"Chromium's audited toolchain and crates."
+msgstr ""
+
+#: src/chromium/cargo.md:11
+msgid ""
+"Use `cargo`, but [restrict yourself to Chromium's audited toolchain and "
+"crates](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/"
+"docs/rust.md#Using-cargo)"
+msgstr ""
+
+#: src/chromium/cargo.md:13
+msgid ""
+"Use `cargo`, trusting a [toolchain](https://rustup.rs/) and/or [crates "
+"downloaded from the internet](https://crates.io/)"
+msgstr ""
+
+#: src/chromium/cargo.md:16
+msgid ""
+"From here on we'll be focusing on `gn` and `ninja`, because this is how Rust "
+"code can be built into the Chromium browser. At the same time, Cargo is an "
+"important part of the Rust ecosystem and you should keep it in your toolbox."
+msgstr ""
+
+#: src/chromium/cargo.md:20
+#, fuzzy
+msgid "Mini exercise"
+msgstr "練習問題"
+
+#: src/chromium/cargo.md:22
+msgid "Split into small groups and:"
+msgstr ""
+
+#: src/chromium/cargo.md:24
+msgid ""
+"Brainstorm scenarios where `cargo` may offer an advantage and assess the "
+"risk profile of these scenarios."
+msgstr ""
+
+#: src/chromium/cargo.md:26
+msgid ""
+"Discuss which tools, libraries, and groups of people need to be trusted when "
+"using `gn` and `ninja`, offline `cargo`, etc."
+msgstr ""
+
+#: src/chromium/cargo.md:31
+msgid ""
+"Ask students to avoid peeking at the speaker notes before completing the "
+"exercise. Assuming folks taking the course are physically together, ask them "
+"to discuss in small groups of 3-4 people."
+msgstr ""
+
+#: src/chromium/cargo.md:35
+msgid ""
+"Notes/hints related to the first part of the exercise (\"scenarios where "
+"Cargo may offer an advantage\"):"
+msgstr ""
+
+#: src/chromium/cargo.md:38
+msgid ""
+"It's fantastic that when writing a tool, or prototyping a part of Chromium, "
+"one has access to the rich ecosystem of crates.io libraries. There is a "
+"crate for almost anything and they are usually quite pleasant to use. "
+"(`clap` for command-line parsing, `serde` for serializing/deserializing to/"
+"from various formats, `itertools` for working with iterators, etc.)."
+msgstr ""
+
+#: src/chromium/cargo.md:44
+msgid ""
+"`cargo` makes it easy to try a library (just add a single line to `Cargo."
+"toml` and start writing code)"
+msgstr ""
+
+#: src/chromium/cargo.md:46
+msgid ""
+"It may be worth comparing how CPAN helped make `perl` a popular choice. Or "
+"comparing with `python` + `pip`."
+msgstr ""
+
+#: src/chromium/cargo.md:49
+msgid ""
+"Development experience is made really nice not only by core Rust tools (e.g. "
+"using `rustup` to switch to a different `rustc` version when testing a crate "
+"that needs to work on nightly, current stable, and older stable) but also by "
+"an ecosystem of third-party tools (e.g. Mozilla provides `cargo vet` for "
+"streamlining and sharing security audits; `criterion` crate gives a "
+"streamlined way to run benchmarks)."
+msgstr ""
+
+#: src/chromium/cargo.md:56
+msgid ""
+"`cargo` makes it easy to add a tool via `cargo install --locked cargo-vet`."
+msgstr ""
+
+#: src/chromium/cargo.md:57
+msgid "It may be worth comparing with Chrome Extensions or VScode extensions."
+msgstr ""
+
+#: src/chromium/cargo.md:59
+msgid ""
+"Broad, generic examples of projects where `cargo` may be the right choice:"
+msgstr ""
+
+#: src/chromium/cargo.md:61
+msgid ""
+"Perhaps surprisingly, Rust is becoming increasingly popular in the industry "
+"for writing command line tools. The breadth and ergonomics of libraries is "
+"comparable to Python, while being more robust (thanks to the rich "
+"typesystem) and running faster (as a compiled, rather than interpreted "
+"language)."
+msgstr ""
+
+#: src/chromium/cargo.md:66
+msgid ""
+"Participating in the Rust ecosystem requires using standard Rust tools like "
+"Cargo. Libraries that want to get external contributions, and want to be "
+"used outside of Chromium (e.g. in Bazel or Android/Soong build environments) "
+"should probably use Cargo."
+msgstr ""
+
+#: src/chromium/cargo.md:71
+msgid "Examples of Chromium-related projects that are `cargo`\\-based:"
+msgstr ""
+
+#: src/chromium/cargo.md:72
+msgid ""
+"`serde_json_lenient` (experimented with in other parts of Google which "
+"resulted in PRs with performance improvements)"
+msgstr ""
+
+#: src/chromium/cargo.md:74
+msgid "Fontations libraries like `font-types`"
+msgstr ""
+
+#: src/chromium/cargo.md:75
+msgid ""
+"`gnrt` tool (we will meet it later in the course) which depends on `clap` "
+"for command-line parsing and on `toml` for configuration files."
+msgstr ""
+
+#: src/chromium/cargo.md:77
+msgid ""
+"Disclaimer: a unique reason for using `cargo` was unavailability of `gn` "
+"when building and bootstrapping Rust standard library when building Rust "
+"toolchain.)"
+msgstr ""
+
+#: src/chromium/cargo.md:80
+msgid ""
+"`run_gnrt.py` uses Chromium's copy of `cargo` and `rustc`. `gnrt` depends on "
+"third-party libraries downloaded from the internet, by `run_gnrt.py` asks "
+"`cargo` that only `--locked` content is allowed via `Cargo.lock`.)"
+msgstr ""
+
+#: src/chromium/cargo.md:84
+msgid ""
+"Students may identify the following items as being implicitly or explicitly "
+"trusted:"
+msgstr ""
+
+#: src/chromium/cargo.md:87
+msgid ""
+"`rustc` (the Rust compiler) which in turn depends on the LLVM libraries, the "
+"Clang compiler, the `rustc` sources (fetched from GitHub, reviewed by Rust "
+"compiler team), binary Rust compiler downloaded for bootstrapping"
+msgstr ""
+
+#: src/chromium/cargo.md:90
+msgid ""
+"`rustup` (it may be worth pointing out that `rustup` is developed under the "
+"umbrella of the https://github.com/rust-lang/ organization - same as `rustc`)"
+msgstr ""
+
+#: src/chromium/cargo.md:92
+msgid "`cargo`, `rustfmt`, etc."
+msgstr ""
+
+#: src/chromium/cargo.md:93
+msgid ""
+"Various internal infrastructure (bots that build `rustc`, system for "
+"distributing the prebuilt toolchain to Chromium engineers, etc.)"
+msgstr ""
+
+#: src/chromium/cargo.md:95
+msgid "Cargo tools like `cargo audit`, `cargo vet`, etc."
+msgstr ""
+
+#: src/chromium/cargo.md:96
+msgid ""
+"Rust libraries vendored into `//third_party/rust` (audited by "
+"security@chromium.org)"
+msgstr ""
+
+#: src/chromium/cargo.md:98
+msgid "Other Rust libraries (some niche, some quite popular and commonly used)"
+msgstr ""
+
+#: src/chromium/policy.md:1
+msgid "Chromium Rust policy"
+msgstr ""
+
+#: src/chromium/policy.md:3
+msgid ""
+"Chromium does not yet allow first-party Rust except in rare cases as "
+"approved by Chromium's [Area Tech Leads](https://source.chromium.org/"
+"chromium/chromium/src/+/main:ATL_OWNERS)."
+msgstr ""
+
+#: src/chromium/policy.md:7
+msgid ""
+"Chromium's policy on third party libraries is outlined [here](https://"
+"chromium.googlesource.com/chromium/src/+/main/docs/adding_to_third_party."
+"md#rust) - Rust is allowed for third party libraries under various "
+"circumstances, including if they're the best option for performance or for "
+"security."
+msgstr ""
+
+#: src/chromium/policy.md:12
+msgid ""
+"Very few Rust libraries directly expose a C/C++ API, so that means that "
+"nearly all such libraries will require a small amount of first-party glue "
+"code."
+msgstr ""
+
+#: src/chromium/policy.md:15
+msgid ""
+"```bob\n"
+"\"C++\"                           Rust\n"
+".- - - - - - - - - -.           .- - - - - - - - - - - - - - - - - - - - - - "
+"-.\n"
+":                   :           :                                             :\n"
+": Existing Chromium :           :  Chromium Rust              Existing "
+"Rust   :\n"
+": \"C++\"             :           :  \"wrapper\"                  "
+"crate           :\n"
+": +---------------+ :           : +----------------+          +-------------"
+"+ :\n"
+": |               | :           : |                |          |             "
+"| :\n"
+": |         o-----+-+-----------+-+->            o-+----------+-->          "
+"| :\n"
+": |               | : Language  : |                | Crate    |             "
+"| :\n"
+": +---------------+ : boundary  : +----------------+ API      +-------------"
+"+ :\n"
+":                   :           :                                             :\n"
+"`- - - - - - - - - -'           `- - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
+"```"
+msgstr ""
+
+#: src/chromium/policy.md:30
+msgid ""
+"First-party Rust glue code for a particular third-party crate should "
+"normally be kept in `third_party/rust/<crate>/<version>/wrapper`."
+msgstr ""
+
+#: src/chromium/policy.md:33
+msgid "Because of this, today's course will be heavily focused on:"
+msgstr ""
+
+#: src/chromium/policy.md:35
+msgid "Bringing in third-party Rust libraries (\"crates\")"
+msgstr ""
+
+#: src/chromium/policy.md:36
+msgid "Writing glue code to be able to use those crates from Chromium C++."
+msgstr ""
+
+#: src/chromium/policy.md:38
+msgid "If this policy changes over time, the course will evolve to keep up."
+msgstr ""
+
+#: src/chromium/build-rules.md:1
+#, fuzzy
+msgid "Build rules"
+msgstr "ビルドのルール"
+
+#: src/chromium/build-rules.md:3
+msgid ""
+"Rust code is usually built using `cargo`. Chromium builds with `gn` and "
+"`ninja` for efficiency --- its static rules allow maximum parallelism. Rust "
+"is no exception."
+msgstr ""
+
+#: src/chromium/build-rules.md:7
+msgid "Adding Rust code to Chromium"
+msgstr ""
+
+#: src/chromium/build-rules.md:9
+msgid ""
+"In some existing Chromium `BUILD.gn` file, declare a `rust_static_library`:"
+msgstr ""
+
+#: src/chromium/build-rules.md:11
+msgid ""
+"```gn\n"
+"import(\"//build/rust/rust_static_library.gni\")\n"
+"\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [ \"lib.rs\" ]\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/chromium/build-rules.md:20
+msgid ""
+"You can also add `deps` on other Rust targets. Later we'll use this to "
+"depend upon third party code."
+msgstr ""
+
+#: src/chromium/build-rules.md:25
+msgid ""
+"You must specify _both_ the crate root, _and_ a full list of sources. The "
+"`crate_root` is the file given to the Rust compiler representing the root "
+"file of the compilation unit --- typically `lib.rs`. `sources` is a complete "
+"list of all source files which `ninja` needs in order to determine when "
+"rebuilds are necessary."
+msgstr ""
+
+#: src/chromium/build-rules.md:31
+msgid ""
+"(There's no such thing as a Rust `source_set`, because in Rust, an entire "
+"crate is a compilation unit. A `static_library` is the smallest unit.)"
+msgstr ""
+
+#: src/chromium/build-rules.md:34
+msgid ""
+"Students might be wondering why we need a gn template, rather than using "
+"[gn's built-in support for Rust static libraries](https://gn.googlesource."
+"com/gn/+/main/docs/reference.md#func_static_library). The answer is that "
+"this template provides support for CXX interop, Rust features, and unit "
+"tests, some of which we'll use later."
+msgstr ""
+
+#: src/chromium/build-rules/unsafe.md:1
+msgid "Including `unsafe` Rust Code"
+msgstr ""
+
+#: src/chromium/build-rules/unsafe.md:3
+msgid ""
+"Unsafe Rust code is forbidden in `rust_static_library` by default --- it "
+"won't compile. If you need unsafe Rust code, add `allow_unsafe = true` to "
+"the gn target. (Later in the course we'll see circumstances where this is "
+"necessary.)"
+msgstr ""
+
+#: src/chromium/build-rules/unsafe.md:7
+msgid ""
+"```gn\n"
+"import(\"//build/rust/rust_static_library.gni\")\n"
+"\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [\n"
+"    \"lib.rs\",\n"
+"    \"hippopotamus.rs\"\n"
+"  ]\n"
+"  allow_unsafe = true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/chromium/build-rules/depending.md:3
+msgid "Simply add the above target to the `deps` of some Chromium C++ target."
+msgstr ""
+
+#: src/chromium/build-rules/depending.md:5
+msgid ""
+"```gn\n"
+"import(\"//build/rust/rust_static_library.gni\")\n"
+"\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [ \"lib.rs\" ]\n"
+"}\n"
+"\n"
+"# or source_set, static_library etc.\n"
+"component(\"preexisting_cpp\") {\n"
+"  deps = [ \":my_rust_lib\" ]\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:3
+msgid ""
+"Types are elided in Rust code, which makes a good IDE even more useful than "
+"for C++. Visual Studio code works well for Rust in Chromium. To use it,"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:6
+msgid ""
+"Ensure your VSCode has the `rust-analyzer` extension, not earlier forms of "
+"Rust support"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:8
+msgid ""
+"`gn gen out/Debug --export-rust-project` (or equivalent for your output "
+"directory)"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:10
+msgid "`ln -s out/Debug/rust-project.json rust-project.json`"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:16
+msgid ""
+"A demo of some of the code annotation and exploration features of rust-"
+"analyzer might be beneficial if the audience are naturally skeptical of IDEs."
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:19
+msgid ""
+"The following steps may help with the demo (but feel free to instead use a "
+"piece of Chromium-related Rust that you are most familiar with):"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:22
+msgid "Open `components/qr_code_generator/qr_code_generator_ffi_glue.rs`"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:23
+msgid ""
+"Place the cursor over the `QrCode::new` call (around line 26) in "
+"\\`qr_code_generator_ffi_glue.rs"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:25
+msgid ""
+"Demo **show documentation** (typical bindings: vscode = ctrl k i; vim/CoC = "
+"K)."
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:27
+msgid ""
+"Demo **go to definition** (typical bindings: vscode = F12; vim/CoC = g d). "
+"(This will take you to `//third_party/rust/.../qr_code-.../src/lib.rs`.)"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:29
+msgid ""
+"Demo **outline** and navigate to the `QrCode::with_bits` method (around line "
+"164; the outline is in the file explorer pane in vscode; typical vim/CoC "
+"bindings = space o)"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:32
+msgid ""
+"Demo **type annotations** (there are quote a few nice examples in the "
+"`QrCode::with_bits` method)"
+msgstr ""
+
+#: src/chromium/build-rules/vscode.md:35
+msgid ""
+"It may be worth pointing out that `gn gen ... --export-rust-project` will "
+"need to be rerun after editing `BUILD.gn` files (which we will do a few "
+"times throughout the exercises in this session)."
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:1
+#, fuzzy
+msgid "Build rules exercise"
+msgstr "ビルドのルール"
+
+#: src/exercises/chromium/build-rules.md:3
+msgid ""
+"In your Chromium build, add a new Rust target to `//ui/base/BUILD.gn` "
+"containing:"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:13
+msgid ""
+"**Important**: note that `no_mangle` here is considered a type of unsafety "
+"by the Rust compiler, so you'll need to to allow unsafe code in your `gn` "
+"target."
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:16
+msgid ""
+"Add this new Rust target as a dependency of `//ui/base:base`. Declare this "
+"function at the top of `ui/base/resource/resource_bundle.cc` (later, we'll "
+"see how this can be automated by bindings generation tools):"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:24
+msgid ""
+"Call this function from somewhere in `ui/base/resource/resource_bundle.cc` - "
+"we suggest the top of `ResourceBundle::MaybeMangleLocalizedString`. Build "
+"and run Chromium, and ensure that \"Hello from Rust!\" is printed lots of "
+"times."
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:28
+msgid ""
+"If you use VSCode, now set up Rust to work well in VSCode. It will be useful "
+"in subsequent exercises. If you've succeeded, you will be able to use right-"
+"click \"Go to definition\" on `println!`."
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:32
+#: src/exercises/chromium/interoperability-with-cpp.md:48
+msgid "Where to find help"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:34
+msgid ""
+"The options available to the [`rust_static_library` gn template](https://"
+"source.chromium.org/chromium/chromium/src/+/main:build/rust/"
+"rust_static_library.gni;l=16)"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:35
+msgid ""
+"Information about [`#[no_mangle]`](https://doc.rust-lang.org/beta/reference/"
+"abi.html#the-no_mangle-attribute)"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:36
+msgid ""
+"Information about [`extern \"C\"`](https://doc.rust-lang.org/std/keyword."
+"extern.html)"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:37
+msgid ""
+"Information about gn's [`--export-rust-project`](https://gn.googlesource.com/"
+"gn/+/main/docs/reference.md#compilation-database) switch"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:38
+msgid ""
+"[How to install rust-analyzer in VSCode](https://code.visualstudio.com/docs/"
+"languages/rust)"
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:44
+msgid ""
+"This example is unusual because it boils down to the lowest-common-"
+"denominator interop language, C. Both C++ and Rust can natively declare and "
+"call C ABI functions. Later in the course, we'll connect C++ directly to "
+"Rust."
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:48
+msgid ""
+"`allow_unsafe = true` is required here because `#[no_mangle]` might allow "
+"Rust to generate two functions with the same name, and Rust can no longer "
+"guarantee that the right one is called."
+msgstr ""
+
+#: src/exercises/chromium/build-rules.md:52
+msgid ""
+"If you need a pure Rust executable, you can also do that using the "
+"`rust_executable` gn template."
+msgstr ""
+
+#: src/chromium/testing.md:3
+msgid ""
+"Rust community typically authors unit tests in a module placed in the same "
+"source file as the code being tested. This was covered [earlier](../testing."
+"md) in the course and looks like this:"
+msgstr ""
+
+#: src/chromium/testing.md:17
+msgid ""
+"In Chromium we place unit tests in a separate source file and we continue to "
+"follow this practice for Rust --- this makes tests consistently discoverable "
+"and helps to avoid rebuilding `.rs` files a second time (in the `test` "
+"configuration)."
+msgstr ""
+
+#: src/chromium/testing.md:22
+msgid ""
+"This results in the following options for testing Rust code in Chromium:"
+msgstr ""
+
+#: src/chromium/testing.md:24
+msgid ""
+"Native Rust tests (i.e. `#[test]`). Discouraged outside of `//third_party/"
+"rust`."
+msgstr ""
+
+#: src/chromium/testing.md:26
+msgid ""
+"`gtest` tests authored in C++ and exercising Rust via FFI calls. Sufficient "
+"when Rust code is just a thin FFI layer and the existing unit tests provide "
+"sufficient coverage for the feature."
+msgstr ""
+
+#: src/chromium/testing.md:29
+msgid ""
+"`gtest` tests authored in Rust and using the crate under test through its "
+"public API (using `pub mod for_testing { ... }` if needed). This is the "
+"subject of the next few slides."
+msgstr ""
+
+#: src/chromium/testing.md:35
+msgid ""
+"Mention that native Rust tests of third-party crates should eventually be "
+"exercised by Chromium bots. (Such testing is needed rarely --- only after "
+"adding or updating third-party crates.)"
+msgstr ""
+
+#: src/chromium/testing.md:39
+msgid ""
+"Some examples may help illustrate when C++ `gtest` vs Rust `gtest` should be "
+"used:"
+msgstr ""
+
+#: src/chromium/testing.md:42
+msgid ""
+"QR has very little functionality in the first-party Rust layer (it's just a "
+"thin FFI glue) and therefore uses the existing C++ unit tests for testing "
+"both the C++ and the Rust implementation (parameterizing the tests so they "
+"enable or disable Rust using a `ScopedFeatureList`)."
+msgstr ""
+
+#: src/chromium/testing.md:47
+msgid ""
+"Hypothetical/WIP PNG integration may need to implement memory-safe "
+"implementation of pixel transformations that are provided by `libpng` but "
+"missing in the `png` crate - e.g. RGBA => BGRA, or gamma correction. Such "
+"functionality may benefit from separate tests authored in Rust."
+msgstr ""
+
+#: src/chromium/testing/rust-gtest-interop.md:3
+msgid ""
+"The [`rust_gtest_interop`](https://chromium.googlesource.com/chromium/src/+/"
+"main/testing/rust_gtest_interop/README.md) library provides a way to:"
+msgstr ""
+
+#: src/chromium/testing/rust-gtest-interop.md:5
+msgid ""
+"Use a Rust function as a `gtest` testcase (using the `#[gtest(...)]` "
+"attribute)"
+msgstr ""
+
+#: src/chromium/testing/rust-gtest-interop.md:7
+msgid ""
+"Use `expect_eq!` and similar macros (similar to `assert_eq!` but not "
+"panicking and not terminating the test when the assertion fails)."
+msgstr ""
+
+#: src/chromium/testing/rust-gtest-interop.md:10
+#, fuzzy
+msgid "Example:"
+msgstr "例"
+
+#: src/chromium/testing/build-gn.md:3
+msgid ""
+"The simplest way to build Rust `gtest` tests is to add them to an existing "
+"test binary that already contains tests authored in C++. For example:"
+msgstr ""
+
+#: src/chromium/testing/build-gn.md:6
+msgid ""
+"```gn\n"
+"test(\"ui_base_unittests\") {\n"
+"  ...\n"
+"  sources += [ \"my_rust_lib_unittest.rs\" ]\n"
+"  deps += [ \":my_rust_lib\" ]\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/chromium/testing/build-gn.md:14
+msgid ""
+"Authoring Rust tests in a separate `static_library` also works, but requires "
+"manually declaring the dependency on the support libraries:"
+msgstr ""
+
+#: src/chromium/testing/build-gn.md:17
+msgid ""
+"```gn\n"
+"rust_static_library(\"my_rust_lib_unittests\") {\n"
+"  testonly = true\n"
+"  is_gtest_unittests = true\n"
+"  crate_root = \"my_rust_lib_unittest.rs\"\n"
+"  sources = [ \"my_rust_lib_unittest.rs\" ]\n"
+"  deps = [\n"
+"    \":my_rust_lib\",\n"
+"    \"//testing/rust_gtest_interop\",\n"
+"  ]\n"
+"}\n"
+"\n"
+"test(\"ui_base_unittests\") {\n"
+"  ...\n"
+"  deps += [ \":my_rust_lib_unittests\" ]\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/chromium/testing/chromium-import-macro.md:3
+msgid ""
+"After adding `:my_rust_lib` to GN `deps`, we still need to learn how to "
+"import and use `my_rust_lib` from `my_rust_lib_unittest.rs`. We haven't "
+"provided an explicit `crate_name` for `my_rust_lib` so its crate name is "
+"computed based on the full target path and name. Fortunately we can avoid "
+"working with such an unwieldy name by using the `chromium::import!` macro "
+"from the automatically-imported `chromium` crate:"
+msgstr ""
+
+#: src/chromium/testing/chromium-import-macro.md:12
+msgid "\"//ui/base:my_rust_lib\""
+msgstr ""
+
+#: src/chromium/testing/chromium-import-macro.md:18
+msgid "Under the covers the macro expands to something similar to:"
+msgstr ""
+
+#: src/chromium/testing/chromium-import-macro.md:26
+msgid ""
+"More information can be found in [the doc comment](https://source.chromium."
+"org/chromium/chromium/src/+/main:build/rust/chromium_prelude/"
+"chromium_prelude.rs?q=f:chromium_prelude.rs%20pub.use.*%5Cbimport%5Cb;%20-f:"
+"third_party&ss=chromium%2Fchromium%2Fsrc) of the `chromium::import` macro."
+msgstr ""
+
+#: src/chromium/testing/chromium-import-macro.md:31
+msgid ""
+"`rust_static_library` supports specifying an explicit name via `crate_name` "
+"property, but doing this is discouraged. And it is discouraged because the "
+"crate name has to be globally unique. crates.io guarantees uniqueness of its "
+"crate names so `cargo_crate` GN targets (generated by the `gnrt` tool "
+"covered in a later section) use short crate names."
+msgstr ""
+
+#: src/exercises/chromium/testing.md:1
+#, fuzzy
+msgid "Testing exercise"
+msgstr "練習問題"
+
+#: src/exercises/chromium/testing.md:3
+msgid "Time for another exercise!"
+msgstr ""
+
+#: src/exercises/chromium/testing.md:5
+msgid "In your Chromium build:"
+msgstr ""
+
+#: src/exercises/chromium/testing.md:7
+msgid ""
+"Add a testable function next to `hello_from_rust`. Some suggestions: adding "
+"two integers received as arguments, computing the nth Fibonacci number, "
+"summing integers in a slice, etc."
+msgstr ""
+
+#: src/exercises/chromium/testing.md:10
+msgid "Add a separate `..._unittest.rs` file with a test for the new function."
+msgstr ""
+
+#: src/exercises/chromium/testing.md:11
+msgid "Add the new tests to `BUILD.gn`."
+msgstr ""
+
+#: src/exercises/chromium/testing.md:12
+msgid "Build the tests, run them, and verify that the new test works."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:3
+msgid ""
+"The Rust community offers multiple options for C++/Rust interop, with new "
+"tools being developed all the time. At the moment, Chromium uses a tool "
+"called CXX."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:6
+msgid ""
+"You describe your whole language boundary in an interface definition "
+"language (which looks a lot like Rust) and then CXX tools generate "
+"declarations for functions and types in both Rust and C++."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:12
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for a full example of "
+"using this."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:19
+msgid ""
+"Talk through the diagram. Explain that behind the scenes, this is doing just "
+"the same as you previously did. Point out that automating the process has "
+"the following benefits:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:23
+msgid ""
+"The tool guarantees that the C++ and Rust sides match (e.g. you get compile "
+"errors if the `#[cxx::bridge]` doesn't match the actual C++ or Rust "
+"definitions, but with out-of-sync manual bindings you'd get Undefined "
+"Behavior)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:27
+msgid ""
+"The tool automates generation of FFI thunks (small, C-ABI-compatible, free "
+"functions) for non-C features (e.g. enabling FFI calls into Rust or C++ "
+"methods; manual bindings would require authoring such top-level, free "
+"functions manually)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:31
+msgid "The tool and the library can handle a set of core types - for example:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:32
+msgid ""
+"`&[T]` can be passed across the FFI boundary, even though it doesn't "
+"guarantee any particular ABI or memory layout. With manual bindings `std::"
+"span<T>` / `&[T]` have to be manually destructured and rebuilt out of a "
+"pointer and length - this is error-prone given that each language represents "
+"empty slices slightly differently)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:37
+msgid ""
+"Smart pointers like `std::unique_ptr<T>`, `std::shared_ptr<T>`, and/or `Box` "
+"are natively supported. With manual bindings, one would have to pass C-ABI-"
+"compatible raw pointers, which would increase lifetime and memory-safety "
+"risks."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp.md:41
+msgid ""
+"`rust::String` and `CxxString` types understand and maintain differences in "
+"string representation across the languages (e.g. `rust::String::lossy` can "
+"build a Rust string from non-UTF8 input and `rust::String::c_str` can NUL-"
+"terminate a string)."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:3
+msgid ""
+"CXX requires that the whole C++/Rust boundary is declared in `cxx::bridge` "
+"modules inside `.rs` source code."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:16
+msgid "\"example/include/blobstore.h\""
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:24
+msgid "// Definitions of Rust types and functions go here\n"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:30
+msgid "Point out:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:32
+msgid ""
+"Although this looks like a regular Rust `mod`, the `#[cxx::bridge]` "
+"procedural macro does complex things to it. The generated code is quite a "
+"bit more sophisticated - though this does still result in a `mod` called "
+"`ffi` in your code."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:36
+msgid "Native support for C++'s `std::unique_ptr` in Rust"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:37
+#, fuzzy
+msgid "Native support for Rust slices in C++"
+msgstr "組み込みのテストサポート。"
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:38
+msgid "Calls from C++ to Rust, and Rust types (in the top part)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:39
+msgid "Calls from Rust to C++, and C++ types (in the bottom part)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/example-bindings.md:41
+msgid ""
+"**Common misconception**: It _looks_ like a C++ header is being parsed by "
+"Rust, but this is misleading. This header is never interpreted by Rust, but "
+"simply `#include`d in the generated C++ code for the benefit of C++ "
+"compilers."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:3
+msgid ""
+"By far the most useful page when using CXX is the [type reference](https://"
+"cxx.rs/bindings.html)."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:5
+msgid "CXX fundamentally suits cases where:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:7
+msgid ""
+"Your Rust-C++ interface is sufficiently simple that you can declare all of "
+"it."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:8
+msgid ""
+"You're using only the types natively supported by CXX already, for example "
+"`std::unique_ptr`, `std::string`, `&[u8]` etc."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:11
+msgid ""
+"It has many limitations --- for example lack of support for Rust's `Option` "
+"type."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:14
+msgid ""
+"These limitations constrain us to using Rust in Chromium only for well "
+"isolated \"leaf nodes\" rather than for arbitrary Rust-C++ interop. When "
+"considering a use-case for Rust in Chromium, a good starting point is to "
+"draft the CXX bindings for the language boundary to see if it appears simple "
+"enough."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:26
+msgid ""
+"You should also discuss some of the other sticky points with CXX, for "
+"example:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:28
+msgid ""
+"Its error handling is based around C++ exceptions (given on the next slide)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:29
+msgid "Function pointers are awkward to use."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:3
+msgid ""
+"CXX's [support for `Result<T,E>`](https://cxx.rs/binding/result.html) relies "
+"on C++ exceptions, so we can't use that in Chromium. Alternatives:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:6
+msgid "The `T` part of `Result<T, E>` can be:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:7
+msgid ""
+"Returned via out parameters (e.g. via `&mut T`). This requires that `T` can "
+"be passed across the FFI boundary - for example `T` has to be:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:9
+msgid "A primitive type (like `u32` or `usize`)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:10
+msgid ""
+"A type natively supported by `cxx` (like `UniquePtr<T>`) that has a suitable "
+"default value to use in a failure case (_unlike_ `Box<T>`)."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:12
+msgid ""
+"Retained on the Rust side, and exposed via reference. This may be needed "
+"when `T` is a Rust type, which cannot be passed across the FFI boundary, and "
+"cannot be stored in `UniquePtr<T>`."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:16
+msgid "The `E` part of `Result<T, E>` can be:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:17
+msgid ""
+"Returned as a boolean (e.g. `true` representing success, and `false` "
+"representing failure)"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling.md:19
+msgid ""
+"Preserving error details is in theory possible, but so far hasn't been "
+"needed in practice."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:1
+#, fuzzy
+msgid "CXX Error Handling: QR Example"
+msgstr "エラー処理"
+
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:3
+msgid ""
+"The QR code generator is [an example](https://source.chromium.org/chromium/"
+"chromium/src/+/main:components/qr_code_generator/qr_code_generator_ffi_glue."
+"rs;l=13-18;drc=7bf1b75b910ca430501b9c6a74c1d18a0223ecca) where a boolean is "
+"used to communicate success vs failure, and where the successful result can "
+"be passed across the FFI boundary:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:8
+msgid "\"qr_code_generator\""
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:23
+msgid ""
+"Students may be curious about the semantics of the `out_qr_size` output. "
+"This is not the size of the vector, but the size of the QR code (and "
+"admittedly it is a bit redundant - this is the square root of the size of "
+"the vector)."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:27
+msgid ""
+"It may be worth pointing out the importance of initializing `out_qr_size` "
+"before calling into the Rust function. Creation of a Rust reference that "
+"points to uninitialized memory results in Undefined Behavior (unlike in C++, "
+"when only the act of dereferencing such memory results in UB)."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:32
+msgid ""
+"If students ask about `Pin`, then explain why CXX needs it for mutable "
+"references to C++ data: the answer is that C++ data can’t be moved around "
+"like Rust data, because it may contain self-referential pointers."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:1
+#, fuzzy
+msgid "CXX Error Handling: PNG Example"
+msgstr "エラー処理"
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:3
+msgid ""
+"A prototype of a PNG decoder illustrates what can be done when the "
+"successful result cannot be passed across the FFI boundary:"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:7
+msgid "\"gfx::rust_bindings\""
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:10
+msgid ""
+"/// This returns an FFI-friendly equivalent of `Result<PngReader<'a>,\n"
+"        /// ()>`.\n"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:14
+msgid "/// C++ bindings for the `crate::png::ResultOfPngReader` type.\n"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:21
+msgid "/// C++ bindings for the `crate::png::PngReader` type.\n"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:32
+msgid ""
+"`PngReader` and `ResultOfPngReader` are Rust types --- objects of these "
+"types cannot cross the FFI boundary without indirection of a `Box<T>`. We "
+"can't have an `out_parameter: &mut PngReader`, because CXX doesn't allow C++ "
+"to store Rust objects by value."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:37
+msgid ""
+"This example illustrates that even though CXX doesn't support arbitrary "
+"generics nor templates, we can still pass them across the FFI boundary by "
+"manually specializing / monomorphizing them into a non-generic type. In the "
+"example `ResultOfPngReader` is a non-generic type that forwards into "
+"appropriate methods of `Result<T, E>` (e.g. into `is_err`, `unwrap`, and/or "
+"`as_mut`)."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:1
+msgid "Using cxx in Chromium"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:3
+msgid ""
+"In Chromium, we define an independent `#[cxx::bridge] mod` for each leaf-"
+"node where we want to use Rust. You'd typically have one for each "
+"`rust_static_library`. Just add"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:7
+msgid ""
+"```gn\n"
+"cxx_bindings = [ \"my_rust_file.rs\" ]\n"
+"   # list of files containing #[cxx::bridge], not all source files\n"
+"allow_unsafe = true\n"
+"```"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:13
+msgid ""
+"to your existing `rust_static_library` target alongside `crate_root` and "
+"`sources`."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:16
+msgid "C++ headers will be generated at a sensible location, so you can just"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:19
+msgid "\"ui/base/my_rust_file.rs.h\""
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:22
+msgid ""
+"You will find some utility functions in `//base` to convert to/from Chromium "
+"C++ types to CXX Rust types --- for example [`SpanToRustSlice`](https://"
+"source.chromium.org/chromium/chromium/src/+/main:base/containers/span_rust.h;"
+"l=21)."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:27
+msgid "Students may ask --- why do we still need `allow_unsafe = true`?"
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:29
+msgid ""
+"The broad answer is that no C/C++ code is \"safe\" by the normal Rust "
+"standards. Calling back and forth to C/C++ from Rust may do arbitrary things "
+"to memory, and compromise the safety of Rust's own data layouts. Presence of "
+"_too many_ `unsafe` keywords in C/C++ interop can harm the signal-to-noise "
+"ratio of such a keyword, and is [controversial](https://steveklabnik.com/"
+"writing/the-cxx-debate), but strictly, bringing any foreign code into a Rust "
+"binary can cause unexpected behavior from Rust's perspective."
+msgstr ""
+
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:36
+msgid ""
+"The narrow answer lies in the diagram at the top of [this page](../"
+"interoperability-with-cpp.md) --- behind the scenes, CXX generates Rust "
+"`unsafe` and `extern \"C\"` functions just like we did manually in the "
+"previous section."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:1
+#, fuzzy
+msgid "Exercise: Interoperability with C++"
+msgstr "相互運用性"
+
+#: src/exercises/chromium/interoperability-with-cpp.md:3
+msgid "Part one"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:5
+msgid ""
+"In the Rust file you previously created, add a `#[cxx::bridge]` which "
+"specifies a single function, to be called from C++, called "
+"`hello_from_rust`, taking no parameters and returning no value."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:8
+msgid ""
+"Modify your previous `hello_from_rust` function to remove `extern \"C\"` and "
+"`#[no_mangle]`. This is now just a standard Rust function."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:10
+msgid "Modify your `gn` target to build these bindings."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:11
+msgid ""
+"In your C++ code, remove the forward-declaration of `hello_from_rust`. "
+"Instead, include the generated header file."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:13
+msgid "Build and run!"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:15
+msgid "Part two"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:17
+msgid ""
+"It's a good idea to play with CXX a little. It helps you think about how "
+"flexible Rust in Chromium actually is."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:20
+msgid "Some things to try:"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:22
+msgid "Call back into C++ from Rust. You will need:"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:23
+msgid ""
+"An additional header file which you can `include!` from your `cxx::bridge`. "
+"You'll need to declare your C++ function in that new header file."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:25
+msgid ""
+"An `unsafe` block to call such a function, or alternatively specify the "
+"`unsafe` keyword in your `#[cxx::bridge]` [as described here](https://cxx.rs/"
+"extern-c++.html#functions-and-member-functions)."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:27
+msgid ""
+"You may also need to `#include \"third_party/rust/cxx/v1/crate/include/cxx.h"
+"\"`"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:29
+msgid "Pass a C++ string from C++ into Rust."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:30
+msgid "Pass a reference to a C++ object into Rust."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:31
+msgid ""
+"Intentionally get the Rust function signatures mismatched from the `#[cxx::"
+"bridge]`, and get used to the errors you see."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:33
+msgid ""
+"Intentionally get the C++ function signatures mismatched from the `#[cxx::"
+"bridge]`, and get used to the errors you see."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:35
+msgid ""
+"Pass a `std::unique_ptr` of some type from C++ into Rust, so that Rust can "
+"own some C++ object."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:37
+msgid ""
+"Create a Rust object and pass it into C++, so that C++ owns it. (Hint: you "
+"need a `Box`)."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:39
+msgid "Declare some methods on a C++ type. Call them from Rust."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:40
+msgid "Declare some methods on a Rust type. Call them from C++."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:42
+msgid "Part three"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:44
+msgid ""
+"Now you understand the strengths and limitations of CXX interop, think of a "
+"couple of use-cases for Rust in Chromium where the interface would be "
+"sufficiently simple. Sketch how you might define that interface."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:50
+msgid "The [`cxx` binding reference](https://cxx.rs/bindings.html)"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:51
+msgid ""
+"The [`rust_static_library` gn template](https://source.chromium.org/chromium/"
+"chromium/src/+/main:build/rust/rust_static_library.gni;l=16)"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:57
+msgid "Some of the questions you may encounter:"
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:59
+msgid ""
+"I'm seeing a problem initializing a variable of type X with type Y, where X "
+"and Y are both function types. This is because your C++ function doesn't "
+"quite match the declaration in your `cxx::bridge`."
+msgstr ""
+
+#: src/exercises/chromium/interoperability-with-cpp.md:62
+msgid ""
+"I seem to be able to freely convert C++ references into Rust references. "
+"Doesn't that risk UB? For CXX's _opaque_ types, no, because they are zero-"
+"sized. For CXX trivial types yes, it's _possible_ to cause UB, although "
+"CXX's design makes it quite difficult to craft such an example."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:3
+msgid ""
+"Rust libraries are called \"crates\" and are found at [crates.io](https://"
+"crates.io). It's _very easy_ for Rust crates to depend upon one another. So "
+"they do!"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:6
+#, fuzzy
+msgid "C++ library"
+msgstr "ライブラリ"
+
+#: src/chromium/adding-third-party-crates.md:6
+#, fuzzy
+msgid "Rust crate"
+msgstr "便利クレート"
+
+#: src/chromium/adding-third-party-crates.md:8
+#, fuzzy
+msgid "Build system"
+msgstr "ビルドのルール"
+
+#: src/chromium/adding-third-party-crates.md:8
+#: src/chromium/adding-third-party-crates.md:10
+msgid "Lots"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:8
+msgid "Consistent: `Cargo.toml`"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:9
+msgid "Typical library size"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:9
+msgid "Large-ish"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:9
+msgid "Small"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:10
+msgid "Transitive dependencies"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:10
+msgid "Few"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:12
+msgid "For a Chromium engineer, this has pros and cons:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:14
+msgid ""
+"All crates use a common build system so we can automate their inclusion into "
+"Chromium..."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:16
+msgid ""
+"... but, crates typically have transitive dependencies, so you will likely "
+"have to bring in multiple libraries."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:19
+msgid "We'll discuss:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:21
+msgid "How to put a crate in the Chromium source code tree"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:22
+msgid "How to make `gn` build rules for it"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates.md:23
+msgid "How to audit its source code for sufficient safety."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:1
+msgid "Configuring the `Cargo.toml` file to add crates"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:3
+msgid ""
+"Chromium has a single set of centrally-managed direct crate dependencies. "
+"These are managed through a single [`Cargo.toml`](https://source.chromium."
+"org/chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/Cargo."
+"toml):"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:6
+msgid ""
+"```toml\n"
+"[dependencies]\n"
+"bitflags = \"1\"\n"
+"cfg-if = \"1\"\n"
+"cxx = \"1\"\n"
+"# lots more...\n"
+"```"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:14
+msgid ""
+"As with any other `Cargo.toml`, you can specify [more details about the "
+"dependencies](https://doc.rust-lang.org/cargo/reference/specifying-"
+"dependencies.html) --- most commonly, you'll want to specify the `features` "
+"that you wish to enable in the crate."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:18
+msgid ""
+"When adding a crate to Chromium, you'll often need to provide some extra "
+"information in an additional file, `gnrt_config.toml`, which we'll meet next."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:3
+msgid ""
+"Alongside `Cargo.toml` is [`gnrt_config.toml`](https://source.chromium.org/"
+"chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/gnrt_config."
+"toml). This contains Chromium-specific extensions to crate handling."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:6
+msgid ""
+"If you add a new crate, you should specify at least the `group`. This is one "
+"of:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:15
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:15
+msgid "For instance,"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:22
+msgid ""
+"Depending on the crate source code layout, you may also need to use this "
+"file to specify where its `LICENSE` file(s) can be found."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:25
+msgid ""
+"Later, we'll see some other things you will need to configure in this file "
+"to resolve problems."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:3
+msgid ""
+"A tool called `gnrt` knows how to download crates and how to generate `BUILD."
+"gn` rules."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:6
+msgid "To start, download the crate you want like this:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:13
+msgid ""
+"Although the `gnrt` tool is part of the Chromium source code, by running "
+"this command you will be downloading and running its dependencies from "
+"`crates.io`. See [the earlier section](../cargo.md) discussing this security "
+"decision."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:17
+msgid "This `vendor` command may download:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:19
+#, fuzzy
+msgid "Your crate"
+msgstr "便利クレート"
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:20
+msgid "Direct and transitive dependencies"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:21
+msgid ""
+"New versions of other crates, as required by `cargo` to resolve the complete "
+"set of crates required by Chromium."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/downloading-crates.md:24
+msgid ""
+"Chromium maintains patches for some crates, kept in `//third_party/rust/"
+"chromium_crates_io/patches`. These will be reapplied automatically, but if "
+"patching fails you may need to take manual action."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:3
+msgid ""
+"Once you've downloaded the crate, generate the `BUILD.gn` files like this:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:9
+msgid "Now run `git status`. You should find:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:11
+msgid ""
+"At least one new crate source code in `third_party/rust/chromium_crates_io/"
+"vendor`"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:13
+msgid ""
+"At least one new `BUILD.gn` in `third_party/rust/<crate name>/v<major semver "
+"version>`"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:15
+msgid "An appropriate `README.chromium`"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:17
+#, fuzzy
+msgid ""
+"The \"major semver version\" is a [Rust \"semver\" version number](https://"
+"doc.rust-lang.org/cargo/reference/semver.html)."
+msgstr ""
+"[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)（ワー"
+"クスペース）"
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:19
+msgid ""
+"Take a close look, especially at the things generated in `third_party/rust`."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:23
+msgid ""
+"Talk a little about semver --- and specifically the way that in Chromium "
+"it's to allow multiple incompatible versions of a crate, which is "
+"discouraged but sometimes necessary in the Cargo ecosystem."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:3
+msgid ""
+"If your build fails, it may be because of a `build.rs`: programs which do "
+"arbitrary things at build time. This is fundamentally at odds with the "
+"design of `gn` and `ninja` which aim for static, deterministic, build rules "
+"to maximize parallelism and repeatability of builds."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:8
+msgid ""
+"Some `build.rs` actions are automatically supported; others require action:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
+msgid "build script effect"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
+msgid "Supported by our gn templates"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
+msgid "Work required by you"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+msgid "Checking rustc version to configure features on and off"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
+msgid "None"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
+msgid "Checking platform or CPU to configure features on and off"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
+#, fuzzy
+msgid "Generating code"
+msgstr "ジェネリクス（generics）"
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
+msgid "Yes - specify in `gnrt_config.toml`"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+msgid "Building C/C++"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
+msgid "Patch around it"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
+msgid "Arbitrary other actions"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:18
+msgid ""
+"Fortunately, most crates don't contain a build script, and fortunately, most "
+"build scripts only do the top two actions."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:3
+msgid ""
+"If `ninja` complains about missing files, check the `build.rs` to see if it "
+"writes source code files."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:6
+msgid ""
+"If so, modify [`gnrt_config.toml`](../configuring-gnrt-config-toml.md) to "
+"add `build-script-outputs` to the crate. If this is a transitive dependency, "
+"that is, one on which Chromium code should not directly depend, also add "
+"`allow-first-party-usage=false`. There are several examples already in that "
+"file:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:11
+msgid ""
+"```toml\n"
+"[crate.unicode-linebreak]\n"
+"allow-first-party-usage = false\n"
+"build-script-outputs = [\"tables.rs\"]\n"
+"```"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:17
+msgid ""
+"Now rerun [`gnrt.py -- gen`](../generating-gn-build-rules.md) to regenerate "
+"`BUILD.gn` files to inform ninja that this particular output file is input "
+"to subsequent build steps."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:3
+msgid ""
+"Some crates use the [`cc`](https://crates.io/crates/cc) crate to build and "
+"link C/C++ libraries. Other crates parse C/C++ using [`bindgen`](https://"
+"crates.io/crates/bindgen) within their build scripts. These actions can't be "
+"supported in a Chromium context --- our gn, ninja and LLVM build system is "
+"very specific in expressing relationships between build actions."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:8
+msgid "So, your options are:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:10
+msgid "Avoid these crates"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:11
+msgid "Apply a patch to the crate."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:13
+msgid ""
+"Patches should be kept in `third_party/rust/chromium_crates_io/patches/"
+"<crate>` - see for example the [patches against the `cxx` crate](https://"
+"source.chromium.org/chromium/chromium/src/+/main:third_party/rust/"
+"chromium_crates_io/patches/cxx/) - and will be applied automatically by "
+"`gnrt` each time it upgrades the crate."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:3
+msgid ""
+"Once you've added a third-party crate and generated build rules, depending "
+"on a crate is simple. Find your `rust_static_library` target, and add a "
+"`dep` on the `:lib` target within your crate."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:7
+msgid "Specifically,"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:9
+msgid ""
+"```bob\n"
+"                     +------------+      +----------------------+\n"
+"\"//third_party/rust\" | crate name | \"/v\" | major semver version | \":lib"
+"\"\n"
+"                     +------------+      +----------------------+\n"
+"```"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:17
+msgid ""
+"```gn\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [ \"lib.rs\" ]\n"
+"  deps = [ \"//third_party/rust/example_rust_crate/v1:lib\" ]\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:1
+msgid "Auditing Third Party Crates"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:3
+msgid ""
+"Adding new libraries is subject to Chromium's standard [policies](https://"
+"chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/rust."
+"md#Third_party-review), but of course also subject to security review. As "
+"you may be bringing in not just a single crate but also transitive "
+"dependencies, there may be a lot of code to review. On the other hand, safe "
+"Rust code can have limited negative side effects. How should you review it?"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:9
+msgid ""
+"Over time Chromium aims to move to a process based around [cargo vet]"
+"(https://mozilla.github.io/cargo-vet/)."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:11
+msgid ""
+"Meanwhile, for each new crate addition, we are checking for the following:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:13
+msgid ""
+"Understand why each crate is used. What's the relationship between crates? "
+"If the build system for each crate contains a `build.rs` or procedural "
+"macros, work out what they're for. Are they compatible with the way Chromium "
+"is normally built?"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:17
+msgid "Check each crate seems to be reasonably well maintained"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:18
+msgid ""
+"Use `cd third-party/rust/chromium_crates_io; cargo audit` to check for known "
+"vulnerabilities (first you'll need to `cargo install cargo-audit`, which "
+"ironically involves downloading lots of dependencies from the internet[2](../"
+"cargo.md))"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:21
+msgid ""
+"Ensure any `unsafe` code is good enough for the [Rule of Two](https://"
+"chromium.googlesource.com/chromium/src/+/main/docs/security/rule-of-2."
+"md#unsafe-code-in-safe-languages)"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:22
+msgid "Check for any use of `fs` or `net` APIs"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:23
+msgid ""
+"Read all the code at a sufficient level to look for anything out of place "
+"that might have been maliciously inserted. (You can't realistically aim for "
+"100% perfection here: there's often just too much code.)"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:27
+msgid ""
+"These are just guidelines --- work with reviewers from `security@chromium."
+"org` to work out the right way to become confident of the crate."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:1
+msgid "Checking Crates into Chromium Source Code"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:3
+msgid "`git status` should reveal:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:5
+msgid "Crate code in `//third_party/rust/chromium_crates_io`"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:6
+msgid ""
+"Metadata (`BUILD.gn` and `README.chromium`) in `//third_party/rust/<crate>/"
+"<version>`"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:9
+msgid "Please also add an `OWNERS` file in the latter location."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:11
+msgid ""
+"You should land all this, along with your `Cargo.toml` and `gnrt_config."
+"toml` changes, into the Chromium repo."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:14
+msgid ""
+"**Important**: you need to use `git add -f` because otherwise `.gitignore` "
+"files may result in some files being skipped."
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/checking-in.md:17
+msgid ""
+"As you do so, you might find presubmit checks fail because of non-inclusive "
+"language. This is because Rust crate data tends to include names of git "
+"branches, and many projects still use non-inclusive terminology there. So "
+"you may need to run:"
+msgstr ""
+
+#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:3
+msgid ""
+"As the OWNER of any third party Chromium dependency, you are [expected to "
+"keep it up to date with any security fixes](https://chromium.googlesource."
+"com/chromium/src/+/main/docs/adding_to_third_party.md#add-owners). It is "
+"hoped that we will soon automate this for Rust crates, but for now, it's "
+"still your responsibility just as it is for any other third party dependency."
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:3
+msgid ""
+"Add [uwuify](https://crates.io/crates/uwuify) to Chromium, turning off the "
+"crate's [default features](https://doc.rust-lang.org/cargo/reference/"
+"features.html#the-default-feature). Assume that the crate will be used in "
+"shipping Chromium, but won't be used to handle untrustworthy input."
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:7
+msgid ""
+"(In the next exercise we'll use uwuify from Chromium, but feel free to skip "
+"ahead and do that now if you like. Or, you could create a new "
+"[`rust_executable` target](https://source.chromium.org/chromium/chromium/src/"
+"+/main:build/rust/rust_executable.gni) which uses `uwuify`)."
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:13
+msgid "Students will need to download lots of transitive dependencies."
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:15
+msgid "The total crates needed are:"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:17
+msgid "`instant`,"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:18
+msgid "`lock_api`,"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:19
+msgid "`parking_lot`,"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:20
+msgid "`parking_lot_core`,"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:21
+msgid "`redox_syscall`,"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:22
+msgid "`scopeguard`,"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:23
+msgid "`smallvec`, and"
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:24
+msgid "`uwuify`."
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:26
+msgid ""
+"If students are downloading even more than that, they probably forgot to "
+"turn off the default features."
+msgstr ""
+
+#: src/exercises/chromium/third-party.md:29
+msgid ""
+"Thanks to [Daniel Liu](https://github.com/Daniel-Liu-c0deb0t) for this crate!"
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:1
+msgid "Bringing It Together --- Exercise"
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:3
+msgid ""
+"In this exercise, you're going to add a whole new Chromium feature, bringing "
+"together everything you already learned."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:6
+msgid "The Brief from Product Management"
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:8
+msgid ""
+"A community of pixies has been discovered living in a remote rainforest. "
+"It's important that we get Chromium for Pixies delivered to them as soon as "
+"possible."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:11
+msgid ""
+"The requirement is to translate all Chromium's UI strings into Pixie "
+"language."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:13
+msgid ""
+"There's not time to wait for proper translations, but fortunately pixie "
+"language is very close to English, and it turns out there's a Rust crate "
+"which does the translation."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:17
+msgid ""
+"In fact, you already [imported that crate in the previous exercise](https://"
+"crates.io/crates/uwuify)."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:19
+msgid ""
+"(Obviously, real translations of Chrome require incredible care and "
+"diligence. Don't ship this!)"
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:22
+msgid "Steps"
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:24
+msgid ""
+"Modify `ResourceBundle::MaybeMangleLocalizedString` so that it uwuifies all "
+"strings before display. In this special build of Chromium, it should always "
+"do this irrespective of the setting of `mangle_localized_strings_`."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:28
+msgid ""
+"If you've done everything right across all these exercises, congratulations, "
+"you should have created Chrome for pixies!"
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:36
+msgid ""
+"UTF16 vs UTF8. Students should be aware that Rust strings are always UTF8, "
+"and will probably decide that it's better to do the conversion on the C++ "
+"side using `base::UTF16ToUTF8` and back again."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:39
+msgid ""
+"If students decide to do the conversion on the Rust side, they'll need to "
+"consider [`String::from_utf16`](https://doc.rust-lang.org/std/string/struct."
+"String.html#method.from_utf16), consider error handling, and consider which "
+"[CXX supported types can transfer a lot of u16s](https://cxx.rs/binding/"
+"slice.html)."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:42
+msgid ""
+"Students may design the C++/Rust boundary in several different ways, e.g. "
+"taking and returning strings by value, or taking a mutable reference to a "
+"string. If a mutable reference is used, CXX will likely tell the student "
+"that they need to use [`Pin`](https://doc.rust-lang.org/std/pin/). You may "
+"need to explain what `Pin` does, and then explain why CXX needs it for "
+"mutable references to C++ data: the answer is that C++ data can't be moved "
+"around like Rust data, because it may contain self-referential pointers."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:49
+msgid ""
+"The C++ target containing `ResourceBundle::MaybeMangleLocalizedString` will "
+"need to depend on a `rust_static_library` target. The student probably "
+"already did this."
+msgstr ""
+
+#: src/exercises/chromium/bringing-it-together.md:52
+msgid ""
+"The `rust_static_library` target will need to depend on `//third_party/rust/"
+"uwuify/v0_2:lib`."
+msgstr ""
+
+#: src/exercises/chromium/solutions.md:3
+msgid ""
+"Solutions to the Chromium exercises can be found in [this series of CLs]"
+"(https://chromium-review.googlesource.com/c/chromium/src/+/5096560)."
+msgstr ""
+
 #: src/bare-metal.md:1
 msgid "Welcome to Bare Metal Rust"
 msgstr "ベアメタルRustへようこそ"
@@ -10610,7 +14591,7 @@ msgstr ""
 "Rustの基本的な部分に関しては習得済みな人で（例えば、本講座で）、Cなどの他の言"
 "語でベアメタル開発の経験があると理想的です。"
 
-#: src/bare-metal.md:7
+#: src/bare-metal.md:8
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
 "underneath us. This will be divided into several parts:"
@@ -10618,23 +14599,23 @@ msgstr ""
 "今日、取り扱うのは、ベアメタルRustです。すなわち、OSなしでRustのコードを実行"
 "します。この章は以下のような構成になります:"
 
-#: src/bare-metal.md:10
+#: src/bare-metal.md:11
 msgid "What is `no_std` Rust?"
 msgstr "`no_std` Rustとは?"
 
-#: src/bare-metal.md:11
+#: src/bare-metal.md:12
 msgid "Writing firmware for microcontrollers."
 msgstr "マイクロコントローラ向けのファームウェア開発。"
 
-#: src/bare-metal.md:12
+#: src/bare-metal.md:13
 msgid "Writing bootloader / kernel code for application processors."
 msgstr "アプリケーションプロセッサ向けのブートローダ／カーネル開発。"
 
-#: src/bare-metal.md:13
+#: src/bare-metal.md:14
 msgid "Some useful crates for bare-metal Rust development."
 msgstr "ベアメタルRust開発に役立つクレートの紹介。"
 
-#: src/bare-metal.md:15
+#: src/bare-metal.md:16
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
 "(https://microbit.org/) v2 as an example. It's a [development board](https://"
@@ -10647,34 +14628,26 @@ msgstr ""
 "(https://tech.microbit.org/hardware/) で、いくつかのLEDやボタンスイッチ、I2C"
 "接続の加速度センサやコンパス、そしてオンボードSWDデバッガを搭載しています。"
 
-#: src/bare-metal.md:20
+#: src/bare-metal.md:22
 msgid ""
 "To get started, install some tools we'll need later. On gLinux or Debian:"
 msgstr ""
 "まずはじめに、後ほど必要となるいくつかのツールをインストールします。gLinuxま"
 "たはDebianの場合は以下のようになります:"
 
-#: src/bare-metal.md:30
+#: src/bare-metal.md:34
 msgid ""
 "And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
 "さらに、`plugdev`グループにmicro:bitプログラム用デバイスへのアクセスを付与し"
 "ます:"
 
-#: src/bare-metal.md:38 src/bare-metal/microcontrollers/debugging.md:27
+#: src/bare-metal.md:44 src/bare-metal/microcontrollers/debugging.md:33
 msgid "On MacOS:"
 msgstr "MacOSの場合は以下のようになります:"
 
-#: src/bare-metal/no_std.md:1
-msgid "`no_std`"
-msgstr ""
-
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
-msgstr ""
-
-#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
-msgid "`alloc`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:17
@@ -10777,23 +14750,23 @@ msgstr "`std`は`core`と`alloc`の両方を再エクスポートします。"
 msgid "A minimal `no_std` program"
 msgstr "最小限の`no_std`プログラム"
 
-#: src/bare-metal/minimal.md:17
+#: src/bare-metal/minimal.md:19
 msgid "This will compile to an empty binary."
 msgstr "このコードは空のバイナリにコンパイルされます。"
 
-#: src/bare-metal/minimal.md:18
+#: src/bare-metal/minimal.md:20
 msgid "`std` provides a panic handler; without it we must provide our own."
 msgstr ""
 "パニックハンドラは`std`が提供するので、それを使わない場合は自分で提供する必要"
 "があります。"
 
-#: src/bare-metal/minimal.md:19
+#: src/bare-metal/minimal.md:21
 msgid "It can also be provided by another crate, such as `panic-halt`."
 msgstr ""
 "あるいは、`panic-halt`のような別のクレートが提供するパニックハンドラを利用す"
 "ることもできます。"
 
-#: src/bare-metal/minimal.md:20
+#: src/bare-metal/minimal.md:22
 msgid ""
 "Depending on the target, you may need to compile with `panic = \"abort\"` to "
 "avoid an error about `eh_personality`."
@@ -10801,7 +14774,7 @@ msgstr ""
 "ターゲットによっては、`eh_personality`に関するエラーを回避するために`panic = "
 "\"abort\"`を指定してコンパイルする必要があります。"
 
-#: src/bare-metal/minimal.md:22
+#: src/bare-metal/minimal.md:24
 msgid ""
 "Note that there is no `main` or any other entry point; it's up to you to "
 "define your own entry point. This will typically involve a linker script and "
@@ -10828,15 +14801,15 @@ msgstr ""
 msgid "// Give the allocator some memory to allocate.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md:31
+#: src/bare-metal/alloc.md:29
 msgid "// Now we can do things that require heap allocation.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md:33
+#: src/bare-metal/alloc.md:31
 msgid "\"A string\""
 msgstr ""
 
-#: src/bare-metal/alloc.md:39
+#: src/bare-metal/alloc.md:37
 msgid ""
 "`buddy_system_allocator` is a third-party crate implementing a basic buddy "
 "system allocator. Other crates are available, or you can write your own or "
@@ -10846,15 +14819,15 @@ msgstr ""
 "ロケータです。その他にも利用できるクレートはありますし、自前で実装したり、別"
 "のアロケータに自分のコードをフックすることも可能です。"
 
-#: src/bare-metal/alloc.md:41
+#: src/bare-metal/alloc.md:40
 msgid ""
 "The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
 "in this case it can allocate regions of up to 2\\*\\*32 bytes."
 msgstr ""
-"パラメータ定数`LockedHeap`はアロケータの最大オーダを示します。この場合、"
-"2\\*\\*32バイトの領域を確保することが可能です。"
+"パラメータ定数`LockedHeap`はアロケータの最大オーダを示します。この場合、2\\*"
+"\\*32バイトの領域を確保することが可能です。"
 
-#: src/bare-metal/alloc.md:43
+#: src/bare-metal/alloc.md:42
 msgid ""
 "If any crate in your dependency tree depends on `alloc` then you must have "
 "exactly one global allocator defined in your binary. Usually this is done in "
@@ -10886,7 +14859,7 @@ msgstr ""
 "`cortex_m_rt`クレートはCortex Mマイクロコントローラ向けのリセットハンドラ（と"
 "その他もろもろ）を提供します。"
 
-#: src/bare-metal/microcontrollers.md:21
+#: src/bare-metal/microcontrollers.md:24
 msgid ""
 "Next we'll look at how to access peripherals, with increasing levels of "
 "abstraction."
@@ -10894,7 +14867,7 @@ msgstr ""
 "次は、抽象度の低いレベルから順に周辺I/Oにアクセスする方法について見ていきま"
 "す。"
 
-#: src/bare-metal/microcontrollers.md:25
+#: src/bare-metal/microcontrollers.md:29
 msgid ""
 "The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
 "> !`, because returning to the reset handler doesn't make sense."
@@ -10902,7 +14875,7 @@ msgstr ""
 "リセットハンドラはリターンしないので、`cortex_m_rt::entry`マクロは対象関数が"
 "`fn() -> !`という型であることを要求します。"
 
-#: src/bare-metal/microcontrollers.md:27
+#: src/bare-metal/microcontrollers.md:31
 msgid "Run the example with `cargo embed --bin minimal`"
 msgstr "この例は`cargo embed --bin minimal`により実行します"
 
@@ -10928,24 +14901,24 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:34
 #: src/bare-metal/microcontrollers/pacs.md:21
-#: src/bare-metal/microcontrollers/hals.md:25
+#: src/bare-metal/microcontrollers/hals.md:26
 msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:37
-#: src/bare-metal/microcontrollers/mmio.md:51
+#: src/bare-metal/microcontrollers/mmio.md:59
 msgid ""
 "// Safe because the pointers are to valid peripheral control registers, and\n"
 "    // no aliases exist.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:48
+#: src/bare-metal/microcontrollers/mmio.md:56
 #: src/bare-metal/microcontrollers/pacs.md:39
-#: src/bare-metal/microcontrollers/hals.md:29
+#: src/bare-metal/microcontrollers/hals.md:30
 msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:64
+#: src/bare-metal/microcontrollers/mmio.md:72
 msgid ""
 "GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
 "to the first row."
@@ -10953,10 +14926,10 @@ msgstr ""
 "GPIO 0のピン21はマトリクスLEDの一番目の列に、ピン28は最初の行に接続されていま"
 "す。"
 
-#: src/bare-metal/microcontrollers/mmio.md:66
-#: src/bare-metal/microcontrollers/pacs.md:59
-#: src/bare-metal/microcontrollers/hals.md:43
-#: src/bare-metal/microcontrollers/board-support.md:34
+#: src/bare-metal/microcontrollers/mmio.md:75
+#: src/bare-metal/microcontrollers/pacs.md:61
+#: src/bare-metal/microcontrollers/hals.md:44
+#: src/bare-metal/microcontrollers/board-support.md:37
 msgid "Run the example with:"
 msgstr "例の実行方法:"
 
@@ -10999,11 +14972,11 @@ msgstr ""
 "SVDファイルにはよく誤りがあり、また情報が不足していることも多いので、様々なプ"
 "ロジェクトがそれを修正・追加し、クレートとして公開しています。"
 
-#: src/bare-metal/microcontrollers/pacs.md:55
+#: src/bare-metal/microcontrollers/pacs.md:56
 msgid "`cortex-m-rt` provides the vector table, among other things."
 msgstr "`cortex-m-rt`はベクタテーブルも提供します。"
 
-#: src/bare-metal/microcontrollers/pacs.md:56
+#: src/bare-metal/microcontrollers/pacs.md:57
 msgid ""
 "If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
 "pac -- -d --no-show-raw-insn` to see the resulting binary."
@@ -11028,18 +15001,18 @@ msgstr ""
 "するラッパーを提供しています。これらのクレートの多くは[`embedded-hal`]"
 "(https://crates.io/crates/embedded-hal)が定義するトレイトを実装しています。"
 
-#: src/bare-metal/microcontrollers/hals.md:22
+#: src/bare-metal/microcontrollers/hals.md:23
 msgid "// Create HAL wrapper for GPIO port 0.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md:39
+#: src/bare-metal/microcontrollers/hals.md:40
 msgid ""
 "`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
 msgstr ""
 "`set_low`と`set_high`は`embedded_hal`の`OutputPin`トレイトの定義するメソッド"
 "です。"
 
-#: src/bare-metal/microcontrollers/hals.md:40
+#: src/bare-metal/microcontrollers/hals.md:41
 msgid ""
 "HAL crates exist for many Cortex-M and RISC-V devices, including various "
 "STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
@@ -11059,7 +15032,7 @@ msgstr ""
 "ボードサポートクレードは特定のボードに対して更に利便性を向上させるラッパーを"
 "提供します。"
 
-#: src/bare-metal/microcontrollers/board-support.md:28
+#: src/bare-metal/microcontrollers/board-support.md:31
 msgid ""
 "In this case the board support crate is just providing more useful names, "
 "and a bit of initialisation."
@@ -11067,7 +15040,7 @@ msgstr ""
 "この例では、ボードサポートクレートは単に分かりやすい名前を提供し、少しの初期"
 "化を実施しているだけです。"
 
-#: src/bare-metal/microcontrollers/board-support.md:30
+#: src/bare-metal/microcontrollers/board-support.md:33
 msgid ""
 "The crate may also include drivers for some on-board devices outside of the "
 "microcontroller itself."
@@ -11075,7 +15048,7 @@ msgstr ""
 "マイクロコントローラの外に実装されたオンボードデバイスに対するドライバも提供"
 "されていることがあります。"
 
-#: src/bare-metal/microcontrollers/board-support.md:32
+#: src/bare-metal/microcontrollers/board-support.md:35
 msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr "`microbit-v2`はマトリクスLEDに対する簡単なドライバを含んでいます。"
 
@@ -11091,7 +15064,7 @@ msgstr ""
 msgid "// pin_input.is_high(); // Error, moved.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:32
+#: src/bare-metal/microcontrollers/type-state.md:33
 msgid ""
 "Pins don't implement `Copy` or `Clone`, so only one instance of each can "
 "exist. Once a pin is moved out of the port struct nobody else can take it."
@@ -11100,7 +15073,7 @@ msgstr ""
 "だ一つのインスタンスだけが存在可能です。ピンがポート構造体からムーブされる"
 "と、他の誰もそのピンにアクセスすることはできなくなります。"
 
-#: src/bare-metal/microcontrollers/type-state.md:34
+#: src/bare-metal/microcontrollers/type-state.md:35
 msgid ""
 "Changing the configuration of a pin consumes the old pin instance, so you "
 "can’t keep use the old instance afterwards."
@@ -11108,7 +15081,7 @@ msgstr ""
 "ピンの設定を変更することは古いピンのインスタンスを消費することになります。そ"
 "のため、それ以降は古いインスタンスを使い続けることはできなくなります。"
 
-#: src/bare-metal/microcontrollers/type-state.md:36
+#: src/bare-metal/microcontrollers/type-state.md:37
 msgid ""
 "The type of a value indicates the state that it is in: e.g. in this case, "
 "the configuration state of a GPIO pin. This encodes the state machine into "
@@ -11121,7 +15094,7 @@ msgstr ""
 "で、正しい設定をせずにピンを使ってしまうことがなくなります。不正な状態遷移に"
 "関してはコンパイル時に発見されるようになります。"
 
-#: src/bare-metal/microcontrollers/type-state.md:40
+#: src/bare-metal/microcontrollers/type-state.md:42
 msgid ""
 "You can call `is_high` on an input pin and `set_high` on an output pin, but "
 "not vice-versa."
@@ -11130,13 +15103,9 @@ msgstr ""
 "て`set_high`を呼び出すことも可能です。しかし、その逆の組み合わせは不可能で"
 "す。"
 
-#: src/bare-metal/microcontrollers/type-state.md:41
+#: src/bare-metal/microcontrollers/type-state.md:44
 msgid "Many HAL crates follow this pattern."
 msgstr "多くのHALクレートがこのパターンを用いています。"
-
-#: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "`embedded-hal`"
-msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
@@ -11180,7 +15149,7 @@ msgstr ""
 "com/rust-embedded/awesome-embedded-rust#driver-crates)を実装します。例えば、"
 "加速度センサのドライバにはI2CやSPIバスの実装が必要かもしれません。"
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:19
+#: src/bare-metal/microcontrollers/embedded-hal.md:20
 msgid ""
 "There are implementations for many microcontrollers, as well as other "
 "platforms such as Linux on Raspberry Pi."
@@ -11188,16 +15157,12 @@ msgstr ""
 "多くのマイクロコントローラに対する実装に加えて、Raspberry Pi上のLinux向けの実"
 "装も存在します。"
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:21
+#: src/bare-metal/microcontrollers/embedded-hal.md:22
 msgid ""
 "There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
 "`embedded-hal`の`async`バージョンも開発中ですが、まだ安定してはいません。"
-
-#: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "`probe-rs`, `cargo-embed`"
-msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
@@ -11244,7 +15209,7 @@ msgstr ""
 "のコアサイト・デバッグ・アクセスポートにアクセスするためのものです。BBC "
 "micro:bit のオンボード・デバッガもこれを利用しています。"
 
-#: src/bare-metal/microcontrollers/probe-rs.md:19
+#: src/bare-metal/microcontrollers/probe-rs.md:20
 msgid ""
 "ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
 "is a range from SEGGER."
@@ -11252,7 +15217,7 @@ msgstr ""
 "ST-Link はST Microelectronicsによるインサーキット・デバッガの総称で、 J-Link"
 "はSEGGERによるインサーキット・デバッガの総称です。"
 
-#: src/bare-metal/microcontrollers/probe-rs.md:21
+#: src/bare-metal/microcontrollers/probe-rs.md:22
 msgid ""
 "The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
 "Serial Wire Debug."
@@ -11260,14 +15225,14 @@ msgstr ""
 "デバッグ・アクセスポートは通常５ピンのJTAGインタフェースか、2ピンのシリアルワ"
 "イヤデバッグです。"
 
-#: src/bare-metal/microcontrollers/probe-rs.md:22
+#: src/bare-metal/microcontrollers/probe-rs.md:24
 msgid ""
 "probe-rs is a library which you can integrate into your own tools if you "
 "want to."
 msgstr ""
 "probe-rsは自分で独自のツールを統合したい場合に利用できるライブラリです。"
 
-#: src/bare-metal/microcontrollers/probe-rs.md:23
+#: src/bare-metal/microcontrollers/probe-rs.md:26
 msgid ""
 "The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
 "adapter-protocol/) lets VSCode and other IDEs debug code running on any "
@@ -11277,11 +15242,11 @@ msgstr ""
 "protocol/) はVSCodeや他のIDEから、サポートされたマイクロコントローラ上で実行"
 "されているコードをデバッグすることを可能にします。"
 
-#: src/bare-metal/microcontrollers/probe-rs.md:25
+#: src/bare-metal/microcontrollers/probe-rs.md:30
 msgid "cargo-embed is a binary built using the probe-rs library."
 msgstr "cargo-embedはprobe-rsライブラリを利用して生成されたバイナリです。"
 
-#: src/bare-metal/microcontrollers/probe-rs.md:26
+#: src/bare-metal/microcontrollers/probe-rs.md:31
 msgid ""
 "RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
 "host and the target through a number of ringbuffers."
@@ -11293,21 +15258,21 @@ msgstr ""
 msgid "_Embed.toml_:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:13
+#: src/bare-metal/microcontrollers/debugging.md:15
 msgid "In one terminal under `src/bare-metal/microcontrollers/examples/`:"
 msgstr ""
 "ひとつのターミナルで、`src/bare-metal/microcontrollers/examples/`において下記"
 "を実行:"
 
-#: src/bare-metal/microcontrollers/debugging.md:19
+#: src/bare-metal/microcontrollers/debugging.md:23
 msgid "In another terminal in the same directory:"
 msgstr "別のターミナルで、同じディレクトリで下記を実行:"
 
-#: src/bare-metal/microcontrollers/debugging.md:21
+#: src/bare-metal/microcontrollers/debugging.md:25
 msgid "On gLinux or Debian:"
 msgstr "gLinuxまたはDebianの場合:"
 
-#: src/bare-metal/microcontrollers/debugging.md:34
+#: src/bare-metal/microcontrollers/debugging.md:43
 msgid "In GDB, try running:"
 msgstr "GDBで下記を実行してみてください:"
 
@@ -11351,11 +15316,11 @@ msgstr ""
 "セキュリティに焦点をあてたRTOSで、プリエンプティブ・スケジューリングとMemory "
 "Protection Unitをサポート"
 
-#: src/bare-metal/microcontrollers/other-projects.md:10
+#: src/bare-metal/microcontrollers/other-projects.md:11
 msgid "[Hubris](https://hubris.oxide.computer/)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:11
+#: src/bare-metal/microcontrollers/other-projects.md:12
 msgid ""
 "Microkernel RTOS from Oxide Computer Company with memory protection, "
 "unprivileged drivers, IPC"
@@ -11363,12 +15328,12 @@ msgstr ""
 "Oxide Computer CompanyによるマイクロカーネルのRTOSでメモリ保護、非特権ドライ"
 "バ、IPCを提供"
 
-#: src/bare-metal/microcontrollers/other-projects.md:12
+#: src/bare-metal/microcontrollers/other-projects.md:14
 msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
 msgstr ""
 "[FreeRTOSに対するRustバインディング](https://github.com/lobaro/FreeRTOS-rust)"
 
-#: src/bare-metal/microcontrollers/other-projects.md:13
+#: src/bare-metal/microcontrollers/other-projects.md:15
 msgid ""
 "Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
 "github.io/book/overview/using-the-standard-library.html)."
@@ -11376,17 +15341,17 @@ msgstr ""
 "いくつかのプラットフォームでは `std`の実装あり、例えば [esp-idf](https://esp-"
 "rs.github.io/book/overview/using-the-standard-library.html)。"
 
-#: src/bare-metal/microcontrollers/other-projects.md:18
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid "RTIC can be considered either an RTOS or a concurrency framework."
 msgstr ""
 "RTICはRTOSとして捉えることもできますし、並行実行のフレームワークとして捉える"
 "こともできます。"
 
-#: src/bare-metal/microcontrollers/other-projects.md:19
+#: src/bare-metal/microcontrollers/other-projects.md:21
 msgid "It doesn't include any HALs."
 msgstr "他のHALを全く含んでいません。"
 
-#: src/bare-metal/microcontrollers/other-projects.md:20
+#: src/bare-metal/microcontrollers/other-projects.md:22
 msgid ""
 "It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
 "scheduling rather than a proper kernel."
@@ -11394,18 +15359,18 @@ msgstr ""
 "スケジューリングはカーネルではなく、Cortex-M NVIC (Nested Virtual Interrupt "
 "Controller)を利用して行います。"
 
-#: src/bare-metal/microcontrollers/other-projects.md:22
+#: src/bare-metal/microcontrollers/other-projects.md:24
 msgid "Cortex-M only."
 msgstr "Cortex-Mのみの対応です。"
 
-#: src/bare-metal/microcontrollers/other-projects.md:23
+#: src/bare-metal/microcontrollers/other-projects.md:25
 msgid ""
 "Google uses TockOS on the Haven microcontroller for Titan security keys."
 msgstr ""
 "GoogleはTockOSをTitanセキュリティキーのHavenマイクロコントローラで利用してい"
 "ます。"
 
-#: src/bare-metal/microcontrollers/other-projects.md:24
+#: src/bare-metal/microcontrollers/other-projects.md:26
 msgid ""
 "FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
@@ -11420,6 +15385,14 @@ msgid ""
 msgstr ""
 "I2C接続のコンパスから方位を読み取り、その結果をシリアルポートに出力します。"
 
+#: src/exercises/bare-metal/morning.md:8
+#: src/exercises/concurrency/morning.md:12
+msgid ""
+"After looking at the exercises, you can look at the [solutions](solutions-"
+"morning.md) provided."
+msgstr ""
+"練習問題に取り組んだあとは、 [解答](solutions-morning.md)をみても構いません。"
+
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
@@ -11429,11 +15402,11 @@ msgstr ""
 "I2C接続のコンパスから方位を読み取り、その結果をシリアルポートに出力します。も"
 "し時間があれば、LEDやボタンをなんとか利用して方位を出力してみてください。"
 
-#: src/exercises/bare-metal/compass.md:6
+#: src/exercises/bare-metal/compass.md:7
 msgid "Hints:"
 msgstr "ヒント:"
 
-#: src/exercises/bare-metal/compass.md:8
+#: src/exercises/bare-metal/compass.md:9
 msgid ""
 "Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
 "latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
@@ -11445,17 +15418,17 @@ msgstr ""
 "メント、ならびに[micro:bitハードウェア仕様](https://tech.microbit.org/"
 "hardware/)を確認してみてください。"
 
-#: src/exercises/bare-metal/compass.md:11
+#: src/exercises/bare-metal/compass.md:13
 msgid ""
 "The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
 msgstr "LSM303AGR慣性計測器は内部のI2Cバスに接続されています。"
 
-#: src/exercises/bare-metal/compass.md:12
+#: src/exercises/bare-metal/compass.md:14
 msgid ""
 "TWI is another name for I2C, so the I2C master peripheral is called TWIM."
 msgstr "TWIはI2Cの別名なので、I2CマスタはTWIMという名前になっています。"
 
-#: src/exercises/bare-metal/compass.md:13
+#: src/exercises/bare-metal/compass.md:15
 msgid ""
 "The LSM303AGR driver needs something implementing the `embedded_hal::"
 "blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
@@ -11465,7 +15438,7 @@ msgstr ""
 "要とします。 [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/"
 "microbit/hal/struct.Twim.html)構造体がこれを実装しています。"
 
-#: src/exercises/bare-metal/compass.md:17
+#: src/exercises/bare-metal/compass.md:19
 msgid ""
 "You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
 "struct.Board.html) struct with fields for the various pins and peripherals."
@@ -11473,7 +15446,7 @@ msgstr ""
 "様々なピンや周辺I/Oのための [`microbit::Board`](https://docs.rs/microbit-v2/"
 "latest/microbit/struct.Board.html)という構造体があります。"
 
-#: src/exercises/bare-metal/compass.md:19
+#: src/exercises/bare-metal/compass.md:22
 msgid ""
 "You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
 "com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
@@ -11483,7 +15456,7 @@ msgstr ""
 "nRF52833_PS_v1.5.pdf)を見ることもできますが、この練習問題のためには必要ないは"
 "ずです。"
 
-#: src/exercises/bare-metal/compass.md:23
+#: src/exercises/bare-metal/compass.md:26
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
 "look in the `compass` directory for the following files."
@@ -11491,56 +15464,91 @@ msgstr ""
 "[練習問題のテンプレート](../../comprehensive-rust-exercises.zip) をダウンロー"
 "ドして、`compass`というディレクトリの中にある下記のファイルを見てください。"
 
-#: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
+#: src/exercises/bare-metal/compass.md:29 src/exercises/bare-metal/rtc.md:22
 msgid "_src/main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:44
+#: src/exercises/bare-metal/compass.md:47
 #: src/exercises/bare-metal/solutions-morning.md:32
 msgid "// Configure serial port.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:52
+#: src/exercises/bare-metal/compass.md:55
 msgid ""
 "// Set up the I2C controller and Inertial Measurement Unit.\n"
 "    // TODO\n"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:55
+#: src/exercises/bare-metal/compass.md:58
 #: src/exercises/bare-metal/solutions-morning.md:56
 msgid "\"Ready.\""
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:58
+#: src/exercises/bare-metal/compass.md:61
 msgid ""
 "// Read compass data and log it to the serial port.\n"
 "        // TODO\n"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:64 src/exercises/bare-metal/rtc.md:385
+#: src/exercises/bare-metal/compass.md:67 src/exercises/bare-metal/rtc.md:387
 msgid "_Cargo.toml_ (you shouldn't need to change this):"
 msgstr "_Cargo.toml_ (変更は不要なはずです):"
 
-#: src/exercises/bare-metal/compass.md:85
+#: src/exercises/bare-metal/compass.md:89
 msgid "_Embed.toml_ (you shouldn't need to change this):"
 msgstr "_Embed.toml_ (変更は不要なはずです):"
 
-#: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
+#: src/exercises/bare-metal/compass.md:105 src/exercises/bare-metal/rtc.md:988
 msgid "_.cargo/config.toml_ (you shouldn't need to change this):"
 msgstr "_.cargo/config.toml_ (変更は不要なはずです):"
 
-#: src/exercises/bare-metal/compass.md:112
+#: src/exercises/bare-metal/compass.md:118
 msgid "See the serial output on Linux with:"
 msgstr "Linuxではシリアルポート出力を下記のコマンドで確認します:"
 
-#: src/exercises/bare-metal/compass.md:118
+#: src/exercises/bare-metal/compass.md:126
 msgid ""
 "Or on Mac OS something like (the device name may be slightly different):"
 msgstr "Mac OSではこんな感じになります（デバイス名が少し違うかもしれません）:"
 
-#: src/exercises/bare-metal/compass.md:124
+#: src/exercises/bare-metal/compass.md:134
 msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr "Ctrl+A Ctrl+Q でpicocomを終了します。"
+
+#: src/exercises/bare-metal/solutions-morning.md:1
+msgid "Bare Metal Rust Morning Exercise"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:5
+msgid "([back to exercise](compass.md))"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:40
+msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:41
+msgid "\"Setting up IMU...\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:49
+msgid "// Set up display and timer.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:59
+msgid "// Read compass data and log it to the serial port.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:67
+msgid "\"{},{},{}\\t{},{},{}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:105
+msgid ""
+"// If button A is pressed, switch to the next mode and briefly blink all "
+"LEDs\n"
+"        // on.\n"
+msgstr ""
 
 #: src/bare-metal/aps.md:1
 msgid "Application processors"
@@ -11558,7 +15566,7 @@ msgstr ""
 "は（本物のハードウェアではなく）QEMUのaarch64 ['virt'](https://qemu-project."
 "gitlab.io/qemu/system/arm/virt.html)ボードを利用します。"
 
-#: src/bare-metal/aps.md:9
+#: src/bare-metal/aps.md:10
 msgid ""
 "Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
 "privilege (exception levels on Arm CPUs, rings on x86), while application "
@@ -11568,7 +15576,7 @@ msgstr ""
 "例外レベル、x86におけるリング）を持たないのに対し、アプリケーションプロセッサ"
 "はこれらを持っています。"
 
-#: src/bare-metal/aps.md:11
+#: src/bare-metal/aps.md:13
 msgid ""
 "QEMU supports emulating various different machines or board models for each "
 "architecture. The 'virt' board doesn't correspond to any particular real "
@@ -11680,7 +15688,7 @@ msgstr ""
 "よる領域の浪費を避けるためにイメージからは除外されています。コンパイラはロー"
 "ダがこの領域をゼロ初期化することを想定しているのです。"
 
-#: src/bare-metal/aps/entry-point.md:83
+#: src/bare-metal/aps/entry-point.md:84
 msgid ""
 "The BSS may already be zeroed, depending on how memory is initialised and "
 "the image is loaded, but we zero it to be sure."
@@ -11688,7 +15696,7 @@ msgstr ""
 "メモリの初期化方法やイメージのロード方法によってはBSSはすでにゼロ埋めされてい"
 "ることがありますが、ここでは念の為にゼロ埋めしています。"
 
-#: src/bare-metal/aps/entry-point.md:85
+#: src/bare-metal/aps/entry-point.md:86
 msgid ""
 "We need to enable the MMU and cache before reading or writing any memory. If "
 "we don't:"
@@ -11696,7 +15704,7 @@ msgstr ""
 "いかなるメモリのreadやwriteよりも前にMMUとキャッシュを有効化する必要がありま"
 "す。それをしないと："
 
-#: src/bare-metal/aps/entry-point.md:86
+#: src/bare-metal/aps/entry-point.md:88
 msgid ""
 "Unaligned accesses will fault. We build the Rust code for the `aarch64-"
 "unknown-none` target which sets `+strict-align` to prevent the compiler "
@@ -11708,7 +15716,7 @@ msgstr ""
 "`aarch64-unknown-none` ターゲット向けにRustコードをビルドします。そのためここ"
 "では問題にはなりませんが、一般的にはそうとは言えません。"
 
-#: src/bare-metal/aps/entry-point.md:89
+#: src/bare-metal/aps/entry-point.md:92
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -11727,7 +15735,7 @@ msgstr ""
 "ちらかによる変更が失われてしまいます。（キャッシュは仮想アドレスやIPAではなく"
 "物理アドレスをキーとしてアクセスされます）"
 
-#: src/bare-metal/aps/entry-point.md:94
+#: src/bare-metal/aps/entry-point.md:99
 msgid ""
 "For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
 "identity maps the first 1 GiB of address space for devices, the next 1 GiB "
@@ -11739,14 +15747,14 @@ msgstr ""
 "さらなるデバイス用に透過的にマップします。これはQEMUのメモリレイアウトに合致"
 "します。"
 
-#: src/bare-metal/aps/entry-point.md:97
+#: src/bare-metal/aps/entry-point.md:103
 msgid ""
 "We also set up the exception vector (`vbar_el1`), which we'll see more about "
 "later."
 msgstr ""
 "例外ベクタ（`vbar_el1`）も設定します。これに関しては後ほど詳しく見ます。"
 
-#: src/bare-metal/aps/entry-point.md:98
+#: src/bare-metal/aps/entry-point.md:105
 msgid ""
 "All examples this afternoon assume we will be running at exception level 1 "
 "(EL1). If you need to run at a different exception level you'll need to "
@@ -11770,49 +15778,49 @@ msgstr ""
 "す。例えば、電源を落とすためにファームウェアに対してHVC（ハイパーバイザコー"
 "ル）を発行する場合です："
 
-#: src/bare-metal/aps/inline-assembly.md:19
+#: src/bare-metal/aps/inline-assembly.md:20
 msgid ""
 "// Safe because this only uses the declared registers and doesn't do\n"
 "    // anything with memory.\n"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:22
+#: src/bare-metal/aps/inline-assembly.md:23
 msgid "\"hvc #0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:23
+#: src/bare-metal/aps/inline-assembly.md:24
 msgid "\"w0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:24
+#: src/bare-metal/aps/inline-assembly.md:25
 msgid "\"w1\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:25
+#: src/bare-metal/aps/inline-assembly.md:26
 msgid "\"w2\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:26
+#: src/bare-metal/aps/inline-assembly.md:27
 msgid "\"w3\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:27
+#: src/bare-metal/aps/inline-assembly.md:28
 msgid "\"w4\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:28
+#: src/bare-metal/aps/inline-assembly.md:29
 msgid "\"w5\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:29
+#: src/bare-metal/aps/inline-assembly.md:30
 msgid "\"w6\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:30
+#: src/bare-metal/aps/inline-assembly.md:31
 msgid "\"w7\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:39
+#: src/bare-metal/aps/inline-assembly.md:40
 msgid ""
 "(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
 "smccc) crate which has wrappers for all these functions.)"
@@ -11821,7 +15829,7 @@ msgstr ""
 "するラッパーを提供している[`smccc`](https://crates.io/crates/smccc)を使うと良"
 "いでしょう。）"
 
-#: src/bare-metal/aps/inline-assembly.md:43
+#: src/bare-metal/aps/inline-assembly.md:45
 msgid ""
 "PSCI is the Arm Power State Coordination Interface, a standard set of "
 "functions to manage system and CPU power states, among other things. It is "
@@ -11831,7 +15839,7 @@ msgstr ""
 "CPU電力状態管理の機能を含む標準的なセットです。これは多くのシステムでEL3"
 "ファームウェアとハイパーバイザにより実装されています。"
 
-#: src/bare-metal/aps/inline-assembly.md:46
+#: src/bare-metal/aps/inline-assembly.md:48
 msgid ""
 "The `0 => _` syntax means initialise the register to 0 before running the "
 "inline assembly code, and ignore its contents afterwards. We need to use "
@@ -11843,7 +15851,7 @@ msgstr ""
 "く`inout`を使う必要があるのは、この実行でレジスタの値を上書きしてしまう可能性"
 "があるからです。"
 
-#: src/bare-metal/aps/inline-assembly.md:49
+#: src/bare-metal/aps/inline-assembly.md:52
 msgid ""
 "This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
 "it is called from our entry point in `entry.S`."
@@ -11851,7 +15859,7 @@ msgstr ""
 "この `main` 関数は`entry.S`にあるエントリポイントから呼ばれるため、"
 "`#[no_mangle]`と`extern \"C\"`を必要とします。"
 
-#: src/bare-metal/aps/inline-assembly.md:51
+#: src/bare-metal/aps/inline-assembly.md:54
 msgid ""
 "`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
 "used by the bootloader to pass things like a pointer to the device tree. "
@@ -11866,7 +15874,7 @@ msgstr ""
 "渡すのに利用されることになっているため、`entry.S` はこれらの値を変更しないよ"
 "うにする以外の特別なことをする必要はありません。"
 
-#: src/bare-metal/aps/inline-assembly.md:56
+#: src/bare-metal/aps/inline-assembly.md:60
 msgid ""
 "Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
@@ -11894,7 +15902,7 @@ msgstr ""
 "`addr_of!`を用いると、中間的な参照を作らずに構造体のフィールドにアクセスする"
 "ことができます。"
 
-#: src/bare-metal/aps/mmio.md:9
+#: src/bare-metal/aps/mmio.md:10
 msgid ""
 "Volatile access: read or write operations may have side-effects, so prevent "
 "the compiler or hardware from reordering, duplicating or eliding them."
@@ -11903,7 +15911,7 @@ msgstr ""
 "ンパイラやハードウェアが実行順序を変更したり、複製したり、省略したりできない"
 "ようにするためのものです。"
 
-#: src/bare-metal/aps/mmio.md:11
+#: src/bare-metal/aps/mmio.md:12
 msgid ""
 "Usually if you write and then read, e.g. via a mutable reference, the "
 "compiler may assume that the value read is the same as the value just "
@@ -11913,7 +15921,7 @@ msgstr ""
 "たのと同じ値がリードで読み出されると想定し、実際にメモリをリードする必要はな"
 "いと判断します。"
 
-#: src/bare-metal/aps/mmio.md:13
+#: src/bare-metal/aps/mmio.md:15
 msgid ""
 "Some existing crates for volatile access to hardware do hold references, but "
 "this is unsound. Whenever a reference exist, the compiler may choose to "
@@ -11923,7 +15931,7 @@ msgstr ""
 "ものがありますが、これは健全ではありません。参照が存在する間はいつでもコンパ"
 "イラがその参照を外して（MMIO領域にアクセスして）しまう可能性があります。"
 
-#: src/bare-metal/aps/mmio.md:15
+#: src/bare-metal/aps/mmio.md:18
 msgid ""
 "Use the `addr_of!` macro to get struct field pointers from a pointer to the "
 "struct."
@@ -11961,13 +15969,13 @@ msgid ""
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:27
-#: src/exercises/bare-metal/rtc.md:336
+#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:25
+#: src/exercises/bare-metal/rtc.md:337
 msgid "/// Writes a single byte to the UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:29
-#: src/exercises/bare-metal/rtc.md:338
+#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:27
+#: src/exercises/bare-metal/rtc.md:339
 msgid "// Wait until there is room in the TX buffer.\n"
 msgstr ""
 
@@ -11977,13 +15985,13 @@ msgid ""
 "        // registers of a PL011 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:35
-#: src/exercises/bare-metal/rtc.md:344
+#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:33
+#: src/exercises/bare-metal/rtc.md:345
 msgid "// Write to the TX buffer.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:39
-#: src/exercises/bare-metal/rtc.md:348
+#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:37
+#: src/exercises/bare-metal/rtc.md:349
 msgid "// Wait until the UART is no longer busy.\n"
 msgstr ""
 
@@ -12003,7 +16011,7 @@ msgstr ""
 "事前条件が満たされていると想定することができ`write_byte`を常に安全に呼び出す"
 "ことができるようになることが理由です。"
 
-#: src/bare-metal/aps/uart.md:60
+#: src/bare-metal/aps/uart.md:61
 msgid ""
 "We could have done it the other way around (making `new` safe but "
 "`write_byte` unsafe), but that would be much less convenient to use as every "
@@ -12013,7 +16021,7 @@ msgstr ""
 "が、そうすると`write_byte`の全呼び出し箇所において安全性を考慮しなければなら"
 "なくなり、利便性が低下します"
 
-#: src/bare-metal/aps/uart.md:63
+#: src/bare-metal/aps/uart.md:64
 msgid ""
 "This is a common pattern for writing safe wrappers of unsafe code: moving "
 "the burden of proof for soundness from a large number of places to a smaller "
@@ -12034,14 +16042,14 @@ msgstr ""
 "ここでは`Debug`トレイトを導出しました。この他にもいくつかのトレイトを実装する"
 "と良いでしょう。"
 
-#: src/bare-metal/aps/uart/traits.md:16 src/exercises/bare-metal/rtc.md:379
-#: src/exercises/bare-metal/solutions-afternoon.md:231
+#: src/bare-metal/aps/uart/traits.md:17 src/exercises/bare-metal/rtc.md:381
+#: src/exercises/bare-metal/solutions-afternoon.md:223
 msgid ""
 "// Safe because it just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:24
+#: src/bare-metal/aps/uart/traits.md:25
 msgid ""
 "Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
 "`Uart` type."
@@ -12049,7 +16057,7 @@ msgstr ""
 "`Write`を実装すると、`Uart` タイプに対して `write!`と`writeln!`マクロが利用で"
 "きるようになります。"
 
-#: src/bare-metal/aps/uart/traits.md:25
+#: src/bare-metal/aps/uart/traits.md:27
 msgid ""
 "Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
@@ -12107,10 +16115,6 @@ msgstr ""
 msgid "RSR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:10
-msgid "4"
-msgstr ""
-
 #: src/bare-metal/aps/better-uart.md:11
 msgid "0x18"
 msgstr ""
@@ -12131,10 +16135,6 @@ msgstr ""
 msgid "ILPR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
-msgid "8"
-msgstr ""
-
 #: src/bare-metal/aps/better-uart.md:13
 msgid "0x24"
 msgstr ""
@@ -12153,10 +16153,6 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:14
 msgid "FBRD"
-msgstr ""
-
-#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
-msgid "6"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:15
@@ -12228,10 +16224,6 @@ msgstr ""
 msgid "DMACR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:22
-msgid "3"
-msgstr ""
-
 #: src/bare-metal/aps/better-uart.md:26
 msgid "There are also some ID registers which have been omitted for brevity."
 msgstr "いくつかのIDレジスタは簡単化のための省略しています。"
@@ -12244,57 +16236,57 @@ msgstr ""
 "[`bitflags`](https://crates.io/crates/bitflags) クレートはビットフラグを扱う"
 "のに便利です。"
 
-#: src/bare-metal/aps/better-uart/bitflags.md:9
-#: src/exercises/bare-metal/rtc.md:238
+#: src/bare-metal/aps/better-uart/bitflags.md:10
+#: src/exercises/bare-metal/rtc.md:241
 msgid "/// Flags from the UART flag register.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:13
-#: src/exercises/bare-metal/rtc.md:242
+#: src/bare-metal/aps/better-uart/bitflags.md:14
+#: src/exercises/bare-metal/rtc.md:245
 msgid "/// Clear to send.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:15
-#: src/exercises/bare-metal/rtc.md:244
+#: src/bare-metal/aps/better-uart/bitflags.md:16
+#: src/exercises/bare-metal/rtc.md:247
 msgid "/// Data set ready.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:17
-#: src/exercises/bare-metal/rtc.md:246
+#: src/bare-metal/aps/better-uart/bitflags.md:18
+#: src/exercises/bare-metal/rtc.md:249
 msgid "/// Data carrier detect.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:19
-#: src/exercises/bare-metal/rtc.md:248
+#: src/bare-metal/aps/better-uart/bitflags.md:20
+#: src/exercises/bare-metal/rtc.md:251
 msgid "/// UART busy transmitting data.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:21
-#: src/exercises/bare-metal/rtc.md:250
+#: src/bare-metal/aps/better-uart/bitflags.md:22
+#: src/exercises/bare-metal/rtc.md:253
 msgid "/// Receive FIFO is empty.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:23
-#: src/exercises/bare-metal/rtc.md:252
+#: src/bare-metal/aps/better-uart/bitflags.md:24
+#: src/exercises/bare-metal/rtc.md:255
 msgid "/// Transmit FIFO is full.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:25
-#: src/exercises/bare-metal/rtc.md:254
+#: src/bare-metal/aps/better-uart/bitflags.md:26
+#: src/exercises/bare-metal/rtc.md:257
 msgid "/// Receive FIFO is full.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:27
-#: src/exercises/bare-metal/rtc.md:256
+#: src/bare-metal/aps/better-uart/bitflags.md:28
+#: src/exercises/bare-metal/rtc.md:259
 msgid "/// Transmit FIFO is empty.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:29
-#: src/exercises/bare-metal/rtc.md:258
+#: src/bare-metal/aps/better-uart/bitflags.md:30
+#: src/exercises/bare-metal/rtc.md:261
 msgid "/// Ring indicator.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:37
+#: src/bare-metal/aps/better-uart/bitflags.md:38
 msgid ""
 "The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
 "with a bunch of method implementations to get and set flags."
@@ -12312,7 +16304,7 @@ msgid ""
 msgstr ""
 "構造体を使ってUARTのレジスタのメモリレイアウトを表現することができます。"
 
-#: src/bare-metal/aps/better-uart/registers.md:41
+#: src/bare-metal/aps/better-uart/registers.md:43
 msgid ""
 "[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
 "representation) tells the compiler to lay the struct fields out in order, "
@@ -12334,27 +16326,27 @@ msgstr "新しく定義した`Registers` 構造体を我々のドライバで使
 msgid "/// Driver for a PL011 UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:32
-#: src/bare-metal/aps/better-uart/driver.md:55
-#: src/exercises/bare-metal/rtc.md:341 src/exercises/bare-metal/rtc.md:364
+#: src/bare-metal/aps/better-uart/driver.md:30
+#: src/bare-metal/aps/better-uart/driver.md:54
+#: src/exercises/bare-metal/rtc.md:342 src/exercises/bare-metal/rtc.md:366
 msgid ""
 "// Safe because we know that self.registers points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:43
-#: src/exercises/bare-metal/rtc.md:352
+#: src/bare-metal/aps/better-uart/driver.md:41
+#: src/exercises/bare-metal/rtc.md:353
 msgid ""
-"/// Reads and returns a pending byte, or `None` if nothing has been "
-"received.\n"
+"/// Reads and returns a pending byte, or `None` if nothing has been\n"
+"    /// received.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:49
-#: src/exercises/bare-metal/rtc.md:358
+#: src/bare-metal/aps/better-uart/driver.md:48
+#: src/exercises/bare-metal/rtc.md:360
 msgid "// TODO: Check for error conditions in bits 8-11.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:64
+#: src/bare-metal/aps/better-uart/driver.md:63
 msgid ""
 "Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
 "fields without creating an intermediate reference, which would be unsound."
@@ -12377,13 +16369,13 @@ msgstr ""
 "をエコーする小さなプログラムを書いてみましょう。"
 
 #: src/bare-metal/aps/better-uart/using.md:19
-#: src/bare-metal/aps/logging/using.md:18 src/exercises/bare-metal/rtc.md:41
+#: src/bare-metal/aps/logging/using.md:18 src/exercises/bare-metal/rtc.md:44
 #: src/exercises/bare-metal/solutions-afternoon.md:33
 msgid "/// Base address of the primary PL011 UART.\n"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:25
-#: src/bare-metal/aps/logging/using.md:24 src/exercises/bare-metal/rtc.md:47
+#: src/bare-metal/aps/logging/using.md:24 src/exercises/bare-metal/rtc.md:50
 #: src/exercises/bare-metal/solutions-afternoon.md:44
 msgid ""
 "// Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
@@ -12422,7 +16414,7 @@ msgstr ""
 "数は`entry.S`におけるエントリポイントから呼び出されます。詳細はそちらの"
 "speaker notesを参照してください。"
 
-#: src/bare-metal/aps/better-uart/using.md:53
+#: src/bare-metal/aps/better-uart/using.md:54
 msgid ""
 "Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
@@ -12438,15 +16430,15 @@ msgstr ""
 "[`log`](https://crates.io/crates/log) クレートが提供するログ用マクロを使える"
 "と良いでしょう。これは`Log`トレイトを実装することで可能になります。"
 
-#: src/bare-metal/aps/logging.md:28 src/exercises/bare-metal/rtc.md:190
+#: src/bare-metal/aps/logging.md:26 src/exercises/bare-metal/rtc.md:193
 msgid "\"[{}] {}\""
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:37 src/exercises/bare-metal/rtc.md:199
+#: src/bare-metal/aps/logging.md:35 src/exercises/bare-metal/rtc.md:202
 msgid "/// Initialises UART logger.\n"
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:50
+#: src/bare-metal/aps/logging.md:48
 msgid ""
 "The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
@@ -12458,8 +16450,8 @@ msgstr ""
 msgid "We need to initialise the logger before we use it."
 msgstr "使用前にloggerを初期化する必要があります。"
 
-#: src/bare-metal/aps/logging/using.md:38 src/exercises/bare-metal/rtc.md:69
-#: src/exercises/bare-metal/solutions-afternoon.md:121
+#: src/bare-metal/aps/logging/using.md:38 src/exercises/bare-metal/rtc.md:72
+#: src/exercises/bare-metal/solutions-afternoon.md:115
 msgid "\"{info}\""
 msgstr ""
 
@@ -12491,12 +16483,12 @@ msgstr ""
 "こではRustコードの呼び出し前に揮発レジスタの値をスタックに退避するためにベク"
 "ターテーブルをアセンブリ言語で実装しています："
 
-#: src/bare-metal/aps/exceptions.md:64
+#: src/bare-metal/aps/exceptions.md:67
 msgid "EL is exception level; all our examples this afternoon run in EL1."
 msgstr ""
 "ELは例外レベルです。本日の午後に扱ったすべての例はEL1で実行されています。"
 
-#: src/bare-metal/aps/exceptions.md:65
+#: src/bare-metal/aps/exceptions.md:68
 msgid ""
 "For simplicity we aren't distinguishing between SP0 and SPx for the current "
 "EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
@@ -12504,7 +16496,7 @@ msgstr ""
 "簡単化のために、ここでは現在のEL例外におけるSP0とSPｘの違い、低位のELレベルに"
 "おけるAArch32とAArch64の違いを区別していません。"
 
-#: src/bare-metal/aps/exceptions.md:67
+#: src/bare-metal/aps/exceptions.md:70
 msgid ""
 "For this example we just log the exception and power down, as we don't "
 "expect any of them to actually happen."
@@ -12512,7 +16504,7 @@ msgstr ""
 "ここではこれらの例外が発生しないはずなので、ただ例外に関するログを出力し、電"
 "源を落としています。"
 
-#: src/bare-metal/aps/exceptions.md:69
+#: src/bare-metal/aps/exceptions.md:72
 msgid ""
 "We can think of exception handlers and our main execution context more or "
 "less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
@@ -12596,7 +16588,7 @@ msgstr ""
 "をターゲットとしてビルドしているので大丈夫なはずですが、一般的には大丈夫とは"
 "限りません。"
 
-#: src/bare-metal/aps/other-projects.md:22
+#: src/bare-metal/aps/other-projects.md:23
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -12615,6 +16607,10 @@ msgstr ""
 "ウェアで実行する）場合には問題にはなりませんが、一般的には良くないパターンで"
 "す。"
 
+#: src/bare-metal/useful-crates.md:1
+msgid "Useful crates"
+msgstr "便利クレート"
+
 #: src/bare-metal/useful-crates.md:3
 msgid ""
 "We'll go over a few crates which solve some common problems in bare-metal "
@@ -12622,10 +16618,6 @@ msgid ""
 msgstr ""
 "ベアメタルプログラミングにおいて共通に発生する問題に対する解を与えるクレート"
 "についていくつか紹介します。"
-
-#: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "`zerocopy`"
-msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
@@ -12636,7 +16628,7 @@ msgstr ""
 "（Fuchsiaの）[`zerocopy`](https://docs.rs/zerocopy/)クレートはバイトシーケン"
 "スとその他の型の変換を安全に行うためのトレイトやマクロを提供します。"
 
-#: src/bare-metal/useful-crates/zerocopy.md:40
+#: src/bare-metal/useful-crates/zerocopy.md:42
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
 "but can be useful for working with structures shared with hardware e.g. by "
@@ -12646,7 +16638,7 @@ msgstr ""
 "えばDMAのようなハードウェアと共有するデータ構造あるいは外部インタフェースを通"
 "して送信するデータ構造を扱うに場合には有用です。"
 
-#: src/bare-metal/useful-crates/zerocopy.md:45
+#: src/bare-metal/useful-crates/zerocopy.md:48
 msgid ""
 "`FromBytes` can be implemented for types for which any byte pattern is "
 "valid, and so can safely be converted from an untrusted sequence of bytes."
@@ -12654,7 +16646,7 @@ msgstr ""
 "`FromBytes`はいかなるバイトパターンも有効な値となる型に対して実装することがで"
 "き、信用できないバイトシーケンスからの安全な変換を可能にします。"
 
-#: src/bare-metal/useful-crates/zerocopy.md:47
+#: src/bare-metal/useful-crates/zerocopy.md:50
 msgid ""
 "Attempting to derive `FromBytes` for these types would fail, because "
 "`RequestType` doesn't use all possible u32 values as discriminants, so not "
@@ -12664,14 +16656,14 @@ msgstr ""
 "てのバイトパターンが有効とはならず、これらに対する`FromBytes`の導出はフェール"
 "するでしょう。"
 
-#: src/bare-metal/useful-crates/zerocopy.md:49
+#: src/bare-metal/useful-crates/zerocopy.md:53
 msgid ""
 "`zerocopy::byteorder` has types for byte-order aware numeric primitives."
 msgstr ""
 "`zerocopy::byteorder`はバイトオーダを気にする数値プリミティブに関する型を提供"
 "します。"
 
-#: src/bare-metal/useful-crates/zerocopy.md:50
+#: src/bare-metal/useful-crates/zerocopy.md:54
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "zerocopy-example/`. (It won't run in the Playground because of the crate "
@@ -12680,10 +16672,6 @@ msgstr ""
 "この例を`src/bare-metal/useful-crates/zerocopy-example/`において`cargo run`と"
 "とすることで実行してみましょう。（Playgroundではこの例が依存するクレートを利"
 "用できないため実行できません）"
-
-#: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "`aarch64-paging`"
-msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
@@ -12731,10 +16719,6 @@ msgid ""
 msgstr ""
 "この例は本物のハードウェアかQEMUを必要とするので、簡単には実行できません。"
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "`buddy_system_allocator`"
-msgstr ""
-
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
 "[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
@@ -12755,11 +16739,11 @@ msgstr ""
 "るために使えますし、別のアドレス空間をアロケートするためにも使えます。例え"
 "ば、PCI BARに対するMMIO領域をアロケートしたい場合には以下のようにできます："
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:29
 msgid "PCI BARs always have alignment equal to their size."
 msgstr "PCI BARは常にサイズと同じアラインになります。"
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "allocator-example/`. (It won't run in the Playground because of the crate "
@@ -12768,10 +16752,6 @@ msgstr ""
 "この例を`src/bare-metal/useful-crates/allocator-example/`において `cargo run`"
 "とすることで実行してみましょう。（Playgroundではこの例が依存するクレートを利"
 "用できないため実行できません）"
-
-#: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "`tinyvec`"
-msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
@@ -12787,7 +16767,7 @@ msgstr ""
 "実装では、いくつの要素が使われているかが管理され、確保された以上に使おうとす"
 "るとパニックします。"
 
-#: src/bare-metal/useful-crates/tinyvec.md:23
+#: src/bare-metal/useful-crates/tinyvec.md:25
 msgid ""
 "`tinyvec` requires that the element type implement `Default` for "
 "initialisation."
@@ -12795,16 +16775,12 @@ msgstr ""
 "`tinyvec` は初期化のために要素となるタイプが`Default`を実装することを必要とし"
 "ます。"
 
-#: src/bare-metal/useful-crates/tinyvec.md:24
+#: src/bare-metal/useful-crates/tinyvec.md:27
 msgid ""
 "The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 "Rust Playgroundは`tinyvec`を内包しているので、オンラインでこの例を実行するこ"
 "とができます。"
-
-#: src/bare-metal/useful-crates/spin.md:1
-msgid "`spin`"
-msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
@@ -12824,22 +16800,23 @@ msgstr ""
 "[`spin`](https://crates.io/crates/spin) クレートはこれらの多くのプリミティブ"
 "と等価なスピンロックベースのものを提供します。"
 
-#: src/bare-metal/useful-crates/spin.md:23
+#: src/bare-metal/useful-crates/spin.md:26
 msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 "割り込みハンドラでロックを取得する場合にはデッドロックを引き起こさないように"
 "気をつけてください。"
 
-#: src/bare-metal/useful-crates/spin.md:24
+#: src/bare-metal/useful-crates/spin.md:27
+#, fuzzy
 msgid ""
 "`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
-"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+"`Barrier` and `Once` from `std::sync`; and `Lazy` for lazy initialisation."
 msgstr ""
 "`spin` はチケットロックのミューテックス実装も持っています。これは`std::sync`"
 "における`RwLock`, `Barrier`、`Once` と等価であり、またレイジー初期化の観点で"
 "は`Lazy`と等価なものです。"
 
-#: src/bare-metal/useful-crates/spin.md:26
+#: src/bare-metal/useful-crates/spin.md:29
 msgid ""
 "The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
 "useful types for late initialisation with a slightly different approach to "
@@ -12849,7 +16826,7 @@ msgstr ""
 "Once`とは少し異なるアプローチの遅延初期化のための有用な型をいくつか持っていま"
 "す。"
 
-#: src/bare-metal/useful-crates/spin.md:28
+#: src/bare-metal/useful-crates/spin.md:31
 msgid ""
 "The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
@@ -12867,6 +16844,10 @@ msgstr ""
 "イナリを生成するための`cc_binary`というルール、さらにELFを実行可能な形式の生"
 "バイナリに変換する`raw_binary`というルールが必要です。"
 
+#: src/bare-metal/android/vmbase.md:1
+msgid "vmbase"
+msgstr "vmbase"
+
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
 "For VMs running under crosvm on aarch64, the [vmbase](https://android."
@@ -12879,7 +16860,7 @@ msgstr ""
 "crosvm下で実行されるVMに対して、エントリポイント、UARTコンソールロギングなど"
 "に加えて、リンカスクリプトと有用なデフォルトビルドルールを提供してくれます。"
 
-#: src/bare-metal/android/vmbase.md:21
+#: src/bare-metal/android/vmbase.md:24
 msgid ""
 "The `main!` macro marks your main function, to be called from the `vmbase` "
 "entry point."
@@ -12887,7 +16868,7 @@ msgstr ""
 "`main!`というマクロはメイン関数を指定するもので、指定された関数は`vmbase`のエ"
 "ントリポイントから呼び出されることになります。"
 
-#: src/bare-metal/android/vmbase.md:22
+#: src/bare-metal/android/vmbase.md:26
 msgid ""
 "The `vmbase` entry point handles console initialisation, and issues a "
 "PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
@@ -12897,6 +16878,13 @@ msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md:3
 msgid "We will write a driver for the PL031 real-time clock device."
+msgstr ""
+
+#: src/exercises/bare-metal/afternoon.md:7
+#: src/exercises/concurrency/afternoon.md:13
+msgid ""
+"After looking at the exercises, you can look at the [solutions](solutions-"
+"afternoon.md) provided."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:1
@@ -12924,40 +16912,40 @@ msgid ""
 "doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:10
+#: src/exercises/bare-metal/rtc.md:11
 msgid ""
 "_Extension if you have time:_ Enable and handle the interrupt generated by "
 "the RTC match. You can use the driver provided in the [`arm-gic`](https://"
 "docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:12
+#: src/exercises/bare-metal/rtc.md:14
 msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:13
+#: src/exercises/bare-metal/rtc.md:15
 msgid ""
 "Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
 "wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:16
+#: src/exercises/bare-metal/rtc.md:19
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
 "look in the `rtc` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:37
+#: src/exercises/bare-metal/rtc.md:40
 #: src/exercises/bare-metal/solutions-afternoon.md:29
 msgid "/// Base addresses of the GICv3.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:52
+#: src/exercises/bare-metal/rtc.md:55
 #: src/exercises/bare-metal/solutions-afternoon.md:49
 msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:54
+#: src/exercises/bare-metal/rtc.md:57
 #: src/exercises/bare-metal/solutions-afternoon.md:51
 msgid ""
 "// Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
@@ -12965,22 +16953,22 @@ msgid ""
 "    // nothing else accesses those address ranges.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:60
+#: src/exercises/bare-metal/rtc.md:63
 msgid "// TODO: Create instance of RTC driver and print current time.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:62
+#: src/exercises/bare-metal/rtc.md:65
 msgid "// TODO: Wait for 3 seconds.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:75
+#: src/exercises/bare-metal/rtc.md:78
 msgid ""
 "_src/exceptions.rs_ (you should only need to change this for the 3rd part of "
 "the exercise):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:80 src/exercises/bare-metal/rtc.md:154
-#: src/exercises/bare-metal/rtc.md:215 src/exercises/bare-metal/rtc.md:415
+#: src/exercises/bare-metal/rtc.md:84 src/exercises/bare-metal/rtc.md:159
+#: src/exercises/bare-metal/rtc.md:218 src/exercises/bare-metal/rtc.md:418
 msgid ""
 "// Copyright 2023 Google LLC\n"
 "//\n"
@@ -12997,102 +16985,102 @@ msgid ""
 "// limitations under the License.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:101
+#: src/exercises/bare-metal/rtc.md:105
 msgid "\"sync_exception_current\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:107
+#: src/exercises/bare-metal/rtc.md:111
 msgid "\"irq_current\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:108
+#: src/exercises/bare-metal/rtc.md:113
 msgid "\"No pending interrupt\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:109
+#: src/exercises/bare-metal/rtc.md:114
 msgid "\"IRQ {intid:?}\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:114
+#: src/exercises/bare-metal/rtc.md:119
 msgid "\"fiq_current\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:120
+#: src/exercises/bare-metal/rtc.md:125
 msgid "\"serr_current\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:126
+#: src/exercises/bare-metal/rtc.md:131
 msgid "\"sync_lower\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:132
+#: src/exercises/bare-metal/rtc.md:137
 msgid "\"irq_lower\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:138
+#: src/exercises/bare-metal/rtc.md:143
 msgid "\"fiq_lower\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:144
+#: src/exercises/bare-metal/rtc.md:149
 msgid "\"serr_lower\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:149
+#: src/exercises/bare-metal/rtc.md:154
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:167
+#: src/exercises/bare-metal/rtc.md:172
 msgid "// ANCHOR: main\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:210
+#: src/exercises/bare-metal/rtc.md:213
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:233
+#: src/exercises/bare-metal/rtc.md:236
 msgid "// ANCHOR: Flags\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:261
+#: src/exercises/bare-metal/rtc.md:264
 msgid "// ANCHOR_END: Flags\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:265
+#: src/exercises/bare-metal/rtc.md:268
 msgid ""
 "/// Flags from the UART Receive Status Register / Error Clear Register.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:269
+#: src/exercises/bare-metal/rtc.md:272
 msgid "/// Framing error.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:271
+#: src/exercises/bare-metal/rtc.md:274
 msgid "/// Parity error.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:273
+#: src/exercises/bare-metal/rtc.md:276
 msgid "/// Break error.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:275
+#: src/exercises/bare-metal/rtc.md:278
 msgid "/// Overrun error.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:279
+#: src/exercises/bare-metal/rtc.md:282
 msgid "// ANCHOR: Registers\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:311
+#: src/exercises/bare-metal/rtc.md:314
 msgid "// ANCHOR_END: Registers\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:313
+#: src/exercises/bare-metal/rtc.md:316
 msgid ""
 "// ANCHOR: Uart\n"
 "/// Driver for a PL011 UART.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:322
+#: src/exercises/bare-metal/rtc.md:325
 msgid ""
 "/// Constructs a new instance of the UART driver for a PL011 device at the\n"
 "    /// given base address.\n"
@@ -13106,51 +17094,51 @@ msgid ""
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:368
+#: src/exercises/bare-metal/rtc.md:370
 msgid "// ANCHOR_END: Uart\n"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:410
+#: src/exercises/bare-metal/rtc.md:413
 msgid "_build.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:433 src/exercises/bare-metal/rtc.md:435
+#: src/exercises/bare-metal/rtc.md:436 src/exercises/bare-metal/rtc.md:438
 msgid "\"linux\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:434 src/exercises/bare-metal/rtc.md:436
+#: src/exercises/bare-metal/rtc.md:437 src/exercises/bare-metal/rtc.md:439
 msgid "\"CROSS_COMPILE\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:434
+#: src/exercises/bare-metal/rtc.md:437
 msgid "\"aarch64-linux-gnu\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:436
+#: src/exercises/bare-metal/rtc.md:439
 msgid "\"aarch64-none-elf\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:439
+#: src/exercises/bare-metal/rtc.md:442
 msgid "\"entry.S\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:440
+#: src/exercises/bare-metal/rtc.md:443
 msgid "\"exceptions.S\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:441
+#: src/exercises/bare-metal/rtc.md:444
 msgid "\"idmap.S\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:442
+#: src/exercises/bare-metal/rtc.md:445
 msgid "\"empty\""
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:446
+#: src/exercises/bare-metal/rtc.md:449
 msgid "_entry.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:450
+#: src/exercises/bare-metal/rtc.md:453
 msgid ""
 "```armasm\n"
 "/*\n"
@@ -13312,11 +17300,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:595
+#: src/exercises/bare-metal/rtc.md:598
 msgid "_exceptions.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:599
+#: src/exercises/bare-metal/rtc.md:602
 msgid ""
 "```armasm\n"
 "/*\n"
@@ -13510,11 +17498,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:780
+#: src/exercises/bare-metal/rtc.md:783
 msgid "_idmap.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:784
+#: src/exercises/bare-metal/rtc.md:787
 msgid ""
 "```armasm\n"
 "/*\n"
@@ -13563,11 +17551,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:829
+#: src/exercises/bare-metal/rtc.md:832
 msgid "_image.ld_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:833
+#: src/exercises/bare-metal/rtc.md:836
 msgid ""
 "```ld\n"
 "/*\n"
@@ -13678,32 +17666,190 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:940
+#: src/exercises/bare-metal/rtc.md:943
 msgid "_Makefile_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:945
+#: src/exercises/bare-metal/rtc.md:948
 msgid "# Copyright 2023 Google LLC"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:959
+#: src/exercises/bare-metal/rtc.md:962
 msgid "$(shell uname -s)"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:961
+#: src/exercises/bare-metal/rtc.md:964
 msgid "aarch64-linux-gnu"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:978
+#: src/exercises/bare-metal/rtc.md:981
 msgid "stdio -display none -kernel $< -s"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:981
+#: src/exercises/bare-metal/rtc.md:984
 msgid "cargo clean"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:995
+#: src/exercises/bare-metal/rtc.md:999
 msgid "Run the code in QEMU with `make qemu`."
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:1
+msgid "Bare Metal Rust Afternoon"
+msgstr "ベアメタルRust PM"
+
+#: src/exercises/bare-metal/solutions-afternoon.md:5
+msgid "([back to exercise](rtc.md))"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:7
+msgid "_main.rs_:"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:36
+msgid "/// Base address of the PL031 RTC.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:38
+msgid "/// The IRQ used by the PL031 RTC.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:57
+msgid ""
+"// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
+"    // and nothing else accesses that address range.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:62
+msgid "\"RTC: {time}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:70
+msgid "// Wait for 3 seconds, without interrupts.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:73
+#: src/exercises/bare-metal/solutions-afternoon.md:91
+msgid "\"Waiting for {}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:75
+#: src/exercises/bare-metal/solutions-afternoon.md:83
+#: src/exercises/bare-metal/solutions-afternoon.md:96
+#: src/exercises/bare-metal/solutions-afternoon.md:104
+msgid "\"matched={}, interrupt_pending={}\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:87
+#: src/exercises/bare-metal/solutions-afternoon.md:108
+msgid "\"Finished waiting\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:89
+msgid "// Wait another 3 seconds for an interrupt.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:121
+msgid "_pl031.rs_:"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:128
+msgid "/// Data register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:130
+msgid "/// Match register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:132
+msgid "/// Load register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:134
+msgid "/// Control register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:137
+msgid "/// Interrupt Mask Set or Clear register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:140
+msgid "/// Raw Interrupt Status\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:143
+msgid "/// Masked Interrupt Status\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:146
+msgid "/// Interrupt Clear Register\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:150
+msgid "/// Driver for a PL031 real-time clock.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:158
+msgid ""
+"/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
+"    /// given base address.\n"
+"    ///\n"
+"    /// # Safety\n"
+"    ///\n"
+"    /// The given base address must point to the MMIO control registers of "
+"a\n"
+"    /// PL031 device, which must be mapped into the address space of the "
+"process\n"
+"    /// as device memory and not have any other aliases.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:170
+msgid "/// Reads the current RTC value.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:172
+#: src/exercises/bare-metal/solutions-afternoon.md:180
+#: src/exercises/bare-metal/solutions-afternoon.md:188
+#: src/exercises/bare-metal/solutions-afternoon.md:199
+#: src/exercises/bare-metal/solutions-afternoon.md:211
+#: src/exercises/bare-metal/solutions-afternoon.md:218
+msgid ""
+"// Safe because we know that self.registers points to the control\n"
+"        // registers of a PL031 device which is appropriately mapped.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:177
+msgid ""
+"/// Writes a match value. When the RTC value matches this then an interrupt\n"
+"    /// will be generated (if it is enabled).\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:185
+msgid ""
+"/// Returns whether the match register matches the RTC value, whether or "
+"not\n"
+"    /// the interrupt is enabled.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:194
+msgid ""
+"/// Returns whether there is currently an interrupt pending.\n"
+"    ///\n"
+"    /// This should be true if and only if `matched` returns true and the\n"
+"    /// interrupt is masked.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:205
+msgid ""
+"/// Sets or clears the interrupt mask.\n"
+"    ///\n"
+"    /// When the mask is true the interrupt is enabled; when it is false "
+"the\n"
+"    /// interrupt is disabled.\n"
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:216
+msgid "/// Clears a pending interrupt, if any.\n"
 msgstr ""
 
 #: src/concurrency.md:1
@@ -13757,9 +17903,10 @@ msgstr ""
 "です。"
 
 #: src/concurrency/threads.md:32
+#, fuzzy
 msgid ""
-"Notice that the thread is stopped before it reaches 10 — the main thread is "
-"not waiting."
+"Notice that the thread is stopped before it reaches 10 --- the main thread "
+"is not waiting."
 msgstr ""
 "スレッドはカウントが10に到達するまでに止められます。メインのスレッドは待機し"
 "ません。"
@@ -13792,10 +17939,6 @@ msgstr ""
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "通常のスレッドはそれらの環境から借用することはできません:"
 
-#: src/concurrency/scoped-threads.md:11 src/concurrency/scoped-threads.md:30
-msgid "\"Length: {}\""
-msgstr ""
-
 #: src/concurrency/scoped-threads.md:20
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
@@ -13812,7 +17955,7 @@ msgstr ""
 "この理由は、関数`thread::scope`が完了するとき、全てのスレッドはjoinされること"
 "が保証されているので、スレッドが借用したデータを返すことができるためです。"
 
-#: src/concurrency/scoped-threads.md:41
+#: src/concurrency/scoped-threads.md:42
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."
@@ -13844,7 +17987,7 @@ msgstr ""
 "は`Clone`を実装している（よって複数のproducerが作成可能）のですが、`Receiver`"
 "についてはそうではありません。"
 
-#: src/concurrency/channels.md:28
+#: src/concurrency/channels.md:29
 msgid ""
 "`send()` and `recv()` return `Result`. If they return `Err`, it means the "
 "counterpart `Sender` or `Receiver` is dropped and the channel is closed."
@@ -13894,7 +18037,7 @@ msgstr ""
 "す。もし誰もチャネルから値を読み取らない場合は、このスレッドは無期限にブロッ"
 "クされることがあります。"
 
-#: src/concurrency/channels/bounded.md:32
+#: src/concurrency/channels/bounded.md:34
 msgid ""
 "A call to `send` will abort with an error (that is why it returns `Result`) "
 "if the channel is closed. A channel is closed when the receiver is dropped."
@@ -13903,17 +18046,13 @@ msgstr ""
 "（`send`が`Result`を返すのはこのためです。）受け取り側がドロップされたとき"
 "に、チャネルは閉じられます。"
 
-#: src/concurrency/channels/bounded.md:33
+#: src/concurrency/channels/bounded.md:36
 msgid ""
 "A bounded channel with a size of zero is called a \"rendezvous channel\". "
 "Every send will block the current thread until another thread calls `read`."
 msgstr ""
 "サイズが０のBoundedチャネルは「ランデブーチャネル」と呼ばれます。別のスレッド"
 "が`read`を呼ぶまでは、それぞれのsendは現在のスレッドをブロックします。"
-
-#: src/concurrency/send-sync.md:1
-msgid "`Send` and `Sync`"
-msgstr "`Send`と`Sync`"
 
 #: src/concurrency/send-sync.md:3
 #, fuzzy
@@ -13924,7 +18063,7 @@ msgstr ""
 "Rustはどのようにスレッド間での値の共有アクセスを禁止するのでしょうか？その答"
 "えとなるのが、以下の２つのトレイトです："
 
-#: src/concurrency/send-sync.md:5
+#: src/concurrency/send-sync.md:6
 msgid ""
 "[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
 "is `Send` if it is safe to move a `T` across a thread boundary."
@@ -13932,7 +18071,7 @@ msgstr ""
 "[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): スレッド境界"
 "をまたいでの型`T`のムーブが安全に行える場合、型`T`は`Send`である。"
 
-#: src/concurrency/send-sync.md:7
+#: src/concurrency/send-sync.md:8
 msgid ""
 "[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
 "is `Sync` if it is safe to move a `&T` across a thread boundary."
@@ -13940,7 +18079,7 @@ msgstr ""
 "[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): スレッド境界"
 "をまたいで`&T`のムーブが安全に行える場合、型`T`は`Sync`である。"
 
-#: src/concurrency/send-sync.md:10
+#: src/concurrency/send-sync.md:11
 msgid ""
 "`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
 "compiler will automatically derive them for your types as long as they only "
@@ -13952,7 +18091,7 @@ msgstr ""
 "に対して`Send`と`Sync`を自動的に導出します。そうでなくても妥当であるならば"
 "`Send`と`Sync`を自分自身で実装することもできます。"
 
-#: src/concurrency/send-sync.md:20
+#: src/concurrency/send-sync.md:21
 msgid ""
 "One can think of these traits as markers that the type has certain thread-"
 "safety properties."
@@ -13960,15 +18099,11 @@ msgstr ""
 "これらのトレイトは、ある型が特定のスレッドセーフの特性を持っていることを示す"
 "マーカーと考えることもできます。"
 
-#: src/concurrency/send-sync.md:21
+#: src/concurrency/send-sync.md:23
 msgid "They can be used in the generic constraints as normal traits."
 msgstr ""
 "これらは通常のトレイトと同じように、ジェネリック境界の中で利用することができ"
 "ます。"
-
-#: src/concurrency/send-sync/send.md:1
-msgid "`Send`"
-msgstr ""
 
 #: src/concurrency/send-sync/send.md:3
 msgid ""
@@ -13996,10 +18131,6 @@ msgstr ""
 "例を挙げると、SQLiteライブラリへのコネクションは、一つのスレッドからのみアク"
 "セスされる必要があります。"
 
-#: src/concurrency/send-sync/sync.md:1
-msgid "`Sync`"
-msgstr ""
-
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
 "A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
@@ -14025,7 +18156,7 @@ msgstr ""
 "これはつまり、「ある型の共有がスレッドセーフであれば、その参照をスレッド間で"
 "受け渡すこともスレッドセーフである」ということを手短に表したものです。"
 
-#: src/concurrency/send-sync/sync.md:16
+#: src/concurrency/send-sync/sync.md:18
 msgid ""
 "This is because if a type is Sync it means that it can be shared across "
 "multiple threads without the risk of data races or other synchronization "
@@ -14172,10 +18303,6 @@ msgid ""
 "mutually exclusive access to the `T` value."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md:1
-msgid "`Arc`"
-msgstr ""
-
 #: src/concurrency/shared_state/arc.md:3
 msgid ""
 "[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
@@ -14216,12 +18343,8 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md:36
+#: src/concurrency/shared_state/arc.md:37
 msgid "`std::sync::Weak` can help."
-msgstr ""
-
-#: src/concurrency/shared_state/mutex.md:1
-msgid "`Mutex`"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:3
@@ -14245,43 +18368,43 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
-"`Mutex` in Rust looks like a collection with just one element - the "
-"protected data."
-msgstr ""
-
-#: src/concurrency/shared_state/mutex.md:32
-msgid ""
-"It is not possible to forget to acquire the mutex before accessing the "
+"`Mutex` in Rust looks like a collection with just one element --- the "
 "protected data."
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:33
 msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:35
+msgid ""
 "You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
 "`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:35
+#: src/concurrency/shared_state/mutex.md:37
 msgid ""
 "`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
 "implements `Send`."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:36
-msgid "A read-write lock counterpart - `RwLock`."
+#: src/concurrency/shared_state/mutex.md:39
+msgid "A read-write lock counterpart: `RwLock`."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:37
-msgid "Why does `lock()` return a `Result`? "
+#: src/concurrency/shared_state/mutex.md:40
+msgid "Why does `lock()` return a `Result`?"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:38
+#: src/concurrency/shared_state/mutex.md:41
 msgid ""
-"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that the data it protected might be in an "
-"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
-"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
-"You can call `into_inner()` on the error to recover the data regardless."
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes \"poisoned"
+"\" to signal that the data it protected might be in an inconsistent state. "
+"Calling `lock()` on a poisoned mutex fails with a [`PoisonError`](https://"
+"doc.rust-lang.org/std/sync/struct.PoisonError.html). You can call "
+"`into_inner()` on the error to recover the data regardless."
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:3
@@ -14306,19 +18429,19 @@ msgid ""
 "orthogonal."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:52
+#: src/concurrency/shared_state/example.md:53
 msgid ""
 "Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
 "between threads."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:53
+#: src/concurrency/shared_state/example.md:55
 msgid ""
 "`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
 "thread. Note `move` was added to the lambda signature."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:54
+#: src/concurrency/shared_state/example.md:57
 msgid ""
 "Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
@@ -14370,69 +18493,69 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:36
-#: src/exercises/concurrency/dining-philosophers-async.md:31
 #: src/exercises/concurrency/solutions-morning.md:24
+#: src/exercises/concurrency/dining-philosophers-async.md:31
 #: src/exercises/concurrency/solutions-afternoon.md:25
 msgid "\"Eureka! {} has a new idea!\""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:41
-#: src/exercises/concurrency/dining-philosophers-async.md:36
-#: src/exercises/concurrency/solutions-afternoon.md:30
+#: src/exercises/concurrency/dining-philosophers-async.md:37
+#: src/exercises/concurrency/solutions-afternoon.md:31
 msgid "// Pick up forks...\n"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:42
-#: src/exercises/concurrency/dining-philosophers-async.md:37
 #: src/exercises/concurrency/solutions-morning.md:33
-#: src/exercises/concurrency/solutions-afternoon.md:37
+#: src/exercises/concurrency/dining-philosophers-async.md:38
+#: src/exercises/concurrency/solutions-afternoon.md:38
 msgid "\"{} is eating...\""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
 #: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
+#: src/exercises/concurrency/dining-philosophers-async.md:44
+#: src/exercises/concurrency/solutions-afternoon.md:46
 msgid "\"Socrates\""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
 #: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
+#: src/exercises/concurrency/dining-philosophers-async.md:44
+#: src/exercises/concurrency/solutions-afternoon.md:46
 msgid "\"Hypatia\""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
 #: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
+#: src/exercises/concurrency/dining-philosophers-async.md:44
+#: src/exercises/concurrency/solutions-afternoon.md:46
 msgid "\"Plato\""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
 #: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
+#: src/exercises/concurrency/dining-philosophers-async.md:44
+#: src/exercises/concurrency/solutions-afternoon.md:46
 msgid "\"Aristotle\""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:48
-#: src/exercises/concurrency/dining-philosophers-async.md:43
 #: src/exercises/concurrency/solutions-morning.md:39
-#: src/exercises/concurrency/solutions-afternoon.md:45
+#: src/exercises/concurrency/dining-philosophers-async.md:44
+#: src/exercises/concurrency/solutions-afternoon.md:46
 msgid "\"Pythagoras\""
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:51
-#: src/exercises/concurrency/dining-philosophers-async.md:47
-#: src/exercises/concurrency/solutions-afternoon.md:49
+#: src/exercises/concurrency/dining-philosophers-async.md:48
+#: src/exercises/concurrency/solutions-afternoon.md:50
 msgid "// Create forks\n"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:53
-#: src/exercises/concurrency/dining-philosophers-async.md:49
-#: src/exercises/concurrency/solutions-afternoon.md:53
+#: src/exercises/concurrency/dining-philosophers-async.md:50
+#: src/exercises/concurrency/solutions-afternoon.md:54
 msgid "// Create philosophers\n"
 msgstr ""
 
@@ -14441,7 +18564,7 @@ msgid "// Make each of them think and eat 100 times\n"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:57
-#: src/exercises/concurrency/dining-philosophers-async.md:53
+#: src/exercises/concurrency/dining-philosophers-async.md:54
 #: src/exercises/concurrency/solutions-afternoon.md:88
 msgid "// Output their thoughts\n"
 msgstr ""
@@ -14507,8 +18630,8 @@ msgid ""
 "publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
-"tls\"] }\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls"
+"\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -14524,59 +18647,114 @@ msgstr ""
 msgid "Your `src/main.rs` file should look something like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:64
-#: src/exercises/concurrency/solutions-morning.md:95
+#: src/exercises/concurrency/link-checker.md:65
+#: src/exercises/concurrency/solutions-morning.md:97
 msgid "\"request error: {0}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:66
-#: src/exercises/concurrency/solutions-morning.md:97
+#: src/exercises/concurrency/link-checker.md:67
+#: src/exercises/concurrency/solutions-morning.md:99
 msgid "\"bad http response: {0}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:77
-#: src/exercises/concurrency/solutions-morning.md:108
+#: src/exercises/concurrency/link-checker.md:78
+#: src/exercises/concurrency/solutions-morning.md:110
 msgid "\"Checking {:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:95
-#: src/exercises/concurrency/solutions-morning.md:126
+#: src/exercises/concurrency/link-checker.md:96
+#: src/exercises/concurrency/solutions-morning.md:128
 msgid "\"href\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:102
-#: src/exercises/concurrency/solutions-morning.md:133
+#: src/exercises/concurrency/link-checker.md:103
+#: src/exercises/concurrency/solutions-morning.md:135
 msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:111
-#: src/exercises/concurrency/solutions-morning.md:246
+#: src/exercises/concurrency/link-checker.md:112
+#: src/exercises/concurrency/solutions-morning.md:245
 msgid "\"https://www.google.org\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:114
+#: src/exercises/concurrency/link-checker.md:115
 msgid "\"Links: {links:#?}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:115
+#: src/exercises/concurrency/link-checker.md:116
 msgid "\"Could not extract links: {err:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:120
+#: src/exercises/concurrency/link-checker.md:121
 msgid "Run the code in `src/main.rs` with"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:128
+#: src/exercises/concurrency/link-checker.md:129
 msgid ""
 "Use threads to check the links in parallel: send the URLs to be checked to a "
 "channel and let a few threads check the URLs in parallel."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:130
+#: src/exercises/concurrency/link-checker.md:131
 msgid ""
 "Extend this to recursively extract links from all pages on the `www.google."
 "org` domain. Put an upper limit of 100 pages or so so that you don't end up "
 "being blocked by the site."
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:1
+msgid "Concurrency Morning Exercise"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:5
+msgid "([back to exercise](dining-philosophers.md))"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:29
+msgid "\"{} is trying to eat\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:53
+msgid ""
+"// To avoid a deadlock, we have to break the symmetry\n"
+"        // somewhere. This will swap the forks without deinitializing\n"
+"        // either of them.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:77
+msgid "\"{thought}\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:82
+#, fuzzy
+msgid "Link Checker"
+msgstr "マルチスレッド・リンクチェッカー"
+
+#: src/exercises/concurrency/solutions-morning.md:84
+msgid "([back to exercise](link-checker.md))"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:154
+msgid ""
+"/// Determine whether links within the given page should be extracted.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:162
+msgid ""
+"/// Mark the given page as visited, returning false if it had already\n"
+"    /// been visited.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:188
+msgid "// The sender got dropped. No more commands coming in.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:229
+msgid "\"Got crawling error: {:#}\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-morning.md:247
+msgid "\"Bad URLs: {:#?}\""
 msgstr ""
 
 #: src/async.md:1
@@ -14617,10 +18795,6 @@ msgstr ""
 "Futureは非同期的なランタイムによりポーリングされます。ランタイムにはいくつか"
 "の選択肢があります。"
 
-#: src/async.md:17
-msgid "Comparisons"
-msgstr "他の言語との比較"
-
 #: src/async.md:19
 msgid ""
 "Python has a similar model in its `asyncio`. However, its `Future` type is "
@@ -14641,10 +18815,6 @@ msgstr ""
 "JavaScriptの`Promise`は似ているものの、これもまたもやコールバックに基づきま"
 "す。 この言語のランタイムはイベントループにより実装されているため、多くの"
 "Promise解決の詳細は隠されています。"
-
-#: src/async/async-await.md:1
-msgid "`async`/`await`"
-msgstr "`async`/`await`"
 
 #: src/async/async-await.md:3
 msgid ""
@@ -14677,9 +18847,10 @@ msgstr ""
 "い。"
 
 #: src/async/async-await.md:33
+#, fuzzy
 msgid ""
 "The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type with a future. "
+"type with a future."
 msgstr ""
 "「async」キーワードは糖衣構文です。コンパイラは返り値をfutureに置き換えます。"
 
@@ -14692,9 +18863,10 @@ msgstr ""
 "示を含めない限り、`main`をasyncにすることはできません。"
 
 #: src/async/async-await.md:39
+#, fuzzy
 msgid ""
 "You need an executor to run async code. `block_on` blocks the current thread "
-"until the provided future has run to completion. "
+"until the provided future has run to completion."
 msgstr ""
 "非同期のコードを実行するためには、エグゼキュータが必要です。`block_on`は、与"
 "えられたfutureが最後まで実行されるまで、現在のスレッドをブロックします。"
@@ -14708,9 +18880,10 @@ msgstr ""
 "は現在のスレッドをブロックしません。"
 
 #: src/async/async-await.md:45
+#, fuzzy
 msgid ""
 "`.await` can only be used inside an `async` function (or block; these are "
-"introduced later). "
+"introduced later)."
 msgstr ""
 "`.await`はasync関数(またはasync ブロック)の中でのみ利用できます。(async関数・"
 "ブロックについては後ほど紹介します。)"
@@ -14849,49 +19022,50 @@ msgstr ""
 "作さえ始めない）という点で「怠惰」です。例えば、これは、エグゼキュータがなく"
 "とも最後まで実行されるJavaScriptのPromiseとは異なります。"
 
-#: src/async/runtimes/tokio.md:4
-msgid "Tokio provides: "
+#: src/async/runtimes/tokio.md:3
+#, fuzzy
+msgid "Tokio provides:"
 msgstr "Tokioは以下を提供します: "
 
-#: src/async/runtimes/tokio.md:6
+#: src/async/runtimes/tokio.md:5
 msgid "A multi-threaded runtime for executing asynchronous code."
 msgstr "非同期のコードを実行するためのマルチスレッドのランタイム。"
 
-#: src/async/runtimes/tokio.md:7
+#: src/async/runtimes/tokio.md:6
 msgid "An asynchronous version of the standard library."
 msgstr "標準ライブラリの非同期バージョン。"
 
-#: src/async/runtimes/tokio.md:8
+#: src/async/runtimes/tokio.md:7
 msgid "A large ecosystem of libraries."
 msgstr "大きなライブラリのエコシステム。"
 
-#: src/async/runtimes/tokio.md:15
+#: src/async/runtimes/tokio.md:14
 msgid "\"Count in task: {i}!\""
 msgstr ""
 
-#: src/async/runtimes/tokio.md:25
+#: src/async/runtimes/tokio.md:24
 msgid "\"Main task: {i}\""
 msgstr ""
 
-#: src/async/runtimes/tokio.md:33
+#: src/async/runtimes/tokio.md:32
 msgid "With the `tokio::main` macro we can now make `main` async."
 msgstr "`tokio::main`のマクロにより、`main`の非同期処理を作ることができます。"
 
-#: src/async/runtimes/tokio.md:35
+#: src/async/runtimes/tokio.md:34
 msgid "The `spawn` function creates a new, concurrent \"task\"."
 msgstr "`spawn`関数は新しい並行の「タスク」を作成します。"
 
-#: src/async/runtimes/tokio.md:37
+#: src/async/runtimes/tokio.md:36
 msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 "注意：`spawn`は`Future`を引数に取るため、`count_to`に対して`.await`を呼ぶこと"
 "はありません。"
 
-#: src/async/runtimes/tokio.md:39
+#: src/async/runtimes/tokio.md:38
 msgid "**Further exploration:**"
 msgstr "**さらなる探求:**"
 
-#: src/async/runtimes/tokio.md:41
+#: src/async/runtimes/tokio.md:40
 msgid ""
 "Why does `count_to` not (usually) get to 10? This is an example of async "
 "cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
@@ -14901,12 +19075,12 @@ msgstr ""
 "のキャンセルの例です。 `tokio::spawn`は完了まで待機するためのハンドラを返しま"
 "す。"
 
-#: src/async/runtimes/tokio.md:45
+#: src/async/runtimes/tokio.md:44
 msgid "Try `count_to(10).await` instead of spawning."
 msgstr ""
 "プロセスを新しく作る代わりに、`count_to(10).await`を試してみてください。"
 
-#: src/async/runtimes/tokio.md:47
+#: src/async/runtimes/tokio.md:46
 msgid "Try awaiting the task returned from `tokio::spawn`."
 msgstr "`tokio::spawn`から返されたタスクを待機してみてください。"
 
@@ -14930,11 +19104,11 @@ msgstr ""
 "ることにより可能になります。"
 
 #: src/async/tasks.md:16
-msgid "\"127.0.0.1:6142\""
+msgid "\"127.0.0.1:0\""
 msgstr ""
 
 #: src/async/tasks.md:17
-msgid "\"listening on port 6142\""
+msgid "\"listening on port {}\""
 msgstr ""
 
 #: src/async/tasks.md:22
@@ -14945,21 +19119,28 @@ msgstr ""
 msgid "b\"Who are you?\\n\""
 msgstr ""
 
-#: src/async/tasks.md:26 src/async/tasks.md:37 src/async/tasks.md:43
-msgid "\"socket error: {e:?}\""
+#: src/async/tasks.md:25 src/async/tasks.md:28 src/async/tasks.md:31
+msgid "\"socket error\""
 msgstr ""
 
-#: src/async/tasks.md:34
+#: src/async/tasks.md:30
 msgid "\"Thanks for dialing in, {name}!\\n\""
 msgstr ""
 
-#: src/async/tasks.md:52 src/async/control-flow/join.md:36
+#: src/async/tasks.md:39 src/async/control-flow/join.md:36
 msgid ""
 "Copy this example into your prepared `src/main.rs` and run it from there."
 msgstr ""
 "この例を準備した`src/main.rs`にコピーして、そこから実行してみましょう。"
 
-#: src/async/tasks.md:54
+#: src/async/tasks.md:41
+msgid ""
+"Try connecting to it with a TCP connection tool like [nc](https://www.unix."
+"com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
+"telnet/)."
+msgstr ""
+
+#: src/async/tasks.md:45
 msgid ""
 "Ask students to visualize what the state of the example server would be with "
 "a few connected clients. What tasks exist? What are their Futures?"
@@ -14968,17 +19149,18 @@ msgstr ""
 "あるのかを、可視化するように受講者に指示してください。どんなタスクが存在して"
 "いますか？それらのfutureは何ですか？"
 
-#: src/async/tasks.md:57
+#: src/async/tasks.md:48
+#, fuzzy
 msgid ""
 "This is the first time we've seen an `async` block. This is similar to a "
 "closure, but does not take any arguments. Its return value is a Future, "
-"similar to an `async fn`. "
+"similar to an `async fn`."
 msgstr ""
 "私たちが`async`ブロックを見かけるのは初めてですね。これはクロージャと似ていま"
 "すが、何も引数は取りません。この返り値はFutureであり、`async fn`と似ていま"
 "す。"
 
-#: src/async/tasks.md:61
+#: src/async/tasks.md:52
 msgid ""
 "Refactor the async block into a function, and improve the error handling "
 "using `?`."
@@ -15100,11 +19282,6 @@ msgstr ""
 msgid "\"BAD_URL\""
 msgstr ""
 
-#: src/async/control-flow/join.md:30
-#: src/exercises/day-1/solutions-morning.md:78
-msgid "\"{:?}\""
-msgstr ""
-
 #: src/async/control-flow/join.md:38
 msgid ""
 "For multiple futures of disjoint types, you can use `std::future::join!` but "
@@ -15117,9 +19294,10 @@ msgstr ""
 "される予定です。"
 
 #: src/async/control-flow/join.md:42
+#, fuzzy
 msgid ""
 "The risk of `join` is that one of the futures may never resolve, this would "
-"cause your program to stall. "
+"cause your program to stall."
 msgstr ""
 "`join`のリスクは、複数のfutureのうちの１つでも解決されないとプログラムがス"
 "トールしてしまうということです。 "
@@ -15162,31 +19340,31 @@ msgstr ""
 "整った時、その`statement`は`future`の結果に紐づく`pattern`の変数を用いて実行"
 "されます。"
 
-#: src/async/control-flow/select.md:40
+#: src/async/control-flow/select.md:39
 msgid "\"Felix\""
 msgstr ""
 
-#: src/async/control-flow/select.md:42
+#: src/async/control-flow/select.md:39
 msgid "\"Failed to send cat.\""
 msgstr ""
 
-#: src/async/control-flow/select.md:47
+#: src/async/control-flow/select.md:43
 msgid "\"Rex\""
 msgstr ""
 
-#: src/async/control-flow/select.md:49
+#: src/async/control-flow/select.md:43
 msgid "\"Failed to send dog.\""
 msgstr ""
 
-#: src/async/control-flow/select.md:54
+#: src/async/control-flow/select.md:48
 msgid "\"Failed to receive winner\""
 msgstr ""
 
-#: src/async/control-flow/select.md:56
+#: src/async/control-flow/select.md:50
 msgid "\"Winner is {winner:?}\""
 msgstr ""
 
-#: src/async/control-flow/select.md:62
+#: src/async/control-flow/select.md:56
 #, fuzzy
 msgid ""
 "In this example, we have a race between a cat and a dog. "
@@ -15198,7 +19376,7 @@ msgstr ""
 "のチャネルをリッスンし、先に到着した方を選びます。犬は到着まで50msかかるの"
 "で、500msかかる猫に勝ちます。"
 
-#: src/async/control-flow/select.md:67
+#: src/async/control-flow/select.md:61
 msgid ""
 "You can use `oneshot` channels in this example as the channels are supposed "
 "to receive only one `send`."
@@ -15206,7 +19384,7 @@ msgstr ""
 "この例では`oneshot`チャネルを使うこともできます。なぜなら、チャネルは一回きり"
 "の`send`を受け取ることになっているからです。"
 
-#: src/async/control-flow/select.md:70
+#: src/async/control-flow/select.md:64
 msgid ""
 "Try adding a deadline to the race, demonstrating selecting different sorts "
 "of futures."
@@ -15214,7 +19392,7 @@ msgstr ""
 "レースに制限時間を追加することによって、違う種類のfutureをselectすることを実"
 "演してみてください。"
 
-#: src/async/control-flow/select.md:73
+#: src/async/control-flow/select.md:67
 msgid ""
 "Note that `select!` drops unmatched branches, which cancels their futures. "
 "It is easiest to use when every execution of `select!` creates new futures."
@@ -15224,7 +19402,7 @@ msgstr ""
 "毎回実行する際に新たなfutureが作成されるときに、`select!`を使うのが最も簡単で"
 "す。"
 
-#: src/async/control-flow/select.md:76
+#: src/async/control-flow/select.md:70
 msgid ""
 "An alternative is to pass `&mut future` instead of the future itself, but "
 "this can lead to issues, further discussed in the pinning slide."
@@ -15245,19 +19423,19 @@ msgid ""
 "chapter:"
 msgstr ""
 
-#: src/async/pitfalls.md:5
+#: src/async/pitfalls.md:7
 msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
 msgstr ""
 
-#: src/async/pitfalls.md:6
+#: src/async/pitfalls.md:8
 msgid "[Pin](pitfalls/pin.md)"
 msgstr ""
 
-#: src/async/pitfalls.md:7
+#: src/async/pitfalls.md:9
 msgid "[Async Traits](pitfalls/async-traits.md)"
 msgstr ""
 
-#: src/async/pitfalls.md:8
+#: src/async/pitfalls.md:10
 msgid "[Cancellation](pitfalls/cancellation.md)"
 msgstr ""
 
@@ -15332,7 +19510,7 @@ msgstr ""
 #: src/async/pitfalls/pin.md:8
 msgid ""
 "Therefore, you must guarantee that the addresses your future points to don't "
-"change. That is why we need to `pin` futures. Using the same future "
+"change. That is why we need to \"pin\" futures. Using the same future "
 "repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
@@ -15362,63 +19540,63 @@ msgstr ""
 msgid "// A requester which requests work and waits for it to complete.\n"
 msgstr ""
 
-#: src/async/pitfalls/pin.md:51
+#: src/async/pitfalls/pin.md:48
 msgid "\"failed to send on work queue\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md:52
+#: src/async/pitfalls/pin.md:49
 msgid "\"failed waiting for response\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md:61
+#: src/async/pitfalls/pin.md:58
 msgid "\"work result for iteration {i}: {resp}\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md:68
+#: src/async/pitfalls/pin.md:65
 msgid ""
 "You may recognize this as an example of the actor pattern. Actors typically "
 "call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:71
+#: src/async/pitfalls/pin.md:68
 msgid ""
 "This serves as a summation of a few of the previous lessons, so take your "
 "time with it."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:74
+#: src/async/pitfalls/pin.md:71
 msgid ""
 "Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
 "the `select!`. This will never execute. Why?"
 msgstr ""
 
-#: src/async/pitfalls/pin.md:77
+#: src/async/pitfalls/pin.md:74
 msgid ""
 "Instead, add a `timeout_fut` containing that future outside of the `loop`:"
 msgstr ""
 
-#: src/async/pitfalls/pin.md:88
+#: src/async/pitfalls/pin.md:85
 msgid ""
 "This still doesn't work. Follow the compiler errors, adding `&mut` to the "
 "`timeout_fut` in the `select!` to work around the move, then using `Box::"
 "pin`:"
 msgstr ""
 
-#: src/async/pitfalls/pin.md:102
+#: src/async/pitfalls/pin.md:99
 msgid ""
 "This compiles, but once the timeout expires it is `Poll::Ready` on every "
 "iteration (a fused future would help with this). Update to reset "
 "`timeout_fut` every time it expires."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:106
+#: src/async/pitfalls/pin.md:103
 msgid ""
 "Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
 "stabilized, with older code often using `tokio::pin!`) is also an option, "
 "but that is difficult to use for a future that is reassigned."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:110
+#: src/async/pitfalls/pin.md:107
 msgid ""
 "Another alternative is to not use `pin` at all but spawn another task that "
 "will send to a `oneshot` channel every 100ms."
@@ -15432,27 +19610,27 @@ msgid ""
 "nightly.html))"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:5
+#: src/async/pitfalls/async-traits.md:6
 msgid ""
 "The crate [async_trait](https://docs.rs/async-trait/latest/async_trait/) "
 "provides a workaround through a macro:"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:30
+#: src/async/pitfalls/async-traits.md:35
 msgid "\"running all sleepers..\""
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:34
+#: src/async/pitfalls/async-traits.md:39
 msgid "\"slept for {}ms\""
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:51
+#: src/async/pitfalls/async-traits.md:56
 msgid ""
 "`async_trait` is easy to use, but note that it's using heap allocations to "
 "achieve this. This heap allocation has performance overhead."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:54
+#: src/async/pitfalls/async-traits.md:59
 msgid ""
 "The challenges in language support for `async trait` are deep Rust and "
 "probably not worth describing in-depth. Niko Matsakis did a good job of "
@@ -15461,7 +19639,7 @@ msgid ""
 "digging deeper."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:60
+#: src/async/pitfalls/async-traits.md:65
 msgid ""
 "Try creating a new sleeper struct that will sleep for a random amount of "
 "time and adding it to the Vec."
@@ -15509,33 +19687,31 @@ msgid ""
 "dropped."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:82
+#: src/async/pitfalls/cancellation.md:83
 msgid ""
 "`LinesReader` can be made cancellation-safe by making `buf` part of the "
 "struct:"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:95
-msgid ""
-"// prefix buf and bytes with self.\n"
-"        // ...\n"
+#: src/async/pitfalls/cancellation.md:97
+msgid "// prefix buf and bytes with self.\n"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:104
+#: src/async/pitfalls/cancellation.md:106
 msgid ""
 "[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
 "html#method.tick) is cancellation-safe because it keeps track of whether a "
 "tick has been 'delivered'."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:107
+#: src/async/pitfalls/cancellation.md:110
 msgid ""
 "[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
 "AsyncReadExt.html#method.read) is cancellation-safe because it either "
 "returns or doesn't read data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:110
+#: src/async/pitfalls/cancellation.md:113
 msgid ""
 "[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
 "AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
@@ -15561,8 +19737,9 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:3
-msgid "Dining Philosophers - Async"
-msgstr ""
+#, fuzzy
+msgid "Dining Philosophers --- Async"
+msgstr "食事する哲学者"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
@@ -15577,18 +19754,18 @@ msgid ""
 "main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:51
-#: src/exercises/concurrency/solutions-afternoon.md:77
+#: src/exercises/concurrency/dining-philosophers-async.md:52
+#: src/exercises/concurrency/solutions-afternoon.md:78
 msgid "// Make them think and eat\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:57
+#: src/exercises/concurrency/dining-philosophers-async.md:58
 msgid ""
 "Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:62
+#: src/exercises/concurrency/dining-philosophers-async.md:63
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -15597,19 +19774,19 @@ msgid ""
 "edition = \"2021\"\n"
 "\n"
 "[dependencies]\n"
-"tokio = {version = \"1.26.0\", features = [\"sync\", \"time\", \"macros\", "
-"\"rt-multi-thread\"]}\n"
+"tokio = { version = \"1.26.0\", features = [\"sync\", \"time\", \"macros\", "
+"\"rt-multi-thread\"] }\n"
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:72
+#: src/exercises/concurrency/dining-philosophers-async.md:73
 msgid ""
 "Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "Can you make your implementation single-threaded? "
+#: src/exercises/concurrency/dining-philosophers-async.md:78
+msgid "Can you make your implementation single-threaded?"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
@@ -15625,19 +19802,19 @@ msgstr ""
 msgid ""
 "For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
 "sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
-"(https://docs.rs/tokio-websockets/0.4.0/tokio_websockets/) for the "
-"communication between the client and the server."
+"(https://docs.rs/tokio-websockets/) for the communication between the client "
+"and the server."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:13
+#: src/exercises/concurrency/chat-app.md:12
 msgid "Create a new Cargo project and add the following dependencies:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:15
+#: src/exercises/concurrency/chat-app.md:14
 msgid "_Cargo.toml_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:19
+#: src/exercises/concurrency/chat-app.md:18
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -15646,37 +19823,36 @@ msgid ""
 "edition = \"2021\"\n"
 "\n"
 "[dependencies]\n"
-"futures-util = { version = \"0.3.28\", features = [\"sink\"] }\n"
-"http = \"0.2.9\"\n"
+"futures-util = { version = \"0.3.30\", features = [\"sink\"] }\n"
+"http = \"1.0.0\"\n"
 "tokio = { version = \"1.28.1\", features = [\"full\"] }\n"
-"tokio-websockets = { version = \"0.4.0\", features = [\"client\", "
-"\"fastrand\", \"server\", \"sha1_smol\"] }\n"
+"tokio-websockets = { version = \"0.5.0\", features = [\"client\", \"fastrand"
+"\", \"server\", \"sha1_smol\"] }\n"
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:32
+#: src/exercises/concurrency/chat-app.md:31
 msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
 "You are going to need the following functions from `tokio` and "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.4.0/"
-"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
-"API. "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/). Spend a few minutes "
+"to familiarize yourself with the API."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
 "[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
-"trait.StreamExt.html#method.next) implemented by `WebsocketStream`: for "
+"trait.StreamExt.html#method.next) implemented by `WebSocketStream`: for "
 "asynchronously reading messages from a Websocket Stream."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:39
 msgid ""
 "[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
-"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"trait.SinkExt.html#method.send) implemented by `WebSocketStream`: for "
 "asynchronously sending messages on a Websocket Stream."
 msgstr ""
 
@@ -15693,11 +19869,11 @@ msgid ""
 "struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:46
+#: src/exercises/concurrency/chat-app.md:45
 msgid "Two binaries"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:48
+#: src/exercises/concurrency/chat-app.md:47
 msgid ""
 "Normally in a Cargo project, you can have only one binary, and one `src/main."
 "rs` file. In this project, we need two binaries. One for the client, and one "
@@ -15705,57 +19881,57 @@ msgid ""
 "but we are going to put them in a single Cargo project with two binaries. "
 "For this to work, the client and the server code should go under `src/bin` "
 "(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
-"targets.html#binaries)). "
+"targets.html#binaries))."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:55
+#: src/exercises/concurrency/chat-app.md:54
 msgid ""
 "Copy the following server and client code into `src/bin/server.rs` and `src/"
 "bin/client.rs`, respectively. Your task is to complete these files as "
-"described below. "
+"described below."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:59
+#: src/exercises/concurrency/chat-app.md:58
 #: src/exercises/concurrency/solutions-afternoon.md:99
 msgid "_src/bin/server.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:78
-#: src/exercises/concurrency/chat-app.md:125
+#: src/exercises/concurrency/chat-app.md:77
+#: src/exercises/concurrency/chat-app.md:124
 msgid "// TODO: For a hint, see the description of the task below.\n"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:86
-#: src/exercises/concurrency/solutions-afternoon.md:149
+#: src/exercises/concurrency/chat-app.md:85
+#: src/exercises/concurrency/solutions-afternoon.md:147
 msgid "\"127.0.0.1:2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:87
-#: src/exercises/concurrency/solutions-afternoon.md:150
+#: src/exercises/concurrency/chat-app.md:86
+#: src/exercises/concurrency/solutions-afternoon.md:148
 msgid "\"listening on port 2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:91
-#: src/exercises/concurrency/solutions-afternoon.md:154
+#: src/exercises/concurrency/chat-app.md:90
+#: src/exercises/concurrency/solutions-afternoon.md:152
 msgid "\"New connection from {addr:?}\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:94
-#: src/exercises/concurrency/solutions-afternoon.md:157
+#: src/exercises/concurrency/chat-app.md:93
+#: src/exercises/concurrency/solutions-afternoon.md:155
 msgid "// Wrap the raw TCP stream into a websocket.\n"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:103
-#: src/exercises/concurrency/solutions-afternoon.md:166
+#: src/exercises/concurrency/chat-app.md:102
+#: src/exercises/concurrency/solutions-afternoon.md:164
 msgid "_src/bin/client.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:117
-#: src/exercises/concurrency/solutions-afternoon.md:178
+#: src/exercises/concurrency/chat-app.md:116
+#: src/exercises/concurrency/solutions-afternoon.md:176
 msgid "\"ws://127.0.0.1:2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:130
+#: src/exercises/concurrency/chat-app.md:129
 msgid "Running the binaries"
 msgstr ""
 
@@ -15796,10 +19972,70 @@ msgid ""
 "clients, but the sender of the message."
 msgstr ""
 
+#: src/exercises/concurrency/solutions-afternoon.md:1
+msgid "Concurrency Afternoon Exercise"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:5
+msgid "([back to exercise](dining-philosophers-async.md))"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:33
+msgid ""
+"// Add a delay before picking the second fork to allow the execution\n"
+"        // to transfer to another task\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:41
+msgid "// The locks are dropped here\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:61
+msgid ""
+"// To avoid a deadlock, we have to break the symmetry\n"
+"            // somewhere. This will swap the forks without deinitializing\n"
+"            // either of them.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:75
+msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:90
+msgid "\"Here is a thought: {thought}\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:97
+msgid "([back to exercise](chat-app.md))"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:116
+msgid "\"Welcome to chat! Type a message\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:119
+msgid ""
+"// A continuous loop for concurrently performing two tasks: (1) receiving\n"
+"    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
+"    // messages on `bcast_rx` and sending them to the client.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:128
+msgid "\"From client {addr:?} {text:?}\""
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:183
+msgid "// Continuous loop for concurrently sending and receiving messages.\n"
+msgstr ""
+
+#: src/exercises/concurrency/solutions-afternoon.md:190
+msgid "\"From server: {}\""
+msgstr ""
+
 #: src/thanks.md:3
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
-"that it was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
+"it was useful."
 msgstr ""
 
 #: src/thanks.md:6
@@ -15824,308 +20060,434 @@ msgid ""
 msgstr ""
 
 #: src/glossary.md:32
-msgid "argument:"
+msgid ""
+"argument:  \n"
+"Information that is passed into a function or method."
 msgstr ""
 
-#: src/glossary.md:33
+#: src/glossary.md:34
 msgid ""
 "Bare-metal Rust:  \n"
 "Low-level Rust development, often deployed to a system without an operating "
 "system. See [Bare-metal Rust](bare-metal.md)."
 msgstr ""
 
-#: src/glossary.md:36
+#: src/glossary.md:37
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
 msgstr ""
 
-#: src/glossary.md:38
+#: src/glossary.md:39
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
 msgstr ""
 
-#: src/glossary.md:40
+#: src/glossary.md:41
 msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
 msgstr ""
 
-#: src/glossary.md:42
+#: src/glossary.md:43
 msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
 msgstr ""
 
-#: src/glossary.md:44
-msgid "build:"
-msgstr ""
-
 #: src/glossary.md:45
-msgid "call:"
+msgid ""
+"build:  \n"
+"The process of converting source code into executable code or a usable "
+"program."
 msgstr ""
 
-#: src/glossary.md:46
+#: src/glossary.md:48
+msgid ""
+"call:  \n"
+"To invoke or execute a function or method."
+msgstr ""
+
+#: src/glossary.md:50
 msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
 msgstr ""
 
-#: src/glossary.md:48
+#: src/glossary.md:52
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
 msgstr ""
 
-#: src/glossary.md:50
-#, fuzzy
-msgid "concurrency:"
-msgstr "並行性"
+#: src/glossary.md:54
+msgid ""
+"concurrency:  \n"
+"The execution of multiple tasks or processes at the same time."
+msgstr ""
 
-#: src/glossary.md:51
+#: src/glossary.md:56
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
 msgstr ""
 
-#: src/glossary.md:53
-msgid "constant:"
-msgstr ""
-
-#: src/glossary.md:54
-#, fuzzy
-msgid "control flow:"
-msgstr "制御フロー"
-
-#: src/glossary.md:55
-msgid "crash:"
-msgstr ""
-
-#: src/glossary.md:56
-#, fuzzy
-msgid "enumeration:"
-msgstr "実装"
-
-#: src/glossary.md:57
-msgid "error:"
-msgstr ""
-
 #: src/glossary.md:58
-#, fuzzy
-msgid "error handling:"
-msgstr "エラー処理"
-
-#: src/glossary.md:59
-#, fuzzy
-msgid "exercise:"
-msgstr "練習問題"
+msgid ""
+"constant:  \n"
+"A value that does not change during the execution of a program."
+msgstr ""
 
 #: src/glossary.md:60
-#, fuzzy
-msgid "function:"
-msgstr "関数"
-
-#: src/glossary.md:61
-#, fuzzy
-msgid "garbage collector:"
-msgstr "ガベージコレクション"
-
-#: src/glossary.md:62
-#, fuzzy
-msgid "generics:"
-msgstr "ジェネリクス（generics）"
+msgid ""
+"control flow:  \n"
+"The order in which the individual statements or instructions are executed in "
+"a program."
+msgstr ""
 
 #: src/glossary.md:63
-msgid "immutable:"
+msgid ""
+"crash:  \n"
+"An unexpected and unhandled failure or termination of a program."
 msgstr ""
-
-#: src/glossary.md:64
-#, fuzzy
-msgid "integration test:"
-msgstr "インテグレーションテスト"
 
 #: src/glossary.md:65
-msgid "keyword:"
+msgid ""
+"enumeration:  \n"
+"A data type that consists of named constant values."
 msgstr ""
-
-#: src/glossary.md:66
-#, fuzzy
-msgid "library:"
-msgstr "ライブラリ"
 
 #: src/glossary.md:67
-msgid "macro:"
+msgid ""
+"error:  \n"
+"An unexpected condition or result that deviates from the expected behavior."
 msgstr ""
-
-#: src/glossary.md:68
-#, fuzzy
-msgid "main function:"
-msgstr "Unsafe関数の呼び出し"
 
 #: src/glossary.md:69
-msgid "match:"
+msgid ""
+"error handling:  \n"
+"The process of managing and responding to errors that occur during program "
+"execution."
 msgstr ""
-
-#: src/glossary.md:70
-msgid "memory leak:"
-msgstr ""
-
-#: src/glossary.md:71
-#, fuzzy
-msgid "method:"
-msgstr "メソッド"
 
 #: src/glossary.md:72
-#, fuzzy
-msgid "module:"
-msgstr "モジュール"
-
-#: src/glossary.md:73
-msgid "move:"
+msgid ""
+"exercise:  \n"
+"A task or problem designed to practice and test programming skills."
 msgstr ""
 
 #: src/glossary.md:74
-msgid "mutable:"
+msgid ""
+"function:  \n"
+"A reusable block of code that performs a specific task."
 msgstr ""
-
-#: src/glossary.md:75
-#, fuzzy
-msgid "ownership:"
-msgstr "所有権"
 
 #: src/glossary.md:76
-#, fuzzy
-msgid "panic:"
-msgstr "パニック（panic）"
-
-#: src/glossary.md:77
-msgid "parameter:"
-msgstr ""
-
-#: src/glossary.md:78
-msgid "pattern:"
+msgid ""
+"garbage collector:  \n"
+"A mechanism that automatically frees up memory occupied by objects that are "
+"no longer in use."
 msgstr ""
 
 #: src/glossary.md:79
-msgid "payload:"
-msgstr ""
-
-#: src/glossary.md:80
-msgid "program:"
-msgstr ""
-
-#: src/glossary.md:81
-msgid "programming language:"
+msgid ""
+"generics:  \n"
+"A feature that allows writing code with placeholders for types, enabling "
+"code reuse with different data types."
 msgstr ""
 
 #: src/glossary.md:82
-#, fuzzy
-msgid "receiver:"
-msgstr "ドライバ"
-
-#: src/glossary.md:83
-msgid "reference counting:"
+msgid ""
+"immutable:  \n"
+"Unable to be changed after creation."
 msgstr ""
 
 #: src/glossary.md:84
-msgid "return:"
+msgid ""
+"integration test:  \n"
+"A type of test that verifies the interactions between different parts or "
+"components of a system."
 msgstr ""
 
-#: src/glossary.md:85
-#, fuzzy
-msgid "Rust:"
-msgstr "Rustdoc"
+#: src/glossary.md:87
+msgid ""
+"keyword:  \n"
+"A reserved word in a programming language that has a specific meaning and "
+"cannot be used as an identifier."
+msgstr ""
 
-#: src/glossary.md:86
+#: src/glossary.md:90
+msgid ""
+"library:  \n"
+"A collection of precompiled routines or code that can be used by programs."
+msgstr ""
+
+#: src/glossary.md:92
+msgid ""
+"macro:  \n"
+"Rust macros can be recognized by a `!` in the name. Macros are used when "
+"normal functions are not enough. A typical example is `format!`, which takes "
+"a variable number of arguments, which isn't supported by Rust functions."
+msgstr ""
+
+#: src/glossary.md:96
+msgid ""
+"`main` function:  \n"
+"Rust programs start executing with the `main` function."
+msgstr ""
+
+#: src/glossary.md:98
+msgid ""
+"match:  \n"
+"A control flow construct in Rust that allows for pattern matching on the "
+"value of an expression."
+msgstr ""
+
+#: src/glossary.md:101
+msgid ""
+"memory leak:  \n"
+"A situation where a program fails to release memory that is no longer "
+"needed, leading to a gradual increase in memory usage."
+msgstr ""
+
+#: src/glossary.md:104
+msgid ""
+"method:  \n"
+"A function associated with an object or a type in Rust."
+msgstr ""
+
+#: src/glossary.md:106
+msgid ""
+"module:  \n"
+"A namespace that contains definitions, such as functions, types, or traits, "
+"to organize code in Rust."
+msgstr ""
+
+#: src/glossary.md:109
+msgid ""
+"move:  \n"
+"The transfer of ownership of a value from one variable to another in Rust."
+msgstr ""
+
+#: src/glossary.md:111
+msgid ""
+"mutable:  \n"
+"A property in Rust that allows variables to be modified after they have been "
+"declared."
+msgstr ""
+
+#: src/glossary.md:114
+msgid ""
+"ownership:  \n"
+"The concept in Rust that defines which part of the code is responsible for "
+"managing the memory associated with a value."
+msgstr ""
+
+#: src/glossary.md:117
+msgid ""
+"panic:  \n"
+"An unrecoverable error condition in Rust that results in the termination of "
+"the program."
+msgstr ""
+
+#: src/glossary.md:120
+msgid ""
+"parameter:  \n"
+"A value that is passed into a function or method when it is called."
+msgstr ""
+
+#: src/glossary.md:122
+msgid ""
+"pattern:  \n"
+"A combination of values, literals, or structures that can be matched against "
+"an expression in Rust."
+msgstr ""
+
+#: src/glossary.md:125
+msgid ""
+"payload:  \n"
+"The data or information carried by a message, event, or data structure."
+msgstr ""
+
+#: src/glossary.md:127
+msgid ""
+"program:  \n"
+"A set of instructions that a computer can execute to perform a specific task "
+"or solve a particular problem."
+msgstr ""
+
+#: src/glossary.md:130
+msgid ""
+"programming language:  \n"
+"A formal system used to communicate instructions to a computer, such as Rust."
+msgstr ""
+
+#: src/glossary.md:132
+msgid ""
+"receiver:  \n"
+"The first parameter in a Rust method that represents the instance on which "
+"the method is called."
+msgstr ""
+
+#: src/glossary.md:135
+msgid ""
+"reference counting:  \n"
+"A memory management technique in which the number of references to an object "
+"is tracked, and the object is deallocated when the count reaches zero."
+msgstr ""
+
+#: src/glossary.md:138
+msgid ""
+"return:  \n"
+"A keyword in Rust used to indicate the value to be returned from a function."
+msgstr ""
+
+#: src/glossary.md:140
+msgid ""
+"Rust:  \n"
+"A systems programming language that focuses on safety, performance, and "
+"concurrency."
+msgstr ""
+
+#: src/glossary.md:143
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 3 of this course."
 msgstr ""
 
-#: src/glossary.md:88
+#: src/glossary.md:145
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
 msgstr ""
 
-#: src/glossary.md:90
-msgid "safe:"
+#: src/glossary.md:147
+msgid ""
+"Rust in Chromium:  \n"
+"See [Rust in Chromium](chromium.md)."
 msgstr ""
 
-#: src/glossary.md:91
-msgid "scope:"
+#: src/glossary.md:149
+msgid ""
+"safe:  \n"
+"Refers to code that adheres to Rust's ownership and borrowing rules, "
+"preventing memory-related errors."
 msgstr ""
 
-#: src/glossary.md:92
-#, fuzzy
-msgid "standard library:"
-msgstr "標準ライブラリ"
-
-#: src/glossary.md:93
-msgid "static:"
+#: src/glossary.md:152
+msgid ""
+"scope:  \n"
+"The region of a program where a variable is valid and can be used."
 msgstr ""
 
-#: src/glossary.md:94
-#, fuzzy
-msgid "string:"
-msgstr "文字列（String）"
-
-#: src/glossary.md:95
-#, fuzzy
-msgid "struct:"
-msgstr "構造体（structs）"
-
-#: src/glossary.md:96
-msgid "test:"
+#: src/glossary.md:154
+msgid ""
+"standard library:  \n"
+"A collection of modules providing essential functionality in Rust."
 msgstr ""
 
-#: src/glossary.md:97
-#, fuzzy
-msgid "thread:"
-msgstr "スレッド"
-
-#: src/glossary.md:98
-msgid "thread safety:"
+#: src/glossary.md:156
+msgid ""
+"static:  \n"
+"A keyword in Rust used to define static variables or items with a `'static` "
+"lifetime."
 msgstr ""
 
-#: src/glossary.md:99
-#, fuzzy
-msgid "trait:"
-msgstr "トレイト（trait）"
-
-#: src/glossary.md:100
-msgid "type:"
+#: src/glossary.md:159
+msgid ""
+"string:  \n"
+"A data type storing textual data. See [`String` vs `str`](basic-syntax/"
+"string-slices.html) for more."
 msgstr ""
 
-#: src/glossary.md:101
-#, fuzzy
-msgid "type inference:"
-msgstr "型推論"
-
-#: src/glossary.md:102
-#, fuzzy
-msgid "undefined behavior:"
-msgstr "実行時に未定義の動作はありません："
-
-#: src/glossary.md:103
-#, fuzzy
-msgid "union:"
-msgstr "共用体"
-
-#: src/glossary.md:104
-#, fuzzy
-msgid "unit test:"
-msgstr "ユニットテスト"
-
-#: src/glossary.md:105
-msgid "unsafe:"
+#: src/glossary.md:162
+msgid ""
+"struct:  \n"
+"A composite data type in Rust that groups together variables of different "
+"types under a single name."
 msgstr ""
 
-#: src/glossary.md:106
-#, fuzzy
-msgid "variable:\\"
-msgstr "変数"
+#: src/glossary.md:165
+msgid ""
+"test:  \n"
+"A Rust module containing functions that test the correctness of other "
+"functions."
+msgstr ""
+
+#: src/glossary.md:168
+msgid ""
+"thread:  \n"
+"A separate sequence of execution in a program, allowing concurrent execution."
+msgstr ""
+
+#: src/glossary.md:170
+msgid ""
+"thread safety:  \n"
+"The property of a program that ensures correct behavior in a multithreaded "
+"environment."
+msgstr ""
+
+#: src/glossary.md:173
+msgid ""
+"trait:  \n"
+"A collection of methods defined for an unknown type, providing a way to "
+"achieve polymorphism in Rust."
+msgstr ""
+
+#: src/glossary.md:176
+msgid ""
+"trait bound:  \n"
+"An abstraction where you can require types to implement some traits of your "
+"interest."
+msgstr ""
+
+#: src/glossary.md:179
+msgid ""
+"type:  \n"
+"A classification that specifies which operations can be performed on values "
+"of a particular kind in Rust."
+msgstr ""
+
+#: src/glossary.md:182
+msgid ""
+"type inference:  \n"
+"The ability of the Rust compiler to deduce the type of a variable or "
+"expression."
+msgstr ""
+
+#: src/glossary.md:185
+msgid ""
+"undefined behavior:  \n"
+"Actions or conditions in Rust that have no specified result, often leading "
+"to unpredictable program behavior."
+msgstr ""
+
+#: src/glossary.md:188
+msgid ""
+"union:  \n"
+"A data type that can hold values of different types but only one at a time."
+msgstr ""
+
+#: src/glossary.md:190
+msgid ""
+"unit test:  \n"
+"Rust comes with built-in support for running small unit tests and larger "
+"integration tests. See [Unit Tests](testing/unit-tests.html)."
+msgstr ""
+
+#: src/glossary.md:193
+msgid ""
+"unsafe:  \n"
+"The subset of Rust which allows you to trigger _undefined behavior_. See "
+"[Unsafe Rust](unsafe.html)."
+msgstr ""
+
+#: src/glossary.md:196
+msgid ""
+"variable:  \n"
+"A memory location storing data. Variables are valid in a _scope_."
+msgstr ""
 
 #: src/other-resources.md:1
 msgid "Other Rust Resources"
@@ -16218,20 +20580,20 @@ msgid ""
 "firmware in C."
 msgstr ""
 
-#: src/other-resources.md:42
+#: src/other-resources.md:41
 msgid ""
 "[Rust for professionals](https://overexact.com/rust-for-professionals/): "
 "covers the syntax of Rust using side-by-side comparisons with other "
 "languages such as C, C++, Java, JavaScript, and Python."
 msgstr ""
 
-#: src/other-resources.md:45
+#: src/other-resources.md:44
 msgid ""
 "[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
 "you learn Rust."
 msgstr ""
 
-#: src/other-resources.md:47
+#: src/other-resources.md:46
 msgid ""
 "[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
 "material/index.html): a series of small presentations covering both basic "
@@ -16239,7 +20601,7 @@ msgid ""
 "and async/await are also covered."
 msgstr ""
 
-#: src/other-resources.md:52
+#: src/other-resources.md:50
 msgid ""
 "[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
 "series-to-rust/) and [Take your first steps with Rust](https://docs."
@@ -16248,14 +20610,14 @@ msgid ""
 "11 modules which covers Rust syntax and basic constructs."
 msgstr ""
 
-#: src/other-resources.md:58
+#: src/other-resources.md:56
 msgid ""
 "[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
 "github.io/too-many-lists/): in-depth exploration of Rust's memory management "
 "rules, through implementing a few different types of list structures."
 msgstr ""
 
-#: src/other-resources.md:63
+#: src/other-resources.md:61
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
 "for even more Rust books."
@@ -16309,643 +20671,816 @@ msgid ""
 "directory for details, including the license terms."
 msgstr ""
 
-#: src/credits.md:34
-msgid ""
-"The [Why Rust? - An Example in C](why-rust/an-example-in-c.md) section has "
-"been taken from the presentation slides of [Colin Finck's Master Thesis]"
-"(https://colinfinck.de/Master_Thesis_Colin_Finck.pdf). It has been "
-"relicensed under the terms of the Apache 2.0 license for this course by the "
-"author."
-msgstr ""
+#~ msgid "Small Example"
+#~ msgstr "プログラムの例"
 
-#: src/exercises/solutions.md:3
-msgid "You will find solutions to the exercises on the following pages."
-msgstr ""
-
-#: src/exercises/solutions.md:5
-msgid ""
-"Feel free to ask questions about the solutions [on GitHub](https://github."
-"com/google/comprehensive-rust/discussions). Let us know if you have a "
-"different or better solution than what is presented here."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:1
-msgid "Day 1 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:5
-msgid "([back to exercise](for-loops.md))"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:20
-msgid "\"{row:?}\""
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:27
-#: src/exercises/day-1/solutions-morning.md:35
-msgid "//\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:57
-msgid "Bonus question"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:59
-msgid ""
-"It requires more advanced concepts. It might seem that we could use a slice-"
-"of-slices (`&[&[i32]]`) as the input type to transpose and thus make our "
-"function handle any size of matrix. However, this quickly breaks down: the "
-"return type cannot be `&[&[i32]]` since it needs to own the data you return."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:61
-msgid ""
-"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work "
-"out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to "
-"`&[&[i32]]` so now you cannot easily use `pretty_print` either."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:63
-msgid ""
-"Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
-"abstract over anything that can be referenced as a slice."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:72
-msgid "// A line references a slice of items\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:74
-msgid "// A matrix references a slice of lines\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:83
-msgid "// &[&[i32]]\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:85
-msgid "// [[&str; 2]; 2]\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:87
-msgid "// Vec<Vec<i32>>\n"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:92
-msgid ""
-"In addition, the type itself would not enforce that the child slices are of "
-"the same length, so such variable could contain an invalid matrix."
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:1
-msgid "Day 1 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:5
-msgid "([back to exercise](luhn.md))"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:34
-msgid "\"1234 5678 1234 5670\""
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:36
-msgid "\"Is {cc_number} a valid credit card number? {}\""
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:80
 #, fuzzy
-msgid "Pattern matching"
-msgstr "パターンマッチング"
+#~ msgid "An Example in C"
+#~ msgstr "例"
 
-#: src/exercises/day-1/solutions-afternoon.md:205
-msgid "\"expr: {:?}\""
-msgstr ""
+#~ msgid "Compile Time Guarantees"
+#~ msgstr "コンパイル時の保証"
 
-#: src/exercises/day-1/solutions-afternoon.md:206
-msgid "\"result: {:?}\""
-msgstr ""
+#~ msgid "Runtime Guarantees"
+#~ msgstr "実行時の保証"
 
-#: src/exercises/day-2/solutions-morning.md:1
-msgid "Day 2 Morning Exercises"
-msgstr ""
+#~ msgid "Modern Features"
+#~ msgstr "現代的な機能"
 
-#: src/exercises/day-2/solutions-morning.md:3
-msgid "Designing a Library"
-msgstr "ライブラリをデザイン"
+#~ msgid "String vs str"
+#~ msgstr "文字列（String） vs 文字列スライス（str）"
 
-#: src/exercises/day-2/solutions-morning.md:5
-msgid "([back to exercise](book-library.md))"
-msgstr ""
+#~ msgid "Rustdoc"
+#~ msgstr "Rustdoc"
 
-#: src/exercises/day-2/solutions-morning.md:54
-msgid "\"{}, published in {}\""
-msgstr ""
+#~ msgid "Overloading"
+#~ msgstr "オーバーロード"
 
-#: src/exercises/day-2/solutions-morning.md:59
-msgid ""
-"// Using a closure and a built-in method:\n"
-"        // self.books.iter().min_by_key(|book| book.year)\n"
-msgstr ""
+#~ msgid "Arrays and for Loops"
+#~ msgstr "配列とforループ"
 
-#: src/exercises/day-2/solutions-morning.md:62
-msgid "// Longer hand-written solution:\n"
-msgstr ""
+#~ msgid "if expressions"
+#~ msgstr "if式"
 
-#: src/exercises/day-2/solutions-morning.md:127
-msgid ""
-"// We could try and capture stdout, but let us just call the\n"
-"    // method to start with.\n"
-msgstr ""
+#~ msgid "for expressions"
+#~ msgstr "for式"
 
-#: src/exercises/day-2/solutions-morning.md:153
-msgid "([back to exercise](health-statistics.md))"
-msgstr ""
+#~ msgid "while expressions"
+#~ msgstr "while式"
 
-#: src/exercises/day-2/solutions-afternoon.md:1
-msgid "Day 2 Afternoon Exercises"
-msgstr ""
+#~ msgid "break & continue"
+#~ msgstr "break & continue"
 
-#: src/exercises/day-2/solutions-afternoon.md:5
-msgid "([back to exercise](strings-iterators.md))"
-msgstr ""
+#~ msgid "loop expressions"
+#~ msgstr "loop式"
 
-#: src/exercises/day-2/solutions-afternoon.md:10
-#: src/exercises/day-2/solutions-afternoon.md:12
-msgid "'/'"
-msgstr ""
+#~ msgid "Variant Payloads"
+#~ msgstr "列挙子のペイロード"
 
-#: src/exercises/day-2/solutions-afternoon.md:16
-msgid "\"*\""
-msgstr ""
+#~ msgid "Enum Sizes"
+#~ msgstr "列挙型のサイズ"
 
-#: src/exercises/day-2/solutions-afternoon.md:22
-msgid ""
-"// Alternatively, Iterator::zip() lets us iterate simultaneously over "
-"prefix\n"
-"    // and request segments. The zip() iterator is finished as soon as one "
-"of\n"
-"    // the source iterators is finished, but we need to iterate over all "
-"request\n"
-"    // segments. A neat trick that makes zip() work is to use map() and "
-"chain()\n"
-"    // to produce an iterator that returns Some(str) for each pattern "
-"segments,\n"
-"    // and then returns None indefinitely.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:1
-msgid "Day 3 Morning Exercise"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:5
-msgid "([back to exercise](simple-gui.md))"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:75
-msgid "// Add 4 paddings for borders\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:87
-msgid ""
-"// TODO: after learning about error handling, you can change\n"
-"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
-"        // the ?-operator here instead of .unwrap().\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:90
-#: src/exercises/day-3/solutions-morning.md:96
-msgid "\"+-{:-<inner_width$}-+\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:91
-msgid "\"| {:^inner_width$} |\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:92
-msgid "\"+={:=<inner_width$}=+\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:94
-msgid "\"| {:inner_width$} |\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:102
-msgid "// add a bit of padding\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:110
-#: src/exercises/day-3/solutions-morning.md:114
-msgid "\"+{:-<width$}+\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:112
-msgid "\"|{:^width$}|\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:144
-msgid "([back to exercise](points-polygons.md))"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:223
-msgid ""
-"// Alternatively, Iterator::zip() lets us iterate over the points as pairs\n"
-"        // but we need to pair each point with the next one, and the last "
-"point\n"
-"        // with the first point. The zip() iterator is finished as soon as "
-"one of \n"
-"        // the source iterators is finished, a neat trick is to combine "
-"Iterator::cycle\n"
-"        // with Iterator::skip to create the second iterator for the zip and "
-"using map \n"
-"        // and sum to calculate the total length.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:1
-msgid "Day 3 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:5
-msgid "([back to exercise](safe-ffi-wrapper.md))"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:77
-msgid "\"Invalid path: {err}\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:78
-msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:81
-msgid "\"Could not open {:?}\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:91
-msgid ""
-"// Keep calling readdir until we get a NULL pointer back.\n"
-"        // SAFETY: self.dir is never NULL.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:95
-msgid "// We have reached the end of the directory.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:98
-msgid ""
-"// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
-"        // terminated.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:110
-msgid "// SAFETY: self.dir is not NULL.\n"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:112
-msgid "\"Could not close {:?}\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:131
-msgid "\"no-such-directory\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:139
-#: src/exercises/day-3/solutions-afternoon.md:154
-msgid "\"Non UTF-8 character in path\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:143
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"..\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:150
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"foo.txt\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:150
-msgid "\"The Foo Diaries\\n\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:151
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"bar.png\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:151
-msgid "\"<PNG>\\n\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:152
-#: src/exercises/day-3/solutions-afternoon.md:158
-msgid "\"crab.rs\""
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:152
-msgid "\"//! Crab\\n\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:1
-msgid "Bare Metal Rust Morning Exercise"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:5
-msgid "([back to exercise](compass.md))"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:40
-msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:41
-msgid "\"Setting up IMU...\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:49
-msgid "// Set up display and timer.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:59
-msgid "// Read compass data and log it to the serial port.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:67
-msgid "\"{},{},{}\\t{},{},{}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:103
-msgid ""
-"// If button A is pressed, switch to the next mode and briefly blink all "
-"LEDs on.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:5
-msgid "([back to exercise](rtc.md))"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:7
-msgid "_main.rs_:"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:36
-msgid "/// Base address of the PL031 RTC.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:38
-msgid "/// The IRQ used by the PL031 RTC.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:57
-msgid ""
-"// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
-"    // and nothing else accesses that address range.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:62
-msgid "\"RTC: {time}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:70
-msgid "// Wait for 3 seconds, without interrupts.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:74
-#: src/exercises/bare-metal/solutions-afternoon.md:95
-msgid "\"Waiting for {}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:78
-#: src/exercises/bare-metal/solutions-afternoon.md:86
-#: src/exercises/bare-metal/solutions-afternoon.md:102
-#: src/exercises/bare-metal/solutions-afternoon.md:110
-msgid "\"matched={}, interrupt_pending={}\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:90
-#: src/exercises/bare-metal/solutions-afternoon.md:114
-msgid "\"Finished waiting\""
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:92
-msgid "// Wait another 3 seconds for an interrupt.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:127
-msgid "_pl031.rs_:"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:134
-msgid "/// Data register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:136
-msgid "/// Match register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:138
-msgid "/// Load register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:140
-msgid "/// Control register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:143
-msgid "/// Interrupt Mask Set or Clear register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:146
-msgid "/// Raw Interrupt Status\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:149
-msgid "/// Masked Interrupt Status\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:152
-msgid "/// Interrupt Clear Register\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:156
-msgid "/// Driver for a PL031 real-time clock.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:164
-msgid ""
-"/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
-"    /// given base address.\n"
-"    ///\n"
-"    /// # Safety\n"
-"    ///\n"
-"    /// The given base address must point to the MMIO control registers of "
-"a\n"
-"    /// PL031 device, which must be mapped into the address space of the "
-"process\n"
-"    /// as device memory and not have any other aliases.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:178
-msgid "/// Reads the current RTC value.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:180
-#: src/exercises/bare-metal/solutions-afternoon.md:188
-#: src/exercises/bare-metal/solutions-afternoon.md:196
-#: src/exercises/bare-metal/solutions-afternoon.md:207
-#: src/exercises/bare-metal/solutions-afternoon.md:219
-#: src/exercises/bare-metal/solutions-afternoon.md:226
-msgid ""
-"// Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:185
-msgid ""
-"/// Writes a match value. When the RTC value matches this then an interrupt\n"
-"    /// will be generated (if it is enabled).\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:193
-msgid ""
-"/// Returns whether the match register matches the RTC value, whether or "
-"not\n"
-"    /// the interrupt is enabled.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:202
-msgid ""
-"/// Returns whether there is currently an interrupt pending.\n"
-"    ///\n"
-"    /// This should be true if and only if `matched` returns true and the\n"
-"    /// interrupt is masked.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:213
-msgid ""
-"/// Sets or clears the interrupt mask.\n"
-"    ///\n"
-"    /// When the mask is true the interrupt is enabled; when it is false "
-"the\n"
-"    /// interrupt is disabled.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:224
-msgid "/// Clears a pending interrupt, if any.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:1
-msgid "Concurrency Morning Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:5
-msgid "([back to exercise](dining-philosophers.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:29
-msgid "\"{} is trying to eat\""
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:53
-msgid ""
-"// To avoid a deadlock, we have to break the symmetry\n"
-"        // somewhere. This will swap the forks without deinitializing\n"
-"        // either of them.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:77
-msgid "\"{thought}\""
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:82
 #, fuzzy
-msgid "Link Checker"
-msgstr "マルチスレッド・リンクチェッカー"
+#~ msgid "Novel Control Flow"
+#~ msgstr "制御フロー"
 
-#: src/exercises/concurrency/solutions-morning.md:84
-msgid "([back to exercise](link-checker.md))"
-msgstr ""
+#~ msgid "if let expressions"
+#~ msgstr "if let式"
 
-#: src/exercises/concurrency/solutions-morning.md:155
-msgid ""
-"/// Determine whether links within the given page should be extracted.\n"
-msgstr ""
+#~ msgid "while let expressions"
+#~ msgstr "while let式"
 
-#: src/exercises/concurrency/solutions-morning.md:163
-msgid ""
-"/// Mark the given page as visited, returning false if it had already\n"
-"    /// been visited.\n"
-msgstr ""
+#~ msgid "match expressions"
+#~ msgstr "match式"
 
-#: src/exercises/concurrency/solutions-morning.md:189
-msgid "// The sender got dropped. No more commands coming in.\n"
-msgstr ""
+#~ msgid "Destructuring Structs"
+#~ msgstr "構造体編"
 
-#: src/exercises/concurrency/solutions-morning.md:230
-msgid "\"Got crawling error: {:#}\""
-msgstr ""
+#~ msgid "Destructuring Arrays"
+#~ msgstr "配列編"
 
-#: src/exercises/concurrency/solutions-morning.md:248
-msgid "\"Bad URLs: {:#?}\""
-msgstr ""
+#~ msgid "Match Guards"
+#~ msgstr "マッチガード"
 
-#: src/exercises/concurrency/solutions-afternoon.md:1
-msgid "Concurrency Afternoon Exercise"
-msgstr ""
+#~ msgid "Stack vs Heap"
+#~ msgstr "スタック vs ヒープ"
 
-#: src/exercises/concurrency/solutions-afternoon.md:5
-msgid "([back to exercise](dining-philosophers-async.md))"
-msgstr ""
+#~ msgid "Stack Memory"
+#~ msgstr "スタックメモリ"
 
-#: src/exercises/concurrency/solutions-afternoon.md:32
-msgid ""
-"// Add a delay before picking the second fork to allow the execution\n"
-"        // to transfer to another task\n"
-msgstr ""
+#~ msgid "Manual Memory Management"
+#~ msgstr "手動でのメモリ管理"
 
-#: src/exercises/concurrency/solutions-afternoon.md:40
-msgid "// The locks are dropped here\n"
-msgstr ""
+#~ msgid "Scope-Based Memory Management"
+#~ msgstr "スコープに基づくメモリ管理"
 
-#: src/exercises/concurrency/solutions-afternoon.md:60
-msgid ""
-"// To avoid a deadlock, we have to break the symmetry\n"
-"            // somewhere. This will swap the forks without deinitializing\n"
-"            // either of them.\n"
-msgstr ""
+#~ msgid "Garbage Collection"
+#~ msgstr "ガベージコレクション"
 
-#: src/exercises/concurrency/solutions-afternoon.md:74
-msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
-msgstr ""
+#~ msgid "Moved Strings in Rust"
+#~ msgstr "文字列のムーブ"
 
-#: src/exercises/concurrency/solutions-afternoon.md:90
-msgid "\"Here is a thought: {thought}\""
-msgstr ""
+#~ msgid "Double Frees in Modern C++"
+#~ msgstr "現代C++の二重解放"
 
-#: src/exercises/concurrency/solutions-afternoon.md:97
-msgid "([back to exercise](chat-app.md))"
-msgstr ""
+#~ msgid "Moves in Function Calls"
+#~ msgstr "関数とムーブ"
 
-#: src/exercises/concurrency/solutions-afternoon.md:117
-msgid "\"Welcome to chat! Type a message\""
-msgstr ""
+#~ msgid "Copying and Cloning"
+#~ msgstr "コピーとクローン"
 
-#: src/exercises/concurrency/solutions-afternoon.md:121
-msgid ""
-"// A continuous loop for concurrently performing two tasks: (1) receiving\n"
-"    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
-"    // messages on `bcast_rx` and sending them to the client.\n"
-msgstr ""
+#~ msgid "Shared and Unique Borrows"
+#~ msgstr "共有参照と固有参照"
 
-#: src/exercises/concurrency/solutions-afternoon.md:130
-msgid "\"From client {addr:?} {text:?}\""
-msgstr ""
+#~ msgid "Field Shorthand Syntax"
+#~ msgstr "フィールドの省略"
 
-#: src/exercises/concurrency/solutions-afternoon.md:185
-msgid "// Continuous loop for concurrently sending and receiving messages.\n"
-msgstr ""
+#~ msgid "Method Receiver"
+#~ msgstr "メソッドレシーバ"
 
-#: src/exercises/concurrency/solutions-afternoon.md:192
-msgid "\"From server: {}\""
-msgstr ""
+#, fuzzy
+#~ msgid "Storing Books"
+#~ msgstr "文字列（String）"
+
+#~ msgid "Option and Result"
+#~ msgstr "OptionとResult"
+
+#~ msgid "Vec"
+#~ msgstr "ベクタ（Vec）"
+
+#~ msgid "HashMap"
+#~ msgstr "ハッシュマップ（HashMap）"
+
+#~ msgid "Box"
+#~ msgstr "ボックス（Box）"
+
+#~ msgid "Rc"
+#~ msgstr "Rc"
+
+#~ msgid "Iterators and Ownership"
+#~ msgstr "イテレータと所有権"
+
+#~ msgid "Strings and Iterators"
+#~ msgstr "文字列とイテレータ"
+
+#~ msgid "Generic Methods"
+#~ msgstr "ジェネリックメソッド"
+
+#~ msgid "Monomorphization"
+#~ msgstr "単相化"
+
+#~ msgid "Default Methods"
+#~ msgstr "デフォルトメソッド"
+
+#~ msgid "impl Trait"
+#~ msgstr "impl Trait"
+
+#~ msgid "Important Traits"
+#~ msgstr "重要なトレイト"
+
+#~ msgid "From and Into"
+#~ msgstr "FromとInto"
+
+#~ msgid "Default"
+#~ msgstr "Default"
+
+#~ msgid "Operators: Add, Mul, ..."
+#~ msgstr "演算子： Add, Mul, …"
+
+#~ msgid "Closures: Fn, FnMut, FnOnce"
+#~ msgstr "クロージャ：Fn, FnMut, FnOnce"
+
+#~ msgid "Points and Polygons"
+#~ msgstr "ポイントとポリゴン"
+
+#~ msgid "Catching Stack Unwinding"
+#~ msgstr "スタックの巻き戻し"
+
+#~ msgid "Structured Error Handling"
+#~ msgstr "構造化されたエラー処理"
+
+#~ msgid "Propagating Errors with ?"
+#~ msgstr "？でエラーを伝播する"
+
+#~ msgid "Converting Error Types"
+#~ msgstr "エラーの型変換"
+
+#~ msgid "Deriving Error Enums"
+#~ msgstr "列挙型エラーの導出"
+
+#~ msgid "Adding Context to Errors"
+#~ msgstr "コンテキストをエラーに追加"
+
+#~ msgid "no_std"
+#~ msgstr "no_std"
+
+#~ msgid "alloc"
+#~ msgstr "alloc"
+
+#~ msgid "embedded-hal"
+#~ msgstr "embedded-hal"
+
+#~ msgid "zerocopy"
+#~ msgstr "zerocopy"
+
+#~ msgid "aarch64-paging"
+#~ msgstr "aarch64-paging"
+
+#~ msgid "buddy_system_allocator"
+#~ msgstr "buddy_system_allocator"
+
+#~ msgid "tinyvec"
+#~ msgstr "tinyvec"
+
+#~ msgid "spin"
+#~ msgstr "spin"
+
+#~ msgid "Send and Sync"
+#~ msgstr "SendとSync"
+
+#~ msgid "Send"
+#~ msgstr "Send"
+
+#~ msgid "Sync"
+#~ msgstr "Sync"
+
+#~ msgid "Arc"
+#~ msgstr "Arc"
+
+#~ msgid "Mutex"
+#~ msgstr "Mutex"
+
+#~ msgid "async/await"
+#~ msgstr "async/await"
+
+#~ msgid "Pin"
+#~ msgstr "Pin"
+
+#~ msgid "Day 1 Morning"
+#~ msgstr "Day 1 AM"
+
+#~ msgid "Day 1 Afternoon"
+#~ msgstr "Day 1 PM"
+
+#~ msgid "Day 2 Morning"
+#~ msgstr "Day 2 AM"
+
+#~ msgid "Day 2 Afternoon"
+#~ msgstr "Day 2 PM"
+
+#~ msgid "Day 3 Morning"
+#~ msgstr "Day 3 AM"
+
+#~ msgid "Day 3 Afternoon"
+#~ msgstr "Day 3 PM"
+
+#~ msgid "Bare Metal Rust Morning"
+#~ msgstr "ベアメタルRust AM"
+
+#~ msgid "Concurrency Morning"
+#~ msgstr "並行性 AM"
+
+#~ msgid "Concurrency Afternoon"
+#~ msgstr "並行性 PM"
+
+#, fuzzy
+#~ msgid ""
+#~ "Day 2: Memory management, ownership, compound data types, and the "
+#~ "standard library."
+#~ msgstr "Day 2： 複合データ型、パターンマッチング、標準ライブラリ"
+
+#, fuzzy
+#~ msgid "Day 3: Generics, traits, error handling, testing, and unsafe Rust."
+#~ msgstr "Day 3： トレイトとジェネリクス、エラー処理、テスト、unsafe Rust"
+
+#~ msgid ""
+#~ "The idea for the first day is to show _just enough_ of Rust to be able to "
+#~ "speak about the famous borrow checker. The way Rust handles memory is a "
+#~ "major feature and we should show students this right away."
+#~ msgstr ""
+#~ "本日の目的は、Rust特有の借用チェッカーについて話ができるように、Rustについ"
+#~ "て最低限の情報提供を行う事です。Rustがメモリをどのように扱うかは重要な機能"
+#~ "であり、なるべく早く受講生に説明すべき内容です。"
+
+#~ msgid ""
+#~ "If you're teaching this in a classroom, this is a good place to go over "
+#~ "the schedule. We suggest splitting the day into two parts (following the "
+#~ "slides):"
+#~ msgstr ""
+#~ "この時点でスケジュール確認を行なってください。以下のように1日を２パートに"
+#~ "分けて実施する事を推奨しています："
+
+#~ msgid "Morning: 9:00 to 12:00,"
+#~ msgstr "AM： 9:00 ~ 12:00"
+
+#~ msgid "Afternoon: 13:00 to 16:00."
+#~ msgstr "PM： 13:00 ~ 16:00"
+
+#~ msgid ""
+#~ "You can of course adjust this as necessary. Please make sure to include "
+#~ "breaks, we recommend a break every hour!"
+#~ msgstr ""
+#~ "必要に応じて調整してください。また、1時間ごとに休憩を取る事をおすすめしま"
+#~ "す！"
+
+#~ msgid "Here is a small example program in Rust:"
+#~ msgstr "ここでは、Rustによる小さなサンプルプログラムを紹介します："
+
+#~ msgid "// Program entry point\n"
+#~ msgstr "// プログラムのエントリーポイント\n"
+
+#~ msgid "// Macro for printing, like printf\n"
+#~ msgstr "// printfのような、出力用マクロ\n"
+
+#~ msgid "// No parenthesis around expression\n"
+#~ msgstr "// 式を囲む括弧は不要\n"
+
+#~ msgid ""
+#~ "The code implements the Collatz conjecture: it is believed that the loop "
+#~ "will always end, but this is not yet proved. Edit the code and play with "
+#~ "different inputs."
+#~ msgstr ""
+#~ "この例はCollatz予想を実装したものです： このループは必ず終了すると言われて"
+#~ "いますが、まだ証明はされていません。コードを編集して、異なる入力値で試して"
+#~ "みてください。"
+
+#~ msgid ""
+#~ "Explain that all variables are statically typed. Try removing `i32` to "
+#~ "trigger type inference. Try with `i8` instead and trigger a runtime "
+#~ "integer overflow."
+#~ msgstr ""
+#~ "すべての変数が静的型付けされている事を説明してください。`i32`を削除して型"
+#~ "推論を試してください。代わりに`i8`を使用して、実行時に整数オーバーフローを"
+#~ "引き起こしてみてください。"
+
+#~ msgid "Change `let mut x` to `let x`, discuss the compiler error."
+#~ msgstr ""
+#~ "`let mut x`を`let x`に変更し、コンパイルエラーについて説明してください。"
+
+#~ msgid ""
+#~ "Show how `print!` gives a compilation error if the arguments don't match "
+#~ "the format string."
+#~ msgstr ""
+#~ "`print!`の引数がフォーマット文字列と一致しない場合、コンパイルエラーが発生"
+#~ "する事を実演してください。"
+
+#~ msgid ""
+#~ "Show how you need to use `{}` as a placeholder if you want to print an "
+#~ "expression which is more complex than just a single variable."
+#~ msgstr ""
+#~ "単一の変数よりも複雑な式を表示したい場合は、`{}`をプレースホルダとして使用"
+#~ "する必要がある事を実演してください。"
+
+#~ msgid ""
+#~ "Show the students the standard library, show them how to search for `std::"
+#~ "fmt` which has the rules of the formatting mini-language. It's important "
+#~ "that the students become familiar with searching in the standard library."
+#~ msgstr ""
+#~ "受講生に標準ライブラリを紹介し、`std::fmt`の検索方法を説明してください。"
+#~ "`std::fmt`には、フォーマット機能のルールや構文が説明されています。受講者が"
+#~ "標準ライブラリの検索に慣れておく事は重要です。"
+
+#~ msgid "Compile time memory safety."
+#~ msgstr "コンパイル時のメモリ安全性。"
+
+#~ msgid "Lack of undefined runtime behavior."
+#~ msgstr "未定義の実行時動作がない。"
+
+#~ msgid "Modern language features."
+#~ msgstr "現代的な言語機能。"
+
+#~ msgid "Static memory management at compile time:"
+#~ msgstr "コンパイル時の静的メモリの管理："
+
+#~ msgid "No memory leaks (_mostly_, see notes)."
+#~ msgstr "メモリリークの心配が（ほとんど）ない (ノートを参照)。"
+
+#~ msgid ""
+#~ "It is possible to produce memory leaks in (safe) Rust. Some examples are:"
+#~ msgstr ""
+#~ "SafeなRustの範囲内でメモリリークを引き起こすことは可能です。例として以下の"
+#~ "ような手段があります："
+
+#, fuzzy
+#~ msgid ""
+#~ "You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+#~ "html#method.leak) to leak a pointer. A use of this could be to get "
+#~ "runtime-initialized and runtime-sized static variables"
+#~ msgstr ""
+#~ "[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
+#~ "leak)を使ってポインタをリークさせることができます。この関数は実行時に初期"
+#~ "化され、実行時にサイズが決まるstatic変数の取得などに使われます。"
+
+#, fuzzy
+#~ msgid ""
+#~ "You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn."
+#~ "forget.html) to make the compiler \"forget\" about a value (meaning the "
+#~ "destructor is never run)."
+#~ msgstr ""
+#~ "[`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html)を"
+#~ "使って、コンパイラに値を忘れさせることができます (つまり、デストラクタが実"
+#~ "行されない)。"
+
+#, fuzzy
+#~ msgid ""
+#~ "You can also accidentally create a [reference cycle](https://doc.rust-"
+#~ "lang.org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+#~ msgstr ""
+#~ "`Rc`や`Arc`を使って\\[循環参照（reference cycle）\\]を誤って作成することが"
+#~ "あります。"
+
+#, fuzzy
+#~ msgid ""
+#~ "In fact, some will consider infinitely populating a collection a memory "
+#~ "leak and Rust does not protect from those."
+#~ msgstr ""
+#~ "コレクションを無限に拡張し続けることをメモリリークと見なす場合があり、Rust"
+#~ "にはこれを防ぐ機能はありません。"
+
+#~ msgid ""
+#~ "For the purpose of this course, \"No memory leaks\" should be understood "
+#~ "as \"Pretty much no _accidental_ memory leaks\"."
+#~ msgstr ""
+#~ "本講座での「メモリリークが起きない」は「\\_意図しない_メモリリークはほとん"
+#~ "ど起きない」と解釈すべきです。"
+
+#~ msgid "No undefined behavior at runtime:"
+#~ msgstr "実行時に未定義の動作はありません："
+
+#, fuzzy
+#~ msgid ""
+#~ "Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
+#~ "lang.org/rustc/codegen-options/index.html#overflow-checks) compile-time "
+#~ "flag. If enabled, the program will panic (a controlled crash of the "
+#~ "program), otherwise you get wrap-around semantics. By default, you get "
+#~ "panics in debug mode (`cargo build`) and wrap-around in release mode "
+#~ "(`cargo build --release`)."
+#~ msgstr ""
+#~ "整数オーバーフローは、コンパイル時のフラグで定義されます。選択肢として、パ"
+#~ "ニック（プログラムの制御されたクラッシュ）またはラップアラウンドのセマン"
+#~ "ティクスがあります。デフォルトとして、デバッグモード（`cargo build`）では"
+#~ "パニックが発生し、リリースモード（`cargo build —release`）ではラップアラウ"
+#~ "ンドが行われます。"
+
+#~ msgid ""
+#~ "Bounds checking cannot be disabled with a compiler flag. It can also not "
+#~ "be disabled directly with the `unsafe` keyword. However, `unsafe` allows "
+#~ "you to call functions such as `slice::get_unchecked` which does not do "
+#~ "bounds checking."
+#~ msgstr ""
+#~ "境界チェックは、コンパイル時のフラグで無効にすることはできません。また、"
+#~ "`unsafe`のキーワードを使って直接無効にすることもできません。しかし、"
+#~ "`unsafe`を使って境界チェックを行わない`slice::get_unchecked`のような関数を"
+#~ "呼び出すことができます。"
+
+#, fuzzy
+#~ msgid "Rust is built with all the experience gained in the last decades."
+#~ msgstr "Rustは過去40年間の経験を基に構築されています。"
+
+#~ msgid "Language Features"
+#~ msgstr "言語の特徴"
+
+#~ msgid ""
+#~ "Zero-cost abstractions, similar to C++, means that you don't have to "
+#~ "'pay' for higher-level programming constructs with memory or CPU. For "
+#~ "example, writing a loop using `for` should result in roughly the same low "
+#~ "level instructions as using the `.iter().fold()` construct."
+#~ msgstr ""
+#~ "C++と同様に、ゼロコスト抽象化とは、より高水準なプログラミング構造の利用に"
+#~ "メモリやCPUのコストを支払う必要がないことを意味します。例えば、`for`を使っ"
+#~ "たループの場合、`iter().fold()`構文を使った場合とおおよそ同じ低水準の処理"
+#~ "になります。"
+
+#~ msgid ""
+#~ "It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
+#~ "also known as 'sum types', which allow the type system to express things "
+#~ "like `Option<T>` and `Result<T, E>`."
+#~ msgstr ""
+#~ "Rustの列挙型は「代数的データ型」であり、「直和型」と呼ばれます。"
+#~ "`Option<T>`や`Result<T, E>`のような要素を表現することができます。"
+
+#~ msgid ""
+#~ "Remind people to read the errors --- many developers have gotten used to "
+#~ "ignore lengthy compiler output. The Rust compiler is significantly more "
+#~ "talkative than other compilers. It will often provide you with "
+#~ "_actionable_ feedback, ready to copy-paste into your code."
+#~ msgstr ""
+#~ "エラーをちゃんと確認するよう注意してください。多くの開発者は、長いコンパイ"
+#~ "ラ出力を無視することに慣れてしまっています。Rustのコンパイラは他のコンパイ"
+#~ "ラよりもわかりやすく実用的なフィードバックを提供してくれます。そして多くの"
+#~ "場合、コードにそのままコピペできるようなフィードバックが提供されます。"
+
+#~ msgid ""
+#~ "The Rust standard library is small compared to languages like Java, "
+#~ "Python, and Go. Rust does not come with several things you might consider "
+#~ "standard and essential:"
+#~ msgstr ""
+#~ "Rustの標準ライブラリは、Java、Python、Goなどのそれと比べると小規模です。"
+#~ "Rustには標準的かつ必須と思われるいくつかの機能が含まれていません："
+
+#~ msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+#~ msgstr "乱数生成器。[rand](https://docs.rs/rand/)を確認してください。"
+
+#~ msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+#~ msgstr ""
+#~ "SSLやTLSのサポート。[rusttls](https://docs.rs/rustls/)を確認してください。"
+
+#~ msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+#~ msgstr ""
+#~ "JSONのサポート。[serde_json](https://docs.rs/serde_json/)を確認してくださ"
+#~ "い。 "
+
+#~ msgid ""
+#~ "The reasoning behind this is that functionality in the standard library "
+#~ "cannot go away, so it has to be very stable. For the examples above, the "
+#~ "Rust community is still working on finding the best solution --- and "
+#~ "perhaps there isn't a single \"best solution\" for some of these things."
+#~ msgstr ""
+#~ "この理由は、標準ライブラリの機能は消えることがなく、非常に安定したものでな"
+#~ "ければならないからです。上記の例については、Rustコミュニティが未だに最適な"
+#~ "解決策を探し続けています。そもそも、これらに対する「最適解」は一つであると"
+#~ "は限らないのです。"
+
+#~ msgid ""
+#~ "Rust comes with a built-in package manager in the form of Cargo and this "
+#~ "makes it trivial to download and compile third-party crates. A "
+#~ "consequence of this is that the standard library can be smaller."
+#~ msgstr ""
+#~ "Rustには、Cargoという外部クレートのダウンロードからコンパイルまでを簡単に"
+#~ "行ってくれるパッケージマネージャが組み込まれています。これにより、標準ライ"
+#~ "ブラリを小規模に保つことができています。"
+
+#~ msgid ""
+#~ "Discovering good third-party crates can be a problem. Sites like <https://"
+#~ "lib.rs/> help with this by letting you compare health metrics for crates "
+#~ "to find a good and trusted one."
+#~ msgstr ""
+#~ "良い外部クレートを見つけるのは難しいときがあります。<https://lib.rs/>のよ"
+#~ "うなサイトを使うことで、クレートの評価基準を参考にしながら比較を行うことが"
+#~ "できます。"
+
+#~ msgid ""
+#~ "[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+#~ "implementation used in major IDEs and text editors."
+#~ msgstr ""
+#~ "[rust-analyzer](https://rust-analyzer.github.io/)は、主要IDEやテキストエ"
+#~ "ディタで使用できる、サポートが充実しているLSPの実装です。"
+
+#~ msgid ""
+#~ "As we have seen, `if` is an expression in Rust. It is used to "
+#~ "conditionally evaluate one of two blocks, but the blocks can have a value "
+#~ "which then becomes the value of the `if` expression. Other control flow "
+#~ "expressions work similarly in Rust."
+#~ msgstr ""
+#~ "今まで見てきたように、Rust において `if` は式です。`if` 式のブロックは値を"
+#~ "持っており、条件判定の結果に応じて評価されたブロックの値が `if` 式の値とな"
+#~ "ります。Rust では他の制御フローの式も同様の動作をします。"
+
+#~ msgid ""
+#~ "The same rule is used for functions: the value of the function body is "
+#~ "the return value:"
+#~ msgstr ""
+#~ "同じルールが関数についても適用されます。関数の body ブロックの値が、その関"
+#~ "数の返り値となります。"
+
+#~ msgid ""
+#~ "The point of this slide is to show that blocks have a type and value in "
+#~ "Rust. "
+#~ msgstr ""
+#~ "このスライドのポイントは、Rust におけるブロックは型と値を持つということで"
+#~ "す。"
+
+#~ msgid ""
+#~ "The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is "
+#~ "closely related to the [`while let` loop](while-let-expressions.md). It "
+#~ "will automatically call `into_iter()` on the expression and then iterate "
+#~ "over it:"
+#~ msgstr ""
+#~ "[`for` loop](https://doc.rust-lang.org/std/keyword.for.html) は、[`while "
+#~ "let` loop](while-let-expressions.md) とよく似ています。`for` ループは "
+#~ "`in` キーワードの右側にある式に対して自動的に `into_iter()` を呼び出し、そ"
+#~ "の結果生成されたイテレータを用いて走査を行います。"
+
+#~ msgid "You can use `break` and `continue` here as usual."
+#~ msgstr ""
+#~ "`for` ループの中では、いつも通り `break` や `continue` を使うことができま"
+#~ "す。"
+
+#~ msgid "Index iteration is not a special syntax in Rust for just that case."
+#~ msgstr ""
+#~ "Rust では、インデックスによる反復処理のために特別な構文は提供されていませ"
+#~ "ん。"
+
+#~ msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+#~ msgstr "`(0..10)` は Range 型であり、`Iterator` トレイトを実装しています。"
+
+#~ msgid ""
+#~ "`step_by` is a method that returns another `Iterator` that skips every "
+#~ "other element. "
+#~ msgstr ""
+#~ "`step_by` は、元のイテレータとは別の、各要素をスキップする `Iterator` を返"
+#~ "すメソッドです。"
+
+#~ msgid ""
+#~ "Modify the elements in the vector and explain the compiler errors. Change "
+#~ "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
+#~ msgstr ""
+#~ "ベクタ内の要素を変更してみて、その結果生じるコンパイルエラーについて説明し"
+#~ "てください。また、ベクタ `v` をミュータブルに、for ループを `for x in v."
+#~ "iter_mut()` に変更してみましょう。"
+
+#~ msgid "`loop` expressions"
+#~ msgstr "`loop` 式"
+
+#~ msgid ""
+#~ "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
+#~ "expressions/loop-expr.html#infinite-loops) which creates an endless loop."
+#~ msgstr ""
+#~ "最後に、無限ループを作る [`loop` キーワード](https://doc.rust-lang.org/"
+#~ "reference/expressions/loop-expr.html#infinite-loops) について説明します。"
+
+#~ msgid "Here you must either `break` or `return` to stop the loop:"
+#~ msgstr ""
+#~ "下の例で、ループから抜けるためには `break` あるいは `return` を使う必要が"
+#~ "あります。"
+
+#~ msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+#~ msgstr ""
+#~ "例えば `break 8` のようにループを値と共に抜け、それを print してみましょ"
+#~ "う。"
+
+#, fuzzy
+#~ msgid "The Luhn algorithm,"
+#~ msgstr "Luhnアルゴリズム"
+
+#, fuzzy
+#~ msgid "An exercise on pattern matching."
+#~ msgstr "列挙型とパターンマッチング"
+
+#~ msgid ""
+#~ "Memory management: stack vs heap, manual memory management, scope-based "
+#~ "memory management, and garbage collection."
+#~ msgstr ""
+#~ "メモリ管理： スタック vs ヒープ、手動でのメモリ管理、スコープに基づくメモ"
+#~ "リ管理、ガベージコレクション。"
+
+#~ msgid ""
+#~ "Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+#~ msgstr ""
+#~ "所有権： ムーブセマンティクス、コピーとクローン、借用、ライフタイム。"
+
+#, fuzzy
+#~ msgid "Structs and methods."
+#~ msgstr "文字列とイテレータ"
+
+#, fuzzy
+#~ msgid "Stack and Heap Example"
+#~ msgstr "スタック vs ヒープ"
+
+#~ msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
+#~ msgstr ""
+#~ "次のような新しい変数を宣言してみてください `let p = Point { x: 5, y: "
+#~ "10.0 };`."
+
+#~ msgid "Fix the code to allow points that have elements of different types."
+#~ msgstr "異なる型の要素を持つ点を許容するように、コードを修正してください。"
+
+#~ msgid "You can declare a generic type on your `impl` block:"
+#~ msgstr "`impl`に対して、ジェネリックな型を宣言することもできます："
+
+#~ msgid ""
+#~ "Generic code is turned into non-generic code based on the call sites:"
+#~ msgstr ""
+#~ "ジェネリクスのコードは呼び出し箇所に基づいて、ジェネリックでないコードに変"
+#~ "換されます："
+
+#~ msgid "behaves as if you wrote"
+#~ msgstr "上のコードは、次のように書いた時と同じように動作します"
+
+#~ msgid ""
+#~ "Rust derive macros work by automatically generating code that implements "
+#~ "the specified traits for a data structure."
+#~ msgstr ""
+#~ "Rustのderiveマクロは、データ構造体に対して、指定されたトレイトを実装する"
+#~ "コードを自動的に生成します。"
+
+#~ msgid "You can let the compiler derive a number of traits as follows:"
+#~ msgstr ""
+#~ "コンパイラには、以下のような多くのトレイトを導出させることができます："
+
+#~ msgid "Traits can implement behavior in terms of other trait methods:"
+#~ msgstr ""
+#~ "トレイトでは、別のトレイトメソッドを用いて挙動を定義することが可能です："
+
+#~ msgid "Move method `not_equals` to a new trait `NotEquals`."
+#~ msgstr ""
+#~ "メソッド `not_equals` を新しいトレイト `NotEquals` に移してみましょう。"
+
+#~ msgid "Make `Equals` a super trait for `NotEquals`."
+#~ msgstr "`Equals` を `NotEquals` のスーパートレイトにしてみましょう。"
+
+#~ msgid "Provide a blanket implementation of `NotEquals` for `Equals`."
+#~ msgstr "`Equals`に対する`NotEquals`のブランケット実装を示してみましょう。"
+
+#~ msgid ""
+#~ "With the blanket implementation, you no longer need `Equals` as a super "
+#~ "trait for `NotEqual`."
+#~ msgstr ""
+#~ "ブランケット実装を用いれば、`Equals` を`NotEqual`のスーパートレイトとする"
+#~ "必要はなくなります。"
+
+#~ msgid "`impl Trait` allows you to work with types which you cannot name."
+#~ msgstr ""
+#~ "`impl Trait`を用いれば、型名を明示せずに型を限定することができます。"
+
+#~ msgid ""
+#~ "This example is great, because it uses `impl Display` twice. It helps to "
+#~ "explain that nothing here enforces that it is _the same_ `impl Display` "
+#~ "type. If we used a single  `T: Display`, it would enforce the constraint "
+#~ "that input `T` and return `T` type are the same type. It would not work "
+#~ "for this particular function, as the type we expect as input is likely "
+#~ "not what `format!` returns. If we wanted to do the same via `: Display` "
+#~ "syntax, we'd need two independent generic parameters."
+#~ msgstr ""
+#~ "この例は素晴らしい例です。なぜなら、 `impl Display`を２回用いているからで"
+#~ "す。 ここでは `impl Display` の型が同一になることを強制するものはない、と"
+#~ "いう説明をするのに役立ちます。もし単一の`T: Display`を用いた場合、入力の"
+#~ "`T`と返り値の`T`が同一の型であることが強制されてしまいます。例で示した関数"
+#~ "ではうまくいかないでしょう。なぜなら、我々が期待する入力の型は、`format!`"
+#~ "が返すものではおそらくないからです。もしも同じことを`: Display`の構文で行"
+#~ "いたい場合、２つの独立したジェネリックなパラメタが必要となるでしょう。"
+
+#, fuzzy
+#~ msgid "Drawing A Simple GUI"
+#~ msgstr "GUIライブラリ"
+
+#, fuzzy
+#~ msgid "concurrency:"
+#~ msgstr "並行性"
+
+#, fuzzy
+#~ msgid "control flow:"
+#~ msgstr "制御フロー"
+
+#, fuzzy
+#~ msgid "enumeration:"
+#~ msgstr "実装"
+
+#, fuzzy
+#~ msgid "error handling:"
+#~ msgstr "エラー処理"
+
+#, fuzzy
+#~ msgid "garbage collector:"
+#~ msgstr "ガベージコレクション"
+
+#, fuzzy
+#~ msgid "generics:"
+#~ msgstr "ジェネリクス（generics）"
+
+#, fuzzy
+#~ msgid "integration test:"
+#~ msgstr "インテグレーションテスト"
+
+#, fuzzy
+#~ msgid "main function:"
+#~ msgstr "Unsafe関数の呼び出し"
+
+#, fuzzy
+#~ msgid "method:"
+#~ msgstr "メソッド"
+
+#, fuzzy
+#~ msgid "module:"
+#~ msgstr "モジュール"
+
+#, fuzzy
+#~ msgid "ownership:"
+#~ msgstr "所有権"
+
+#, fuzzy
+#~ msgid "panic:"
+#~ msgstr "パニック（panic）"
+
+#, fuzzy
+#~ msgid "receiver:"
+#~ msgstr "ドライバ"
+
+#, fuzzy
+#~ msgid "standard library:"
+#~ msgstr "標準ライブラリ"
+
+#, fuzzy
+#~ msgid "struct:"
+#~ msgstr "構造体（structs）"
+
+#, fuzzy
+#~ msgid "thread:"
+#~ msgstr "スレッド"
+
+#, fuzzy
+#~ msgid "trait:"
+#~ msgstr "トレイト（trait）"
+
+#, fuzzy
+#~ msgid "undefined behavior:"
+#~ msgstr "実行時に未定義の動作はありません："
+
+#, fuzzy
+#~ msgid "union:"
+#~ msgstr "共用体"
+
+#, fuzzy
+#~ msgid "unit test:"
+#~ msgstr "ユニットテスト"
+
+#, fuzzy
+#~ msgid "variable:\\"
+#~ msgstr "変数"
+
+#, fuzzy
+#~ msgid "Pattern matching"
+#~ msgstr "パターンマッチング"
+
+#~ msgid "Designing a Library"
+#~ msgstr "ライブラリをデザイン"


### PR DESCRIPTION
Hi, ja-translators, #652 ! I've refreshed `ja.po` file as of today, Jan 8th 2024.
I used the following procedures. Could you review the diff? Thanks 😊 

```
MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' \
  mdbook build -d po
```

```
msgmerge --update po/ja.po po/messages.pot
```