### PR TITLE
split typos and formatting checks into separate workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,6 @@ jobs:
       - name: Check formatting
         uses: dprint/check@v2.2
 
-      - name: Check for typos
-        uses: crate-ci/typos@v1.17.1
-        with:
-          config: ./.github/typos.toml
-
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,17 @@ jobs:
         with:
           config: ./.github/typos.toml
 
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for typos
+        uses: crate-ci/typos@v1.17.1
+        with:
+          config: ./.github/typos.toml
+
   cargo:
     strategy:
       matrix:


### PR DESCRIPTION
Without this it's easy for failures of one of these checks to hide failures of the other.