### PR TITLE
Make the "break with label" example more illustrative

### DIFF
--- a/src/control-flow-basics/break-continue/labels.md
+++ b/src/control-flow-basics/break-continue/labels.md
@@ -7,16 +7,18 @@ to break out of nested loops:
 fn main() {
     let s = [[5, 6, 7], [8, 9, 10], [21, 15, 32]];
     let mut found = false;
+    let mut elements_searched = 0;
     let target_value = 10;
     'outer: for i in 0..=2 {
         for j in 0..=2 {
+            elements_searched += 1;
             if s[i][j] == target_value {
                 found = true;
                 break 'outer;
             }
         }
     }
-    print!("{}", found)
+    print!("found: {}, elements searched: {}", found, elements_searched);
 }
 ```
 

--- a/src/control-flow-basics/break-continue/labels.md
+++ b/src/control-flow-basics/break-continue/labels.md
@@ -6,19 +6,17 @@ to break out of nested loops:
 ```rust,editable
 fn main() {
     let s = [[5, 6, 7], [8, 9, 10], [21, 15, 32]];
-    let mut found = false;
     let mut elements_searched = 0;
     let target_value = 10;
     'outer: for i in 0..=2 {
         for j in 0..=2 {
             elements_searched += 1;
             if s[i][j] == target_value {
-                found = true;
                 break 'outer;
             }
         }
     }
-    print!("found: {}, elements searched: {}", found, elements_searched);
+    print!("elements searched: {}", elements_searched);
 }
 ```
 

--- a/src/control-flow-basics/break-continue/labels.md
+++ b/src/control-flow-basics/break-continue/labels.md
@@ -16,7 +16,7 @@ fn main() {
             }
         }
     }
-    print!("elements searched: {}", elements_searched);
+    print!("elements searched: {elements_searched}");
 }
 ```
 


### PR DESCRIPTION
In the old version, using "break 'outer;" and using "break;" (without the label) produce the same output.

This version fixes that to make the example more illustrative.