### PR TITLE
Tweak timings of exercises to better reflect teaching times

### DIFF
--- a/src/borrowing/exercise.md
+++ b/src/borrowing/exercise.md
@@ -1,5 +1,5 @@
 ---
-minutes: 30
+minutes: 20
 ---
 
 # Exercise: Health Statistics

--- a/src/control-flow-basics/exercise.md
+++ b/src/control-flow-basics/exercise.md
@@ -1,5 +1,5 @@
 ---
-minutes: 30
+minutes: 15
 ---
 
 # Exercise: Collatz Sequence

--- a/src/error-handling/exercise.md
+++ b/src/error-handling/exercise.md
@@ -1,5 +1,5 @@
 ---
-minutes: 20
+minutes: 30
 ---
 
 # Exercise: Rewriting with Result

--- a/src/references/exercise.md
+++ b/src/references/exercise.md
@@ -1,5 +1,5 @@
 ---
-minutes: 30
+minutes: 15
 ---
 
 # Exercise: Geometry

--- a/src/std-types/exercise.md
+++ b/src/std-types/exercise.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 20
 ---
 
 # Exercise: Counter

--- a/src/tuples-and-arrays/exercise.md
+++ b/src/tuples-and-arrays/exercise.md
@@ -1,5 +1,5 @@
 ---
-minutes: 30
+minutes: 15
 ---
 
 # Exercise: Nested Arrays

--- a/src/types-and-values/exercise.md
+++ b/src/types-and-values/exercise.md
@@ -1,5 +1,5 @@
 ---
-minutes: 30
+minutes: 15
 ---
 
 # Exercise: Fibonacci


### PR DESCRIPTION
A few of the early exercises had much larger estimates than were actually necessary for the super simple early exercises. I've gone through and reviewed the time estimates for exercises and tweaked the estimates based on how much time students have actually needed in my classes so far.