### PR TITLE
Make content of variable "name" an actual name

### DIFF
--- a/src/std-traits/closures.md
+++ b/src/std-traits/closures.md
@@ -68,7 +68,7 @@ fn make_greeter(prefix: String) -> impl Fn(&str) {
 
 fn main() {
     let hi = make_greeter("Hi".to_string());
-    hi("there");
+    hi("Greg");
 }
 ```
 


### PR DESCRIPTION
In the example, somebody who is trying to understand this code has to follow a lot of moving pieces: prefix, name, make_greeter, and then also learn the new move concept at the same time.

It'd be better if the content were to actually match the name of the variables.  "Hi" is a good prefix, but "there" is not a name, so let's go with an actual name.