### PR TITLE
further explanation of blocks

### DIFF
--- a/src/control-flow-basics/blocks-and-scopes.md
+++ b/src/control-flow-basics/blocks-and-scopes.md
@@ -6,7 +6,7 @@ minutes: 10
 
 ## Blocks
 
-A block in Rust contains a sequence of expressions. Each block has a value and a
+A block in Rust contains a sequence of expressions, and are enclosed by braces {}. Each block has a value and a
 type, which are those of the last expression of the block:
 
 ```rust,editable


### PR DESCRIPTION
Included that blocks are enclosed by braces. This hopefully clarifies how blocks are delimited.