### PR TITLE
Adjust morning-session timings downward

### DIFF
--- a/mdbook-course/src/bin/course-schedule.rs
+++ b/mdbook-course/src/bin/course-schedule.rs
@@ -12,21 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Command;
 use mdbook::MDBook;
-use mdbook_course::course::{Course, Courses};
+use mdbook_course::course::Courses;
 use mdbook_course::markdown::duration;
 
 fn main() {
     pretty_env_logger::init();
+    let app = Command::new("mdbook-course")
+        .about("mdbook preprocessor for Comprehensive Rust")
+        .subcommand(Command::new("sessions").about("Show session summary (default)"))
+        .subcommand(Command::new("segments").about("Show segment summary"))
+        .subcommand(Command::new("pr").about("Show summary for a PR"));
+    let matches = app.get_matches();
+
     let root_dir = ".";
     let mdbook = MDBook::load(root_dir).expect("Unable to load the book");
     let (courses, _) = Courses::extract_structure(mdbook.book)
         .expect("Unable to extract course structure");
 
-    println!("## Course Schedule");
-    println!("With this pull request applied, the course schedule is as follows:");
-    for course in &courses {
-        print_summary(course);
+    match matches.subcommand() {
+        Some(("session", _)) | None => session_summary(&courses),
+        Some(("pr", _)) => pr_summary(&courses),
+        _ => unreachable!(),
     }
 }
 
@@ -44,18 +52,42 @@ fn timediff(actual: u64, target: u64, slop: u64) -> String {
     }
 }
 
-fn print_summary(course: &Course) {
-    if course.target_minutes() == 0 {
-        return;
+fn session_summary(courses: &Courses) {
+    for course in courses {
+        if course.target_minutes() == 0 {
+            return;
+        }
+        for session in course {
+            println!("### {} // {}", course.name, session.name);
+            println!(
+                "_{}_",
+                timediff(session.minutes(), session.target_minutes(), 15)
+            );
+            println!();
+            for segment in session {
+                println!("* {} - _{}_", segment.name, duration(segment.minutes()));
+            }
+            println!();
+        }
     }
-    println!("### {}", course.name);
-    println!("_{}_", timediff(course.minutes(), course.target_minutes(), 15));
+}
 
-    for session in course {
-        println!(
-            "* {} - _{}_",
-            session.name,
-            timediff(session.minutes(), session.target_minutes(), 5)
-        );
+fn pr_summary(courses: &Courses) {
+    println!("## Course Schedule");
+    println!("With this pull request applied, the course schedule is as follows:");
+    for course in courses {
+        if course.target_minutes() == 0 {
+            return;
+        }
+        println!("### {}", course.name);
+        println!("_{}_", timediff(course.minutes(), course.target_minutes(), 15));
+
+        for session in course {
+            println!(
+                "* {} - _{}_",
+                session.name,
+                timediff(session.minutes(), session.target_minutes(), 5)
+            );
+        }
     }
 }

--- a/src/control-flow-basics/blocks-and-scopes.md
+++ b/src/control-flow-basics/blocks-and-scopes.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Blocks and Scopes

--- a/src/control-flow-basics/break-continue.md
+++ b/src/control-flow-basics/break-continue.md
@@ -1,5 +1,5 @@
 ---
-minutes: 5
+minutes: 4
 ---
 
 # `break` and `continue`

--- a/src/control-flow-basics/conditionals.md
+++ b/src/control-flow-basics/conditionals.md
@@ -1,5 +1,5 @@
 ---
-minutes: 5
+minutes: 4
 ---
 
 # Conditionals

--- a/src/generics/generic-data.md
+++ b/src/generics/generic-data.md
@@ -1,5 +1,5 @@
 ---
-minutes: 15
+minutes: 10
 ---
 
 # Generic Data Types

--- a/src/generics/trait-bounds.md
+++ b/src/generics/trait-bounds.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 8
 ---
 
 # Trait Bounds

--- a/src/iterators/iterator.md
+++ b/src/iterators/iterator.md
@@ -2,10 +2,6 @@
 minutes: 5
 ---
 
-<!-- NOTES:
-The Iterator trait and basic usage
--->
-
 # `Iterator`
 
 The [`Iterator`][1] trait supports iterating over values in a collection. It

--- a/src/memory-management/copy-types.md
+++ b/src/memory-management/copy-types.md
@@ -2,10 +2,6 @@
 minutes: 5
 ---
 
-<!-- NOTES:
-Present Copy as added functionality on top of the default move semantics: with Copy, the old value does not become invalid; Can derive Copy for a type if it implements Clone
--->
-
 # Copy Types
 
 While move semantics are the default, certain types are copied by default:

--- a/src/memory-management/drop.md
+++ b/src/memory-management/drop.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 8
 ---
 
 # The `Drop` Trait

--- a/src/memory-management/move.md
+++ b/src/memory-management/move.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Move Semantics

--- a/src/methods-and-traits/deriving.md
+++ b/src/methods-and-traits/deriving.md
@@ -1,5 +1,5 @@
 ---
-minutes: 5
+minutes: 3
 ---
 
 # Deriving

--- a/src/methods-and-traits/methods.md
+++ b/src/methods-and-traits/methods.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 8
 ---
 
 # Methods

--- a/src/methods-and-traits/traits.md
+++ b/src/methods-and-traits/traits.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 8
 ---
 
 # Traits

--- a/src/modules/modules.md
+++ b/src/modules/modules.md
@@ -1,5 +1,5 @@
 ---
-minutes: 5
+minutes: 3
 ---
 
 # Modules

--- a/src/modules/paths.md
+++ b/src/modules/paths.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 8
 ---
 
 # use, super, self

--- a/src/pattern-matching/destructuring.md
+++ b/src/pattern-matching/destructuring.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 8
 ---
 
 # Destructuring

--- a/src/smart-pointers/box.md
+++ b/src/smart-pointers/box.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 8
 ---
 
 # `Box<T>`

--- a/src/testing/lints.md
+++ b/src/testing/lints.md
@@ -1,5 +1,5 @@
 ---
-minutes: 5
+minutes: 3
 ---
 
 # Compiler Lints and Clippy

--- a/src/testing/other.md
+++ b/src/testing/other.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Other Types of Tests

--- a/src/testing/unit-tests.md
+++ b/src/testing/unit-tests.md
@@ -23,7 +23,7 @@ fn first_word(text: &str) -> &str {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/types-and-values/arithmetic.md
+++ b/src/types-and-values/arithmetic.md
@@ -1,5 +1,5 @@
 ---
-minutes: 5
+minutes: 3
 ---
 
 # Arithmetic

--- a/src/types-and-values/inference.md
+++ b/src/types-and-values/inference.md
@@ -1,5 +1,5 @@
 ---
-minutes: 5
+minutes: 3
 ---
 
 # Type Inference

--- a/src/types-and-values/strings.md
+++ b/src/types-and-values/strings.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Strings

--- a/src/types-and-values/values.md
+++ b/src/types-and-values/values.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Values


### PR DESCRIPTION
Based on feedback from @marshallpierce that mornings took about 2.5 hours, this adjusts a bunch of the morning times downward to try to match that. In other words, this is trying to make the times in the course more accurate, rather than reducing the amount of time available for these slides.

This also updates the `course-schedule` tool to be able to show per-segment timings.