### PR TITLE
Suggest --locked for cargo installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Then install these tools with:
 
 ```shell
 cargo install mdbook
-cargo install mdbook-svgbob
-cargo install mdbook-i18n-helpers
-cargo install --path mdbook-exerciser
-cargo install --path mdbook-course
+cargo install --locked mdbook-svgbob
+cargo install --locked mdbook-i18n-helpers
+cargo install --locked --path mdbook-exerciser
+cargo install --locked --path mdbook-course
 ```
 
 Run


### PR DESCRIPTION
This is already used in the GitHub actions, and avoids issues like those in #1791.

Fixes #1791.