### PR TITLE
Tell translators to remove line numbers from PO files

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -53,7 +53,7 @@ To extract the original English text and generate a `messages.pot` file, you run
 `mdbook` with a special renderer:
 
 ```shell
-MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' \
+MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot", "granularity": 0}}' \
   mdbook build -d po
 ```
 


### PR DESCRIPTION
A `granularity` setting of `0` will remove the line numbers from the PO files. This reduces the churn as we update the English source texts.