### PR TITLE
Cover Supertraits, Generic Traits

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -82,6 +82,7 @@
   - [Methods](methods-and-traits/methods.md)
   - [Traits](methods-and-traits/traits.md)
     - [Implmementing Traits](methods-and-traits/traits/implementing.md)
+    - [Supertraits](methods-and-traits/traits/supertraits.md)
     - [Associated Types](methods-and-traits/traits/associated-types.md)
   - [Deriving](methods-and-traits/deriving.md)
   - [Exercise: Generic Logger](methods-and-traits/exercise.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -90,6 +90,7 @@
 - [Generics](generics.md)
   - [Generic Functions](generics/generic-functions.md)
   - [Generic Data Types](generics/generic-data.md)
+  - [Generic Traits](generics/generic-traits.md)
   - [Trait Bounds](generics/trait-bounds.md)
   - [`impl Trait`](generics/impl-trait.md)
   - [Exercise: Generic `min`](generics/exercise.md)

--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -13,13 +13,13 @@ struct Foo(String);
 
 impl From<u32> for Foo {
     fn from(from: u32) -> Foo {
-        Foo(format!("Converted from integer: {from}"));
+        Foo(format!("Converted from integer: {from}"))
     }
 }
 
 impl From<bool> for Foo {
     fn from(from: bool) -> Foo {
-        Foo(format!("Converted from bool: {from}"));
+        Foo(format!("Converted from bool: {from}"))
     }
 }
 

--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -12,13 +12,13 @@ get concrete types when it is used.
 struct Foo(String);
 
 impl From<u32> for Foo {
-    fn from(from: u32) {
+    fn from(from: u32) -> Foo {
         Foo(format!("Converted from integer: {from}"));
     }
 }
 
 impl From<bool> for Foo {
-    fn from(from: bool) {
+    fn from(from: bool) -> Foo {
         Foo(format!("Converted from bool: {from}"));
     }
 }

--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -1,0 +1,51 @@
+---
+Minutes: 5
+---
+
+# Generic Traits
+
+Traits can also be generic, just like types and functions. A trait's parameters
+get concrete types when it is used.
+
+```rust,editable
+trait Sink<T> {
+    fn push(&mut self, v: T);
+}
+
+struct ConsoleSink;
+impl<T: std::fmt::Display> Sink<T> for ConsoleSink {
+    fn push(&mut self, v: T) {
+        println!("{}", v);
+    }
+}
+
+fn generate_numbers<S: Sink<u32>>(n: u32, sink: &mut S) {
+    for i in 0..n {
+        sink.push(i);
+    }
+}
+
+fn main() {
+    generate_numbers(5, &mut ConsoleSink);
+}
+```
+
+<details>
+
+- Generic traits take types as "input", while associated traits are a kind of
+  "output trait.
+
+- Implementations of the trait do not need to cover all possible type
+  parameters. Here, `ConsoleSink` only covers types `T` that implement
+  `Display`. Add a simple `SumSink` that only takes `u32`'s and sums them:
+
+  ```rust,compile_fail
+  struct SumSink(u32);
+  impl Sink<u32> for SumSink {
+      fn push(&mut self, v: u32) {
+          self.0 += v;
+      }
+  }
+  ```
+
+</details>

--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -8,44 +8,45 @@ Traits can also be generic, just like types and functions. A trait's parameters
 get concrete types when it is used.
 
 ```rust,editable
-trait Sink<T> {
-    fn push(&mut self, v: T);
-}
+#[derive(Debug)]
+struct Foo(String);
 
-struct ConsoleSink;
-impl<T: std::fmt::Display> Sink<T> for ConsoleSink {
-    fn push(&mut self, v: T) {
-        println!("{}", v);
+impl From<u32> for Foo {
+    fn from(from: u32) {
+        Foo(format!("Converted from integer: {from}"));
     }
 }
 
-fn generate_numbers<S: Sink<u32>>(n: u32, sink: &mut S) {
-    for i in 0..n {
-        sink.push(i);
+impl From<bool> for Foo {
+    fn from(from: bool) {
+        Foo(format!("Converted from bool: {from}"));
     }
 }
 
 fn main() {
-    generate_numbers(5, &mut ConsoleSink);
+    let from_int = Foo::from(123);
+    let from_bool = Foo::from(true);
+    println!("{from_int:?}, {from_bool:?}");
 }
 ```
 
 <details>
 
-- Generic traits take types as "input", while associated traits are a kind of
-  "output trait.
+- The `From` trait will be covered later in the course, but its
+  [definition in the `std` docs](https://doc.rust-lang.org/std/convert/trait.From.html)
+  is simple.
 
 - Implementations of the trait do not need to cover all possible type
-  parameters. Here, `ConsoleSink` only covers types `T` that implement
-  `Display`. Add a simple `SumSink` that only takes `u32`'s and sums them:
+  parameters. Here, `Foo::From("hello")` would not compile because there is no
+  `From<&str>` implementation for `Foo`.
 
-  ```rust,compile_fail
-  struct SumSink(u32);
-  impl Sink<u32> for SumSink {
-      fn push(&mut self, v: u32) {
-          self.0 += v;
-      }
-  }
-  ```
+- Generic traits take types as "input", while associated types are a kind of
+  "output type. A trait can have multiple implementations for different input
+  types.
+
+- In fact, Rust requires that at most one implementation of a trait match for
+  any type T. Unlike some other languages, Rust has no heuristic for choosing
+  the "most specific" match. There is work on adding this support, called
+  [specialization](https://rust-lang.github.io/rfcs/1210-impl-specialization.html).
 
 </details>

--- a/src/methods-and-traits/traits.md
+++ b/src/methods-and-traits/traits.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 15
 ---
 
 # Traits

--- a/src/methods-and-traits/traits/associated-types.md
+++ b/src/methods-and-traits/traits/associated-types.md
@@ -1,6 +1,6 @@
 # Associated Types
 
-Associated types are placeholder types which are filled in by the trait
+Associated types are placeholder types which are supplied by the trait
 implementation.
 
 ```rust,editable

--- a/src/methods-and-traits/traits/supertraits.md
+++ b/src/methods-and-traits/traits/supertraits.md
@@ -1,0 +1,41 @@
+# Supertraits
+
+A trait can require that types implementing it also implement other traits,
+called _supertraits_. Here, any type implementing `Pet` must implement `Animal`.
+
+```rust,editable
+trait Animal {
+    fn leg_count(&self) -> u32;
+}
+
+trait Pet: Animal {
+    fn name(&self) -> String;
+}
+
+struct Dog(String);
+
+impl Animal for Dog {
+    fn leg_count(&self) -> u32 {
+        4
+    }
+}
+
+impl Pet for Dog {
+    fn name(&self) -> String {
+        string.name.clone()
+    }
+}
+
+fn main() {
+    let puppy = Dog(String::from("Rex"));
+    println!("{} has {} legs", puppy.name(), puppy.leg_count());
+}
+```
+
+<details>
+
+This is sometimes called "trait inheritance" but students should not expect this
+to behave like OO inheritance. It just specifies an additional requirement on
+implementations of a trait.
+
+<details>

--- a/src/methods-and-traits/traits/supertraits.md
+++ b/src/methods-and-traits/traits/supertraits.md
@@ -22,7 +22,7 @@ impl Animal for Dog {
 
 impl Pet for Dog {
     fn name(&self) -> String {
-        string.name.clone()
+        self.0.clone()
     }
 }
 


### PR DESCRIPTION
Fixes #1511.

This also fixes a typo in the associated-types subslide.
