### PR TITLE
Group Dependabot PRs by minor/patch level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,15 @@ updates:
       - djmitche
       - mgeisler
       - qwandor
+    commit-message:
+      prefix: cargo
+    groups:
+      minor:
+        update-types:
+          - minor
+      patch:
+        update-types:
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This should help us limit the number of PRs opened by Dependabot. The intention is for the bot to mostly open two PRs per week:

- one for patch updates (the ‘z’ in ‘x.y.z’)
- one for minor updates (the ‘y’ in ‘x.y.z’)

The rare major version updates (the ‘x’ in ‘x.y.z’) are sent individually.

The configuration options here are taken from

  https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

This might help with #1681, but I don’t know yet how the new PR description looks.