### PR TITLE
Remove tangential text from `if` slide

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -233,6 +233,8 @@ use-boolean-and = true
 'unsafe/extern-functions.html' = '../unsafe-rust/unsafe-functions.html'
 'unsafe/unsafe-traits.html' = '../unsafe-rust/unsafe-traits.html'
 'exercises/day-3/safe-ffi-wrapper.html' = '../../unsafe-rust/exercise.html'
+'hello-world/hello-world.html' = '../types-and-values/hello-world.html'
+'control-flow-basics/conditionals.html' = 'if.html'
 
 [output.exerciser]
 output-directory = "comprehensive-rust-exercises"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -30,7 +30,7 @@
   - [Exercise: Fibonacci](types-and-values/exercise.md)
     - [Solution](types-and-values/solution.md)
 - [Control Flow Basics](control-flow-basics.md)
-  - [Conditionals](control-flow-basics/conditionals.md)
+  - [`if` Expressions](control-flow-basics/if.md)
   - [Loops](control-flow-basics/loops.md)
     - [`for`](control-flow-basics/loops/for.md)
     - [`loop`](control-flow-basics/loops/loop.md)

--- a/src/control-flow-basics/if.md
+++ b/src/control-flow-basics/if.md
@@ -2,17 +2,7 @@
 minutes: 4
 ---
 
-# Conditionals
-
-Much of the Rust syntax will be familiar to you from C, C++ or Java:
-
-- Blocks are delimited by curly braces.
-- Line comments are started with `//`, block comments are delimited by
-  `/* ... */`.
-- Keywords like `if` and `while` work the same.
-- Variable assignment is done with `=`, comparison is done with `==`.
-
-## `if` expressions
+# `if` expressions
 
 You use
 [`if` expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions)

--- a/src/control-flow-basics/if.md
+++ b/src/control-flow-basics/if.md
@@ -11,8 +11,8 @@ exactly like `if` statements in other languages:
 ```rust,editable
 fn main() {
     let x = 10;
-    if x < 20 {
-        println!("small");
+    if x == 0 {
+        println!("zero!");
     } else if x < 100 {
         println!("biggish");
     } else {


### PR DESCRIPTION
The text at the top of the slide on `if` expressions included some tangential info about Rust syntax that I think is more distracting than helpful. If we think it's important to demonstrate any of this syntax, e.g. the syntax for comments, it might make more sense to add that to the hello world example (or another early example) that way it can be pointed out more naturally as we go.

I also renamed `conditionals.md` to `if.md` to better reflect its updated contents.