### PR TITLE
Add missing editable attribute to exercise

### DIFF
--- a/src/control-flow-basics/exercise.md
+++ b/src/control-flow-basics/exercise.md
@@ -25,7 +25,7 @@ For example, beginning with _n<sub>1</sub>_ = 3:
 Write a function to calculate the length of the collatz sequence for a given
 initial `n`.
 
-```rust,should_panic
+```rust,editable,should_panic
 {{#include exercise.rs:collatz_length}}
   todo!("Implement this")
 }


### PR DESCRIPTION
I was reading the docs and I stumbled upon this.
I'm unsure about when exercises should be solved directly on the site and when they should be copied and pasted into a playground. But since the previous chapter's exercise is solvable in the site [(fibonacci sequence)](https://github.com/google/comprehensive-rust/blob/0cb7f496b542d76468fa950718f57f4037abc8fa/src/types-and-values/exercise.md?plain=1#L15), I figured this one might be missing the attribute. Anyway amazing work on the docs!