### PR TITLE
Fix translation in section 17.2

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -348,7 +348,7 @@ msgstr "Comparaciones"
 #: src/SUMMARY.md src/std-traits/operators.md
 #, fuzzy
 msgid "Operators"
-msgstr "Iteradores"
+msgstr "Operadores"
 
 #: src/SUMMARY.md src/std-traits/from-and-into.md
 msgid "`From` and `Into`"


### PR DESCRIPTION
Changed 'Iteradores' to 'Operadores' in the section 17.2 title, as 'Operadores' is the correct translation for 'Operators'.