### PR TITLE
Rendered PDF improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install mdbook-pandoc and related dependencies
         run: |
-          cargo install mdbook-pandoc --locked --version 0.4.0
+          cargo install mdbook-pandoc --locked --version 0.5.0
           sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
           curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.11/pandoc-3.1.11-linux-amd64.tar.gz | tar zxf -
           echo "$PWD/pandoc-3.1.11/bin" >> $GITHUB_PATH

--- a/book.toml
+++ b/book.toml
@@ -31,6 +31,7 @@ verbose = false # Report timing information.
 
 [output.pandoc]
 optional = true
+hosted-html = "https://google.github.io/comprehensive-rust/"
 
 [output.pandoc.profile.pdf]
 output-file = "comprehensive-rust.pdf"


### PR DESCRIPTION
Updates `mdbook-pandoc` to [0.5.0](https://github.com/max-heller/mdbook-pandoc/releases/tag/v0.5.0) to use some new features:
- Table wrapping (closes #1709)
  
  The wrapping logic mirror's [Pandoc's](https://pandoc.org/MANUAL.html#extension-pipe_tables) (i.e., compare the relative widths of the `---` columns to determine column widths) so tables in the source may need tweaking to get the proportions right
- Replace broken links in PDF with corresponding links to https://google.github.io/comprehensive-rust/