### PR TITLE
Added a different way of vector intialization.

### DIFF
--- a/src/std-types/vec.md
+++ b/src/std-types/vec.md
@@ -20,6 +20,9 @@ fn main() {
     // Canonical macro to initialize a vector with elements.
     let mut v3 = vec![0, 0, 1, 2, 3, 4];
 
+    // specifying the type when initializing a vector.
+    let mut v4 = Vec::<String>::new();
+
     // Retain only the even elements.
     v3.retain(|x| x % 2 == 0);
     println!("{v3:?}");


### PR DESCRIPTION
I am taking example datatype as String you can intialize with any datatype that is supported by rust.
Specifying ```Vec::<String>::new()``` explicitly indicates that variable is intended to be a vector containing String elements. This can be helpful for documenting the code and ensuring that variable is used correctly throughout the codebase.