### PR TITLE
Fix style in glossary.md

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -5,19 +5,19 @@ terms. For translations, this also serves to connect the term back to the
 English original.
 
 <style>
-h1#glossary ~ ul {
+h1 ~ ul {
     list-style: none;
     padding-inline-start: 0;
 }
 
-h1#glossary ~ ul > li {
+h1 ~ ul > li {
     /* Simplify with "text-indent: 2em hanging" when supported:
        https://caniuse.com/mdn-css_properties_text-indent_hanging */
     padding-left: 2em;
     text-indent: -2em;
 }
 
-h1#glossary ~ ul > li:first-line {
+h1 ~ ul > li:first-line {
     font-weight: bold;
 }
 </style>


### PR DESCRIPTION
`id` of `h1` title in the translated version will be changed to the translated text. 
Fixed `id` configured here will not take effect in the translated version.

Correct style: <https://google.github.io/comprehensive-rust/glossary.html>
Wrong style (zh-CN): <https://google.github.io/comprehensive-rust/zh-CN/glossary.html>