### PR TITLE
it: Fix monospace for block comments

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -3327,7 +3327,7 @@ msgid ""
 "*/`."
 msgstr ""
 "I commenti di riga iniziano con `//`, i commenti di blocco sono delimitati "
-"da \\`/\\* ... \\*/'."
+"da `/\\* ... \\*/`."
 
 #: src/control-flow-basics/conditionals.md:8
 msgid "Keywords like `if` and `while` work the same."


### PR DESCRIPTION
This should fix the formatting on https://google.github.io/comprehensive-rust/it/control-flow-basics/conditionals.html.