### PR TITLE
Translation correction on Update es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -1282,7 +1282,6 @@ msgid "Show you common Rust idioms."
 msgstr "Brindarte idiomática propia de Rust."
 
 #: src/index.md
-#, fuzzy
 msgid "We call the first four course days Rust Fundamentals."
 msgstr "Llamamos a los cuatro primeros días del curso Fundamentos de Rust."
 

--- a/po/es.po
+++ b/po/es.po
@@ -1284,7 +1284,7 @@ msgstr "Brindarte idiomática propia de Rust."
 #: src/index.md
 #, fuzzy
 msgid "We call the first four course days Rust Fundamentals."
-msgstr "Llamamos a los tres primeros días del curso Fundamentos de Rust."
+msgstr "Llamamos a los cuatro primeros días del curso Fundamentos de Rust."
 
 #: src/index.md
 msgid ""


### PR DESCRIPTION
I added a tranlation correction on the line 1287, I change "tres" instead "cuatro", because "cuatro" is the meaningful of four in Spanish.