### PR TITLE
Always use a nightly `rustfmt` in `dprint fmt`

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -9,7 +9,7 @@
       "command": "yapf3",
       "exts": ["py"]
     }, {
-      "command": "rustfmt --edition 2021",
+      "command": "rustup run nightly rustfmt --edition 2021",
       "exts": ["rs"]
     }, {
       "command": "msgcat -",


### PR DESCRIPTION
Without this, several of the formatting directives in our `rustfmt.toml` file won’t have any effect. This will in turn lead to mismatches between the formatting done locally and in CI.

This creates a dependency on `rustup`, but I think this is overall better than silently ignoring the formatting directives.

From the discussion in #1682.