### PR TITLE
set fallback fonts for PDF rendering

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -19,8 +19,8 @@ runs:
       run: |
         cargo install mdbook-pandoc --locked --version 0.5.0
         sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
-        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.11/pandoc-3.1.11-linux-amd64.tar.gz | tar zxf -
-        echo "$PWD/pandoc-3.1.11/bin" >> $GITHUB_PATH
+        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.12.2/pandoc-3.1.12.2-linux-amd64.tar.gz | tar zxf -
+        echo "$PWD/pandoc-3.1.12.2/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: Install mdbook-i18n-helpers

--- a/book.toml
+++ b/book.toml
@@ -34,6 +34,12 @@ pdf-engine = "lualatex"
 mainfont = "Noto Serif"
 sansfont = "Noto Sans"
 monofont = "Noto Sans Mono"
+mainfontfallback = ["NotoColorEmoji:mode=harf"]
+monofontfallback = [
+  "NotoColorEmoji:mode=harf",
+  "NotoSansMath:",
+  "NotoSansMonoCJKSC:",
+]
 geometry = ["margin=1.25in"]
 linkcolor = "blue"
 urlcolor = "red"


### PR DESCRIPTION
Once a new version of Pandoc is released that includes https://github.com/jgm/pandoc/pull/9204 and https://github.com/jgm/pandoc/pull/9353 (both merged), this will fix the emoji and symbol rendering issues in #1708.

It doesn't seem to be possible to set fallback fonts with `luatexja-fontspec` (used to configure CJK fonts), which results in some missing symbols in the translations but at least renders the emoji properly.

Closes #1708