### PR TITLE
Run dependabot on bare-metal examples and exercises too.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,91 @@ updates:
       patch:
         update-types:
           - patch
+  - package-ecosystem: cargo
+    directory: /src/bare-metal/alloc-example/
+    schedule:
+      interval: weekly
+    reviewers:
+      - djmitche
+      - mgeisler
+      - qwandor
+    commit-message:
+      prefix: cargo
+    groups:
+      minor:
+        update-types:
+          - minor
+      patch:
+        update-types:
+          - patch
+  - package-ecosystem: cargo
+    directory: /src/bare-metal/aps/examples/
+    schedule:
+      interval: weekly
+    reviewers:
+      - djmitche
+      - mgeisler
+      - qwandor
+    commit-message:
+      prefix: cargo
+    groups:
+      minor:
+        update-types:
+          - minor
+      patch:
+        update-types:
+          - patch
+  - package-ecosystem: cargo
+    directory: /src/bare-metal/microcontrollers/examples/
+    schedule:
+      interval: weekly
+    reviewers:
+      - djmitche
+      - mgeisler
+      - qwandor
+    commit-message:
+      prefix: cargo
+    groups:
+      minor:
+        update-types:
+          - minor
+      patch:
+        update-types:
+          - patch
+  - package-ecosystem: cargo
+    directory: /src/exercises/bare-metal/compass/
+    schedule:
+      interval: weekly
+    reviewers:
+      - djmitche
+      - mgeisler
+      - qwandor
+    commit-message:
+      prefix: cargo
+    groups:
+      minor:
+        update-types:
+          - minor
+      patch:
+        update-types:
+          - patch
+  - package-ecosystem: cargo
+    directory: /src/exercises/bare-metal/rtc/
+    schedule:
+      interval: weekly
+    reviewers:
+      - djmitche
+      - mgeisler
+      - qwandor
+    commit-message:
+      prefix: cargo
+    groups:
+      minor:
+        update-types:
+          - minor
+      patch:
+        update-types:
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
These can't be in the main workspace due to needing custom cargo config for linker scripts and targets.