### PR TITLE
Update lifetime-elision.md

### DIFF
--- a/src/slices-and-lifetimes/lifetime-elision.md
+++ b/src/slices-and-lifetimes/lifetime-elision.md
@@ -61,7 +61,7 @@ references in its arguments that requires explicit annotation.
 Try adjusting the signature to "lie" about the lifetimes returned:
 
 ```rust,ignore
-fn nearest<'a, 'q'>(points: &'a [Point], query: &'q Point) -> Option<&'q Point> {
+fn nearest<'a, 'q>(points: &'a [Point], query: &'q Point) -> Option<&'q Point> {
 ```
 
 This won't compile, demonstrating that the annotations are checked for validity


### PR DESCRIPTION
In the details section, it is suggested to adjust the signature of the nearest function to "lie" about the lifetimes returned to:

fn nearest<'a, 'q'>(points: &'a [Point], query: &'q Point) -> Option<&'q Point> {

to demonstrate the compiler checks lifetimes for validity. However, the syntax for 'q is incorrect and it should instead be

fn nearest<'a, 'q>(points: &'a [Point], query: &'q Point) -> Option<&'q Point> {