### PR TITLE
Update course-schedule PR comments in-place

### DIFF
--- a/.github/workflows/course-schedule-comment.yml
+++ b/.github/workflows/course-schedule-comment.yml
@@ -60,9 +60,32 @@ jobs:
             var pr_number = Number(fs.readFileSync('pr-number'));
             var upstream = fs.readFileSync('upstream-schedule').toString();
             var schedule = fs.readFileSync('schedule').toString();
-            if (upstream != schedule) {
-              schedule = schedule + "# New Course Schedule\n";
-              schedule = schedule + "This PR changes the course schedule. The new schedule is shown below.";
+            schedule = "<!-- course-schedule -->\n" +
+                       "# Changes to Course Schedule\n" +
+                       "This PR changes the course schedule. The new schedule is shown below.\n\n" +
+                       schedule;
+
+            // Look for existing comments
+            var existing_comment;
+            for await ({ data: comments } of github.paginate.iterator(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number
+            })) {
+              existing_comment = comments.find((c) => c.body.includes("<!-- course-schedule -->"));
+              if (existing_comment) {
+                break;
+              }
+            }
+
+            if (existing_comment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing_comment.id,
+                body: schedule,
+              });
+            } else if (upstream != schedule) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
Instead of always adding a new comment, just update the existing comment if one exists.

This fixes #1834.