### PR TITLE
Fix typo in googletest.md

### DIFF
--- a/src/testing/googletest.md
+++ b/src/testing/googletest.md
@@ -40,7 +40,7 @@ Error: See failure output above
 
 - This just scratches the surface, there are many builtin matchers.
 
-- A particularly nice feature is that mismatches in multi-line strings strings
+- A particularly nice feature is that mismatches in multi-line strings
   are shown as a diff:
 
 ```rust,ignore

--- a/src/testing/googletest.md
+++ b/src/testing/googletest.md
@@ -40,8 +40,7 @@ Error: See failure output above
 
 - This just scratches the surface, there are many builtin matchers.
 
-- A particularly nice feature is that mismatches in multi-line strings
-  are shown as a diff:
+- A particularly nice feature is that mismatches in multi-line strings are shown as a diff:
 
 ```rust,ignore
 {{#include googletest.rs:test_multiline_string_diff}}


### PR DESCRIPTION
The word `strings` is repeated unnecessarily