### PR TITLE
Change String representation to actual

### DIFF
--- a/src/memory-management/review.md
+++ b/src/memory-management/review.md
@@ -29,17 +29,17 @@ fn main() {
 ```
 
 ```bob
- Stack                             Heap
-.- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.
-:                           :     :                               :
+ Stack
+.- - - - - - - - - - - - - -.      Heap
+:                           :     .- - - - - - - - - - - - - - - -.
 :    s1                     :     :                               :
-:   +-----------+-------+   :     :   +----+----+----+----+----+  :
-:   | ptr       |   o---+---+-----+-->| H  | e  | l  | l  | o  |  :
-:   | len       |     5 |   :     :   +----+----+----+----+----+  :
-:   | capacity  |     5 |   :     :                               :
 :   +-----------+-------+   :     :                               :
-:                           :     `- - - - - - - - - - - - - - - -'
-`- - - - - - - - - - - - - -'
+:   | capacity  |     5 |   :     :   +----+----+----+----+----+  :
+:   | ptr       |     o-+---+-----+-->| H  | e  | l  | l  | o  |  :
+:   | len       |     5 |   :     :   +----+----+----+----+----+  :
+:   +-----------+-------+   :     :                               :
+:                           :     :                               :
+`- - - - - - - - - - - - - -'     `- - - - - - - - - - - - - - - -'
 ```
 
 <details>
@@ -65,8 +65,8 @@ fn main() {
     // String provides no guarantees about its layout, so this could lead to
     // undefined behavior.
     unsafe {
-        let (ptr, capacity, len): (usize, usize, usize) = std::mem::transmute(s1);
-        println!("ptr = {ptr:#x}, len = {len}, capacity = {capacity}");
+        let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);
+        println!("capacity = {capacity}, ptr = {ptr:#x}, len = {len}");
     }
 }
 ```


### PR DESCRIPTION
Tested with rust 2015, 2018, 2021 and 2024, on amd64 musl, amd64 glibc and aarch64 musl, all of them represent Strings with (ptr, capacity, len).

This is an internal implementation detail, that shouldn't be exposed anyway, so it's no big deal, but in the speaker notes, we provide a debugging tool for demonstration purposes, so at least that should have a correct output.