### PR TITLE
Always install and run `mdbook-pandoc`

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -37,9 +37,7 @@ else
 fi
 
 mdbook build -d "$dest_dir"
-if [ -f "$dest_dir/pandoc/pdf/comprehensive-rust.pdf" ]; then
-    mv "$dest_dir/pandoc/pdf/comprehensive-rust.pdf" "$dest_dir/html/"
-fi
+mv "$dest_dir/pandoc/pdf/comprehensive-rust.pdf" "$dest_dir/html/"
 (cd "$dest_dir/exerciser" && zip --recurse-paths ../html/comprehensive-rust-exercises.zip comprehensive-rust-exercises/)
 
 echo "::endgroup::"

--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -15,6 +15,14 @@ runs:
       run: cargo install mdbook-svgbob --locked --version 0.2.1
       shell: bash
 
+    - name: Install mdbook-pandoc and related dependencies
+      run: |
+        cargo install mdbook-pandoc --locked --version 0.5.0
+        sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
+        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.11/pandoc-3.1.11-linux-amd64.tar.gz | tar zxf -
+        echo "$PWD/pandoc-3.1.11/bin" >> $GITHUB_PATH
+      shell: bash
+
     - name: Install mdbook-i18n-helpers
       run: cargo install mdbook-i18n-helpers --locked --version 0.3.1
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,13 +39,6 @@ jobs:
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook
 
-      - name: Install mdbook-pandoc and related dependencies
-        run: |
-          cargo install mdbook-pandoc --locked --version 0.5.0
-          sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
-          curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.11/pandoc-3.1.11-linux-amd64.tar.gz | tar zxf -
-          echo "$PWD/pandoc-3.1.11/bin" >> $GITHUB_PATH
-
       - name: Build course in English
         run: .github/workflows/build.sh en book
 


### PR DESCRIPTION
Before, we only installed and ran `mdbook-pandoc` when publishing the course — which means that a PR change could accidentally break the publish workflow. We now test that it works on every PR.

From a discussion in #1704.