### PR TITLE
es: Merge CR v.2 Spanish translation back into main

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -10,7 +10,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.4\n"
 
 #: src/SUMMARY.md src/index.md
 msgid "Welcome to Comprehensive Rust 🦀"
@@ -14758,15 +14757,17 @@ msgstr ""
 "tenga un fragmento de código que se pueda convertir en Rust sobre la marcha."
 
 #: src/chromium.md
-#, fuzzy
 msgid "Welcome to Rust in Chromium"
-msgstr "Te Damos la Bienvenida a Rust en Android"
+msgstr "Te Damos la Bienvenida a Rust en Chromium"
 
 #: src/chromium.md
 msgid ""
 "Rust is supported for third-party libraries in Chromium, with first-party "
 "glue code to connect between Rust and existing Chromium C++ code."
 msgstr ""
+"Rust es compatible con bibliotecas de terceros en Chromium, con código "
+"pegamento propio para conectar Rust y el código de C++ de Chromium ya "
+"existente."
 
 #: src/chromium.md
 msgid ""
@@ -14775,6 +14776,10 @@ msgid ""
 "feel free to follow this recipe in your part of the codebase instead of the "
 "exact part we talk about."
 msgstr ""
+"Hoy vamos a llamar a Rust para que haga algo divertido con las cadenas. Si "
+"tienes una esquina del código donde se muestra una cadena UTF8 al usuario, "
+"no dudes en seguir estas instrucciones en tu parte del código base en lugar "
+"de la parte exacta de la que hablamos."
 
 #: src/chromium/setup.md
 msgid ""
@@ -14782,12 +14787,18 @@ msgid ""
 "flags is OK, so long as your code is relatively recent (commit position "
 "1223636 onwards, corresponding to November 2023):"
 msgstr ""
+"Asegúrate de que puedes compilar y ejecutar Chromium. Cualquier plataforma y "
+"conjunto de marcas de compilación es apto, siempre que tu código sea "
+"relativamente reciente (posición de commit 1223636 en adelante, "
+"correspondiente a noviembre del 2023):"
 
 #: src/chromium/setup.md
 msgid ""
 "(A component, debug build is recommended for quickest iteration time. This "
 "is the default!)"
 msgstr ""
+"(Se recomienda una versión de depuración de componentes para que el tiempo "
+"de iteración sea más rápido. Esta es la opción predeterminada)."
 
 #: src/chromium/setup.md
 msgid ""
@@ -14795,14 +14806,17 @@ msgid ""
 "the-code/) if you aren't already at that point. Be warned: setting up to "
 "build Chromium takes time."
 msgstr ""
+"Consulta [cómo compilar Chromium](https://www.chromium.org/developers/how-"
+"tos/get-the-code/) si aún no lo has hecho. Advertencia: el proceso de "
+"configuración para compilar Chromium puede tardar."
 
 #: src/chromium/setup.md
 msgid "It's also recommended that you have Visual Studio code installed."
-msgstr ""
+msgstr "Se recomienda que tengas instalado Visual Studio Code."
 
 #: src/chromium/setup.md
 msgid "About the exercises"
-msgstr ""
+msgstr "Información sobre los ejercicios"
 
 #: src/chromium/setup.md
 msgid ""
@@ -14811,6 +14825,10 @@ msgid ""
 "If you don't have time to complete a certain part, don't worry: you can "
 "catch up in the next slot."
 msgstr ""
+"Esta parte del curso consta de una serie de ejercicios que se complementan "
+"entre sí. Las iremos repartiendo a lo largo del curso en lugar de hacerlos "
+"todo al final. Si no tienes tiempo para completar una parte concreta, no te "
+"preocupes, podrás ponerte al día en la siguiente clase."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14818,10 +14836,13 @@ msgid ""
 "crates.io/). Chromium is built using `gn` and `ninja` and a curated set of "
 "dependencies."
 msgstr ""
+"La comunidad de Rust suele usar `cargo` y bibliotecas de [crates.io](https://"
+"crates.io/). Chromium se compila usando `gn` y `ninja`, además de un "
+"conjunto seleccionado de dependencias."
 
 #: src/chromium/cargo.md
 msgid "When writing code in Rust, your choices are:"
-msgstr ""
+msgstr "A la hora de escribir código en Rust, hay disponibles varias opciones:"
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14829,6 +14850,9 @@ msgid ""
 "gni` (e.g. `rust_static_library` that we'll meet later). This uses "
 "Chromium's audited toolchain and crates."
 msgstr ""
+"Usar `gn` y `ninja` con la ayuda de las plantillas de `//build/rust/*.gni` "
+"(por ejemplo, `rust_static_library`, que veremos más adelante). Se usan la "
+"cadena de herramientas y los crates auditados de Chromium."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14836,12 +14860,17 @@ msgid ""
 "crates](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/"
 "docs/rust.md#Using-cargo)"
 msgstr ""
+"Usar `cargo`, pero [restringiendo el uso de la cadena de herramientas y los "
+"crates auditados de Chromium](https://chromium.googlesource.com/chromium/src/"
+"+/refs/heads/main/docs/rust.md#Using-cargo)."
 
 #: src/chromium/cargo.md
 msgid ""
 "Use `cargo`, trusting a [toolchain](https://rustup.rs/) and/or [crates "
 "downloaded from the internet](https://crates.io/)"
 msgstr ""
+"Usa `cargo` con una [cadena de herramientas](https://rustup.rs/) o [crates "
+"descargados de Internet](https://crates.io/)."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14849,27 +14878,34 @@ msgid ""
 "code can be built into the Chromium browser. At the same time, Cargo is an "
 "important part of the Rust ecosystem and you should keep it in your toolbox."
 msgstr ""
+"A partir de ahora, nos centraremos en `gn` y `ninja`, ya que así es como se "
+"puede compilar el código de Rust en el navegador Chromium. De igual forma, "
+"Cargo es una parte importante del ecosistema de Rust y deberías conservarlo "
+"en tu caja de herramientas."
 
 #: src/chromium/cargo.md
-#, fuzzy
 msgid "Mini exercise"
-msgstr "Ejercicios"
+msgstr "Ejercicio rápido"
 
 #: src/chromium/cargo.md
 msgid "Split into small groups and:"
-msgstr ""
+msgstr "Formad grupos pequeños para:"
 
 #: src/chromium/cargo.md
 msgid ""
 "Brainstorm scenarios where `cargo` may offer an advantage and assess the "
 "risk profile of these scenarios."
 msgstr ""
+"Hacer una lluvia de ideas sobre situaciones en las que `cargo` pueda ofrecer "
+"ventajas y evaluar el perfil de riesgo."
 
 #: src/chromium/cargo.md
 msgid ""
 "Discuss which tools, libraries, and groups of people need to be trusted when "
 "using `gn` and `ninja`, offline `cargo`, etc."
 msgstr ""
+"Debatir en qué herramientas, bibliotecas y grupos de personas hay que "
+"confiar al usar `gn` y `ninja`, `cargo` offline, etc."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14877,12 +14913,18 @@ msgid ""
 "exercise. Assuming folks taking the course are physically together, ask them "
 "to discuss in small groups of 3-4 people."
 msgstr ""
+"Pide a los participantes que eviten mirar las notas del orador antes de "
+"completar el ejercicio. Suponiendo que todas las personas que hacen el curso "
+"están en la misma sala, pídeles que hablen en grupos pequeños de 3 a 4 "
+"personas."
 
 #: src/chromium/cargo.md
 msgid ""
 "Notes/hints related to the first part of the exercise (\"scenarios where "
 "Cargo may offer an advantage\"):"
 msgstr ""
+"Notas y sugerencias relacionadas con la primera parte del ejercicio "
+"(\"situaciones en las que Cargo puede ofrecer ventajas\"):"
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14892,18 +14934,28 @@ msgid ""
 "(`clap` for command-line parsing, `serde` for serializing/deserializing to/"
 "from various formats, `itertools` for working with iterators, etc.)."
 msgstr ""
+"Es genial que al escribir una herramienta o crear prototipos de una parte de "
+"Chromium se pueda acceder al extenso ecosistema de bibliotecas crates.io. "
+"Hay un crate para casi cualquier cosa y suelen ser muy fáciles de usar "
+"(`clap` para el análisis de la línea de comandos, `serde` para la "
+"serialización y deserialización a/desde varios formatos, `itertools` para "
+"trabajar con iteradores, etc.)."
 
 #: src/chromium/cargo.md
 msgid ""
 "`cargo` makes it easy to try a library (just add a single line to `Cargo."
 "toml` and start writing code)"
 msgstr ""
+"`cargo` permite probar una biblioteca fácilmente (solo hay que añadir una "
+"línea a `Cargo.toml` y empezar a escribir el código)."
 
 #: src/chromium/cargo.md
 msgid ""
 "It may be worth comparing how CPAN helped make `perl` a popular choice. Or "
 "comparing with `python` + `pip`."
 msgstr ""
+"Merece la pena comparar cómo la CPAN ayudó a que `perl` fuera una opción "
+"popular o compararlo con `python` + `pip`."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14914,20 +14966,32 @@ msgid ""
 "streamlining and sharing security audits; `criterion` crate gives a "
 "streamlined way to run benchmarks)."
 msgstr ""
+"La experiencia de desarrollo no solo es agradable gracias a las herramientas "
+"principales de Rust (por ejemplo, al usar `rustup` para cambiar a una "
+"versión diferente de `rustc` cuando se prueba un crate que necesita "
+"funcionar en nightly, stable actual y antiguas versiones de stable), sino "
+"también a un ecosistema de herramientas de terceros (por ejemplo, Mozilla "
+"proporciona `cargo vet` para optimizar y compartir auditorías de seguridad; "
+"el crate `criterion` ofrece un método optimizado para ejecutar comparativas)."
 
 #: src/chromium/cargo.md
 msgid ""
 "`cargo` makes it easy to add a tool via `cargo install --locked cargo-vet`."
 msgstr ""
+"`cargo` permite añadir fácilmente una herramienta mediante `cargoinstall --"
+"locked cargo-vet`."
 
 #: src/chromium/cargo.md
 msgid "It may be worth comparing with Chrome Extensions or VScode extensions."
 msgstr ""
+"Merece la pena compararlo con las extensiones de Chrome o con las de VScode."
 
 #: src/chromium/cargo.md
 msgid ""
 "Broad, generic examples of projects where `cargo` may be the right choice:"
 msgstr ""
+"Ejemplos generales y genéricos de proyectos en los que `cargo` puede ser la "
+"opción más adecuada:"
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14937,6 +15001,11 @@ msgid ""
 "typesystem) and running faster (as a compiled, rather than interpreted "
 "language)."
 msgstr ""
+"Sorprendentemente, Rust se está volviendo cada vez más popular en el sector "
+"por su función de escritura de herramientas de línea de comandos. La "
+"amplitud y la ergonomía de las bibliotecas son similares a las de Python, "
+"pero son más sólidas (gracias al sistema de tipos enriquecido) y funcionan "
+"más rápido (como lenguaje compilado en lugar de interpretado)."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14945,26 +15014,36 @@ msgid ""
 "used outside of Chromium (e.g. in Bazel or Android/Soong build environments) "
 "should probably use Cargo."
 msgstr ""
+"Para participar en el ecosistema de Rust, es necesario usar herramientas "
+"estándar de Rust, como Cargo. Las bibliotecas que quieran recibir "
+"contribuciones externas y actuar fuera de Chromium (por ejemplo, en entornos "
+"de desarrollo de Bazel o Android/Soong) deberían utilizar Cargo."
 
 #: src/chromium/cargo.md
 msgid "Examples of Chromium-related projects that are `cargo`\\-based:"
 msgstr ""
+"Ejemplos de proyectos relacionados con Chromium que se basan en `cargo`\\:"
 
 #: src/chromium/cargo.md
 msgid ""
 "`serde_json_lenient` (experimented with in other parts of Google which "
 "resulted in PRs with performance improvements)"
 msgstr ""
+"`serde_json_lenient` (experimentado en otras partes de Google que ha dado "
+"lugar a PRs con mejoras de rendimiento)."
 
 #: src/chromium/cargo.md
 msgid "Fontations libraries like `font-types`"
-msgstr ""
+msgstr "Bibliotecas de fuentes, como `font-types`."
 
 #: src/chromium/cargo.md
 msgid ""
 "`gnrt` tool (we will meet it later in the course) which depends on `clap` "
 "for command-line parsing and on `toml` for configuration files."
 msgstr ""
+"La herramienta `gnrt` (la veremos más adelante en el curso), que depende de "
+"`clap` para el análisis de la línea de comandos y de `toml` para los "
+"archivos de configuración."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14972,6 +15051,9 @@ msgid ""
 "when building and bootstrapping Rust standard library when building Rust "
 "toolchain.)"
 msgstr ""
+"Aclaración: una razón principal para usar `cargo` es que `gn` no está "
+"disponible al compilar e iniciar la biblioteca estándar de Rust cuando se "
+"compila su cadena de herramientas."
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14979,12 +15061,17 @@ msgid ""
 "third-party libraries downloaded from the internet, by `run_gnrt.py` asks "
 "`cargo` that only `--locked` content is allowed via `Cargo.lock`.)"
 msgstr ""
+"`run_gnrt.py` usa la copia de Chromium de `cargo` y `rustc`. `gnrt` depende "
+"de las bibliotecas de terceros descargadas de Internet. `run_gnrt.py` pide a "
+"`cargo` que solo se permita el contenido `--locked` a través de `Cargo.lock`."
 
 #: src/chromium/cargo.md
 msgid ""
 "Students may identify the following items as being implicitly or explicitly "
 "trusted:"
 msgstr ""
+"Los participantes pueden tratar de identificar si los siguientes elementos "
+"son de confianza implícita o explícita:"
 
 #: src/chromium/cargo.md
 msgid ""
@@ -14992,40 +15079,53 @@ msgid ""
 "Clang compiler, the `rustc` sources (fetched from GitHub, reviewed by Rust "
 "compiler team), binary Rust compiler downloaded for bootstrapping"
 msgstr ""
+"`rustc` (el compilador de Rust), que a su vez depende de las bibliotecas "
+"LLVM, el compilador Clang, las fuentes `rustc` (obtenidas de GitHub y "
+"revisadas por el equipo de compilación de Rust), y el compilador binario de "
+"Rust descargado para el bootstrapping."
 
 #: src/chromium/cargo.md
 msgid ""
 "`rustup` (it may be worth pointing out that `rustup` is developed under the "
 "umbrella of the https://github.com/rust-lang/ organization - same as `rustc`)"
 msgstr ""
+"`rustup` (merece la pena destacar que `rustup` se desarrolla en la misma "
+"organización que `rustc`, https://github.com/rust-lang/)."
 
 #: src/chromium/cargo.md
 msgid "`cargo`, `rustfmt`, etc."
-msgstr ""
+msgstr "`cargo`, `rustfmt`, etc."
 
 #: src/chromium/cargo.md
 msgid ""
 "Various internal infrastructure (bots that build `rustc`, system for "
 "distributing the prebuilt toolchain to Chromium engineers, etc.)"
 msgstr ""
+"Varias infraestructuras internas (bots que compilan `rustc`, sistemas para "
+"distribuir la cadena de herramientas precompiladas a los ingenieros de "
+"Chromium, etc.)"
 
 #: src/chromium/cargo.md
 msgid "Cargo tools like `cargo audit`, `cargo vet`, etc."
-msgstr ""
+msgstr "Herramientas de Cargo, como `cargo audit`, `cargo vet`, etc."
 
 #: src/chromium/cargo.md
 msgid ""
 "Rust libraries vendored into `//third_party/rust` (audited by "
 "security@chromium.org)"
 msgstr ""
+"Bibliotecas de Rust incluidas en `//third_party/rust` (auditoría de "
+"security@chromium.org)."
 
 #: src/chromium/cargo.md
 msgid "Other Rust libraries (some niche, some quite popular and commonly used)"
 msgstr ""
+"Otras bibliotecas de Rust (algunas de nicho, otras bastante populares y de "
+"uso común)."
 
 #: src/chromium/policy.md
 msgid "Chromium Rust policy"
-msgstr ""
+msgstr "Política de Chromium Rust"
 
 #: src/chromium/policy.md
 msgid ""
@@ -15033,6 +15133,9 @@ msgid ""
 "approved by Chromium's [Area Tech Leads](https://source.chromium.org/"
 "chromium/chromium/src/+/main:ATL_OWNERS)."
 msgstr ""
+"Chromium aún no permite usar Rust propio, excepto en casos excepcionales, "
+"según lo aprobado por [Area Tech Leads](https://source.chromium.org/chromium/"
+"chromium/src/+/main:ATL_OWNERS)."
 
 #: src/chromium/policy.md
 msgid ""
@@ -15042,6 +15145,11 @@ msgid ""
 "circumstances, including if they're the best option for performance or for "
 "security."
 msgstr ""
+"La política de Chromium sobre bibliotecas de terceros se describe [aquí]"
+"(https://chromium.googlesource.com/chromium/src/+/main/docs/"
+"adding_to_third_party.md#rust). Se permite el uso de Rust para bibliotecas "
+"de terceros en algunos casos, incluido si son la mejor opción en cuanto al "
+"rendimiento o seguridad."
 
 #: src/chromium/policy.md
 msgid ""
@@ -15049,9 +15157,11 @@ msgid ""
 "nearly all such libraries will require a small amount of first-party glue "
 "code."
 msgstr ""
+"Muy pocas bibliotecas de Rust exponen directamente una API de C o C++, por "
+"lo que casi todas estas bibliotecas necesitarán una pequeña parte de código "
+"pegamento propio."
 
 #: src/chromium/policy.md
-#, fuzzy
 msgid ""
 "```bob\n"
 "\"C++\"                           Rust\n"
@@ -15078,21 +15188,26 @@ msgid ""
 "```"
 msgstr ""
 "```bob\n"
-" _Stack_                        _Heap_\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"\"C++\"                           Rust\n"
+".- - - - - - - - - -.           .- - - - - - - - - - - - - - - - - - - - - - "
 "-.\n"
-":                         :     :                                             :\n"
-":    "
-"list                 :     :                                             :\n"
-":   +----+----+           :     :    +----+----+    +----+------"
-"+             :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
-"|             :\n"
-":   +----+----+           :     :    +----+----+    +----+------"
-"+             :\n"
-":                         :     :                                             :\n"
-":                         :     :                                             :\n"
-"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+":                   :           :                                             :\n"
+": Existing Chromium :           :  Chromium Rust              Existing "
+"Rust   :\n"
+": \"C++\"             :           :  \"wrapper\"                  "
+"crate           :\n"
+": +---------------+ :           : +----------------+          +-------------"
+"+ :\n"
+": |               | :           : |                |          |             "
+"| :\n"
+": |         o-----+-+-----------+-+->            o-+----------+-->          "
+"| :\n"
+": |               | : Language  : |                | Crate    |             "
+"| :\n"
+": +---------------+ : boundary  : +----------------+ API      +-------------"
+"+ :\n"
+":                   :           :                                             :\n"
+"`- - - - - - - - - -'           `- - - - - - - - - - - - - - - - - - - - - - "
 "-'\n"
 "```"
 
@@ -15101,27 +15216,31 @@ msgid ""
 "First-party Rust glue code for a particular third-party crate should "
 "normally be kept in `third_party/rust/<crate>/<version>/wrapper`."
 msgstr ""
+"El código pegamento propio de Rust para un crate de terceros concreto "
+"normalmente debe guardarse en `third_party/rust/<crate>/<version>/wrapper`."
 
 #: src/chromium/policy.md
 msgid "Because of this, today's course will be heavily focused on:"
-msgstr ""
+msgstr "Por este motivo, el curso de hoy se centrará en los siguientes temas:"
 
 #: src/chromium/policy.md
 msgid "Bringing in third-party Rust libraries (\"crates\")"
-msgstr ""
+msgstr "Incorporación de bibliotecas Rust de terceros (\"crates\")."
 
 #: src/chromium/policy.md
 msgid "Writing glue code to be able to use those crates from Chromium C++."
 msgstr ""
+"Escribir código pegamento para poder usar esos crates desde Chromium C++."
 
 #: src/chromium/policy.md
 msgid "If this policy changes over time, the course will evolve to keep up."
 msgstr ""
+"Si esta política cambia con el tiempo, el curso irá evolucionando para "
+"adaptarse al cambio."
 
 #: src/chromium/build-rules.md
-#, fuzzy
 msgid "Build rules"
-msgstr "Reglas de Compilación (Build)"
+msgstr "Reglas de Compilación (_Build_)"
 
 #: src/chromium/build-rules.md
 msgid ""
@@ -15129,15 +15248,20 @@ msgid ""
 "`ninja` for efficiency --- its static rules allow maximum parallelism. Rust "
 "is no exception."
 msgstr ""
+"El código de Rust se suele compilar con `cargo`. Chromium se compila con "
+"`gn` y `ninja` para aumentar la eficiencia. Sus reglas estáticas permiten el "
+"máximo paralelismo. Rust no es una excepción."
 
 #: src/chromium/build-rules.md
 msgid "Adding Rust code to Chromium"
-msgstr ""
+msgstr "Añadir código de Rust a Chromium"
 
 #: src/chromium/build-rules.md
 msgid ""
 "In some existing Chromium `BUILD.gn` file, declare a `rust_static_library`:"
 msgstr ""
+"En algunos archivos `BUILD.gn` de Chromium, declara una "
+"`rust_static_library`:"
 
 #: src/chromium/build-rules.md
 msgid ""
@@ -15150,12 +15274,22 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```gn\n"
+"import(\"//build/rust/rust_static_library.gni\")\n"
+"\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [ \"lib.rs\" ]\n"
+"}\n"
+"```"
 
 #: src/chromium/build-rules.md
 msgid ""
 "You can also add `deps` on other Rust targets. Later we'll use this to "
 "depend upon third party code."
 msgstr ""
+"También puedes añadir `deps` en otros segmentos de Rust. Más adelante, lo "
+"usaremos en función del código de terceros."
 
 #: src/chromium/build-rules.md
 msgid ""
@@ -15165,12 +15299,19 @@ msgid ""
 "list of all source files which `ninja` needs in order to determine when "
 "rebuilds are necessary."
 msgstr ""
+"Debes especificar _tanto_ la raíz del crate _como_ una lista completa de "
+"recursos. `crate_root` es el archivo proporcionado al compilador de Rust que "
+"representa el archivo raíz de la unidad de compilación, que suele ser `lib."
+"rs`. `sources` es una lista completa de todos los archivos de origen que "
+"necesita `ninja` para determinar cuándo es necesario compilar de nuevo."
 
 #: src/chromium/build-rules.md
 msgid ""
 "(There's no such thing as a Rust `source_set`, because in Rust, an entire "
 "crate is a compilation unit. A `static_library` is the smallest unit.)"
 msgstr ""
+"(No existe `source_set` en Rust porque un crate completo ya es una unidad de "
+"compilación. Una `static_library` es la unidad más pequeña)."
 
 #: src/chromium/build-rules.md
 msgid ""
@@ -15180,10 +15321,16 @@ msgid ""
 "this template provides support for CXX interop, Rust features, and unit "
 "tests, some of which we'll use later."
 msgstr ""
+"Puede que los participantes se pregunten por qué necesitamos una plantilla "
+"gn en vez de usar [la compatibilidad integrada de gn para las bibliotecas "
+"estáticas de Rust](https://gn.googlesource.com/gn/+/main/docs/reference."
+"md#func_static_library). La respuesta es que esta plantilla es compatible "
+"con la interoperabilidad de CXX, las funciones de Rust y las pruebas "
+"unitarias, algunas de las cuales usaremos más adelante."
 
 #: src/chromium/build-rules/unsafe.md
 msgid "Including `unsafe` Rust Code"
-msgstr ""
+msgstr "Incluir código de Rust `unsafe`"
 
 #: src/chromium/build-rules/unsafe.md
 msgid ""
@@ -15192,6 +15339,10 @@ msgid ""
 "the gn target. (Later in the course we'll see circumstances where this is "
 "necessary.)"
 msgstr ""
+"El código de Rust inseguro está prohibido en `rust_static_library` de forma "
+"predeterminada, por lo que no se podrá compilar. Si necesitas código de Rust "
+"inseguro, añade `allow_unsafe = true` al elemento de destino de gn. (Más "
+"adelante en el curso veremos circunstancias en las que es necesario hacerlo)."
 
 #: src/chromium/build-rules/unsafe.md
 msgid ""
@@ -15208,10 +15359,24 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```gn\n"
+"import(\"//build/rust/rust_static_library.gni\")\n"
+"\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [\n"
+"    \"lib.rs\",\n"
+"    \"hippopotamus.rs\"\n"
+"  ]\n"
+"  allow_unsafe = true\n"
+"}\n"
+"```"
 
 #: src/chromium/build-rules/depending.md
 msgid "Simply add the above target to the `deps` of some Chromium C++ target."
 msgstr ""
+"Solo tienes que añadir el elemento de destino que aparece arriba a los "
+"`deps` de algún elemento de destino de Chromium C++."
 
 #: src/chromium/build-rules/depending.md
 msgid ""
@@ -15229,62 +15394,93 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```gn\n"
+"import(\"//build/rust/rust_static_library.gni\")\n"
+"\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [ \"lib.rs\" ]\n"
+"}\n"
+"\n"
+"# or source_set, static_library etc.\n"
+"component(\"preexisting_cpp\") {\n"
+"  deps = [ \":my_rust_lib\" ]\n"
+"}\n"
+"```"
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "Types are elided in Rust code, which makes a good IDE even more useful than "
 "for C++. Visual Studio code works well for Rust in Chromium. To use it,"
 msgstr ""
+"Los tipos se omiten en el código de Rust, lo que hace que un buen IDE sea "
+"aún más útil para C++. El código de Visual Studio funciona bien con Rust en "
+"Chromium. Para utilizarlo, haz lo siguiente:"
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "Ensure your VSCode has the `rust-analyzer` extension, not earlier forms of "
 "Rust support"
 msgstr ""
+"Asegúrate de que VSCode tenga la extensión `rust-analyzer`, no versiones "
+"anteriores de compatibilidad con Rust."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "`gn gen out/Debug --export-rust-project` (or equivalent for your output "
 "directory)"
 msgstr ""
+"`gn gen out/Debug --export-rust-project` (o el equivalente en tu directorio "
+"de salida)."
 
 #: src/chromium/build-rules/vscode.md
 msgid "`ln -s out/Debug/rust-project.json rust-project.json`"
-msgstr ""
+msgstr "`ln -s out/Debug/rust-project.json rust-project.json`."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "A demo of some of the code annotation and exploration features of rust-"
 "analyzer might be beneficial if the audience are naturally skeptical of IDEs."
 msgstr ""
+"Una demo de algunas de las funciones de anotación de código y exploración de "
+"rust-analyzer puede ser útil si los asistentes se muestran escépticos por "
+"los IDE."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "The following steps may help with the demo (but feel free to instead use a "
 "piece of Chromium-related Rust that you are most familiar with):"
 msgstr ""
+"Los siguientes pasos pueden servir de ayuda con la demo (aunque puedes usar "
+"un fragmento de Rust relacionado con Chromium que te resulte más familiar):"
 
 #: src/chromium/build-rules/vscode.md
 msgid "Open `components/qr_code_generator/qr_code_generator_ffi_glue.rs`"
-msgstr ""
+msgstr "Abre `components/qr_code_generator/qr_code_generator_ffi_glue.rs`."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "Place the cursor over the `QrCode::new` call (around line 26) in "
 "\\`qr_code_generator_ffi_glue.rs"
 msgstr ""
+"Coloca el cursor sobre la llamada `QrCode::new` (aproximadamente en la línea "
+"26) en \\`qr_code_generator_ffi_glue.rs."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "Demo **show documentation** (typical bindings: vscode = ctrl k i; vim/CoC = "
 "K)."
 msgstr ""
+"Demo **mostrar la documentación** (enlaces típicos: vscode = ctrl ki; vim/"
+"CoC = K)."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "Demo **go to definition** (typical bindings: vscode = F12; vim/CoC = g d). "
 "(This will take you to `//third_party/rust/.../qr_code-.../src/lib.rs`.)"
 msgstr ""
+"Demo **ir a la definición** (enlaces típicos: vscode = F12; vim/CoC = gd) "
+"(Esta acción te llevará a `//third_party/rust/.../qr_code-.../src/lib.rs`)."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
@@ -15292,12 +15488,17 @@ msgid ""
 "164; the outline is in the file explorer pane in vscode; typical vim/CoC "
 "bindings = space o)"
 msgstr ""
+"Demo **esquema** y desplázate hasta el método `QrCode::with_bits` (en la "
+"línea 164. El esquema se encuentra en el panel del explorador de archivos de "
+"vscode. Enlaces típicos de vim/CoC = espacio o)."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
 "Demo **type annotations** (there are quote a few nice examples in the "
 "`QrCode::with_bits` method)"
 msgstr ""
+"Demo **anotaciones de tipos** (hay varios ejemplos en el método `QrCode::"
+"with_bits`)."
 
 #: src/chromium/build-rules/vscode.md
 msgid ""
@@ -15305,17 +15506,21 @@ msgid ""
 "need to be rerun after editing `BUILD.gn` files (which we will do a few "
 "times throughout the exercises in this session)."
 msgstr ""
+"Es necesario destacar que hay que volver a ejecutar `gn gen ... --export-"
+"rust-project` después de editar los archivos `BUILD.gn` (lo haremos varias "
+"veces a lo largo de los ejercicios de esta sesión)."
 
 #: src/exercises/chromium/build-rules.md
-#, fuzzy
 msgid "Build rules exercise"
-msgstr "Reglas de Compilación (Build)"
+msgstr "Ejercicio de reglas de compilación"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
 "In your Chromium build, add a new Rust target to `//ui/base/BUILD.gn` "
 "containing:"
 msgstr ""
+"En tu compilación de Chromium, añade un nuevo elemento de destino de Rust a "
+"`//ui/base/build.gn` que contenga lo siguiente:"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
@@ -15323,6 +15528,9 @@ msgid ""
 "by the Rust compiler, so you'll need to to allow unsafe code in your `gn` "
 "target."
 msgstr ""
+"**Importante:** Ten en cuenta que `no_mangle` en este caso se considera un "
+"tipo de inseguridad según el compilador de Rust, por lo que tendrás que "
+"permitir código inseguro en el elemento de destino `gn`."
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
@@ -15330,6 +15538,10 @@ msgid ""
 "function at the top of `ui/base/resource/resource_bundle.cc` (later, we'll "
 "see how this can be automated by bindings generation tools):"
 msgstr ""
+"Añade este nuevo elemento de destino de Rust como una dependencia de `//ui/"
+"base:base`. Declara esta función en la parte superior de `ui/base/resource/"
+"resource_bundle.cc` (más adelante veremos cómo se puede automatizar mediante "
+"herramientas de generación de enlaces):"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
@@ -15338,6 +15550,10 @@ msgid ""
 "and run Chromium, and ensure that \"Hello from Rust!\" is printed lots of "
 "times."
 msgstr ""
+"Llama a esta función desde algún lugar de `ui/base/resource/resource_bundle."
+"cc`. Recomendamos hacerlo en la parte superior de `ResourceBundle::"
+"RSMangleLocalizedString`. Compila y ejecuta Chromium y asegúrate de que se "
+"imprima \"¡Rust te manda un saludo!\" muchas veces."
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
@@ -15345,11 +15561,15 @@ msgid ""
 "in subsequent exercises. If you've succeeded, you will be able to use right-"
 "click \"Go to definition\" on `println!`."
 msgstr ""
+"Si usas VSCode, ahora debes configurar Rust para que funcione correctamente "
+"en VSCode. Nos será útil en ejercicios posteriores. Si lo has completado "
+"correctamente, podrás hacer clic con el botón derecho y pulsar \"Ir a la "
+"definición\" en `println!`."
 
 #: src/exercises/chromium/build-rules.md
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Where to find help"
-msgstr ""
+msgstr "Dónde obtener ayuda"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
@@ -15357,30 +15577,41 @@ msgid ""
 "source.chromium.org/chromium/chromium/src/+/main:build/rust/"
 "rust_static_library.gni;l=16)"
 msgstr ""
+"Opciones disponibles de la [plantilla gn `rust_static_library`](https://"
+"source.chromium.org/chromium/chromium/src/+/main:build/rust/"
+"rust_static_library.gni;l=16)"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
 "Information about [`#[no_mangle]`](https://doc.rust-lang.org/beta/reference/"
 "abi.html#the-no_mangle-attribute)"
 msgstr ""
+"Información sobre [`#[no_mangle]`](https://doc.rust-lang.org/beta/reference/"
+"abi.html#the-no_mangle-attribute)"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
 "Information about [`extern \"C\"`](https://doc.rust-lang.org/std/keyword."
 "extern.html)"
 msgstr ""
+"Información sobre [`extern \"C\"`](https://doc.rust-lang.org/std/keyword."
+"extern.html)"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
 "Information about gn's [`--export-rust-project`](https://gn.googlesource.com/"
 "gn/+/main/docs/reference.md#compilation-database) switch"
 msgstr ""
+"Información sobre el interruptor [`--export-rust-project`](https://gn."
+"googlesource.com/gn/+/main/docs/reference.md#compilation-database) de gn"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
 "[How to install rust-analyzer in VSCode](https://code.visualstudio.com/docs/"
 "languages/rust)"
 msgstr ""
+"[Cómo instalar rust-analyzer en VSCode](https://code.visualstudio.com/docs/"
+"languages/rust)"
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
@@ -15389,6 +15620,10 @@ msgid ""
 "call C ABI functions. Later in the course, we'll connect C++ directly to "
 "Rust."
 msgstr ""
+"Este ejemplo no es habitual porque se reduce al lenguaje de "
+"interoperabilidad con el mínimo común denominador, C. Tanto C++ como Rust "
+"pueden declarar y llamar de forma nativa funciones ABI de C. Más adelante, "
+"conectaremos C++ directamente con Rust."
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
@@ -15396,12 +15631,17 @@ msgid ""
 "Rust to generate two functions with the same name, and Rust can no longer "
 "guarantee that the right one is called."
 msgstr ""
+"`allow_unsafe = true` es obligatorio porque `#[no_mangle]` podría permitir "
+"que Rust genere dos funciones con el mismo nombre, y Rust ya no puede "
+"asegurar que se llame a la correcta."
 
 #: src/exercises/chromium/build-rules.md
 msgid ""
 "If you need a pure Rust executable, you can also do that using the "
 "`rust_executable` gn template."
 msgstr ""
+"Si necesitas un ejecutable puro de Rust, también puedes hacerlo con la "
+"plantilla gn `rust_executable`."
 
 #: src/chromium/testing.md
 msgid ""
@@ -15409,6 +15649,9 @@ msgid ""
 "source file as the code being tested. This was covered [earlier](../testing."
 "md) in the course and looks like this:"
 msgstr ""
+"La comunidad de Rust suele crear las pruebas unitarias en un módulo situado "
+"en el mismo archivo fuente que el código que se está probando. Este tema ya "
+"se ha tratado [antes](../testing.md) en el curso y tiene este aspecto:"
 
 #: src/chromium/testing.md
 msgid ""
@@ -15417,17 +15660,25 @@ msgid ""
 "and helps to avoid rebuilding `.rs` files a second time (in the `test` "
 "configuration)."
 msgstr ""
+"En Chromium colocamos las pruebas unitarias en un archivo fuente "
+"independiente y continuamos con esta práctica con Rust. De esta forma, las "
+"pruebas se pueden encontrar de forma coherente y se evita volver a crear "
+"archivos `.rs` (en la configuración `test`)."
 
 #: src/chromium/testing.md
 msgid ""
 "This results in the following options for testing Rust code in Chromium:"
 msgstr ""
+"Esta acción genera las siguientes opciones para probar el código de Rust en "
+"Chromium:"
 
 #: src/chromium/testing.md
 msgid ""
 "Native Rust tests (i.e. `#[test]`). Discouraged outside of `//third_party/"
 "rust`."
 msgstr ""
+"Pruebas nativas de Rust (es decir, `#[test]`). No se recomienda hacerlas "
+"fuera de `//third_party/rust`."
 
 #: src/chromium/testing.md
 msgid ""
@@ -15435,6 +15686,10 @@ msgid ""
 "when Rust code is just a thin FFI layer and the existing unit tests provide "
 "sufficient coverage for the feature."
 msgstr ""
+"Pruebas `gtest` escritas en C++ y ejercicios con Rust mediante llamadas de "
+"FFI. Suficiente cuando el código de Rust es solo una capa fina de FFI y las "
+"pruebas unitarias existentes proporcionan suficiente cobertura para la "
+"función."
 
 #: src/chromium/testing.md
 msgid ""
@@ -15442,6 +15697,9 @@ msgid ""
 "public API (using `pub mod for_testing { ... }` if needed). This is the "
 "subject of the next few slides."
 msgstr ""
+"Pruebas `gtest` creadas en Rust y usando el crate en prueba a través de su "
+"API pública (mediante `pub mod for_testing { ... }` si es necesario). Este "
+"es el tema de las siguientes diapositivas."
 
 #: src/chromium/testing.md
 msgid ""
@@ -15449,12 +15707,17 @@ msgid ""
 "exercised by Chromium bots. (Such testing is needed rarely --- only after "
 "adding or updating third-party crates.)"
 msgstr ""
+"Menciona que los bots de Chromium deberían hacer pruebas nativas de Rust de "
+"crates de terceros tarde o temprano. (Estas pruebas rara vez son necesarias, "
+"solo después de añadir o actualizar crates de terceros)."
 
 #: src/chromium/testing.md
 msgid ""
 "Some examples may help illustrate when C++ `gtest` vs Rust `gtest` should be "
 "used:"
 msgstr ""
+"Algunos ejemplos pueden ayudarte a ilustrar cuándo se debe usar `gtest` de C+"
+"+ o `gtest` de Rust:"
 
 #: src/chromium/testing.md
 msgid ""
@@ -15463,6 +15726,11 @@ msgid ""
 "both the C++ and the Rust implementation (parameterizing the tests so they "
 "enable or disable Rust using a `ScopedFeatureList`)."
 msgstr ""
+"QR cuenta con muy pocas funciones en la capa de Rust propia (solo es un "
+"código pegamento de FFI) y, por lo tanto, utiliza las pruebas unitarias de C+"
+"+ existentes para probar la implementación de C++ y la de Rust "
+"(parametrizando las pruebas de modo que habiliten o inhabiliten Rust "
+"mediante un `ScopedFeatureList`)."
 
 #: src/chromium/testing.md
 msgid ""
@@ -15471,35 +15739,48 @@ msgid ""
 "missing in the `png` crate - e.g. RGBA => BGRA, or gamma correction. Such "
 "functionality may benefit from separate tests authored in Rust."
 msgstr ""
+"La integración hipotética/WIP de PNG puede necesitar una implementación "
+"segura en memoria de las transformaciones de píxeles que proporciona "
+"`libpng` pero que faltan en el crate `png`, como por ejemplo, RGBA => BGRA o "
+"corrección gamma. Dicha función puede beneficiarse de pruebas independientes "
+"creadas en Rust."
 
 #: src/chromium/testing/rust-gtest-interop.md
 msgid ""
 "The [`rust_gtest_interop`](https://chromium.googlesource.com/chromium/src/+/"
 "main/testing/rust_gtest_interop/README.md) library provides a way to:"
 msgstr ""
+"La biblioteca [`rust_gtest_interop`](https://chromium.googlesource.com/"
+"chromium/src/+/main/testing/rust_gtest_interop/README.md) permite hacer lo "
+"siguiente:"
 
 #: src/chromium/testing/rust-gtest-interop.md
 msgid ""
 "Use a Rust function as a `gtest` testcase (using the `#[gtest(...)]` "
 "attribute)"
 msgstr ""
+"Usar una función de Rust como caso de prueba `gtest` (con el atributo "
+"`#[gtest(...)]`)."
 
 #: src/chromium/testing/rust-gtest-interop.md
 msgid ""
 "Use `expect_eq!` and similar macros (similar to `assert_eq!` but not "
 "panicking and not terminating the test when the assertion fails)."
 msgstr ""
+"Usar `expect_eq!` y macros similares (similares a `assert_eq!`, pero sin que "
+"se produzcan pánicos o sin finalizar la prueba cuando la aserción falle)."
 
 #: src/chromium/testing/rust-gtest-interop.md
-#, fuzzy
 msgid "Example:"
-msgstr "Ejemplo"
+msgstr "Ejemplo:"
 
 #: src/chromium/testing/build-gn.md
 msgid ""
 "The simplest way to build Rust `gtest` tests is to add them to an existing "
 "test binary that already contains tests authored in C++. For example:"
 msgstr ""
+"La forma más sencilla de compilar pruebas `gtest` de Rust es añadirlas a un "
+"binario de prueba que ya contenga pruebas creadas en C++. Por ejemplo:"
 
 #: src/chromium/testing/build-gn.md
 msgid ""
@@ -15511,12 +15792,22 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```gn\n"
+"test(\"ui_base_unittests\") {\n"
+"  ...\n"
+"  sources += [ \"my_rust_lib_unittest.rs\" ]\n"
+"  deps += [ \":my_rust_lib\" ]\n"
+"}\n"
+"```"
 
 #: src/chromium/testing/build-gn.md
 msgid ""
 "Authoring Rust tests in a separate `static_library` also works, but requires "
 "manually declaring the dependency on the support libraries:"
 msgstr ""
+"La creación de pruebas de Rust en una `static_library` independiente también "
+"funciona, pero es necesario declarar manualmente la dependencia en las "
+"bibliotecas de compatibilidad:"
 
 #: src/chromium/testing/build-gn.md
 msgid ""
@@ -15538,6 +15829,23 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```gn\n"
+"rust_static_library(\"my_rust_lib_unittests\") {\n"
+"  testonly = true\n"
+"  is_gtest_unittests = true\n"
+"  crate_root = \"my_rust_lib_unittest.rs\"\n"
+"  sources = [ \"my_rust_lib_unittest.rs\" ]\n"
+"  deps = [\n"
+"    \":my_rust_lib\",\n"
+"    \"//testing/rust_gtest_interop\",\n"
+"  ]\n"
+"}\n"
+"\n"
+"test(\"ui_base_unittests\") {\n"
+"  ...\n"
+"  deps += [ \":my_rust_lib_unittests\" ]\n"
+"}\n"
+"```"
 
 #: src/chromium/testing/chromium-import-macro.md
 msgid ""
@@ -15548,14 +15856,22 @@ msgid ""
 "working with such an unwieldy name by using the `chromium::import!` macro "
 "from the automatically-imported `chromium` crate:"
 msgstr ""
+"Después de añadir `:my_rust_lib` a GN `deps`, tenemos que aprender a "
+"importar y usar `my_rust_lib` desde `my_rust_lib_unittest.rs`. No hemos "
+"proporcionado un `crate_name` explícito para `my_rust_lib`, por lo que el "
+"nombre del crate se calcula en función de la ruta y el nombre de destino "
+"completos. Por suerte, podemos evitar trabajar con un nombre tan poco "
+"práctico usando la macro `chromium::import!` del crate `chromium` importado "
+"automáticamente:"
 
 #: src/chromium/testing/chromium-import-macro.md
 msgid "\"//ui/base:my_rust_lib\""
-msgstr ""
+msgstr "\"//ui/base:my_rust_lib\""
 
 #: src/chromium/testing/chromium-import-macro.md
 msgid "Under the covers the macro expands to something similar to:"
 msgstr ""
+"En un segundo plano, la macro se expande a algo parecido a lo siguiente:"
 
 #: src/chromium/testing/chromium-import-macro.md
 msgid ""
@@ -15564,6 +15880,10 @@ msgid ""
 "chromium_prelude.rs?q=f:chromium_prelude.rs%20pub.use.*%5Cbimport%5Cb;%20-f:"
 "third_party&ss=chromium%2Fchromium%2Fsrc) of the `chromium::import` macro."
 msgstr ""
+"Puedes obtener más información en [el comentario del documento](https://"
+"source.chromium.org/chromium/chromium/src/+/main:build/rust/chromium_prelude/"
+"chromium_prelude.rs?q=f:chromium_prelude.rs%20pub.use.*%5Cbimport%5Cb;%20-f:"
+"third_party&ss=chromium%2Fchromium%2Fsrc) de la macro `chromium::import`."
 
 #: src/chromium/testing/chromium-import-macro.md
 msgid ""
@@ -15573,19 +15893,24 @@ msgid ""
 "crate names so `cargo_crate` GN targets (generated by the `gnrt` tool "
 "covered in a later section) use short crate names."
 msgstr ""
+"`rust_static_library` permite especificar un nombre explícito mediante la "
+"propiedad `crate_name`, pero no se recomienda hacerlo. El motivo es porque "
+"el nombre del crate debe ser único en todo el mundo. crates.io garantiza la "
+"exclusividad de sus nombres de crate, de modo que los elementos de destino "
+"de GN `cargo_crate` (generados por la herramienta `gnrt` que se explican en "
+"una sección posterior) usan nombres de crate cortos."
 
 #: src/exercises/chromium/testing.md
-#, fuzzy
 msgid "Testing exercise"
-msgstr "Rust on Exercism"
+msgstr "Ejercicio de pruebas"
 
 #: src/exercises/chromium/testing.md
 msgid "Time for another exercise!"
-msgstr ""
+msgstr "¡Vamos a hacer otro ejercicio!"
 
 #: src/exercises/chromium/testing.md
 msgid "In your Chromium build:"
-msgstr ""
+msgstr "En tu compilación de Chromium:"
 
 #: src/exercises/chromium/testing.md
 msgid ""
@@ -15593,18 +15918,25 @@ msgid ""
 "two integers received as arguments, computing the nth Fibonacci number, "
 "summing integers in a slice, etc."
 msgstr ""
+"Añade una función que se pueda probar junto a `hello_from_rust`. Aquí tienes "
+"algunas sugerencias: añadir dos números enteros recibidos como argumentos, "
+"calcular el enésimo número de la serie Fibonacci, sumar los enteros en un "
+"slice, etc."
 
 #: src/exercises/chromium/testing.md
 msgid "Add a separate `..._unittest.rs` file with a test for the new function."
 msgstr ""
+"Añade un archivo `..._unittest.rs` independiente con una prueba de la nueva "
+"función."
 
 #: src/exercises/chromium/testing.md
 msgid "Add the new tests to `BUILD.gn`."
-msgstr ""
+msgstr "Añade las nuevas pruebas a `BUILD.gn`."
 
 #: src/exercises/chromium/testing.md
 msgid "Build the tests, run them, and verify that the new test works."
 msgstr ""
+"Compila las pruebas, ejecútalas y comprueba que la nueva prueba funciona."
 
 #: src/chromium/interoperability-with-cpp.md
 msgid ""
@@ -15612,6 +15944,9 @@ msgid ""
 "tools being developed all the time. At the moment, Chromium uses a tool "
 "called CXX."
 msgstr ""
+"La comunidad de Rust ofrece muchas opciones para la interoperabilidad de C++ "
+"y Rust, y continuamente se están desarrollando nuevas herramientas. "
+"Actualmente, Chromium usa la herramienta CXX."
 
 #: src/chromium/interoperability-with-cpp.md
 msgid ""
@@ -15619,9 +15954,11 @@ msgid ""
 "language (which looks a lot like Rust) and then CXX tools generate "
 "declarations for functions and types in both Rust and C++."
 msgstr ""
+"Describe todos los límites de tu lenguaje en un lenguaje de definición de "
+"interfaz (que se parece mucho a Rust) y, a continuación, las herramientas "
+"CXX generarán declaraciones de funciones y tipos tanto en Rust como en C++."
 
 #: src/chromium/interoperability-with-cpp.md
-#, fuzzy
 msgid ""
 "See the [CXX tutorial](https://cxx.rs/tutorial.html) for a full example of "
 "using this."
@@ -15635,6 +15972,9 @@ msgid ""
 "the same as you previously did. Point out that automating the process has "
 "the following benefits:"
 msgstr ""
+"Aclara el diagrama. Explica que, en segundo plano, esto hace lo mismo que "
+"hemos hecho antes. Señala que automatizar el proceso supone las siguientes "
+"ventajas:"
 
 #: src/chromium/interoperability-with-cpp.md
 msgid ""
@@ -15643,6 +15983,10 @@ msgid ""
 "definitions, but with out-of-sync manual bindings you'd get Undefined "
 "Behavior)"
 msgstr ""
+"La herramienta asegura que C++ y Rust coincidan (por ejemplo, se producen "
+"errores de compilación si `#[cxx::bridge]` no coincide con las definiciones "
+"de C++ o Rust reales, pero con enlaces manuales no sincronizados, se "
+"obtendría un comportamiento no definido)"
 
 #: src/chromium/interoperability-with-cpp.md
 msgid ""
@@ -15651,10 +15995,17 @@ msgid ""
 "methods; manual bindings would require authoring such top-level, free "
 "functions manually)"
 msgstr ""
+"La herramienta automatiza la generación de thunks FFI (funciones pequeñas, "
+"compatibles con la ABI de C y gratuitas) para funciones que no son de C (por "
+"ejemplo, habilitar llamadas de FFI en métodos de Rust o C++. Los enlaces "
+"manuales requerirían la creación manual de estas funciones gratuitas de "
+"nivel superior)."
 
 #: src/chromium/interoperability-with-cpp.md
 msgid "The tool and the library can handle a set of core types - for example:"
 msgstr ""
+"La herramienta y la biblioteca pueden gestionar un conjunto de tipos "
+"principales, como por ejemplo:"
 
 #: src/chromium/interoperability-with-cpp.md
 msgid ""
@@ -15664,6 +16015,11 @@ msgid ""
 "pointer and length - this is error-prone given that each language represents "
 "empty slices slightly differently)"
 msgstr ""
+"`&[T]` se puede transferir a través del límite de FFI, aunque no garantiza "
+"ningún diseño concreto de ABI o de memoria. Con los enlaces manuales, `std::"
+"span<T>` y `&[T]` se tienen que desestructurar manualmente y compilarlos a "
+"partir de un puntero y una longitud. Esto suele acarrear errores, ya que "
+"cada lenguaje representa los slices vacíos de forma ligeramente distinta."
 
 #: src/chromium/interoperability-with-cpp.md
 msgid ""
@@ -15672,6 +16028,10 @@ msgid ""
 "compatible raw pointers, which would increase lifetime and memory-safety "
 "risks."
 msgstr ""
+"Los punteros inteligentes como `std::unique_ptr<T>`, `std::shared_ptr<T>` o "
+"`Box` se admiten de forma nativa. Con los enlaces manuales, sería necesario "
+"pasar punteros sin formato compatibles con ABI de C, lo que aumentaría los "
+"riesgos de tiempo de vida y de seguridad en la memoria."
 
 #: src/chromium/interoperability-with-cpp.md
 msgid ""
@@ -15680,24 +16040,32 @@ msgid ""
 "build a Rust string from non-UTF8 input and `rust::String::c_str` can NUL-"
 "terminate a string)."
 msgstr ""
+"Los tipos `rust::String` y `CxxString` entienden y mantienen las diferencias "
+"en la representación de cadenas en los distintos lenguajes (por ejemplo, "
+"`rust::String::lossy` puede crear una cadena de Rust a partir de una entrada "
+"que no sea UTF8 y `rust::String::: c_str` puede terminar una cadena con un "
+"carácter nulo)."
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid ""
 "CXX requires that the whole C++/Rust boundary is declared in `cxx::bridge` "
 "modules inside `.rs` source code."
 msgstr ""
+"CXX necesita que se declare todo el límite de C++ o Rust en los módulos "
+"`cxx::bridge` del código fuente `.rs`."
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "\"example/include/blobstore.h\""
-msgstr ""
+msgstr "\"example/include/blobstore.h\""
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "// Definitions of Rust types and functions go here\n"
 msgstr ""
+"// Las definiciones de los tipos y las funciones de Rust se colocan aquí\n"
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Point out:"
-msgstr ""
+msgstr "Señala lo siguiente:"
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid ""
@@ -15706,23 +16074,26 @@ msgid ""
 "bit more sophisticated - though this does still result in a `mod` called "
 "`ffi` in your code."
 msgstr ""
+"Aunque parece un `mod` de Rust habitual, la macro de procedimiento `#[cxx::"
+"bridge]` es capaz de desempeñar tareas complejas. El código generado es "
+"bastante más sofisticado, aunque aun así da como resultado un `mod` llamado "
+"`ffi` en el código."
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Native support for C++'s `std::unique_ptr` in Rust"
-msgstr ""
+msgstr "Compatibilidad nativa con `std::unique_ptr` de C++ en Rust."
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
-#, fuzzy
 msgid "Native support for Rust slices in C++"
-msgstr "Asistencia integrada para pruebas."
+msgstr "Compatibilidad nativa con los slices de Rust en C++."
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Calls from C++ to Rust, and Rust types (in the top part)"
-msgstr ""
+msgstr "Llamadas de C++ a Rust y tipos de Rust (en la parte superior)."
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Calls from Rust to C++, and C++ types (in the bottom part)"
-msgstr ""
+msgstr "Llamadas de Rust a C++ y tipos de C++ (en la parte inferior)."
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid ""
@@ -15731,6 +16102,9 @@ msgid ""
 "simply `#include`d in the generated C++ code for the benefit of C++ "
 "compilers."
 msgstr ""
+"**Error común**: _Parece_ que Rust está analizando un encabezado de C++, "
+"pero no es así. Rust nunca interpreta este encabezado, sino que simplifica "
+"`#include`d en el código C++ generado para ayudar a los compiladores de C++."
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 #, fuzzy
@@ -15743,25 +16117,31 @@ msgstr ""
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "CXX fundamentally suits cases where:"
-msgstr ""
+msgstr "CXX se adapta básicamente a los casos en los que:"
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "Your Rust-C++ interface is sufficiently simple that you can declare all of "
 "it."
 msgstr ""
+"La interfaz de Rust-C++ es lo suficientemente sencilla como para se pueda "
+"declarar por completo."
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "You're using only the types natively supported by CXX already, for example "
 "`std::unique_ptr`, `std::string`, `&[u8]` etc."
 msgstr ""
+"Solo estás usando los tipos compatibles de forma nativa con CXX, como `std::"
+"unique_ptr`, `std::string` o `&[u8]`, entre otros."
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "It has many limitations --- for example lack of support for Rust's `Option` "
 "type."
 msgstr ""
+"Tiene muchas limitaciones, por ejemplo, la falta de compatibilidad con el "
+"tipo `Option` de Rust."
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
@@ -15771,47 +16151,65 @@ msgid ""
 "draft the CXX bindings for the language boundary to see if it appears simple "
 "enough."
 msgstr ""
+"Estas restricciones nos limitan a usar Rust en Chromium solo para \"nodos "
+"hoja\" muy aislados, en lugar de para la interoperabilidad arbitraria de "
+"Rust-C++. Si te planteas un caso práctico de Rust en Chromium, un buen punto "
+"de partida es hacer un borrador de los enlaces de CXX para el límite del "
+"lenguaje para ver si te parece lo suficientemente sencillo."
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "You should also discuss some of the other sticky points with CXX, for "
 "example:"
 msgstr ""
+"También debes hablar de algunos de los otros aspectos delicados con CXX, "
+"como los siguientes:"
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "Its error handling is based around C++ exceptions (given on the next slide)"
 msgstr ""
+"Su gestión de errores se basa en las excepciones de C++ (como se muestra en "
+"la siguiente diapositiva)."
 
 #: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "Function pointers are awkward to use."
-msgstr ""
+msgstr "Los punteros de función no son muy fáciles de usar."
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "CXX's [support for `Result<T,E>`](https://cxx.rs/binding/result.html) relies "
 "on C++ exceptions, so we can't use that in Chromium. Alternatives:"
 msgstr ""
+"La [compatibilidad con `Result<T,E>`](https://cxx.rs/binding/result.html) de "
+"CXX se basa en excepciones de C++, por lo que no podemos usarlo en Chromium. "
+"Alternativas:"
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid "The `T` part of `Result<T, E>` can be:"
-msgstr ""
+msgstr "La parte `T` de `Result<T, E>` puede:"
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "Returned via out parameters (e.g. via `&mut T`). This requires that `T` can "
 "be passed across the FFI boundary - for example `T` has to be:"
 msgstr ""
+"Devolverse a través de parámetros externos (por ejemplo, mediante `&mut T`). "
+"Esto requiere que `T` se pueda transferir a través del límite de FFI. Por "
+"ejemplo, `T` tiene que ser:"
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid "A primitive type (like `u32` or `usize`)"
-msgstr ""
+msgstr "Un tipo primitivo (como `u32` o `usize`)."
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "A type natively supported by `cxx` (like `UniquePtr<T>`) that has a suitable "
 "default value to use in a failure case (_unlike_ `Box<T>`)."
 msgstr ""
+"Un tipo compatible de forma nativa con `cxx` (como `UniquePtr<T>`) que tiene "
+"un valor predeterminado adecuado para usarlo en caso de fallo (_a diferencia "
+"de_ `Box<T>`)."
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
@@ -15819,27 +16217,33 @@ msgid ""
 "when `T` is a Rust type, which cannot be passed across the FFI boundary, and "
 "cannot be stored in `UniquePtr<T>`."
 msgstr ""
+"Mantenerse en el lado de Rust y mostrarse mediante referencia. Esto puede "
+"ser necesario cuando `T` es un tipo de Rust, que no se puede transmitir "
+"mediante el límite de FFI ni se puede almacenar en `UniquePtr<T>`."
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid "The `E` part of `Result<T, E>` can be:"
-msgstr ""
+msgstr "La parte `E` de `Result<T, E>` puede:"
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "Returned as a boolean (e.g. `true` representing success, and `false` "
 "representing failure)"
 msgstr ""
+"Devolverse como un valor booleano (por ejemplo, `true` representa el éxito y "
+"`false` representa el error)."
 
 #: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "Preserving error details is in theory possible, but so far hasn't been "
 "needed in practice."
 msgstr ""
+"En teoría, es posible conservar los detalles de los errores, pero hasta "
+"ahora no se ha necesitado en la práctica."
 
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
-#, fuzzy
 msgid "CXX Error Handling: QR Example"
-msgstr "Manejo de Errores"
+msgstr "Manejo de Errores en CXX: Ejemplo de QR"
 
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
@@ -15849,10 +16253,16 @@ msgid ""
 "used to communicate success vs failure, and where the successful result can "
 "be passed across the FFI boundary:"
 msgstr ""
+"El generador de código QR es [un ejemplo](https://source.chromium.org/"
+"chromium/chromium/src/+/main:components/qr_code_generator/"
+"qr_code_generator_ffi_glue.rs;l=13-18;"
+"drc=7bf1b75b910ca430501b9c6a74c1d18a0223ecca) en el que el valor booleano se "
+"utiliza para comunicar que el resultado es correcto o no, y dónde se puede "
+"transmitir el resultado correcto a través del límite de FFI:"
 
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid "\"qr_code_generator\""
-msgstr ""
+msgstr "\"qr_code_generator\""
 
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
@@ -15861,6 +16271,10 @@ msgid ""
 "admittedly it is a bit redundant - this is the square root of the size of "
 "the vector)."
 msgstr ""
+"Puede que los participantes sientan curiosidad acerca de la semántica del "
+"resultado de salida `out_qr_size`. No se trata del tamaño del vector, sino "
+"del tamaño del código QR (y admitimos que es un poco redundante, ya que se "
+"trata de la raíz cuadrada del tamaño del vector)."
 
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
@@ -15869,6 +16283,11 @@ msgid ""
 "points to uninitialized memory results in Undefined Behavior (unlike in C++, "
 "when only the act of dereferencing such memory results in UB)."
 msgstr ""
+"Cabe destacar la importancia de inicializar `out_qr_size` antes de llamar a "
+"la función de Rust. La creación de una referencia de Rust que apunte a una "
+"memoria no inicializada tiene como resultado un comportamiento indefinido (a "
+"diferencia de C++, cuando solo el acto de desreferenciar la memoria resulta "
+"en comportamiento indefinido)."
 
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
@@ -15876,6 +16295,10 @@ msgid ""
 "references to C++ data: the answer is that C++ data can’t be moved around "
 "like Rust data, because it may contain self-referential pointers."
 msgstr ""
+"Si los participantes preguntan por `Pin`, explica por qué CXX lo necesita "
+"para referencias mutables a datos de C++. Los datos de C++ no se pueden "
+"mover como los datos de Rust, ya que pueden contener punteros de "
+"autorreferencia."
 
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
 #, fuzzy
@@ -15887,24 +16310,28 @@ msgid ""
 "A prototype of a PNG decoder illustrates what can be done when the "
 "successful result cannot be passed across the FFI boundary:"
 msgstr ""
+"Un prototipo de un decodificador PNG ilustra lo que se puede hacer cuando el "
+"resultado correcto no se puede transmitir a través del límite de FFI:"
 
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "\"gfx::rust_bindings\""
-msgstr ""
+msgstr "\"gfx::rust_bindings\""
 
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid ""
 "/// This returns an FFI-friendly equivalent of `Result<PngReader<'a>,\n"
 "        /// ()>`.\n"
 msgstr ""
+"/// Esto devuelve un equivalente de `Result<PngReader<'a>,\n"
+"        /// ()>`, compatible con FFI.\n"
 
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "/// C++ bindings for the `crate::png::ResultOfPngReader` type.\n"
-msgstr ""
+msgstr "/// Enlaces de C++ para el tipo `crate::png::ResultOfPngReader`.\n"
 
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "/// C++ bindings for the `crate::png::PngReader` type.\n"
-msgstr ""
+msgstr "/// Enlaces de C++ para el tipo `crate::png::PngReader`.\n"
 
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid ""
@@ -15913,6 +16340,10 @@ msgid ""
 "can't have an `out_parameter: &mut PngReader`, because CXX doesn't allow C++ "
 "to store Rust objects by value."
 msgstr ""
+"`PngReader` y `ResultOfPngReader` son tipos de Rust. Los objetos de estos "
+"tipos no pueden cruzar el límite de FFI sin la indirección de un `Box<T>`. "
+"No se puede tener un `out_parameter: &mut PngReader`, ya que CXX no permite "
+"que C++ almacene objetos de Rust por valor."
 
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid ""
@@ -15923,10 +16354,16 @@ msgid ""
 "appropriate methods of `Result<T, E>` (e.g. into `is_err`, `unwrap`, and/or "
 "`as_mut`)."
 msgstr ""
+"Este ejemplo ilustra que, aunque CXX no es compatible con plantillas ni "
+"genéricos arbitrarios, podemos transmitirlos a través de los límites de FFI "
+"si los especializamos de forma manual o los monomorfizamos en un tipo no "
+"genérico. En el ejemplo, `ResultOfPngReader` es un tipo no genérico que "
+"redirige los métodos adecuados de `Result<T, E>` (por ejemplo, a `is_err`, "
+"`unwrap` o `as_mut`)."
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "Using cxx in Chromium"
-msgstr ""
+msgstr "Usar cxx en Chromium"
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
@@ -15934,6 +16371,9 @@ msgid ""
 "node where we want to use Rust. You'd typically have one for each "
 "`rust_static_library`. Just add"
 msgstr ""
+"En Chromium, definimos un `#[cxx::bridge] mod` independiente para cada nodo "
+"hoja en el que queremos usar Rust. Normalmente hay uno por cada "
+"`rust_static_library`. Solo tienes que añadir"
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
@@ -15943,20 +16383,29 @@ msgid ""
 "allow_unsafe = true\n"
 "```"
 msgstr ""
+"```gn\n"
+"cxx_bindings = [ \"my_rust_file.rs\" ]\n"
+"   # list of files containing #[cxx::bridge], not all source files\n"
+"allow_unsafe = true\n"
+"```"
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
 "to your existing `rust_static_library` target alongside `crate_root` and "
 "`sources`."
 msgstr ""
+"al elemento `rust_static_library` que ya tengas junto con `crate_root` y "
+"`sources`."
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "C++ headers will be generated at a sensible location, so you can just"
 msgstr ""
+"Los encabezados de C++ se generarán en una ubicación razonable, por lo que "
+"puedes simplemente incluir"
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "\"ui/base/my_rust_file.rs.h\""
-msgstr ""
+msgstr "\"ui/base/my_rust_file.rs.h\""
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
@@ -15965,10 +16414,16 @@ msgid ""
 "source.chromium.org/chromium/chromium/src/+/main:base/containers/span_rust.h;"
 "l=21)."
 msgstr ""
+"Encontrarás algunas funciones de utilidad en `//base` para convertir a y "
+"desde los tipos de Chromium C++ en tipos CXX de Rust y viceversa. Por "
+"ejemplo, [`SpanToRustSlice`](https://source.chromium.org/chromium/chromium/"
+"src/+/main:base/containers/span_rust.h;l=21)."
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "Students may ask --- why do we still need `allow_unsafe = true`?"
 msgstr ""
+"Los participantes pueden preguntarse: \"¿por qué sigue siendo necesario "
+"`allow_unsafe = true`?\""
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
@@ -15980,6 +16435,15 @@ msgid ""
 "writing/the-cxx-debate), but strictly, bringing any foreign code into a Rust "
 "binary can cause unexpected behavior from Rust's perspective."
 msgstr ""
+"La respuesta es que ningún código de C o C++ es \"seguro\" según los "
+"estándares normales de Rust. Si se llama a C o C++ desde Rust, se pueden "
+"llevar a cabo acciones arbitrarias en la memoria y se puede poner en peligro "
+"la seguridad de los propios diseños de datos de Rust. La presencia de "
+"_demasiadas_ palabras clave `unsafe` en la interoperabilidad de C o C++ "
+"puede perjudicar la relación señal-ruido de dicha palabra clave, algo "
+"[polémico](https://steveklabnik.com/writing/the-cxx-debate). No obstante, en "
+"términos estrictos, introducir código externo en un binario de Rust puede "
+"provocar un comportamiento inesperado desde el punto de vista de Rust."
 
 #: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
@@ -15988,15 +16452,18 @@ msgid ""
 "`unsafe` and `extern \"C\"` functions just like we did manually in the "
 "previous section."
 msgstr ""
+"La respuesta exacta se encuentra en el diagrama de la parte superior de "
+"[esta página](../Interop-with-cpp.md): en segundo plano, CXX genera "
+"funciones de Rust `unsafe` y `extern \"C\"`, igual que hicimos de forma "
+"manual en la sección anterior."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
-#, fuzzy
 msgid "Exercise: Interoperability with C++"
-msgstr "Interoperabilidad con C"
+msgstr "Ejercicio: Interoperabilidad con C++"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Part one"
-msgstr ""
+msgstr "Primera parte"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
@@ -16004,51 +16471,62 @@ msgid ""
 "specifies a single function, to be called from C++, called "
 "`hello_from_rust`, taking no parameters and returning no value."
 msgstr ""
+"En el archivo de Rust que has creado anteriormente, añade un `#[cxx::"
+"bridge]`, que especifica una sola función, denominada `hello_from_rust`, a "
+"la que se llamará desde C++, sin parámetros y sin devolver ningún valor."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Modify your previous `hello_from_rust` function to remove `extern \"C\"` and "
 "`#[no_mangle]`. This is now just a standard Rust function."
 msgstr ""
+"Modifica la función `hello_from_rust` anterior para eliminar `extern \"C\"` "
+"y `#[no_mangle]`. Ahora es solo una función estándar de Rust."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Modify your `gn` target to build these bindings."
-msgstr ""
+msgstr "Modifica el elemento de destino de `gn` para compilar estos enlaces."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "In your C++ code, remove the forward-declaration of `hello_from_rust`. "
 "Instead, include the generated header file."
 msgstr ""
+"En el código C++, elimina la declaración de `hello_from_rust`. En su lugar, "
+"incluye el archivo de encabezado que se ha generado."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Build and run!"
-msgstr ""
+msgstr "Compila y ejecuta."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Part two"
-msgstr ""
+msgstr "Segunda parte"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "It's a good idea to play with CXX a little. It helps you think about how "
 "flexible Rust in Chromium actually is."
 msgstr ""
+"Se recomienda jugar un poco con CXX, ya que nos ayuda a pensar en la "
+"flexibilidad que tiene Rust en Chromium."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
-#, fuzzy
 msgid "Some things to try:"
-msgstr "Algunas notas:"
+msgstr "Algunas cosas que probar:"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Call back into C++ from Rust. You will need:"
-msgstr ""
+msgstr "Vuelve a llamar a C++ desde Rust. Necesitarás lo siguiente:"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "An additional header file which you can `include!` from your `cxx::bridge`. "
 "You'll need to declare your C++ function in that new header file."
 msgstr ""
+"Un archivo de encabezado adicional que puedes `include!` desde tu `cxx::"
+"bridge`. Deberás declarar la función de C++ en el nuevo archivo de "
+"encabezado."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
@@ -16056,56 +16534,70 @@ msgid ""
 "`unsafe` keyword in your `#[cxx::bridge]` [as described here](https://cxx.rs/"
 "extern-c++.html#functions-and-member-functions)."
 msgstr ""
+"Un bloque `unsafe` para llamar a una función de este tipo, o bien "
+"especificar la palabra clave `unsafe` en el `#[cxx::bridge]`, [como se "
+"describe aquí](https://cxx.rs/extern-c++.html#functions-and-member-"
+"functions)."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "You may also need to `#include \"third_party/rust/cxx/v1/crate/include/cxx."
 "h\"`"
 msgstr ""
+"Es posible que también tengas que incluir `#include \"third_party/rust/cxx/"
+"v1/crate/include/cxx.h\"`"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Pass a C++ string from C++ into Rust."
-msgstr ""
+msgstr "Transfiere una cadena de C++ desde C++ a Rust."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Pass a reference to a C++ object into Rust."
-msgstr ""
+msgstr "Pasa una referencia a un objeto de C++ en Rust."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Intentionally get the Rust function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
+"Obtén de forma intencional las firmas de la función de Rust que no coincidan "
+"con el `#[cxx::bridge]` y familiarízate con los errores que veas."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Intentionally get the C++ function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
+"Obtén de forma intencional las firmas de la función de C++ que no coincidan "
+"con el `#[cxx::bridge]` y familiarízate con los errores que veas."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Pass a `std::unique_ptr` of some type from C++ into Rust, so that Rust can "
 "own some C++ object."
 msgstr ""
+"Transfiere un `std::unique_ptr` de algún tipo de C++ a Rust, para que a Rust "
+"le pertenezca algún objeto de C++."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Create a Rust object and pass it into C++, so that C++ owns it. (Hint: you "
 "need a `Box`)."
 msgstr ""
+"Crea un objeto de Rust y transmítelo a C++ para que sea su propietario. "
+"(Nota: necesitas utilizar un `Box`)."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Declare some methods on a C++ type. Call them from Rust."
-msgstr ""
+msgstr "Declara algunos métodos en un tipo de C++. Llámalos desde Rust."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Declare some methods on a Rust type. Call them from C++."
-msgstr ""
+msgstr "Declara algunos métodos en un tipo de Rust. Llámalos desde C++."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Part three"
-msgstr ""
+msgstr "Tercera parte"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
@@ -16113,6 +16605,10 @@ msgid ""
 "couple of use-cases for Rust in Chromium where the interface would be "
 "sufficiently simple. Sketch how you might define that interface."
 msgstr ""
+"Ahora que conoces los puntos fuertes y las limitaciones de la "
+"interoperabilidad de CXX, piensa en un par de casos prácticos de Rust en "
+"Chromium en los que la interfaz sea bastante sencilla. Haz un boceto sobre "
+"cómo definirías esa interfaz."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 #, fuzzy
@@ -16126,10 +16622,12 @@ msgid ""
 "The [`rust_static_library` gn template](https://source.chromium.org/chromium/"
 "chromium/src/+/main:build/rust/rust_static_library.gni;l=16)"
 msgstr ""
+"La [plantilla gn `rust_static_library`](https://source.chromium.org/chromium/"
+"chromium/src/+/main:build/rust/rust_static_library.gni;l=16)"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Some of the questions you may encounter:"
-msgstr ""
+msgstr "Estas son algunas de las preguntas que pueden surgir:"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
@@ -16137,6 +16635,9 @@ msgid ""
 "and Y are both function types. This is because your C++ function doesn't "
 "quite match the declaration in your `cxx::bridge`."
 msgstr ""
+"Veo un problema al inicializar una variable de tipo X con el tipo Y, donde X "
+"e Y son tipos de funciones. Esto se debe a que la función de C++ no coincide "
+"exactamente con la declaración de `cxx::bridge`."
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
@@ -16145,6 +16646,12 @@ msgid ""
 "sized. For CXX trivial types yes, it's _possible_ to cause UB, although "
 "CXX's design makes it quite difficult to craft such an example."
 msgstr ""
+"Parece que puedo convertir libremente referencias de C++ en referencias de "
+"Rust. ¿Eso no supone ningún riesgo de comportamiento indefinido? En el caso "
+"de los tipos _opacos_ de CXX, no, porque su tamaño es cero. Sí supondría un "
+"problema de comportamiento indefinido en el caso de los tipos triviales de "
+"CXX, aunque el diseño de CXX hace que sea bastante difícil crear un ejemplo "
+"así."
 
 #: src/chromium/adding-third-party-crates.md
 msgid ""
@@ -16152,86 +16659,89 @@ msgid ""
 "crates.io). It's _very easy_ for Rust crates to depend upon one another. So "
 "they do!"
 msgstr ""
+"Las bibliotecas de Rust se llaman \"crates\" y se encuentran en [crates.io]"
+"(https://crates.io). _Es habitual_ que los crates de Rust dependen los unos "
+"de otros."
 
 #: src/chromium/adding-third-party-crates.md
-#, fuzzy
 msgid "C++ library"
-msgstr "Biblioteca"
+msgstr "Biblioteca C++"
 
 #: src/chromium/adding-third-party-crates.md
-#, fuzzy
 msgid "Rust crate"
-msgstr "Ecosistema Rust"
+msgstr "Crate de Rust"
 
 #: src/chromium/adding-third-party-crates.md
-#, fuzzy
 msgid "Build system"
-msgstr "Ecosistema Rust"
+msgstr "Sistema de compilación"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "Lots"
-msgstr ""
+msgstr "Muchos"
 
 #: src/chromium/adding-third-party-crates.md
-#, fuzzy
 msgid "Consistent: `Cargo.toml`"
-msgstr "`Cargo.toml`:"
+msgstr "Consistente: `Cargo.toml`"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "Typical library size"
-msgstr ""
+msgstr "Tamaño habitual de la biblioteca"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "Large-ish"
-msgstr ""
+msgstr "Grande"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "Small"
-msgstr ""
+msgstr "Pequeño"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "Transitive dependencies"
-msgstr ""
+msgstr "Dependencias transitivas"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "Few"
-msgstr ""
+msgstr "Pocos"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "For a Chromium engineer, this has pros and cons:"
-msgstr ""
+msgstr "Para un ingeniero de Chromium, existen ventajas e inconvenientes:"
 
 #: src/chromium/adding-third-party-crates.md
 msgid ""
 "All crates use a common build system so we can automate their inclusion into "
 "Chromium..."
 msgstr ""
+"Todos los crates usan un sistema de compilación común, así que podemos "
+"automatizar su inclusión en Chromium..."
 
 #: src/chromium/adding-third-party-crates.md
 msgid ""
 "... but, crates typically have transitive dependencies, so you will likely "
 "have to bring in multiple libraries."
 msgstr ""
+"... pero los crates suelen tener dependencias transitivas, por lo que es "
+"probable que tengas que introducir varias bibliotecas."
 
 #: src/chromium/adding-third-party-crates.md
 msgid "We'll discuss:"
-msgstr ""
+msgstr "Hablaremos sobre los siguientes temas:"
 
 #: src/chromium/adding-third-party-crates.md
 msgid "How to put a crate in the Chromium source code tree"
-msgstr ""
+msgstr "Cómo colocar un crate en el árbol de código fuente de Chromium."
 
 #: src/chromium/adding-third-party-crates.md
 msgid "How to make `gn` build rules for it"
-msgstr ""
+msgstr "Cómo aplicarle reglas de compilación `gn`."
 
 #: src/chromium/adding-third-party-crates.md
 msgid "How to audit its source code for sufficient safety."
-msgstr ""
+msgstr "Cómo auditar su código fuente para obtener la seguridad suficiente."
 
 #: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid "Configuring the `Cargo.toml` file to add crates"
-msgstr ""
+msgstr "Configurar el archivo `Cargo.toml` para añadir crates"
 
 #: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
@@ -16240,6 +16750,10 @@ msgid ""
 "org/chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/Cargo."
 "toml):"
 msgstr ""
+"Chromium tiene un único conjunto de dependencias directas de crate "
+"gestionadas de forma centralizada. Se gestionan mediante un único elemento "
+"[`Cargo.toml`](https://source.chromium.org/chromium/chromium/src/+/main:"
+"third_party/rust/chromium_crates_io/Cargo.toml):"
 
 #: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
@@ -16251,6 +16765,13 @@ msgid ""
 "# lots more...\n"
 "```"
 msgstr ""
+"```toml\n"
+"[dependencies]\n"
+"bitflags = \"1\"\n"
+"cfg-if = \"1\"\n"
+"cxx = \"1\"\n"
+"# lots more...\n"
+"```"
 
 #: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
@@ -16259,12 +16780,19 @@ msgid ""
 "dependencies.html) --- most commonly, you'll want to specify the `features` "
 "that you wish to enable in the crate."
 msgstr ""
+"Al igual que con cualquier otro archivo `Cargo.toml`, puedes especificar "
+"[más información sobre las dependencias](https://doc.rust-lang.org/cargo/"
+"reference/specifying-dependencies.html). Lo más habitual es que se "
+"especifiquen las funciones `features` que se quieran habilitar en el crate."
 
 #: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
 "When adding a crate to Chromium, you'll often need to provide some extra "
 "information in an additional file, `gnrt_config.toml`, which we'll meet next."
 msgstr ""
+"Al añadir un crate a Chromium, a menudo será necesario proporcionar "
+"información adicional en un archivo adicional, `gnrt_config.toml`, que "
+"veremos a continuación."
 
 #: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
@@ -16272,39 +16800,51 @@ msgid ""
 "chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/gnrt_config."
 "toml). This contains Chromium-specific extensions to crate handling."
 msgstr ""
+"Junto a `Cargo.toml`, se encuentra [`gnrt_config.toml`](https://source."
+"chromium.org/chromium/chromium/src/+/main:third_party/rust/"
+"chromium_crates_io/gnrt_config.toml). Contiene extensiones específicas de "
+"Chromium para la gestión de crates."
 
 #: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
 "If you add a new crate, you should specify at least the `group`. This is one "
 "of:"
 msgstr ""
+"Si añades un nuevo crate, debes especificar al menos el atributo `group`. "
+"Puede ser uno de los siguientes:"
 
 #: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 #: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid "For instance,"
-msgstr ""
+msgstr "Por ejemplo:"
 
 #: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
 "Depending on the crate source code layout, you may also need to use this "
 "file to specify where its `LICENSE` file(s) can be found."
 msgstr ""
+"En función del diseño del código fuente del crate, es posible que también "
+"tengas que usar este archivo para especificar dónde se pueden encontrar los "
+"archivos `LICENSE`."
 
 #: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
 "Later, we'll see some other things you will need to configure in this file "
 "to resolve problems."
 msgstr ""
+"Más adelante, veremos otros elementos que tendrás que configurar en este "
+"archivo para solucionar los problemas."
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
 "A tool called `gnrt` knows how to download crates and how to generate `BUILD."
 "gn` rules."
 msgstr ""
+"La herramienta `gnrt` puede descargar crates y generar reglas `BUILD.gn`."
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "To start, download the crate you want like this:"
-msgstr ""
+msgstr "Para empezar, descarga el crate de esta forma:"
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
@@ -16313,25 +16853,30 @@ msgid ""
 "`crates.io`. See [the earlier section](../cargo.md) discussing this security "
 "decision."
 msgstr ""
+"Aunque la herramienta `gnrt` forma parte del código fuente de Chromium, al "
+"ejecutar este comando, se descargarán y ejecutarán sus dependencias desde "
+"`crates.io`. Consulta [la sección anterior](../cargo.md) sobre la decisión "
+"de seguridad."
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "This `vendor` command may download:"
-msgstr ""
+msgstr "Este comando `vendor` puede descargar los siguientes elementos:"
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
-#, fuzzy
 msgid "Your crate"
-msgstr "Crates Útiles"
+msgstr "Tu crate"
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "Direct and transitive dependencies"
-msgstr ""
+msgstr "Dependencias directas y transitivas."
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
 "New versions of other crates, as required by `cargo` to resolve the complete "
 "set of crates required by Chromium."
 msgstr ""
+"Nuevas versiones de otros crates, según lo requiera `cargo` para resolver el "
+"conjunto completo de crates que requiere Chromium."
 
 #: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
@@ -16339,45 +16884,56 @@ msgid ""
 "chromium_crates_io/patches`. These will be reapplied automatically, but if "
 "patching fails you may need to take manual action."
 msgstr ""
+"Chromium mantiene parches para algunos crates, que se conservan en `//"
+"third_party/rust/chromium_crates_io/patches`. Se volverán a aplicar "
+"automáticamente pero, si no se puede aplicar el parche, es posible que "
+"tengas que realizar una acción manual."
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "Once you've downloaded the crate, generate the `BUILD.gn` files like this:"
 msgstr ""
+"Una vez que hayas descargado el crate, genera los archivos `BUILD.gn` como "
+"se indica a continuación:"
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid "Now run `git status`. You should find:"
-msgstr ""
+msgstr "Ahora, ejecuta `git status`. Deberías encontrar lo siguiente:"
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "At least one new crate source code in `third_party/rust/chromium_crates_io/"
 "vendor`"
 msgstr ""
+"Al menos un nuevo código fuente de crate en `third_party/rust/"
+"chromium_crates_io/vendor`."
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "At least one new `BUILD.gn` in `third_party/rust/<crate name>/v<major semver "
 "version>`"
 msgstr ""
+"Al menos un nuevo `BUILD.gn` en `third_party/rust/<crate name>/v<major "
+"semver version>`."
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid "An appropriate `README.chromium`"
-msgstr ""
+msgstr "Un archivo `README.chromium` adecuado."
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
-#, fuzzy
 msgid ""
 "The \"major semver version\" is a [Rust \"semver\" version number](https://"
 "doc.rust-lang.org/cargo/reference/semver.html)."
 msgstr ""
-"Consulta el libro [Rust Reference](https://doc.rust-lang.org/reference/type-"
-"layout.html)."
+"La \"versión semver mayor\" es un [número de versión \"semver\" de Rust]"
+"(https://doc.rust-lang.org/cargo/reference/semver.html)."
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "Take a close look, especially at the things generated in `third_party/rust`."
 msgstr ""
+"Analiza la situación con detalle, sobre todo los elementos generados en "
+"`third_party/rust`."
 
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
@@ -16385,6 +16941,10 @@ msgid ""
 "it's to allow multiple incompatible versions of a crate, which is "
 "discouraged but sometimes necessary in the Cargo ecosystem."
 msgstr ""
+"Habla un poco sobre el semver y, concretamente, sobre la forma en que "
+"Chromium permite que existan varias versiones incompatibles de un crate. No "
+"es una situación recomendable, pero a veces es necesaria en el ecosistema de "
+"Cargo."
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid ""
@@ -16393,68 +16953,79 @@ msgid ""
 "design of `gn` and `ninja` which aim for static, deterministic, build rules "
 "to maximize parallelism and repeatability of builds."
 msgstr ""
+"Si la compilación falla, puede deberse a un `build.rs`, programas que llevan "
+"a cabo acciones arbitrarias durante la compilación. Esto difiere de los "
+"diseños de `gn` y `ninja`, que tienen como objetivo crear reglas de "
+"compilación estáticas y deterministas para maximizar el paralelismo y la "
+"repetibilidad de las compilaciones."
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid ""
 "Some `build.rs` actions are automatically supported; others require action:"
 msgstr ""
+"Algunas acciones `build.rs` son admitidas automáticamente, pero otras deben "
+"llevar a cabo alguna acción:"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "build script effect"
-msgstr ""
+msgstr "efecto de scripts de compilación"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Supported by our gn templates"
-msgstr ""
+msgstr "Compatible con nuestras plantillas de gn"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Work required by you"
-msgstr ""
+msgstr "Acciones que debes llevar a cabo"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Checking rustc version to configure features on and off"
-msgstr ""
+msgstr "Comprobar la versión de rustc para activar y desactivar funciones"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "None"
-msgstr ""
+msgstr "Ninguno"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Checking platform or CPU to configure features on and off"
-msgstr ""
+msgstr "Comprobar la plataforma o la CPU para activar y desactivar funciones"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
-#, fuzzy
 msgid "Generating code"
-msgstr "Genéricos"
+msgstr "Generar código"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Yes - specify in `gnrt_config.toml`"
-msgstr ""
+msgstr "Sí: especificar en `gnrt_config.toml`"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Building C/C++"
-msgstr ""
+msgstr "Compilar en C o C++"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Patch around it"
-msgstr ""
+msgstr "Poner un parche"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Arbitrary other actions"
-msgstr ""
+msgstr "Otras acciones arbitrarias"
 
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid ""
 "Fortunately, most crates don't contain a build script, and fortunately, most "
 "build scripts only do the top two actions."
 msgstr ""
+"Por suerte, la mayoría de los crates no contienen scripts de compilación y "
+"la mayoría de estos scripts de compilación solo llevan a cabo dos acciones "
+"principales."
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
 "If `ninja` complains about missing files, check the `build.rs` to see if it "
 "writes source code files."
 msgstr ""
+"Si `ninja` se queja de que faltan archivos, comprueba `build.rs` para ver si "
+"escribe archivos de código fuente."
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
@@ -16464,6 +17035,11 @@ msgid ""
 "`allow-first-party-usage=false`. There are several examples already in that "
 "file:"
 msgstr ""
+"Si es así, modifica [`gnrt_config.toml`](../configuring-gnrt-config-toml.md) "
+"para añadir `build-script-outputs` al crate. Si se trata de una dependencia "
+"transitiva, de la que el código Chromium no debería depender de forma "
+"directa, añade también `allow-first-party-usage=false`. En ese archivo ya "
+"hay varios ejemplos:"
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
@@ -16473,6 +17049,11 @@ msgid ""
 "build-script-outputs = [\"tables.rs\"]\n"
 "```"
 msgstr ""
+"```toml\n"
+"[crate.unicode-linebreak]\n"
+"allow-first-party-usage = false\n"
+"build-script-outputs = [\"tables.rs\"]\n"
+"```"
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
@@ -16480,6 +17061,10 @@ msgid ""
 "`BUILD.gn` files to inform ninja that this particular output file is input "
 "to subsequent build steps."
 msgstr ""
+"A continuación, vuelve a ejecutar [`gnrt.py -- gen`](../generating-gn-build-"
+"rules.md) para generar de nuevo los archivos `build.gn` e informar al ninja "
+"de que este archivo de salida concreto se usa como entrada en los pasos de "
+"compilación posteriores."
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid ""
@@ -16489,18 +17074,25 @@ msgid ""
 "supported in a Chromium context --- our gn, ninja and LLVM build system is "
 "very specific in expressing relationships between build actions."
 msgstr ""
+"Algunos crates usan el crate [`cc`](https://crates.io/crates/cc) para "
+"compilar y vincular bibliotecas de C y C++. Otros crates analizan C y C++ "
+"mediante [`bindgen`](https://crates.io/crates/bindgen) en sus scripts de "
+"compilación. Estas acciones no se pueden llevar a cabo en un contexto de "
+"Chromium, ya que nuestro sistema de compilación gn, ninja y LLVM es muy "
+"específico a la hora de expresar las relaciones entre las acciones de "
+"compilación."
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "So, your options are:"
-msgstr ""
+msgstr "Por lo tanto, las opciones son las siguientes:"
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "Avoid these crates"
-msgstr ""
+msgstr "Evitar estos crates."
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "Apply a patch to the crate."
-msgstr ""
+msgstr "Aplicar un parche al crate."
 
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid ""
@@ -16510,6 +17102,10 @@ msgid ""
 "chromium_crates_io/patches/cxx/) - and will be applied automatically by "
 "`gnrt` each time it upgrades the crate."
 msgstr ""
+"Los parches deben guardarse en `third_party/rust/chromium_crates_io/patches/"
+"<crate>`, como los [parches para el crate `cxx`](https://source.chromium.org/"
+"chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/patches/"
+"cxx/), y `gnrt` lo aplicará automáticamente cada vez que actualice el crate."
 
 #: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid ""
@@ -16517,11 +17113,13 @@ msgid ""
 "on a crate is simple. Find your `rust_static_library` target, and add a "
 "`dep` on the `:lib` target within your crate."
 msgstr ""
+"Una vez que se ha añadido un crate de terceros y se han generado reglas de "
+"compilación, utilizar un crate es sencillo. Busca tu elemento de destino "
+"`rust_static_library` y añade un `dep` en el `:lib` dentro del crate."
 
 #: src/chromium/adding-third-party-crates/depending-on-a-crate.md
-#, fuzzy
 msgid "Specifically,"
-msgstr "Específico del SO"
+msgstr "Específicamente:"
 
 #: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid ""
@@ -16532,6 +17130,12 @@ msgid ""
 "                     +------------+      +----------------------+\n"
 "```"
 msgstr ""
+"```bob\n"
+"                     +------------+      +----------------------+\n"
+"\"//third_party/rust\" | crate name | \"/v\" | major semver version | \":"
+"lib\"\n"
+"                     +------------+      +----------------------+\n"
+"```"
 
 #: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid ""
@@ -16543,10 +17147,17 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```gn\n"
+"rust_static_library(\"my_rust_lib\") {\n"
+"  crate_root = \"lib.rs\"\n"
+"  sources = [ \"lib.rs\" ]\n"
+"  deps = [ \"//third_party/rust/example_rust_crate/v1:lib\" ]\n"
+"}\n"
+"```"
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid "Auditing Third Party Crates"
-msgstr ""
+msgstr "Auditoría de Crates de Terceros"
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
@@ -16557,17 +17168,26 @@ msgid ""
 "dependencies, there may be a lot of code to review. On the other hand, safe "
 "Rust code can have limited negative side effects. How should you review it?"
 msgstr ""
+"Añadir nuevas bibliotecas está sujeto a las [políticas](https://chromium."
+"googlesource.com/chromium/src/+/refs/heads/main/docs/rust.md#Third_party-"
+"review) estándar de Chromium, pero también a la revisión de seguridad. Como "
+"puede que no solo incluyas un único crate sino también dependencias "
+"transitivas, es posible que haya mucho código que revisar. Por otro lado, el "
+"código de Rust seguro puede tener efectos secundarios negativos limitados. "
+"¿Cómo se revisa?"
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Over time Chromium aims to move to a process based around [cargo vet]"
 "(https://mozilla.github.io/cargo-vet/)."
 msgstr ""
+"Con el tiempo, Chromium intentará adoptar un proceso basado en [cargo vet]"
+"(https://mozilla.github.io/cargo-vet/)."
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Meanwhile, for each new crate addition, we are checking for the following:"
-msgstr ""
+msgstr "Mientras tanto, se debe hacer lo siguiente para cada nuevo crate:"
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
@@ -16576,10 +17196,14 @@ msgid ""
 "macros, work out what they're for. Are they compatible with the way Chromium "
 "is normally built?"
 msgstr ""
+"Entender por qué se usa cada crate. ¿Cuál es la relación entre los crates? "
+"Si el sistema de compilación de cada crate contiene un archivo `build.rs` o "
+"macros de procedimiento, averigua para qué sirven. ¿Son compatibles con la "
+"forma en la que se compila normalmente Chromium?"
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid "Check each crate seems to be reasonably well maintained"
-msgstr ""
+msgstr "Comprobar que cada crate tenga un mantenimiento razonable."
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
@@ -16588,6 +17212,10 @@ msgid ""
 "ironically involves downloading lots of dependencies from the internet[2](../"
 "cargo.md))"
 msgstr ""
+"Usar `cd third-party/rust/chromium_crates_io; cargo audit` para comprobar si "
+"existen vulnerabilidades (primero se tiene que usar `cargo install cargo-"
+"audit`, lo que, irónicamente, implica descargar muchas dependencias de "
+"Internet[2](../cargo.md))."
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
@@ -16595,10 +17223,13 @@ msgid ""
 "chromium.googlesource.com/chromium/src/+/main/docs/security/rule-of-2."
 "md#unsafe-code-in-safe-languages)"
 msgstr ""
+"Asegúrate de que cualquier código `unsafe` sea adecuado para la [Regla de "
+"dos](https://chromium.googlesource.com/chromium/src/+/main/docs/security/"
+"rule-of-2.md#unsafe-code-in-safe-languages)."
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid "Check for any use of `fs` or `net` APIs"
-msgstr ""
+msgstr "Comprobar si se usan las APIs `fs` o `net`."
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
@@ -16606,46 +17237,58 @@ msgid ""
 "that might have been maliciously inserted. (You can't realistically aim for "
 "100% perfection here: there's often just too much code.)"
 msgstr ""
+"Leer todo el código con suficiente profundidad para comprobar si hay algo "
+"fuera de lugar que pueda haberse insertado de forma malintencionada. (Es "
+"imposible hacerlo perfecto, ya que, a menudo, hay demasiado código)."
 
 #: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "These are just guidelines --- work with reviewers from `security@chromium."
 "org` to work out the right way to become confident of the crate."
 msgstr ""
+"Estas son solo algunas directrices, trabaja con revisores de "
+"`security@chromium.org` para determinar la forma adecuada de utilizar los "
+"crates."
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid "Checking Crates into Chromium Source Code"
-msgstr ""
+msgstr "Comprobar crates en el código fuente de Chromium"
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid "`git status` should reveal:"
-msgstr ""
+msgstr "`git status` debe revelar lo siguiente:"
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid "Crate code in `//third_party/rust/chromium_crates_io`"
-msgstr ""
+msgstr "Código del crate en `//third_party/rust/chromium_crates_io`."
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
 "Metadata (`BUILD.gn` and `README.chromium`) in `//third_party/rust/<crate>/"
 "<version>`"
 msgstr ""
+"Metadatos (`BUILD.gn` y `README.chromium`) en `//third_party/rust/<crate>/"
+"<version>`."
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid "Please also add an `OWNERS` file in the latter location."
-msgstr ""
+msgstr "Añade también un archivo `OWNERS` en esta última ubicación."
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
 "You should land all this, along with your `Cargo.toml` and `gnrt_config."
 "toml` changes, into the Chromium repo."
 msgstr ""
+"Deberías llevar todo esto, junto con los cambios de `Cargo.toml` y "
+"`gnrt_config.toml`, al repositorio de Chromium."
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
 "**Important**: you need to use `git add -f` because otherwise `.gitignore` "
 "files may result in some files being skipped."
 msgstr ""
+"**Importante**: Debes usar `git add -f`, de lo contrario, los archivos `."
+"gitignore` pueden provocar que se omitan algunos archivos."
 
 #: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
@@ -16654,6 +17297,11 @@ msgid ""
 "branches, and many projects still use non-inclusive terminology there. So "
 "you may need to run:"
 msgstr ""
+"Si lo haces, es posible que veas que las comprobaciones presubmit no se han "
+"completado porque incluyen lenguaje no inclusivo. Esto se debe a que los "
+"datos de crate de Rust suelen incluir nombres de ramas en git y muchos "
+"proyectos siguen empleando terminología no inclusiva. Por lo tanto, puede "
+"que debas ejecutar lo siguiente:"
 
 #: src/chromium/adding-third-party-crates/keeping-up-to-date.md
 msgid ""
@@ -16663,6 +17311,12 @@ msgid ""
 "hoped that we will soon automate this for Rust crates, but for now, it's "
 "still your responsibility just as it is for any other third party dependency."
 msgstr ""
+"Como PROPIETARIO de cualquier dependencia de Chromium de terceros, [se "
+"espera que la actualices con las correcciones de seguridad](https://chromium."
+"googlesource.com/chromium/src/+/main/docs/adding_to_third_party.md#add-"
+"owners). La idea es que pronto automaticemos esto para los crates de Rust, "
+"pero por ahora sigue siendo tu responsabilidad, igual que cualquier otra "
+"dependencia de terceros."
 
 #: src/exercises/chromium/third-party.md
 msgid ""
@@ -16671,6 +17325,10 @@ msgid ""
 "features.html#the-default-feature). Assume that the crate will be used in "
 "shipping Chromium, but won't be used to handle untrustworthy input."
 msgstr ""
+"Añade [uwuify](https://crates.io/crates/uwuify) a Chromium para desactivar "
+"las [funciones predeterminadas] del crate (https://doc.rust-lang.org/cargo/"
+"reference/features.html#the-default-feature). Supongamos que el crate se "
+"usará en el envío de Chromium, pero no para gestionar entradas no fiables."
 
 #: src/exercises/chromium/third-party.md
 msgid ""
@@ -16679,72 +17337,82 @@ msgid ""
 "[`rust_executable` target](https://source.chromium.org/chromium/chromium/src/"
 "+/main:build/rust/rust_executable.gni) which uses `uwuify`)."
 msgstr ""
+"(En el siguiente ejercicio, usaremos uwuify de Chromium, pero puedes "
+"saltarte este paso y hacerlo ahora si quieres. También puedes crear un nuevo "
+"[destino `rust_executable`](https://source.chromium.org/chromium/chromium/"
+"src/+/main:build/rust/rust_executable.gni) que utilice `uwuify`)."
 
 #: src/exercises/chromium/third-party.md
 msgid "Students will need to download lots of transitive dependencies."
 msgstr ""
+"Los participantes tendrán que descargar muchas dependencias transitivas."
 
 #: src/exercises/chromium/third-party.md
 msgid "The total crates needed are:"
-msgstr ""
+msgstr "Estos son los crates que se necesitan:"
 
 #: src/exercises/chromium/third-party.md
 #, fuzzy
 msgid "`instant`,"
-msgstr "Constante"
+msgstr "Por ejemplo:"
 
 #: src/exercises/chromium/third-party.md
 msgid "`lock_api`,"
-msgstr ""
+msgstr "`lock_api`"
 
 #: src/exercises/chromium/third-party.md
 msgid "`parking_lot`,"
-msgstr ""
+msgstr "`parking_lot`"
 
 #: src/exercises/chromium/third-party.md
 msgid "`parking_lot_core`,"
-msgstr ""
+msgstr "`parking_lot_core`"
 
 #: src/exercises/chromium/third-party.md
 msgid "`redox_syscall`,"
-msgstr ""
+msgstr "`redox_syscall`"
 
 #: src/exercises/chromium/third-party.md
 msgid "`scopeguard`,"
-msgstr ""
+msgstr "`scopeguard`"
 
 #: src/exercises/chromium/third-party.md
 msgid "`smallvec`, and"
-msgstr ""
+msgstr "`smallvec`"
 
 #: src/exercises/chromium/third-party.md
 msgid "`uwuify`."
-msgstr ""
+msgstr "`uwuify`"
 
 #: src/exercises/chromium/third-party.md
 msgid ""
 "If students are downloading even more than that, they probably forgot to "
 "turn off the default features."
 msgstr ""
+"Si los alumnos se descargan más datos, seguramente habrán olvidado "
+"desactivar las funciones predeterminadas."
 
 #: src/exercises/chromium/third-party.md
 msgid ""
 "Thanks to [Daniel Liu](https://github.com/Daniel-Liu-c0deb0t) for this crate!"
 msgstr ""
+"Gracias a [Daniel Liu](https://github.com/Daniel-Liu-c0deb0t) por este crate."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid "Bringing It Together --- Exercise"
-msgstr ""
+msgstr "Poner en práctica todo lo aprendido: ejercicio"
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "In this exercise, you're going to add a whole new Chromium feature, bringing "
 "together everything you already learned."
 msgstr ""
+"En este ejercicio, vas a añadir una función de Chromium completamente nueva "
+"que pondrá en práctica todo lo que hemos aprendido."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid "The Brief from Product Management"
-msgstr ""
+msgstr "Resumen de la gestión de productos"
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
@@ -16752,12 +17420,17 @@ msgid ""
 "It's important that we get Chromium for Pixies delivered to them as soon as "
 "possible."
 msgstr ""
+"Se ha descubierto una comunidad de hadas que habita en una selva tropical "
+"remota. Es importante que les enviemos la versión Chromium para hadas lo "
+"antes posible."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "The requirement is to translate all Chromium's UI strings into Pixie "
 "language."
 msgstr ""
+"El requisito es traducir todas las cadenas de la IU de Chromium al idioma de "
+"las hadas."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
@@ -16765,22 +17438,29 @@ msgid ""
 "language is very close to English, and it turns out there's a Rust crate "
 "which does the translation."
 msgstr ""
+"No hay tiempo para obtener las traducciones adecuadas pero, por suerte, el "
+"lenguaje de las hadas se parece mucho al inglés y hay un crate de Rust que "
+"hace las traducciones."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "In fact, you already [imported that crate in the previous exercise](https://"
 "crates.io/crates/uwuify)."
 msgstr ""
+"De hecho, ya [importamos ese crate en el ejercicio anterior](https://crates."
+"io/crates/uwuify)."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "(Obviously, real translations of Chrome require incredible care and "
 "diligence. Don't ship this!)"
 msgstr ""
+"(Obviamente, las traducciones reales de Chrome requieren mucha atención y "
+"diligencia. No envíes nada de esto)."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid "Steps"
-msgstr ""
+msgstr "Pasos"
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
@@ -16788,12 +17468,17 @@ msgid ""
 "strings before display. In this special build of Chromium, it should always "
 "do this irrespective of the setting of `mangle_localized_strings_`."
 msgstr ""
+"Modifica `ResourceBundle::RSMangleLocalizedString` para que traduzca todas "
+"las cadenas antes de que se muestren. En esta compilación especial de "
+"Chromium, siempre se debe hacer esto independientemente de la configuración "
+"de `mangle_localized_strings_`."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "If you've done everything right across all these exercises, congratulations, "
 "you should have created Chrome for pixies!"
 msgstr ""
+"Si has hecho correctamente los ejercicios, habrás creado Chrome para hadas."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
@@ -16801,6 +17486,9 @@ msgid ""
 "and will probably decide that it's better to do the conversion on the C++ "
 "side using `base::UTF16ToUTF8` and back again."
 msgstr ""
+"UTF16 y UTF8. Los alumnos deben tener en cuenta que las cadenas de Rust "
+"siempre son UTF8. Probablemente decidirán que es mejor hacer la conversión "
+"en C++ usando `base::UTF16ToUTF8` y viceversa."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
@@ -16810,6 +17498,11 @@ msgid ""
 "[CXX supported types can transfer a lot of u16s](https://cxx.rs/binding/"
 "slice.html)."
 msgstr ""
+"Si los participantes deciden hacer la conversión en Rust, deberán tener en "
+"cuenta [`String::from_utf16`](https://doc.rust-lang.org/std/string/struct."
+"String.html#method.from_utf16), la gestión de errores y los [tipos "
+"compatibles con CXX que pueden transferir un gran número de u16s](https://"
+"cxx.rs/binding/slice.html)."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
@@ -16821,6 +17514,14 @@ msgid ""
 "mutable references to C++ data: the answer is that C++ data can't be moved "
 "around like Rust data, because it may contain self-referential pointers."
 msgstr ""
+"Los alumnos pueden diseñar el límite de C++ o Rust de varias formas "
+"diferentes, por ejemplo, tomando y devolviendo cadenas por valor o colocando "
+"una referencia mutable en una cadena. Si se utiliza una referencia mutable, "
+"es probable que CXX indique que se debe usar [`Pin`](https://doc.rust-lang."
+"org/std/pin/). Puede que debas explicar qué hace `Pin` y, a continuación, "
+"explicar por qué CXX lo necesita para referencias mutables a datos de C++. "
+"La respuesta es que los datos de C++ no se pueden mover como los datos de "
+"Rust, ya que pueden contener punteros de autorreferencia."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
@@ -16828,18 +17529,26 @@ msgid ""
 "need to depend on a `rust_static_library` target. The student probably "
 "already did this."
 msgstr ""
+"El elemento de destino de C++ que contiene `ResourceBundle::"
+"MaybeMangleLocalizedString` deberá depender de un elemento "
+"`rust_static_library`. Seguramente los alumnos ya lo hayan hecho."
 
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "The `rust_static_library` target will need to depend on `//third_party/rust/"
 "uwuify/v0_2:lib`."
 msgstr ""
+"`rust_static_library` deberá depender de `//third_party/rust/uwuify/v0_2:"
+"lib`."
 
 #: src/exercises/chromium/solutions.md
 msgid ""
 "Solutions to the Chromium exercises can be found in [this series of CLs]"
 "(https://chromium-review.googlesource.com/c/chromium/src/+/5096560)."
 msgstr ""
+"Las soluciones a los ejercicios de Chromium están en [esta serie de listas "
+"de cambios](https://chromium-review.googlesource.com/c/chromium/src/"
+"+/5096560)."
 
 #: src/bare-metal.md
 msgid "Welcome to Bare Metal Rust"

--- a/po/es.po
+++ b/po/es.po
@@ -10119,16 +10119,15 @@ msgstr "Hoy vamos a tratar algunos temas más avanzados de Rust:"
 
 #: src/welcome-day-4.md
 msgid "Iterators: a deep dive on the `Iterator` trait."
-msgstr ""
+msgstr "Iteradores: información detallada sobre el trait `Iterator`."
 
 #: src/welcome-day-4.md
 msgid "Modules and visibility."
-msgstr ""
+msgstr "Módulos y visibilidad."
 
 #: src/welcome-day-4.md
-#, fuzzy
 msgid "Testing."
-msgstr "Probando"
+msgstr "Probando."
 
 #: src/welcome-day-4.md
 msgid "Error handling: panics, `Result`, and the try operator `?`."
@@ -10139,39 +10138,43 @@ msgstr ""
 msgid ""
 "Unsafe Rust: the escape hatch when you can't express yourself in safe Rust."
 msgstr ""
+"Rust inseguro: una vía de escape en las situaciones en las que no puedes "
+"expresarte en Rust seguro."
 
 #: src/welcome-day-4.md
 msgid "[Welcome](./welcome-day-4.md) (3 minutes)"
-msgstr ""
+msgstr "[Bienvenida](./welcome-day-4.md) (3 minutos)"
 
 #: src/welcome-day-4.md
 msgid "[Iterators](./iterators.md) (45 minutes)"
-msgstr ""
+msgstr "[Iteradores](./iterators.md) (45 minutos)"
 
 #: src/welcome-day-4.md
 msgid "[Modules](./modules.md) (40 minutes)"
-msgstr ""
+msgstr "[Módulos](./modules.md) (40 minutos)"
 
 #: src/welcome-day-4.md
 msgid "[Testing](./testing.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[Pruebas](./testing.md) (1 hora y 5 minutos)"
 
 #: src/iterators.md
 msgid "[Iterator](./iterators/iterator.md) (5 minutes)"
-msgstr ""
+msgstr "[Iterator](./iterators/iterator.md) (5 minutos)"
 
 #: src/iterators.md
 msgid "[IntoIterator](./iterators/intoiterator.md) (5 minutes)"
-msgstr ""
+msgstr "[IntoIterator](./iterators/intoiterator.md) (5 minutos)"
 
 #: src/iterators.md
 msgid "[FromIterator](./iterators/fromiterator.md) (5 minutes)"
-msgstr ""
+msgstr "[FromIterator](./iterators/fromiterator.md) (5 minutos)"
 
 #: src/iterators.md
 msgid ""
 "[Exercise: Iterator Method Chaining](./iterators/exercise.md) (30 minutes)"
 msgstr ""
+"[Ejercicio: encadenamiento de métodos del iterador](./iterators/exercise.md) "
+"(30 minutos)"
 
 #: src/iterators/iterator.md
 msgid ""
@@ -10180,13 +10183,16 @@ msgid ""
 "method and provides lots of methods. Many standard library types implement "
 "`Iterator`, and you can implement it yourself, too:"
 msgstr ""
+"El trait [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator."
+"html) permite iterar valores en una colección. Requiere un método `next` y "
+"proporciona muchos otros métodos. Muchos tipos de bibliotecas estándar "
+"implementan `Iterator` y también está a nuestro alcance:"
 
 #: src/iterators/iterator.md
 msgid "\"fib({i}): {n}\""
-msgstr ""
+msgstr "\"fib({i}): {n}\""
 
 #: src/iterators/iterator.md
-#, fuzzy
 msgid ""
 "The `Iterator` trait implements many common functional programming "
 "operations over collections (e.g. `map`, `filter`, `reduce`, etc). This is "
@@ -10226,7 +10232,7 @@ msgstr ""
 
 #: src/iterators/intoiterator.md
 msgid "\"point = {x}, {y}\""
-msgstr ""
+msgstr "\"punto = {x}, {y}\""
 
 #: src/iterators/intoiterator.md
 #, fuzzy
@@ -10238,7 +10244,6 @@ msgstr ""
 "declarar dos tipos:"
 
 #: src/iterators/intoiterator.md
-#, fuzzy
 msgid "`Item`: the type to iterate over, such as `i8`,"
 msgstr "`Item`: el tipo sobre el que iteramos, como `i8`,"
 
@@ -10257,18 +10262,25 @@ msgstr ""
 #: src/iterators/intoiterator.md
 msgid "The example iterates over all combinations of x and y coordinates."
 msgstr ""
+"En el ejemplo se itera sobre todas las combinaciones de las coordenadas x e "
+"y."
 
 #: src/iterators/intoiterator.md
 msgid ""
 "Try iterating over the grid twice in `main`. Why does this fail? Note that "
 "`IntoIterator::into_iter` takes ownership of `self`."
 msgstr ""
+"Prueba a iterar sobre la cuadrícula dos veces en `main`. ¿Por qué no "
+"funciona? Ten en cuenta que `IntoIterator::into_iter` tiene la propiedad de "
+"`self`."
 
 #: src/iterators/intoiterator.md
 msgid ""
 "Fix this issue by implementing `IntoIterator` for `&Grid` and storing a "
 "reference to the `Grid` in `GridIter`."
 msgstr ""
+"Soluciona este problema implementando `IntoIterator` para `&Grid` y "
+"almacenando una referencia a `Grid` en `GridIter`."
 
 #: src/iterators/intoiterator.md
 msgid ""
@@ -10277,6 +10289,10 @@ msgid ""
 "elements from that vector. Use `for e in &some_vector` instead, to iterate "
 "over references to elements of `some_vector`."
 msgstr ""
+"Lo mismo puede ocurrir con los tipos de biblioteca estándar: `for e in "
+"some_vector` adquirirá la propiedad de `some_vector` e iterará sobre los "
+"elementos propios de ese vector. En su lugar, puedes utilizar `for e in "
+"&some_vector` para iterar sobre referencias a elementos de `some_vector`."
 
 #: src/iterators/fromiterator.md
 msgid "FromIterator"
@@ -10294,7 +10310,7 @@ msgstr ""
 
 #: src/iterators/fromiterator.md
 msgid "\"prime_squares: {prime_squares:?}\""
-msgstr ""
+msgstr "\"prime_squares: {prime_squares:?}\""
 
 #: src/iterators/fromiterator.md
 #, fuzzy
@@ -10303,7 +10319,7 @@ msgstr "`Iterator`"
 
 #: src/iterators/fromiterator.md
 msgid "There are two ways to specify `B` for this method:"
-msgstr ""
+msgstr "Hay dos formas de especificar `B` en este método:"
 
 #: src/iterators/fromiterator.md
 msgid ""
@@ -10311,12 +10327,17 @@ msgid ""
 "shown. The `_` shorthand used here lets Rust infer the type of the `Vec` "
 "elements."
 msgstr ""
+"Con \"turbofish\": `some_iterator.collect::<COLLECTION_TYPE>()`, tal como se "
+"muestra. La forma abreviada de `_` que se utiliza aquí permite que Rust "
+"infiera el tipo de los elementos `Vec`."
 
 #: src/iterators/fromiterator.md
 msgid ""
 "With type inference: `let prime_squares: Vec<_> = some_iterator.collect()`. "
 "Rewrite the example to use this form."
 msgstr ""
+"Con inferencia de tipos: `let prime_squares: Vec<_> = some_iterator."
+"collect()`. Reescribe el ejemplo para usar esta opción."
 
 #: src/iterators/fromiterator.md
 #, fuzzy
@@ -10357,31 +10378,40 @@ msgid ""
 "///\n"
 "/// Element `n` of the result is `values[(n+offset)%len] - values[n]`.\n"
 msgstr ""
+"/// Calcula las diferencias entre los elementos de `values` offset por "
+"offset,\n"
+"/// envolviendo de esta forma los elementos desde el final de `values` hasta "
+"el principio.\n"
+"///\n"
+"/// El elemento `n` del resultado es `values[(n+offset)%len] - values[n]`.\n"
 
 #: src/modules.md
 msgid "[Modules](./modules/modules.md) (5 minutes)"
-msgstr ""
+msgstr "[Módulos](./modules/modules.md) (5 minutos)"
 
 #: src/modules.md
 msgid "[Filesystem Hierarchy](./modules/filesystem.md) (5 minutes)"
 msgstr ""
+"[Jerarquía del sistema de archivos](./modules/filesystem.md) (5 minutos)"
 
 #: src/modules.md
 msgid "[Visibility](./modules/visibility.md) (5 minutes)"
-msgstr ""
+msgstr "[Visibilidad](./modules/visible.md) (5 minutos)"
 
 #: src/modules.md
 msgid "[use, super, self](./modules/paths.md) (10 minutes)"
-msgstr ""
+msgstr "[use, super, self](./modules/paths.md) (10 minutos)"
 
 #: src/modules.md
 msgid ""
 "[Exercise: Modules for a GUI Library](./modules/exercise.md) (15 minutes)"
 msgstr ""
+"[Ejercicio: módulos para una biblioteca GUI](./modules/exercise.md) (15 "
+"minutos)"
 
 #: src/modules.md
 msgid "This segment should take about 40 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 40 minutos."
 
 #: src/modules/modules.md
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
@@ -10397,11 +10427,11 @@ msgstr ""
 
 #: src/modules/modules.md
 msgid "\"In the foo module\""
-msgstr ""
+msgstr "\"En el módulo foo\""
 
 #: src/modules/modules.md
 msgid "\"In the bar module\""
-msgstr ""
+msgstr "\"En el módulo bar\""
 
 #: src/modules/modules.md
 msgid ""
@@ -10469,18 +10499,21 @@ msgid ""
 "germination\n"
 "//! implementation.\n"
 msgstr ""
+"//! Este módulo implementa el jardín, incluida una germinación de alto "
+"rendimiento.\n"
+"//!\n"
 
 #: src/modules/filesystem.md
 msgid "// Re-export types from this module.\n"
-msgstr ""
+msgstr "// Vuelve a exportar los tipos de este módulo.\n"
 
 #: src/modules/filesystem.md
 msgid "/// Sow the given seed packets.\n"
-msgstr ""
+msgstr "/// Siembra los paquetes de semilla determinados.\n"
 
 #: src/modules/filesystem.md
 msgid "/// Harvest the produce in the garden that is ready.\n"
-msgstr ""
+msgstr "/// Cosecha el producto en el jardín que esté listo.\n"
 
 #: src/modules/filesystem.md
 msgid ""
@@ -10516,7 +10549,7 @@ msgstr ""
 
 #: src/modules/filesystem.md
 msgid "\"some/path.rs\""
-msgstr ""
+msgstr "\"some/path.rs\""
 
 #: src/modules/filesystem.md
 msgid ""
@@ -10550,19 +10583,19 @@ msgstr ""
 
 #: src/modules/visibility.md
 msgid "\"outer::private\""
-msgstr ""
+msgstr "\"outer::private\""
 
 #: src/modules/visibility.md
 msgid "\"outer::public\""
-msgstr ""
+msgstr "\"outer::public\""
 
 #: src/modules/visibility.md
 msgid "\"outer::inner::private\""
-msgstr ""
+msgstr "\"outer::inner::private\""
 
 #: src/modules/visibility.md
 msgid "\"outer::inner::public\""
-msgstr ""
+msgstr "\"outer::inner::public\""
 
 #: src/modules/visibility.md
 msgid "Use the `pub` keyword to make modules public."
@@ -10603,7 +10636,7 @@ msgstr ""
 
 #: src/modules/paths.md
 msgid "use, super, self"
-msgstr ""
+msgstr "use, super, self"
 
 #: src/modules/paths.md
 msgid ""
@@ -10650,12 +10683,16 @@ msgid ""
 "It is common to \"re-export\" symbols at a shorter path. For example, the "
 "top-level `lib.rs` in a crate might have"
 msgstr ""
+"Es habitual \"volver a exportar\" los símbolos en una ruta más corta. Por "
+"ejemplo, el archivo `lib.rs` de nivel superior de un crate puede hacer que"
 
 #: src/modules/paths.md
 msgid ""
 "making `DiskStorage` and `NetworkStorage` available to other crates with a "
 "convenient, short path."
 msgstr ""
+"DiskStorage` y `NetworkStorage` estén disponibles para otros crates con una "
+"ruta corta y práctica."
 
 #: src/modules/paths.md
 msgid ""
@@ -10665,6 +10702,12 @@ msgid ""
 "`read_to_string` method on a type implementing the `Read` trait, you need to "
 "`use std::io::Read`."
 msgstr ""
+"La mayoría de las veces, únicamente deben ser `use` los elementos que "
+"aparecen en un módulo. Sin embargo, un trait debe encontrarse dentro del "
+"ámbito para llamar a cualquier método de ese trait, incluso aunque ya haya "
+"un tipo que implemente dicho trait dentro del ámbito. Por ejemplo, para usar "
+"el método `read_to_string` en un tipo que implemente el trait `Read`, debes "
+"usar std::io::Read`."
 
 #: src/modules/paths.md
 msgid ""
@@ -10672,6 +10715,9 @@ msgid ""
 "discouraged because it is not clear which items are imported, and those "
 "might change over time."
 msgstr ""
+"La instrucción `use` puede tener un comodín: `use std::io::*`. No se "
+"recomienda su uso porque no está claro qué elementos se importan y cuáles "
+"podrían cambiar con el tiempo."
 
 #: src/modules/exercise.md
 msgid ""
@@ -10679,12 +10725,18 @@ msgid ""
 "This library defines a `Widget` trait and a few implementations of that "
 "trait, as well as a `main` function."
 msgstr ""
+"En este ejercicio, vas a reorganizar una pequeña implementación de una "
+"biblioteca GUI. Esta biblioteca define un trait `Widget` y algunas "
+"implementaciones de dicho trait, así como una función `main`."
 
 #: src/modules/exercise.md
 msgid ""
 "It is typical to put each type or set of closely-related types into its own "
 "module, so each widget type should get its own module."
 msgstr ""
+"Es habitual colocar cada tipo o conjunto de tipos que estén estrechamente "
+"relacionados en su propio módulo, por lo que cada tipo de widget debe tener "
+"su propio módulo."
 
 #: src/modules/exercise.md
 #, fuzzy
@@ -10696,40 +10748,46 @@ msgid ""
 "The Rust playground only supports one file, so you will need to make a Cargo "
 "project on your local filesystem:"
 msgstr ""
+"El playground de Rust solo admite un archivo, por lo que tendrás que crear "
+"un proyecto de Cargo en tu sistema de archivos local:"
 
 #: src/modules/exercise.md
 msgid ""
 "Edit the resulting `src/main.rs` to add `mod` statements, and add additional "
 "files in the `src` directory."
 msgstr ""
+"Edita el archivo `src/main.rs` resultante para añadir instrucciones `mod` y "
+"añade archivos adicionales en el directorio `src`."
 
 #: src/modules/exercise.md
 msgid "Source"
-msgstr ""
+msgstr "Fuente"
 
 #: src/modules/exercise.md
 msgid "Here's the single-module implementation of the GUI library:"
 msgstr ""
+"A continuación, se muestra la implementación de la biblioteca GUI en un solo "
+"módulo:"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "/// Natural width of `self`.\n"
-msgstr ""
+msgstr "/// Ancho natural de `self`.\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "/// Draw the widget into a buffer.\n"
-msgstr ""
+msgstr "/// Coloca el widget en un búfer.\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "/// Draw the widget on standard output.\n"
-msgstr ""
+msgstr "/// Coloca el widget en una salida estándar.\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"{buffer}\""
-msgstr ""
+msgstr "\"{buffer}\""
 
 #: src/modules/exercise.md
 msgid "// Add 4 paddings for borders\n"
-msgstr ""
+msgstr "// Añade 4 espacios de relleno para los bordes\n"
 
 #: src/modules/exercise.md
 msgid ""
@@ -10737,51 +10795,54 @@ msgid ""
 "the\n"
 "        // ?-operator here instead of .unwrap().\n"
 msgstr ""
+"// TAREAS: Cambia draw_into para devolver Result<(), std::fmt::Error>. A "
+"continuación, utiliza el\n"
+"        // operator ? en lugar de .unwrap().\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"+-{:-<inner_width$}-+\""
-msgstr ""
+msgstr "\"+-{:-<inner_width$}-+\""
 
 #: src/modules/exercise.md src/modules/solution.md src/testing/unit-tests.md
 #: src/testing/solution.md
 msgid "\"\""
-msgstr ""
+msgstr "\"\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"| {:^inner_width$} |\""
-msgstr ""
+msgstr "\"| {:^inner_width$} |\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"+={:=<inner_width$}=+\""
-msgstr ""
+msgstr "\"+={:=<inner_width$}=+\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"| {:inner_width$} |\""
-msgstr ""
+msgstr "\"| {:inner_width$} |\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "// add a bit of padding\n"
-msgstr ""
+msgstr "// añade un poco de espacio de relleno\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"+{:-<width$}+\""
-msgstr ""
+msgstr "\"+{:-<width$}+\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"|{:^width$}|\""
-msgstr ""
+msgstr "\"|{:^width$}|\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"Rust GUI Demo 1.23\""
-msgstr ""
+msgstr "\"Demo de la GUI de Rust 1.23\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"This is a small text GUI demo.\""
-msgstr ""
+msgstr "\"Esta es una demo de la GUI con poco texto.\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"Click me!\""
-msgstr ""
+msgstr "\"Haz clic aquí\""
 
 #: src/modules/exercise.md
 msgid ""
@@ -10789,60 +10850,65 @@ msgid ""
 "and get accustomed to the required `mod`, `use`, and `pub` declarations. "
 "Afterward, discuss what organizations are most idiomatic."
 msgstr ""
+"Anima a los participantes a dividir el código de un modo que les parezca "
+"natural para que se familiaricen con las declaraciones `mod`, `use` y `pub`. "
+"Después, comenta qué tipo de organización es más idiomática."
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets.rs ----\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets/label.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets/label.rs ----\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Label-width\n"
-msgstr ""
+msgstr "// ANCHOR_END: Label-width\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR: Label-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR: Label-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Label-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR_END: Label-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets/button.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets/button.rs ----\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Button-width\n"
-msgstr ""
+msgstr "// ANCHOR_END: Button-width\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR: Button-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR: Button-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Button-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR_END: Button-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets/window.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets/window.rs ----\n"
 
 #: src/modules/solution.md
 msgid ""
 "// ANCHOR_END: Window-width\n"
 "        // Add 4 paddings for borders\n"
 msgstr ""
+"// ANCHOR_END: window-width\n"
+"        // Añade 4 espacios de relleno para los bordes\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR: Window-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR: Window-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Window-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR_END: Window-draw_into\n"
 
 #: src/modules/solution.md
 msgid ""
@@ -10850,38 +10916,42 @@ msgid ""
 "        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
 "        // the ?-operator here instead of .unwrap().\n"
 msgstr ""
+"// TAREA: después de saber cómo gestionar los errores, puedes cambiar\n"
+"        // draw_into para devolver Result<(), std::fmt::Error>. A "
+"continuación, usa\n"
+"        // el operator ? en lugar de .unwrap().\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/main.rs ----\n"
-msgstr ""
+msgstr "// ---- src/main.rs ----\n"
 
 #: src/testing.md
 msgid "[Test Modules](./testing/unit-tests.md) (5 minutes)"
-msgstr ""
+msgstr "[Módulos de pruebas](./testing/unit-tests.md) (5 minutos)"
 
 #: src/testing.md
 msgid "[Other Types of Tests](./testing/other.md) (10 minutes)"
-msgstr ""
+msgstr "[Otros tipos de pruebas](./testing/other.md) (10 minutos)"
 
 #: src/testing.md
 msgid "[Useful Crates](./testing/useful-crates.md) (3 minutes)"
-msgstr ""
+msgstr "[Crates útiles](./testing/useful-crates.md) (3 minutos)"
 
 #: src/testing.md
 msgid "[GoogleTest](./testing/googletest.md) (5 minutes)"
-msgstr ""
+msgstr "[GoogleTest](./testing/googletest.md) (5 minutos)"
 
 #: src/testing.md
 msgid "[Mocking](./testing/mocking.md) (5 minutes)"
-msgstr ""
+msgstr "[Simulación](./testing/mocking.md) (5 minutos)"
 
 #: src/testing.md
 msgid "[Compiler Lints and Clippy](./testing/lints.md) (5 minutes)"
-msgstr ""
+msgstr "[Lints de compilador y Clippy](./testing/lints.md) (5 minutos)"
 
 #: src/testing.md
 msgid "[Exercise: Luhn Algorithm](./testing/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[Ejercicio: Algoritmo de Luhn](./testing/exercise.md) (30 minutos)"
 
 #: src/testing/unit-tests.md
 msgid "Unit Tests"
@@ -10906,11 +10976,13 @@ msgid ""
 "`tests` module, using `#[cfg(test)]` to conditionally compile them only when "
 "building tests."
 msgstr ""
+"Las pruebas se marcan con `#[test]`. Las pruebas unitarias se suelen incluir "
+"en un módulo `tests` anidado en el que se utiliza `#[cfg(test)]` para "
+"compilarlas únicamente cuando se compilan las pruebas."
 
 #: src/testing/unit-tests.md
-#, fuzzy
 msgid "\"Hello World\""
-msgstr "¡Hola, mundo!"
+msgstr "\"Hola, mundo\""
 
 #: src/testing/unit-tests.md
 msgid "This lets you unit test private helpers."
@@ -10923,7 +10995,7 @@ msgstr ""
 
 #: src/testing/unit-tests.md
 msgid "Run the tests in the playground in order to show their results."
-msgstr ""
+msgstr "Haz las pruebas en el playground para ver los resultados."
 
 #: src/testing/other.md
 msgid "Integration Tests"
@@ -10940,7 +11012,7 @@ msgstr "Crea un archivo `.rs` en `tests/`:"
 
 #: src/testing/other.md
 msgid "// tests/my_library.rs\n"
-msgstr ""
+msgstr "// tests/my_library.rs\n"
 
 #: src/testing/other.md
 msgid "These tests only have access to the public API of your crate."
@@ -10964,6 +11036,13 @@ msgid ""
 "/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
 "/// ```\n"
 msgstr ""
+"/// Acorta una cadena según la longitud proporcionada.\n"
+"///\n"
+"/// ```\n"
+"/// # use playground::shorten_string;\n"
+"/// assert_eq!(shorten_string(\"Hola, mundo\", 5), \"Hola\");\n"
+"/// assert_eq!(shorten_string(\"Hola, mundo\", 20), \"Hola, mundo\");\n"
+"/// ```\n"
 
 #: src/testing/other.md
 msgid "Code blocks in `///` comments are automatically seen as Rust code."
@@ -10980,6 +11059,8 @@ msgid ""
 "Adding `#` in the code will hide it from the docs, but will still compile/"
 "run it."
 msgstr ""
+"Si añades `#` al código, se ocultará de los documentos, pero se seguirá "
+"compilando o ejecutando."
 
 #: src/testing/other.md
 msgid ""
@@ -11033,17 +11114,19 @@ msgstr ""
 
 #: src/testing/googletest.md
 msgid "\"baz\""
-msgstr ""
+msgstr "\"baz\""
 
 #: src/testing/googletest.md
 msgid "\"xyz\""
-msgstr ""
+msgstr "\"xyz\""
 
 #: src/testing/googletest.md
 msgid ""
 "If we change the last element to `\"!\"`, the test fails with a structured "
 "error message pin-pointing the error:"
 msgstr ""
+"Si cambiamos el último elemento a `\"!\"`, la prueba dará error y aparecerá "
+"un mensaje de error estructurado que señala cuál es el fallo:"
 
 #: src/testing/googletest.md
 msgid ""
@@ -11051,6 +11134,9 @@ msgid ""
 "example in a local environment. Use `cargo add googletest` to quickly add it "
 "to an existing Cargo project."
 msgstr ""
+"GoogleTest no forma parte de Rust Playground, por lo que debes llevar a cabo "
+"este ejemplo en un entorno local. Usa `cargo add googletest` para añadirlo "
+"rápidamente a un proyecto de Cargo que ya tengas."
 
 #: src/testing/googletest.md
 msgid ""
@@ -11058,16 +11144,20 @@ msgid ""
 "macros and types](https://docs.rs/googletest/latest/googletest/prelude/index."
 "html)."
 msgstr ""
+"La línea `use googletest::prelude::*;` importa una serie de [macros y tipos "
+"habituales](https://docs.rs/googletest/latest/googletest/prelude/index.html)."
 
 #: src/testing/googletest.md
 msgid "This just scratches the surface, there are many builtin matchers."
-msgstr ""
+msgstr "Esto es solo el comienzo, existen muchos matchers integrados."
 
 #: src/testing/googletest.md
 msgid ""
 "A particularly nice feature is that mismatches in multi-line strings strings "
 "are shown as a diff:"
 msgstr ""
+"Una característica muy interesante es que las discrepancias en las cadenas "
+"que contienen varias líneas se muestran como un diff:"
 
 #: src/testing/googletest.md
 msgid ""
@@ -11075,6 +11165,9 @@ msgid ""
 "                 Rust's strong typing guides the way,\\n\\\n"
 "                 Secure code you'll write.\""
 msgstr ""
+"\"Se ha encontrado la seguridad de la memoria,\\n\\\n"
+" la potente escritura de Rust guía el camino,\\n\\\n"
+" protege el código que vayas a escribir.\""
 
 #: src/testing/googletest.md
 msgid ""
@@ -11082,20 +11175,25 @@ msgid ""
 "            Rust's silly humor guides the way,\\n\\\n"
 "            Secure code you'll write.\""
 msgstr ""
+"\"Se ha encontrado seguridad en la memoria,\\n\\\n"
+" el divertido sentido del humor de Rust guía el camino,\\n\\\n"
+" protege el código que vayas a escribir.\""
 
 #: src/testing/googletest.md
 msgid "shows a color-coded diff (colors not shown here):"
-msgstr ""
+msgstr "muestra un diff con colores (colores que no se muestran aquí):"
 
 #: src/testing/googletest.md
 msgid ""
 "The crate is a Rust port of [GoogleTest for C++](https://google.github.io/"
 "googletest/)."
 msgstr ""
+"El crate es un puerto de Rust de [GoogleTest para C++](https://google.github."
+"io/googletest/)."
 
 #: src/testing/googletest.md
 msgid "GoogleTest is available for use in AOSP."
-msgstr ""
+msgstr "GoogleTest se puede utilizar en AOSP."
 
 #: src/testing/mocking.md
 msgid ""
@@ -11103,6 +11201,9 @@ msgid ""
 "You need to refactor your code to use traits, which you can then quickly "
 "mock:"
 msgstr ""
+"[Mockall](https://docs.rs/mockall/) es una biblioteca que se usa para hacer "
+"simulaciones. Debes refactorizar tu código para usar traits, con los que "
+"podrás hacer simulaciones:"
 
 #: src/testing/mocking.md
 msgid ""
@@ -11112,6 +11213,13 @@ msgid ""
 "services. The other mocking libraries work in a similar fashion as Mockall, "
 "meaning that they make it easy to get a mock implementation of a given trait."
 msgstr ""
+"Estos consejos son útiles para Android (AOSP), donde Mockall es la "
+"biblioteca de simulaciones recomendada. Hay otras [bibliotecas de simulación "
+"disponibles en crates.io](https://crates.io/keywords/mock), especialmente en "
+"el área de servicios de simulación de HTTP. Las demás bibliotecas de "
+"simulación funcionan de forma similar a Mockall, lo que significa que "
+"facilitan la obtención de una implementación simulada de un trait "
+"determinado."
 
 #: src/testing/mocking.md
 msgid ""
@@ -11120,6 +11228,11 @@ msgid ""
 "more stable test execution. On the other hand, the mocks can be configured "
 "wrongly and return output different from what the real dependencies would do."
 msgstr ""
+"Ten en cuenta que las simulaciones son algo _polémicas_, ya que te permiten "
+"aislar por completo una prueba de sus dependencias. El resultado inmediato "
+"es una ejecución de pruebas más rápida y estable. Por otro lado, las "
+"simulaciones se pueden configurar de forma incorrecta y devuelven un "
+"resultado diferente del que se obtendría con las dependencias reales."
 
 #: src/testing/mocking.md
 msgid ""
@@ -11128,6 +11241,10 @@ msgid ""
 "means that you get the correct behavior in your tests, plus they are fast "
 "and will automatically clean up after themselves."
 msgstr ""
+"Si es posible, te recomendamos que uses las dependencias reales. Por "
+"ejemplo, muchas bases de datos te permiten configurar un backend en la "
+"memoria. Es decir, en tus pruebas obtendrás el comportamiento correcto y, "
+"además, son rápidas y se limpiarán de forma automática tras las pruebas."
 
 #: src/testing/mocking.md
 msgid ""
@@ -11135,6 +11252,10 @@ msgid ""
 "binds to a random port on `localhost`. Always prefer this over mocking away "
 "the framework since it helps you test your code in the real environment."
 msgstr ""
+"Del mismo modo, muchos frameworks web te permiten iniciar un servidor en "
+"proceso que se vincula a un puerto aleatorio en `localhost`. Siempre es "
+"mejor utilizar esta opción en lugar de simular el framework, ya que te ayuda "
+"a hacer pruebas con el código en el entorno real."
 
 #: src/testing/mocking.md
 msgid ""
@@ -11142,6 +11263,9 @@ msgid ""
 "in a local environment. Use `cargo add mockall` to quickly add Mockall to an "
 "existing Cargo project."
 msgstr ""
+"Mockall no forma parte de Rust Playground, por lo que debes ejecutar este "
+"ejemplo en un entorno local. Usa `cargo add modelall` para añadir de forma "
+"rápida Mockall a un proyecto de Cargo."
 
 #: src/testing/mocking.md
 msgid ""
@@ -11149,6 +11273,10 @@ msgid ""
 "expectations which depend on the arguments passed. Here we use this to mock "
 "a cat which becomes hungry 3 hours after the last time it was fed:"
 msgstr ""
+"Mockall tiene muchas más funciones. En concreto, puedes configurar "
+"expectativas en función de los argumentos. Aquí utilizamos el ejemplo para "
+"simular un gato que tiene hambre 3 horas después de que le hayan dado de "
+"comer:"
 
 #: src/testing/mocking.md
 msgid ""
@@ -11156,6 +11284,9 @@ msgid ""
 "called to `n` --- the mock will automatically panic when dropped if this "
 "isn't satisfied."
 msgstr ""
+"Puedes utilizar `.times(n)` para limitar el número de veces que se puede "
+"llamar a un método de simulación a `n`. Si no se cumple, la simulación "
+"activará un pánico automáticamente cuando se elimine."
 
 #: src/testing/lints.md
 msgid ""
@@ -11163,10 +11294,13 @@ msgid ""
 "built-in lints. [Clippy](https://doc.rust-lang.org/clippy/) provides even "
 "more lints, organized into groups that can be enabled per-project."
 msgstr ""
+"El compilador de Rust crea mensajes de error muy buenos, así como lints "
+"integrados útiles. [Clippy](https://doc.rust-lang.org/clippy/) ofrece aún "
+"más lints, organizados en grupos que se pueden habilitar por proyecto."
 
 #: src/testing/lints.md
 msgid "\"X probably fits in a u16, right? {}\""
-msgstr ""
+msgstr "\"Es probable que X encaje en una u16, ¿no? {}\""
 
 #: src/testing/lints.md
 msgid ""
@@ -11174,6 +11308,9 @@ msgid ""
 "visible here, but those will not be shown once the code compiles. Switch to "
 "the Playground site to show those lints."
 msgstr ""
+"Ejecuta el código de ejemplo y analiza el mensaje de error. También se ven "
+"lints, pero no se mostrarán una vez que se compile el código. Ve al "
+"playground para ver los lints."
 
 #: src/testing/lints.md
 msgid ""
@@ -11181,12 +11318,18 @@ msgid ""
 "clippy warnings. Clippy has extensive documentation of its lints, and adds "
 "new lints (including default-deny lints) all the time."
 msgstr ""
+"Después de resolver los lints, ejecuta `clippy` en el playground para "
+"mostrar advertencias de Clippy. Clippy cuenta con una amplia documentación "
+"sobre sus lints y añade otros nuevos continuamente (incluidos los de "
+"denegación de forma predeterminada)."
 
 #: src/testing/lints.md
 msgid ""
 "Note that errors or warnings with `help: ...` can be fixed with `cargo fix` "
 "or via your editor."
 msgstr ""
+"Ten en cuenta que los errores o las advertencias con `help: ...` se pueden "
+"corregir con `cargo fix` o con el editor que uses."
 
 #: src/testing/exercise.md
 msgid "Luhn Algorithm"
@@ -11241,6 +11384,9 @@ msgid ""
 "along with two basic unit tests that confirm that most the algorithm is "
 "implemented correctly."
 msgstr ""
+"El código proporcionado ofrece una implementación errónea del algoritmo de "
+"Luhn, junto con dos pruebas unitarias básicas que confirman que la mayor "
+"parte del algoritmo se ha implementado correctamente."
 
 #: src/testing/exercise.md
 #, fuzzy
@@ -11254,117 +11400,121 @@ msgstr ""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4263 9826 4026 9299\""
-msgstr ""
+msgstr "\"4263 9826 4026 9299\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4539 3195 0343 6467\""
-msgstr ""
+msgstr "\"4539 3195 0343 6467\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"7992 7398 713\""
-msgstr ""
+msgstr "\"7992 7398 713\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4223 9826 4026 9299\""
-msgstr ""
+msgstr "\"4223 9826 4026 9299\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4539 3195 0343 6476\""
-msgstr ""
+msgstr "\"4539 3195 0343 6476\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"8273 1232 7352 0569\""
-msgstr ""
+msgstr "\"8273 1232 7352 0569\""
 
 #: src/testing/solution.md
 msgid "// This is the buggy version that appears in the problem.\n"
-msgstr ""
+msgstr "// Esta es la versión con errores que aparece en el problema.\n"
 
 #: src/testing/solution.md
 msgid "// This is the solution and passes all of the tests below.\n"
-msgstr ""
+msgstr "// Esta es la solución, que pasará todas las siguientes pruebas.\n"
 
 #: src/testing/solution.md
 msgid "\"1234 5678 1234 5670\""
-msgstr ""
+msgstr "\"1234 5678 1234 5670\""
 
 #: src/testing/solution.md
 msgid "\"Is {cc_number} a valid credit card number? {}\""
-msgstr ""
+msgstr "\"¿Es {cc_number} un número de tarjeta de crédito válido? {}\""
 
 #: src/testing/solution.md
 msgid "\"yes\""
-msgstr ""
+msgstr "\"sí\""
 
 #: src/testing/solution.md
 msgid "\"no\""
-msgstr ""
+msgstr "\"no\""
 
 #: src/testing/solution.md
 msgid "\"foo 0 0\""
-msgstr ""
+msgstr "\"foo 0 0\""
 
 #: src/testing/solution.md
 msgid "\" \""
-msgstr ""
+msgstr "\" \""
 
 #: src/testing/solution.md
 msgid "\"  \""
-msgstr ""
+msgstr "\"  \""
 
 #: src/testing/solution.md
 msgid "\"    \""
-msgstr ""
+msgstr "\"    \""
 
 #: src/testing/solution.md
 msgid "\"0\""
-msgstr ""
+msgstr "\"0\""
 
 #: src/testing/solution.md
 msgid "\" 0 0 \""
-msgstr ""
+msgstr "\" 0 0 \""
 
 #: src/welcome-day-4-afternoon.md
 msgid "[Error Handling](./error-handling.md) (45 minutes)"
-msgstr ""
+msgstr "[Gestión de errores](./error-handling.md) (45 minutos)"
 
 #: src/welcome-day-4-afternoon.md
 msgid "[Unsafe Rust](./unsafe-rust.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[Rust inseguro](./unsafe-rust.md) (1 hora y 5 minutos)"
 
 #: src/welcome-day-4-afternoon.md
 msgid "Including 10 minute breaks, this session should take about 2 hours"
 msgstr ""
+"Contando con los descansos de 10 minutos, la duración prevista de la sesión "
+"es de unas 2 horas."
 
 #: src/error-handling.md
 msgid "[Panics](./error-handling/panics.md) (3 minutes)"
-msgstr ""
+msgstr "[Pánicos](./error-handling/panics.md) (3 minutos)"
 
 #: src/error-handling.md
 msgid "[Try Operator](./error-handling/try.md) (5 minutes)"
-msgstr ""
+msgstr "[Operador Try](./error-handling/try.md) (5 minutos)"
 
 #: src/error-handling.md
 msgid "[Try Conversions](./error-handling/try-conversions.md) (5 minutes)"
-msgstr ""
+msgstr "[Conversiones Try](./error-handling/try-conversions.md) (5 minutos)"
 
 #: src/error-handling.md
 msgid "[Error Trait](./error-handling/error.md) (5 minutes)"
-msgstr ""
+msgstr "[Trait Error](./error-handling/error.md) (5 minutos)"
 
 #: src/error-handling.md
 msgid ""
 "[thiserror and anyhow](./error-handling/thiserror-and-anyhow.md) (5 minutes)"
 msgstr ""
+"[thiserror y anyhow](./error-handling/thiserror-and-anyhow.md) (5 minutos)"
 
 #: src/error-handling.md
 msgid ""
 "[Exercise: Rewriting with Result](./error-handling/exercise.md) (20 minutes)"
 msgstr ""
+"[Ejercicio: reescribir con Result](./error-handling/exercise.md) (20 minutos)"
 
 #: src/error-handling/panics.md
 msgid "Rust handles fatal errors with a \"panic\"."
-msgstr ""
+msgstr "Rust gestiona los errores críticos con un \"pánico\"."
 
 #: src/error-handling/panics.md
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
@@ -11372,7 +11522,7 @@ msgstr "Rust activará un _panic_ si se produce un error grave en _runtime_:"
 
 #: src/error-handling/panics.md
 msgid "\"v[100]: {}\""
-msgstr ""
+msgstr "\"v[100]: {}\""
 
 #: src/error-handling/panics.md
 msgid "Panics are for unrecoverable and unexpected errors."
@@ -11385,20 +11535,24 @@ msgstr "Los _panics_ son un síntoma de que hay fallos en el programa."
 #: src/error-handling/panics.md
 msgid "Runtime failures like failed bounds checks can panic"
 msgstr ""
+"Los fallos del tiempo de ejecución, como las comprobaciones de límites "
+"fallidas, pueden activar un pánico."
 
 #: src/error-handling/panics.md
 msgid "Assertions (such as `assert!`) panic on failure"
-msgstr ""
+msgstr "Las aserciones (como `assert!`) activan un pánico cuando hay fallos."
 
 #: src/error-handling/panics.md
 msgid "Purpose-specific panics can use the `panic!` macro."
-msgstr ""
+msgstr "Los pánicos con fines específicos pueden usar la macro `panic!`."
 
 #: src/error-handling/panics.md
 msgid ""
 "A panic will \"unwind\" the stack, dropping values just as if the functions "
 "had returned."
 msgstr ""
+"Cuando se produce un pánico, se \"desenrolla\" la pila y se eliminan los "
+"valores como si las funciones hubieran devuelto un resultado."
 
 #: src/error-handling/panics.md
 msgid ""
@@ -11417,21 +11571,23 @@ msgstr ""
 
 #: src/error-handling/panics.md
 msgid "\"No problem here!\""
-msgstr ""
+msgstr "\"No hay ningún problema.\""
 
 #: src/error-handling/panics.md
 msgid "\"{result:?}\""
-msgstr ""
+msgstr "\"{result:?}\""
 
 #: src/error-handling/panics.md
 msgid "\"oh no!\""
-msgstr ""
+msgstr "\"¡Vaya!\""
 
 #: src/error-handling/panics.md
 msgid ""
 "Catching is unusual; do not attempt to implement exceptions with "
 "`catch_unwind`!"
 msgstr ""
+"El catching no es habitual, por lo que recomendamos no implementar "
+"excepciones con `catch_unwind`."
 
 #: src/error-handling/panics.md
 msgid ""
@@ -11452,6 +11608,11 @@ msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
 "turn the common"
 msgstr ""
+"Los errores de tiempo de ejecución, como los de fallo en la conexión o de "
+"archivo no encontrado, se gestionan con el tipo `Result`, pero hacer "
+"coincidir este tipo en todas las llamadas puede ser complicado. El operador "
+"try `?` se utiliza para devolver errores al llamador. Te permite convertir "
+"lo habitual"
 
 #: src/error-handling/try.md
 msgid "into the much simpler"
@@ -11463,20 +11624,20 @@ msgstr "Podemos utilizarlo para simplificar el código de gestión de errores:"
 
 #: src/error-handling/try.md
 msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
-msgstr ""
+msgstr "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
 
 #: src/error-handling/try.md src/error-handling/try-conversions.md
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"config.dat\""
-msgstr ""
+msgstr "\"config.dat\""
 
 #: src/error-handling/try.md src/error-handling/try-conversions.md
 msgid "\"username or error: {username:?}\""
-msgstr ""
+msgstr "\"nombre de usuario o error: {username:?}\""
 
 #: src/error-handling/try.md
 msgid "Simplify the `read_username` function to use `?`."
-msgstr ""
+msgstr "Simplifica la función `read_username` para usar `?`."
 
 #: src/error-handling/try.md
 msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
@@ -11497,6 +11658,10 @@ msgid ""
 "The executable will print the `Err` variant and return a nonzero exit status "
 "on error."
 msgstr ""
+"Ten en cuenta que `main` puede devolver un `Result<(), E>` siempre que "
+"implemente `std::process:Termination`. En la práctica, esto significa que "
+"`E` implementa `Debug`. El ejecutable imprimirá la variante `Err` y "
+"devolverá un estado de salida distinto a cero si se produce un error."
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11522,16 +11687,16 @@ msgstr ""
 
 #: src/error-handling/try-conversions.md
 msgid "\"IO error: {e}\""
-msgstr ""
+msgstr "\"Error IO: {e}\""
 
 #: src/error-handling/try-conversions.md
 msgid "\"Found no username in {path}\""
-msgstr ""
+msgstr "\"No se ha encontrado ningún nombre de usuario en {path}\""
 
 #: src/error-handling/try-conversions.md
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
-msgstr ""
+msgstr "//fs::write(\"config.dat\", \"\").unwrap();\n"
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11541,12 +11706,20 @@ msgid ""
 "of type `Result<U, ErrorInner>` if `ErrorOuter` and `ErrorInner` are the "
 "same type or if `ErrorOuter` implements `From<ErrorInner>`."
 msgstr ""
+"El operador `?` debe devolver un valor compatible con el tipo de resultado "
+"devuelto de la función. En `Result`, significa que los tipos de error deben "
+"ser compatibles. Una función que devuelve `Result<T, ErrorOuter>` solo puede "
+"usar `?` en un valor del tipo `Result<U, ErrorInner>` si `ErrorOuter` y "
+"`ErrorInner` son del mismo tipo o si `ErrorOuter` implementa `. "
+"From<ErrorInner>`."
 
 #: src/error-handling/try-conversions.md
 msgid ""
 "A common alternative to a `From` implementation is `Result::map_err`, "
 "especially when the conversion only happens in one place."
 msgstr ""
+"Una alternativa habitual a la implementación `From` es `Result::map_err`, "
+"sobre todo si la conversión solo se produce en un lugar."
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11554,6 +11727,9 @@ msgid ""
 "`Option<T>` can use the `?` operator on `Option<U>` for arbitrary `T` and "
 "`U` types."
 msgstr ""
+"No hay ningún requisito de compatibilidad para `Option`. Una función que "
+"devuelve `Option<T>` puede usar el operador `?` en `Option<U>` para tipos "
+"arbitrarios de `T` y `U`."
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11561,6 +11737,9 @@ msgid ""
 "However, `Option::ok_or` converts `Option` to `Result` whereas `Result::ok` "
 "turns `Result` into `Option`."
 msgstr ""
+"Una función que devuelve `Result` no puede usar `?` en `Option` y viceversa. "
+"Sin embargo, `Option::ok_or` convierte `Option` en `Result`, mientras que "
+"`Result::ok` convierte `Result` en `Option`."
 
 #: src/error-handling/error.md
 msgid "Dynamic Error Types"
@@ -11580,25 +11759,27 @@ msgstr ""
 
 #: src/error-handling/error.md
 msgid "\"count.dat\""
-msgstr ""
+msgstr "\"count.dat\""
 
 #: src/error-handling/error.md
 msgid "\"1i3\""
-msgstr ""
+msgstr "\"1i3\""
 
 #: src/error-handling/error.md
 msgid "\"Count: {count}\""
-msgstr ""
+msgstr "\"Recuento: {count}\""
 
 #: src/error-handling/error.md
 msgid "\"Error: {err}\""
-msgstr ""
+msgstr "\"Error: {err}\""
 
 #: src/error-handling/error.md
 msgid ""
 "The `read_count` function can return `std::io::Error` (from file operations) "
 "or `std::num::ParseIntError` (from `String::parse`)."
 msgstr ""
+"La función `read_count` puede devolver `std::io::Error` (de las operaciones "
+"de archivos) o `std::num::ParseIntError` (de `String::parse`)."
 
 #: src/error-handling/error.md
 #, fuzzy
@@ -11623,6 +11804,11 @@ msgid ""
 "compatible with `no_std` in [nightly](https://github.com/rust-lang/rust/"
 "issues/103765) only."
 msgstr ""
+"Asegúrate de implementar el trait `std::error::Error` al definir un tipo de "
+"error personalizado para que pueda tener una estructura box. Sin embargo, si "
+"necesitas el atributo `no_std`, ten en cuenta que el trait `std::error::"
+"Error` de momento solo es compatible con `no_std` en [nightly](https://"
+"github.com/rust-lang/rust/issues/103765)."
 
 #: src/error-handling/thiserror-and-anyhow.md
 #, fuzzy
@@ -11639,32 +11825,36 @@ msgid ""
 "`thiserror` is often used in libraries to create custom error types that "
 "implement `From<T>`."
 msgstr ""
+"`thiserror` se suele usar en bibliotecas para crear tipos de errores "
+"personalizados que implementan `From<T>`."
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "`anyhow` is often used by applications to help with error handling in "
 "functions, including adding contextual information to your errors."
 msgstr ""
+"Las aplicaciones suelen utilizar `anyhow` para gestionar errores en "
+"funciones, como añadir información contextual a los errores."
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Found no username in {0}\""
-msgstr ""
+msgstr "\"No se ha encontrado ningún nombre de usuario en {0}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Failed to open {path}\""
-msgstr ""
+msgstr "\"No se ha podido abrir {path}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Failed to read\""
-msgstr ""
+msgstr "\"No se ha podido leer\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Username: {username}\""
-msgstr ""
+msgstr "\"Nombre de usuario: {username}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Error: {err:?}\""
-msgstr ""
+msgstr "\"Error: {err:?}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 #, fuzzy
@@ -11676,18 +11866,20 @@ msgid ""
 "The `Error` derive macro is provided by `thiserror`, and has lots of useful "
 "attributes to help define error types in a compact way."
 msgstr ""
+"La macro de derivación `Error` la proporciona `thiserror` y ofrece muchos "
+"atributos útiles para definir los tipos de error de forma compacta."
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "The `std::error::Error` trait is derived automatically."
-msgstr ""
+msgstr "El trait `std::error::Error` se deriva automáticamente."
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "The message from `#[error]` is used to derive the `Display` trait."
-msgstr ""
+msgstr "El mensaje de `#[error]` se usa para derivar el trait `Display`."
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "`anyhow`"
-msgstr ""
+msgstr "`anyhow`"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
@@ -11727,10 +11919,13 @@ msgid ""
 "`Option` types. `use anyhow::Context` is necessary to enable `.context()` "
 "and `.with_context()` on those types."
 msgstr ""
+"`anyhow::Context` es un trait implementado para los tipos estándar `Result` "
+"y `Option`. Se necesita `use anyhow::Context` para habilitar `.context()` y "
+"`.with_context()` en esos tipos."
 
 #: src/error-handling/exercise.md
 msgid "Exercise: Rewriting with Result"
-msgstr ""
+msgstr "Ejercicio: reescribir con Result"
 
 #: src/error-handling/exercise.md
 msgid ""
@@ -11739,6 +11934,11 @@ msgid ""
 "error handling and propagate errors to a return from `main`. Feel free to "
 "use `thiserror` and `anyhow`."
 msgstr ""
+"A continuación, se implementa un analizador muy sencillo para un lenguaje de "
+"expresiones. Sin embargo, para gestionar los errores, utiliza pánicos. "
+"Reescribe este texto para utilizar la gestión de errores idiomática y "
+"propagar los errores a un instrucción de retorno desde `main`. No dudes en "
+"usar `thiserror` y `anyhow`."
 
 #: src/error-handling/exercise.md
 msgid ""
@@ -11746,119 +11946,125 @@ msgid ""
 "working correctly, update `Tokenizer` to implement "
 "`Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser."
 msgstr ""
+"CONSEJO: empieza por corregir la gestión de errores en la función `parse`. "
+"Cuando funcione correctamente, actualiza `Tokenizer` para implementar "
+"`Iterator<Item=Result<Token, TokenizerError>>` y gestiónalo en el analizador."
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// An arithmetic operator.\n"
-msgstr ""
+msgstr "/// Un operador aritmético.\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A token in the expression language.\n"
-msgstr ""
+msgstr "/// Un token en el lenguaje expresión.\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// An expression in the expression language.\n"
-msgstr ""
+msgstr "/// Una expresión en el lenguaje de la expresión.\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A reference to a variable.\n"
-msgstr ""
+msgstr "/// Una referencia a una variable.\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A literal number.\n"
-msgstr ""
+msgstr "/// Un número literal.\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A binary operation.\n"
-msgstr ""
+msgstr "/// Una operación binaria.\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'z'"
-msgstr ""
+msgstr "'z'"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'_'"
-msgstr ""
+msgstr "'_'"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'+'"
-msgstr ""
+msgstr "'+'"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'-'"
-msgstr ""
+msgstr "'-'"
 
 #: src/error-handling/exercise.md
 msgid "\"Unexpected character {c}\""
-msgstr ""
+msgstr "\"Carácter inesperado {c}\""
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"Unexpected end of input\""
-msgstr ""
+msgstr "\"Fin de entrada inesperado\""
 
 #: src/error-handling/exercise.md
 msgid "\"Invalid 32-bit integer'\""
-msgstr ""
+msgstr "\"Número entero de 32 bits no válido'\""
 
 #: src/error-handling/exercise.md
 msgid "\"Unexpected token {tok:?}\""
-msgstr ""
+msgstr "\"Token inesperado: {tok:?}\""
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "// Look ahead to parse a binary operation if present.\n"
-msgstr ""
+msgstr "// Analiza la operación binaria, si procede.\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"10+foo+20-30\""
-msgstr ""
+msgstr "\"10+foo+20-30\""
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"{expr:?}\""
-msgstr ""
+msgstr "\"{expr:?}\""
 
 #: src/error-handling/solution.md
 msgid "\"Unexpected character '{0}' in input\""
-msgstr ""
+msgstr "\"Carácter inesperado '{0}' en la entrada\""
 
 #: src/error-handling/solution.md
 msgid "\"Tokenizer error: {0}\""
-msgstr ""
+msgstr "\"Error del tokenizador: {0}\""
 
 #: src/error-handling/solution.md
 msgid "\"Unexpected token {0:?}\""
-msgstr ""
+msgstr "\"Token inesperado: {0:?}\""
 
 #: src/error-handling/solution.md
 msgid "\"Invalid number\""
-msgstr ""
+msgstr "\"Número no válido\""
 
 #: src/unsafe-rust.md
 msgid "[Unsafe](./unsafe-rust/unsafe.md) (5 minutes)"
-msgstr ""
+msgstr "[Inseguro](./unsafe-rust/unsafe.md) (5 minutos)"
 
 #: src/unsafe-rust.md
 msgid ""
 "[Dereferencing Raw Pointers](./unsafe-rust/dereferencing.md) (10 minutes)"
 msgstr ""
+"[Desreferenciar punteros sin formato](./unsafe-rust/dereferencing.md) (10 "
+"minutos)"
 
 #: src/unsafe-rust.md
 msgid "[Mutable Static Variables](./unsafe-rust/mutable-static.md) (5 minutes)"
 msgstr ""
+"[Variables estáticas mutables](./unsafe-rust/mutable-static.md) (5 minutos)"
 
 #: src/unsafe-rust.md
 msgid "[Unions](./unsafe-rust/unions.md) (5 minutes)"
-msgstr ""
+msgstr "[Uniones](./unsafe-rust/unions.md) (5 minutos)"
 
 #: src/unsafe-rust.md
 msgid "[Unsafe Functions](./unsafe-rust/unsafe-functions.md) (5 minutes)"
-msgstr ""
+msgstr "[Funciones inseguras](./unsafe-rust/unsafe-functions.md) (5 minutos)"
 
 #: src/unsafe-rust.md
 msgid "[Unsafe Traits](./unsafe-rust/unsafe-traits.md) (5 minutes)"
-msgstr ""
+msgstr "[Traits inseguros](./unsafe-rust/unsafe-traits.md) (5 minutos)"
 
 #: src/unsafe-rust.md
 msgid "[Exercise: FFI Wrapper](./unsafe-rust/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[Ejercicio: envoltorio de FFI](./unsafe-rust/exercise.md) (30 minutos)"
 
 #: src/unsafe-rust/unsafe.md
 msgid "The Rust language has two parts:"
@@ -11952,7 +12158,7 @@ msgstr ""
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"careful!\""
-msgstr ""
+msgstr "\"¡cuidado!\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
@@ -11963,18 +12169,26 @@ msgid ""
 "    // whole unsafe block, and they are not accessed either through the\n"
 "    // references or concurrently through any other pointers.\n"
 msgstr ""
+"// Es seguro porque r1 y r2 se han obtenido a partir desde referencias y, "
+"por lo tanto,\n"
+"    // se garantiza que no son nulos y que están alineados correctamente. "
+"Los objetos subyacentes\n"
+"    // a las referencias de las que se han obtenido están activos\n"
+"    // en el bloque inseguro y no se puede acceder a ellos ni a través de "
+"las \n"
+"    // referencias ni simultáneamente a través de otros punteros.\n"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"r1 is: {}\""
-msgstr ""
+msgstr "\"r1 es: {}\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"uhoh\""
-msgstr ""
+msgstr "\"oh, oh\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"r2 is: {}\""
-msgstr ""
+msgstr "\"r2 es: {}\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
@@ -11985,6 +12199,12 @@ msgid ""
 "    println!(\"r3 is: {}\", *r3);\n"
 "    */"
 msgstr ""
+"// NO ES SEGURO. NO HAGAS ESTO.\n"
+"    /*\n"
+"    let r3: &String = unsafe { &*r1 };\n"
+"    drop(s);\n"
+"    println!(\"r3 is: {}\", *r3);\n"
+"    */"
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
@@ -12047,19 +12267,23 @@ msgid ""
 "has the `'static` lifetime, so `r3` has type `&'static String`, and thus "
 "outlives `s`. Creating a reference from a pointer requires _great care_."
 msgstr ""
+"En la sección \"INSEGURO\" se muestra un ejemplo de un tipo común de error "
+"comportamiento indefinido: `*r1` tiene el tiempo de vida `'static`, por lo "
+"que `r3` tiene el tipo `&'static String` y, por lo tanto, su duración es "
+"mayor que la de `s`. Para crear una referencia a partir de un puntero hay "
+"que tener _mucho cuidado_."
 
 #: src/unsafe-rust/mutable-static.md
 msgid "It is safe to read an immutable static variable:"
 msgstr "Es seguro leer una variable estática inmutable:"
 
 #: src/unsafe-rust/mutable-static.md
-#, fuzzy
 msgid "\"Hello, world!\""
-msgstr "¡Hola, mundo!"
+msgstr "\"¡Hola, mundo!\""
 
 #: src/unsafe-rust/mutable-static.md
 msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
-msgstr ""
+msgstr "\"HELLO_WORLD: {HELLO_WORLD}\""
 
 #: src/unsafe-rust/mutable-static.md
 msgid ""
@@ -12071,7 +12295,7 @@ msgstr ""
 
 #: src/unsafe-rust/mutable-static.md
 msgid "\"COUNTER: {COUNTER}\""
-msgstr ""
+msgstr "\"CONTADOR: {COUNTER}\""
 
 #: src/unsafe-rust/mutable-static.md
 msgid ""
@@ -12080,6 +12304,10 @@ msgid ""
 "`unsafe` and see how the compiler explains that it is undefined behavior to "
 "mutate a static from multiple threads."
 msgstr ""
+"Este programa es seguro porque tiene un único hilo. Sin embargo, el "
+"compilador de Rust es conservador y asumirá lo peor. Prueba a eliminar "
+"`unsafe` y observa cómo el compilador explica que cambiar un elemento "
+"estático desde varios hilos es un comportamiento indefinido."
 
 #: src/unsafe-rust/mutable-static.md
 msgid ""
@@ -12099,16 +12327,15 @@ msgstr ""
 
 #: src/unsafe-rust/unions.md
 msgid "\"int: {}\""
-msgstr ""
+msgstr "\"int: {}\""
 
 #: src/unsafe-rust/unions.md
 msgid "\"bool: {}\""
-msgstr ""
+msgstr "\"bool: {}\""
 
 #: src/unsafe-rust/unions.md
-#, fuzzy
 msgid "// Undefined behavior!\n"
-msgstr "No hay comportamientos indefinidos en _runtime_:"
+msgstr "// ¡Comportamiento indefinido!\n"
 
 #: src/unsafe-rust/unions.md
 msgid ""
@@ -12152,25 +12379,29 @@ msgstr ""
 #: src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"C\""
-msgstr ""
+msgstr "\"C\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"🗻∈🌏\""
-msgstr ""
+msgstr "\"🗻∈🌏\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "// Safe because the indices are in the correct order, within the bounds of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
 msgstr ""
+"// Es seguro porque los índices están en el orden correcto, dentro de los "
+"límites del\n"
+"    // el slice de la cadena, y se encuentran en los límites de la secuencia "
+"de UTF-8.\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"emoji: {}\""
-msgstr ""
+msgstr "\"emoji: {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"char count: {}\""
-msgstr ""
+msgstr "\"recuento de caracteres: {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 #, fuzzy
@@ -12179,7 +12410,7 @@ msgstr "No hay comportamientos indefinidos en _runtime_:"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"Absolute value of -3 according to C: {}\""
-msgstr ""
+msgstr "\"Valor absoluto de -3 según C: {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
@@ -12188,6 +12419,11 @@ msgid ""
 "    // println!(\"char count: {}\", count_chars(unsafe {\n"
 "    // emojis.get_unchecked(0..3) }));\n"
 msgstr ""
+"// Si no se mantiene el requisito de codificación UTF-8, se verá afectada la "
+"seguridad de la memoria.\n"
+"    // println!(\"emoji: {}\", no seguro { emojis.get_unchecked(0..3) });\n"
+"    // println!(\"recuento de caracteres: {}\", count_chars(no seguro {\n"
+"    // emojis.get_unchecked(0..3) }));\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "Writing Unsafe Functions"
@@ -12209,14 +12445,19 @@ msgid ""
 "///\n"
 "/// The pointers must be valid and properly aligned.\n"
 msgstr ""
+"/// Cambia los valores a los que apuntan los punteros proporcionados.\n"
+"///\n"
+"/// # Seguridad\n"
+"///\n"
+"/// Los punteros deben ser válidos y estar alineados adecuadamente.\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "// Safe because ...\n"
-msgstr ""
+msgstr "// Es seguro porque ...\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"a = {}, b = {}\""
-msgstr ""
+msgstr "\"a = {}, b = {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 #, fuzzy
@@ -12289,10 +12530,16 @@ msgid ""
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
 msgstr ""
+"/// ...\n"
+"/// # Seguridad\n"
+"/// El tipo debe tener una representación definida y no tener espacio de "
+"relleno.\n"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid "// Safe because u32 has a defined representation and no padding.\n"
 msgstr ""
+"// Es seguro porque u32 tiene una representación definida y no tiene espacio "
+"de relleno.\n"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid ""
@@ -12319,7 +12566,6 @@ msgid "Safe FFI Wrapper"
 msgstr "Envoltorio de FFI Seguro"
 
 #: src/unsafe-rust/exercise.md
-#, fuzzy
 msgid ""
 "Rust has great support for calling functions through a _foreign function "
 "interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
@@ -12479,11 +12725,11 @@ msgstr ""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"macos\""
-msgstr ""
+msgstr "\"macos\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-msgstr ""
+msgstr "// Tipo opaco. Consulta https://doc.rust-lang.org/nomicon/ffi.html.\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
@@ -12491,14 +12737,18 @@ msgid ""
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
 msgstr ""
+"// Diseño según la página del manual de Linux para readdir(3), donde ino_t "
+"y\n"
+"    // off_t se resuelven de acuerdo con las definiciones de\n"
+"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}. .\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Layout according to the macOS man page for dir(5).\n"
-msgstr ""
+msgstr "// Diseño según la página del manual de macOS de dir(5).\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"x86_64\""
-msgstr ""
+msgstr "\"x86_64\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
@@ -12510,105 +12760,118 @@ msgid ""
 "        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
 "PowerPC.\n"
 msgstr ""
+"// Consulta https://github.com/rust-lang/libc/issues/414 y la sección sobre\n"
+" // _DARWIN_FEATURE_64_BIT_INODE en la página del manual de macOS de "
+"stat(2).\n"
+" //\n"
+" // \" Las plataformas que existían antes de que estas actualizaciones "
+"estuvieran disponibles\" hacen referencia\n"
+" // a macOS (en lugar de iOS, WearOS, etc.) en Intel y PowerPC.\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"readdir$INODE64\""
-msgstr ""
+msgstr "\"readdir$INODE64\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
 "// Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
 msgstr ""
+"// Llama a opendir y devuelve un valor Ok si ha funcionado,\n"
+"        // de lo contrario, devuelve Err con un mensaje.\n"
 
 #: src/unsafe-rust/exercise.md
 msgid "// Keep calling readdir until we get a NULL pointer back.\n"
-msgstr ""
+msgstr "// Sigue llamando a readdir hasta se obtenga un puntero NULL.\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Call closedir as needed.\n"
-msgstr ""
+msgstr "// Llama a closedir según sea necesario.\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 #: src/android/interoperability/with-c/rust.md
 msgid "\".\""
-msgstr ""
+msgstr "\".\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"files: {:#?}\""
-msgstr ""
+msgstr "\"archivos: {:#?}\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"Invalid path: {err}\""
-msgstr ""
+msgstr "\"Ruta no válida: {err}\""
 
 #: src/unsafe-rust/solution.md
 msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
-msgstr ""
+msgstr "// SEGURIDAD: path.as_ptr() no puede ser NULL.\n"
 
 #: src/unsafe-rust/solution.md
 msgid "\"Could not open {:?}\""
-msgstr ""
+msgstr "\"No se ha podido abrir {:?}\""
 
 #: src/unsafe-rust/solution.md
 msgid ""
 "// Keep calling readdir until we get a NULL pointer back.\n"
 "        // SAFETY: self.dir is never NULL.\n"
 msgstr ""
+"// Sigue llamando a readdir hasta que se obtenga un puntero NULL.\n"
+"        // SEGURIDAD: self.dir nunca es NULL.\n"
 
 #: src/unsafe-rust/solution.md
 msgid "// We have reached the end of the directory.\n"
-msgstr ""
+msgstr "// Hemos llegado al final del directorio.\n"
 
 #: src/unsafe-rust/solution.md
 msgid ""
 "// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
 "        // terminated.\n"
 msgstr ""
+"// SEGURIDAD: dirent no es NULL y dirent.d_name es NULL\n"
+"        // finalizado.\n"
 
 #: src/unsafe-rust/solution.md
 msgid "// SAFETY: self.dir is not NULL.\n"
-msgstr ""
+msgstr "// SEGURIDAD: self.dir no es NULL.\n"
 
 #: src/unsafe-rust/solution.md
 msgid "\"Could not close {:?}\""
-msgstr ""
+msgstr "\"No se ha podido cerrar {:?}.\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"no-such-directory\""
-msgstr ""
+msgstr "\"no-such-directory\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"Non UTF-8 character in path\""
-msgstr ""
+msgstr "\"Hay un carácter no codificado en UTF-8 en la ruta\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"..\""
-msgstr ""
+msgstr "\"..\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"foo.txt\""
-msgstr ""
+msgstr "\"foo.txt\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"The Foo Diaries\\n\""
-msgstr ""
+msgstr "\"The Foo Diaries\\n\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"bar.png\""
-msgstr ""
+msgstr "\"bar.png\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"<PNG>\\n\""
-msgstr ""
+msgstr "\"<PNG>\\n\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"crab.rs\""
-msgstr ""
+msgstr "\"crab.rs\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"//! Crab\\n\""
-msgstr ""
+msgstr "\"//! Crab\\n\""
 
 #: src/android.md
 msgid "Welcome to Rust in Android"

--- a/po/es.po
+++ b/po/es.po
@@ -7826,73 +7826,84 @@ msgstr "Te damos la Bienvenida al Día 3"
 
 #: src/welcome-day-3.md
 msgid "Today, we will cover:"
-msgstr ""
+msgstr "Hoy trataremos los siguientes puntos:"
 
 #: src/welcome-day-3.md
 msgid ""
 "Memory management, lifetimes, and the borrow checker: how Rust ensures "
 "memory safety."
 msgstr ""
+"Gestión de la memoria, _lifetimes_ y el _borrow checker_: cómo garantiza "
+"Rust la seguridad de la memoria."
 
 #: src/welcome-day-3.md
 msgid "Smart pointers: standard library pointer types."
-msgstr ""
+msgstr "Punteros inteligentes: tipos de punteros de biblioteca estándar."
 
 #: src/welcome-day-3.md
 msgid "[Welcome](./welcome-day-3.md) (3 minutes)"
-msgstr ""
+msgstr "[Bienvenida](./welcome-day-3.md) (3 minutos)"
 
 #: src/welcome-day-3.md
 msgid "[Memory Management](./memory-management.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[Gestión de la memoria](./Memory-management.md) (1 hora y 10 minutos)"
 
 #: src/welcome-day-3.md
+#, fuzzy
 msgid "[Smart Pointers](./smart-pointers.md) (45 minutes)"
-msgstr ""
+msgstr "[Punteros inteligentes](./smart-pointers.md) (55 minutos)"
 
 #: src/welcome-day-3.md
+#, fuzzy
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 15 "
 "minutes"
 msgstr ""
+"Contando con los descansos de 10 minutos, la duración prevista de la sesión "
+"es de unas 2 horas y 25 minutos."
 
 #: src/memory-management.md
 msgid "[Review of Program Memory](./memory-management/review.md) (5 minutes)"
 msgstr ""
+"[Revisión de la memoria del programa](./Memory-management/review.md) (5 "
+"minutos)"
 
 #: src/memory-management.md
 msgid ""
 "[Approaches to Memory Management](./memory-management/approaches.md) (10 "
 "minutes)"
 msgstr ""
+"[Estrategias para la gestión de la memoria](./Memory-manageme t/approaches."
+"md) (10 minutos)"
 
 #: src/memory-management.md
 msgid "[Ownership](./memory-management/ownership.md) (5 minutes)"
-msgstr ""
+msgstr "[Ownership](./Memory-management/ownership.md) (5 minutos)"
 
 #: src/memory-management.md
 msgid "[Move Semantics](./memory-management/move.md) (10 minutes)"
-msgstr ""
+msgstr "[Semántica de movimiento](./Memory-management/move.md) (10 minutos)"
 
 #: src/memory-management.md
 msgid "[Clone](./memory-management/clone.md) (2 minutes)"
-msgstr ""
+msgstr "[Clonar](./Memory-management/clone.md) (2 minutos)"
 
 #: src/memory-management.md
 msgid "[Copy Types](./memory-management/copy-types.md) (5 minutes)"
-msgstr ""
+msgstr "[Copiar tipos](./Memory-management/copy-types.md) (5 minutos)"
 
 #: src/memory-management.md
 msgid "[Drop](./memory-management/drop.md) (10 minutes)"
-msgstr ""
+msgstr "[Drop](./Memory-management/drop.md) (10 minutos)"
 
 #: src/memory-management.md
 msgid "[Exercise: Builder Type](./memory-management/exercise.md) (20 minutes)"
 msgstr ""
+"[Ejercicio: tipo de compilador](./Memory-management/exercise.md) (20 minutos)"
 
 #: src/memory-management/review.md
 msgid "Programs allocate memory in two ways:"
-msgstr ""
+msgstr "Los programas asignan memoria de dos formas:"
 
 #: src/memory-management/review.md
 msgid "Stack: Continuous area of memory for local variables."
@@ -7971,11 +7982,11 @@ msgstr ""
 
 #: src/memory-management/review.md src/testing/unit-tests.md
 msgid "' '"
-msgstr ""
+msgstr "' '"
 
 #: src/memory-management/review.md
 msgid "\"world\""
-msgstr ""
+msgstr "\"mundo\""
 
 #: src/memory-management/review.md
 msgid ""
@@ -7984,10 +7995,14 @@ msgid ""
 "to\n"
 "    // undefined behavior.\n"
 msgstr ""
+"// ¡NO HAGÁIS ESTO EN CASA! Solo con fines educativos.\n"
+"    // La cadena no proporciona garantías sobre su diseño, por lo que podría "
+"desencadenar\n"
+"    // un comportamiento indefinido.\n"
 
 #: src/memory-management/review.md
 msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
-msgstr ""
+msgstr "\"ptr = {ptr:#x}, longitud = {len}, capacidad = {capacity}\""
 
 #: src/memory-management/approaches.md
 msgid "Traditionally, languages have fallen into two broad categories:"
@@ -8001,16 +8016,17 @@ msgstr ""
 
 #: src/memory-management/approaches.md
 msgid "Programmer decides when to allocate or free heap memory."
-msgstr ""
+msgstr "El programador decide cuándo asignar o liberar memoria del montículo."
 
 #: src/memory-management/approaches.md
 msgid ""
 "Programmer must determine whether a pointer still points to valid memory."
 msgstr ""
+"El programador debe determinar si un puntero aún apunta a una memoria válida."
 
 #: src/memory-management/approaches.md
 msgid "Studies show, programmers make mistakes."
-msgstr ""
+msgstr "Los estudios demuestran que los programadores cometen errores."
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -8025,11 +8041,15 @@ msgid ""
 "A runtime system ensures that memory is not freed until it can no longer be "
 "referenced."
 msgstr ""
+"Un sistema de tiempo de ejecución asegura que la memoria no se libera hasta "
+"que ya no se pueda hacer referencia a ella."
 
 #: src/memory-management/approaches.md
 msgid ""
 "Typically implemented with reference counting, garbage collection, or RAII."
 msgstr ""
+"Normalmente se implementa con un contador de referencias, la recolección de "
+"elementos no utilizados o RAII."
 
 #: src/memory-management/approaches.md
 msgid "Rust offers a new mix:"
@@ -8053,6 +8073,8 @@ msgid ""
 "This slide is intended to help students coming from other languages to put "
 "Rust in context."
 msgstr ""
+"El objetivo de esta diapositiva es ayudar a los estudiantes de otros "
+"lenguajes a entender mejor Rust."
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -8060,6 +8082,10 @@ msgid ""
 "forgetting to call `free`, calling it multiple times for the same pointer, "
 "or dereferencing a pointer after the memory it points to has been freed."
 msgstr ""
+"C debe gestionar el montículo de forma manual con `malloc` y `free`. Entre "
+"los errores habituales se incluyen olvidarse de llamar a `free`, llamarlo "
+"varias veces para el mismo puntero o desreferenciar un puntero después de "
+"que se haya liberado la memoria a la que apunta."
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -8068,6 +8094,11 @@ msgid ""
 "is freed when a function returns. It is still quite easy to mis-use these "
 "tools and create similar bugs to C."
 msgstr ""
+"C++ tiene herramientas como los punteros inteligentes (`unique_ptr` y "
+"`shared_ptr`) que aprovechan las garantías del lenguaje sobre la llamada a "
+"destructores para garantizar que la memoria se libere cuando se devuelva una "
+"función. Sin embargo, es fácil hacer un uso inadecuado de estas herramientas "
+"y crear errores similares a los de C."
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -8076,6 +8107,12 @@ msgid ""
 "be dereferenced, eliminating use-after-free and other classes of bugs. But, "
 "GC has a runtime cost and is difficult to tune properly."
 msgstr ""
+"Java, Go y Python utilizan el recolector de elementos no utilizados para "
+"identificar la memoria a la que ya no se puede acceder y descartarla. Esto "
+"asegura que se pueda desreferenciar cualquier puntero, de forma que se "
+"eliminan los errores use-after-free y otros tipos de errores. Sin embargo, "
+"el recolector de elementos no utilizados tiene un coste de tiempo de "
+"ejecución y es difícil ajustarlo adecuadamente."
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -8086,6 +8123,13 @@ msgid ""
 "are even third-party crates available to support runtime garbage collection "
 "(not covered in this class)."
 msgstr ""
+"El modelo de propiedad y préstamo de Rust puede, en muchos casos, permitir "
+"obtener el rendimiento de C, con operaciones asignadas y libres donde se "
+"necesiten y sin coste. También proporciona herramientas similares a los "
+"punteros inteligentes de C++. Si es necesario, hay disponibles otras "
+"opciones, como el recuento de referencias, e incluso hay crates de terceros "
+"que admiten la recolección de elementos no utilizados del tiempo de "
+"ejecución (estos elementos no se tratan en esta clase)."
 
 #: src/memory-management/ownership.md
 msgid ""
@@ -8115,23 +8159,27 @@ msgid ""
 "garbage collector starts with a set of \"roots\" to find all reachable "
 "memory. Rust's \"single owner\" principle is a similar idea."
 msgstr ""
+"Los participantes que estén familiarizados con las implementaciones de "
+"recolección de elementos no utilizados sabrán que este tipo de recolector "
+"comienza con un conjunto de \"raíces\" para buscar toda la memoria "
+"disponible. El principio de \"propietario único\" de Rust es una idea "
+"similar."
 
 #: src/memory-management/move.md
 msgid "An assignment will transfer _ownership_ between variables:"
 msgstr "Una asignación transferirá su _ownership_ entre variables:"
 
 #: src/memory-management/move.md
-#, fuzzy
 msgid "\"Hello!\""
-msgstr "¡Hola, mundo!"
+msgstr "\"¡Hola!\""
 
 #: src/memory-management/move.md src/slices-and-lifetimes/str.md
 msgid "\"s2: {s2}\""
-msgstr ""
+msgstr "\"s2: {s2}\""
 
 #: src/memory-management/move.md
 msgid "// println!(\"s1: {s1}\");\n"
-msgstr ""
+msgstr "// println!(\"s1: {s1}\");\n"
 
 #: src/memory-management/move.md
 msgid "The assignment of `s1` to `s2` transfers ownership."
@@ -8208,16 +8256,15 @@ msgstr ""
 
 #: src/memory-management/move.md
 msgid "\"Hello {name}\""
-msgstr ""
+msgstr "\"Hola {name}\""
 
 #: src/memory-management/move.md src/android/interoperability/java.md
-#, fuzzy
 msgid "\"Alice\""
-msgstr "Slices"
+msgstr "\"Alice\""
 
 #: src/memory-management/move.md
 msgid "// say_hello(name);\n"
-msgstr ""
+msgstr "// say_hello(name);\n"
 
 #: src/memory-management/move.md
 msgid ""
@@ -8251,7 +8298,7 @@ msgstr "En Rust, la clonación es explícita (usando `clone`)."
 
 #: src/memory-management/move.md
 msgid "In the `say_hello` example:"
-msgstr ""
+msgstr "En el ejemplo de `say_hello`:"
 
 #: src/memory-management/move.md
 msgid ""
@@ -8305,11 +8352,11 @@ msgstr "La versión moderna de C++ soluciona este problema de forma diferente:"
 
 #: src/memory-management/move.md
 msgid "\"Cpp\""
-msgstr ""
+msgstr "\"Cpp\""
 
 #: src/memory-management/move.md
 msgid "// Duplicate the data in s1.\n"
-msgstr ""
+msgstr "// Duplica los datos en s1.\n"
 
 #: src/memory-management/move.md
 msgid ""
@@ -8337,6 +8384,9 @@ msgid ""
 "the string data has to be cloned. Otherwise we would get a double-free when "
 "either string goes out of scope."
 msgstr ""
+"C++ ha tomado una decisión algo distinta a Rust. Puesto que `=` copia los "
+"datos, los datos de cadena deben clonarse. De lo contrario, obtendríamos un "
+"error double free si alguna de las cadenas saliera fuera del ámbito."
 
 #: src/memory-management/move.md
 msgid ""
@@ -8346,22 +8396,32 @@ msgid ""
 "move, `s1` would be in a valid but unspecified state. Unlike Rust, the "
 "programmer is allowed to keep using `s1`."
 msgstr ""
+"C++ también tiene [`std::move`](https://en.cppreference.com/w/cpp/utility/"
+"move), que se usa para indicar cuándo se puede mover un valor. Si el ejemplo "
+"hubiera sido `s2 = std::move(s1)`, no se llevaría a cabo ninguna asignación "
+"de montículo. Después del movimiento, `s1` tendría un estado válido, pero no "
+"especificado. A diferencia de Rust, el programador puede seguir utilizando "
+"`s1`."
 
 #: src/memory-management/move.md
 msgid ""
 "Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
 "which is being copied or moved."
 msgstr ""
+"A diferencia de Rust, en C++ se puede ejecutar código arbitrario con `=` "
+"según el tipo que se vaya a copiar o mover."
 
 #: src/memory-management/clone.md
 msgid "Clone"
-msgstr ""
+msgstr "Clone"
 
 #: src/memory-management/clone.md
 msgid ""
 "Sometimes you _want_ to make a copy of a value. The `Clone` trait "
 "accomplishes this."
 msgstr ""
+"Cuando _queramos_ hacer una copia de un valor, podemos hacerlo con el trait "
+"`Clone`."
 
 #: src/memory-management/clone.md
 msgid ""
@@ -8369,12 +8429,17 @@ msgid ""
 "occurring. Look for `.clone()` and a few others like `Vec::new` or `Box::"
 "new`."
 msgstr ""
+"La función de `Clone` es poder encontrar fácilmente dónde se producen las "
+"asignaciones de montículos. Busca `.clone()` y otros elementos como `Vec::"
+"new` o `Box::new`."
 
 #: src/memory-management/clone.md
 msgid ""
 "It's common to \"clone your way out\" of problems with the borrow checker, "
 "and return later to try to optimize those clones away."
 msgstr ""
+"Es habitual \"clonar para salir\" de los problemas con el verificador de "
+"préstamos y volver más tarde para optimizar esos clones."
 
 #: src/memory-management/copy-types.md
 msgid ""
@@ -8474,55 +8539,60 @@ msgstr ""
 
 #: src/memory-management/drop.md
 msgid "\"Dropping {}\""
-msgstr ""
+msgstr "\"Suprimiendo {}\""
 
 #: src/memory-management/drop.md src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"a\""
-msgstr ""
+msgstr "\"a\""
 
 #: src/memory-management/drop.md src/testing/googletest.md
 msgid "\"b\""
-msgstr ""
+msgstr "\"b\""
 
 #: src/memory-management/drop.md
 msgid "\"c\""
-msgstr ""
+msgstr "\"c\""
 
 #: src/memory-management/drop.md
 msgid "\"d\""
-msgstr ""
+msgstr "\"d\""
 
 #: src/memory-management/drop.md
 msgid "\"Exiting block B\""
-msgstr ""
+msgstr "\"Saliendo del bloque B\""
 
 #: src/memory-management/drop.md
 msgid "\"Exiting block A\""
-msgstr ""
+msgstr "\"Saliendo del bloque A\""
 
 #: src/memory-management/drop.md
 msgid "\"Exiting main\""
-msgstr ""
+msgstr "\"Saliendo de la página principal\""
 
 #: src/memory-management/drop.md
 msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
 msgstr ""
+"Ten en cuenta que `std::mem::drop` no es igual que `std::ops::Drop::drop`."
 
 #: src/memory-management/drop.md
 msgid "Values are automatically dropped when they go out of scope."
-msgstr ""
+msgstr "Los valores se suprimen automáticamente cuando salen del ámbito."
 
 #: src/memory-management/drop.md
 msgid ""
 "When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
 "drop` implementation will be called."
 msgstr ""
+"Cuando se elimina un valor, si implementa `std::ops::Drop`, se llamará a su "
+"implementación `Drop::drop`."
 
 #: src/memory-management/drop.md
 msgid ""
 "All its fields will then be dropped too, whether or not it implements `Drop`."
 msgstr ""
+"También se suprimirán todos sus campos, independientemente de si implementa "
+"o no `Drop`."
 
 #: src/memory-management/drop.md
 msgid ""
@@ -8531,12 +8601,18 @@ msgid ""
 "scope it gets dropped. This makes it a convenient way to explicitly drop "
 "values earlier than they would otherwise go out of scope."
 msgstr ""
+"`std::mem::drop` es solo una función vacía que toma cualquier valor. Es "
+"importante saber que toma la propiedad del valor, por lo que se descarta al "
+"final de su ámbito. Se trata de una forma sencilla de suprimir los valores "
+"de forma explícita antes que si se salen de su ámbito."
 
 #: src/memory-management/drop.md
 msgid ""
 "This can be useful for objects that do some work on `drop`: releasing locks, "
 "closing files, etc."
 msgstr ""
+"Esta acción puede ser útil para los objetos que trabajan con `drop`, como "
+"liberando bloqueos, cerrando archivos, etc."
 
 #: src/memory-management/drop.md
 msgid "Why doesn't `Drop::drop` take `self`?"
@@ -8561,121 +8637,129 @@ msgid ""
 "data. We will use the \"builder pattern\" to support building a new value "
 "piece-by-piece, using convenience functions."
 msgstr ""
+"En este ejemplo, implementaremos un tipo de datos complejo que posee todos "
+"sus datos. Utilizaremos el \"patrón de compilación\" para permitir la "
+"compilación de un nuevo valor parte por parte mediante funciones prácticas."
 
 #: src/memory-management/exercise.md
 msgid "Fill in the missing pieces."
-msgstr ""
+msgstr "Rellena las partes que faltan."
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// A representation of a software package.\n"
-msgstr ""
+msgstr "/// Una representación de un paquete de software.\n"
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid ""
 "/// Return a representation of this package as a dependency, for use in\n"
 "    /// building other packages.\n"
 msgstr ""
+"/// Devuelve una representación de este paquete como una dependencia para "
+"usarla\n"
+"    /// en la compilación de otros paquetes.\n"
 
 #: src/memory-management/exercise.md
 msgid "\"1\""
-msgstr ""
+msgstr "\"1\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid ""
 "/// A builder for a Package. Use `build()` to create the `Package` itself.\n"
 msgstr ""
+"/// Un compilador para un Package. Usa `build()` para crear el `Package`.\n"
 
 #: src/memory-management/exercise.md
 msgid "\"2\""
-msgstr ""
+msgstr "\"2\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the package version.\n"
-msgstr ""
+msgstr "/// Define la versión del paquete.\n"
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the package authors.\n"
-msgstr ""
+msgstr "/// Define los autores del paquete.\n"
 
 #: src/memory-management/exercise.md
 msgid "\"3\""
-msgstr ""
+msgstr "\"3\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Add an additional dependency.\n"
-msgstr ""
+msgstr "/// Añade una dependencia adicional.\n"
 
 #: src/memory-management/exercise.md
 msgid "\"4\""
-msgstr ""
+msgstr "\"4\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the language. If not set, language defaults to None.\n"
 msgstr ""
+"/// Define el idioma. Si no se define, el idioma predeterminado será None.\n"
 
 #: src/memory-management/exercise.md
 msgid "\"5\""
-msgstr ""
+msgstr "\"5\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"base64\""
-msgstr ""
+msgstr "\"base64\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"0.13\""
-msgstr ""
+msgstr "\"0.13\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"base64: {base64:?}\""
-msgstr ""
+msgstr "\"base64: {base64:?}\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"log\""
-msgstr ""
+msgstr "\"log\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"0.4\""
-msgstr ""
+msgstr "\"0.4\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"log: {log:?}\""
-msgstr ""
+msgstr "\"registro: {log:?}\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"serde\""
-msgstr ""
+msgstr "\"serde\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"djmitche\""
-msgstr ""
+msgstr "\"djmitche\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"4.0\""
-msgstr ""
+msgstr "\"4.0\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"serde: {serde:?}\""
-msgstr ""
+msgstr "\"serde: {serde:?}\""
 
 #: src/memory-management/solution.md
 msgid "\"0.1\""
-msgstr ""
+msgstr "\"0.1\""
 
 #: src/smart-pointers.md
 msgid "[Box"
-msgstr ""
+msgstr "[Box"
 
 #: src/smart-pointers.md
 msgid "](./smart-pointers/box.md) (10 minutes)"
-msgstr ""
+msgstr "](./smart-pointers/box.md) (10 minutos)"
 
 #: src/smart-pointers.md
 msgid "[Rc](./smart-pointers/rc.md) (5 minutes)"
-msgstr ""
+msgstr "[Rc](./smart-pointers/rc.md) (5 minutos)"
 
 #: src/smart-pointers.md
 msgid "[Exercise: Binary Tree](./smart-pointers/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[Ejercicio: árbol binario](./smart-pointers/exercise.md) (30 minutos)"
 
 #: src/smart-pointers/box.md
 msgid ""
@@ -8687,7 +8771,7 @@ msgstr ""
 
 #: src/smart-pointers/box.md
 msgid "\"five: {}\""
-msgstr ""
+msgstr "\"cinco: {}\""
 
 #: src/smart-pointers/box.md
 msgid ""
@@ -8708,15 +8792,15 @@ msgstr ""
 
 #: src/smart-pointers/box.md
 msgid "/// A non-empty list: first element and the rest of the list.\n"
-msgstr ""
+msgstr "/// Una lista no vacía: el primer elemento y el resto de la lista.\n"
 
 #: src/smart-pointers/box.md
 msgid "/// An empty list.\n"
-msgstr ""
+msgstr "/// Una lista vacía.\n"
 
 #: src/smart-pointers/box.md
 msgid "\"{list:?}\""
-msgstr ""
+msgstr "\"{list:?}\""
 
 #: src/smart-pointers/box.md
 #, fuzzy
@@ -8878,11 +8962,11 @@ msgstr ""
 
 #: src/smart-pointers/rc.md
 msgid "\"a: {a}\""
-msgstr ""
+msgstr "\"a: {a}\""
 
 #: src/smart-pointers/rc.md
 msgid "\"b: {b}\""
-msgstr ""
+msgstr "\"b: {b}\""
 
 #: src/smart-pointers/rc.md
 msgid ""
@@ -8953,24 +9037,33 @@ msgid ""
 "value. For a given node N, all nodes in a N's left subtree contain smaller "
 "values, and all nodes in N's right subtree will contain larger values."
 msgstr ""
+"Un árbol binario es una estructura de datos de tipo árbol en la que cada "
+"nodo tiene dos elementos secundarios (izquierda y derecha). Crearemos un "
+"árbol en el que cada nodo almacene un valor. Para un nodo N dado, todos los "
+"nodos del subárbol izquierdo de N contienen valores más pequeños, mientras "
+"que todos los nodos del subárbol derecho de N contendrán valores de mayor "
+"tamaño."
 
 #: src/smart-pointers/exercise.md
 msgid "Implement the following types, so that the given tests pass."
 msgstr ""
+"Implementa los siguientes tipos para superar las pruebas correspondientes."
 
 #: src/smart-pointers/exercise.md
 msgid ""
 "Extra Credit: implement an iterator over a binary tree that returns the "
 "values in order."
 msgstr ""
+"Ejercicio adicional: implementar un iterador sobre un árbol binario que "
+"devuelva los valores en orden."
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "/// A node in the binary tree.\n"
-msgstr ""
+msgstr "/// Un nodo del árbol binario.\n"
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "/// A possibly-empty subtree.\n"
-msgstr ""
+msgstr "/// Un subárbol posiblemente vacío.\n"
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid ""
@@ -8978,49 +9071,58 @@ msgid ""
 "///\n"
 "/// If the same value is added multiple times, it is only stored once.\n"
 msgstr ""
+"/// Contenedor que almacena un conjunto de valores mediante un árbol "
+"binario.\n"
+"///\n"
+"/// Si se añade el mismo valor varias veces, solo se almacena una vez.\n"
 
 #: src/smart-pointers/exercise.md
 msgid "// Implement `new`, `insert`, `len`, and `has`.\n"
-msgstr ""
+msgstr "// Implementa `new`, `insert`, `len` y `has`.\n"
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "// not a unique item\n"
-msgstr ""
+msgstr "// No es un elemento único.\n"
 
 #: src/smart-pointers/solution.md src/testing/googletest.md
 msgid "\"bar\""
-msgstr ""
+msgstr "\"bar\""
 
 #: src/welcome-day-3-afternoon.md
 msgid "[Borrowing](./borrowing.md) (1 hour)"
-msgstr ""
+msgstr "[Préstamos](./borrowing.md) (1 hora)"
 
 #: src/welcome-day-3-afternoon.md
 msgid ""
 "[Slices and Lifetimes](./slices-and-lifetimes.md) (1 hour and 10 minutes)"
 msgstr ""
+"[Slices y tiempos de vida](./slices-and-lifetimes.md) (1 hora y 10 minutos)"
 
 #: src/welcome-day-3-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 20 "
 "minutes"
 msgstr ""
+"Contando con los descansos de 10 minutos, la duración prevista de la sesión "
+"es de unas 2 horas y 20 minutos."
 
 #: src/borrowing.md
 msgid "[Borrowing a Value](./borrowing/shared.md) (10 minutes)"
-msgstr ""
+msgstr "[Tomar prestado un valor](./borrowing/shared.md) (10 minutos)"
 
 #: src/borrowing.md
 msgid "[Borrow Checking](./borrowing/borrowck.md) (10 minutes)"
-msgstr ""
+msgstr "[Comprobación de préstamos](./borrowing/borrowck.md) (10 minutos)"
 
 #: src/borrowing.md
 msgid "[Interior Mutability](./borrowing/interior-mutability.md) (10 minutes)"
 msgstr ""
+"[Mutabilidad interior](./borrowing/interior-mutability.md) (10 minutos)"
 
 #: src/borrowing.md
 msgid "[Exercise: Health Statistics](./borrowing/exercise.md) (30 minutes)"
 msgstr ""
+"[Ejercicio: estadísticas de salud](./borrowing/exercise.md) (30 minutos)"
 
 #: src/borrowing/shared.md
 #, fuzzy
@@ -9044,6 +9146,9 @@ msgid ""
 "This slide is a review of the material on references from day 1, expanding "
 "slightly to include function arguments and return values."
 msgstr ""
+"En esta diapositiva se repasará el material de las referencias desde día 1 y "
+"se ampliará un poco para incluir los argumentos de las funciones y los "
+"valores devueltos."
 
 #: src/borrowing/shared.md
 msgid "Notes on stack returns:"
@@ -9107,6 +9212,9 @@ msgid ""
 "Note that the requirement is that conflicting references not _exist_ at the "
 "same point. It does not matter where the reference is dereferenced."
 msgstr ""
+"Ten en cuenta que el requisito es que las referencias que están en conflicto "
+"no _se encuentren_ en el mismo punto. No importa en el lugar en el que se "
+"desreferencie la referencia."
 
 #: src/borrowing/borrowck.md
 msgid ""
@@ -9141,6 +9249,11 @@ msgid ""
 "optimize code. For example, a value behind a shared reference can be safely "
 "cached in a register for the lifetime of that reference."
 msgstr ""
+"La restricción de referencia exclusiva es bastante sólida. Rust la utiliza "
+"para asegurarse de que no se produzcan data races. Rust también _se basa_ en "
+"esta restricción para optimizar el código. Por ejemplo, el valor de una "
+"referencia compartida se puede almacenar en caché de forma segura en un "
+"registro durante el tiempo de vida de dicha referencia."
 
 #: src/borrowing/borrowck.md
 msgid ""
@@ -9149,6 +9262,11 @@ msgid ""
 "time. But, there are some situations where it doesn't quite \"get it\" and "
 "this often results in \"fighting with the borrow checker.\""
 msgstr ""
+"El verificador de préstamos está diseñado para adaptarse a muchos patrones "
+"comunes, como tomar referencias exclusivas en diferentes campos de un struct "
+"al mismo tiempo. Sin embargo, hay algunas situaciones en las que \"no lo "
+"entiende del todo\", lo que suele dar lugar a \"conflictos con el "
+"comprobador de préstamos.\""
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9156,6 +9274,10 @@ msgid ""
 "only) reference. For example, a shared data structure might have an internal "
 "cache, and wish to update that cache from read-only methods."
 msgstr ""
+"En algunas situaciones, es necesario modificar los datos subyacentes a una "
+"referencia compartida (de solo lectura). Por ejemplo, una estructura de "
+"datos compartida puede contar con una caché interna y pretender actualizarla "
+"con métodos de solo lectura."
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9163,24 +9285,26 @@ msgid ""
 "a shared reference. The standard library provides several ways to do this, "
 "all while still ensuring safety, typically by performing a runtime check."
 msgstr ""
+"El patrón \"mutabilidad interior\" permite el acceso exclusivo (mutable) "
+"desde una referencia compartida. La biblioteca estándar ofrece varias formas "
+"de hacerlo y, al mismo tiempo, garantiza la seguridad, normalmente mediante "
+"una comprobación del tiempo de ejecución."
 
 #: src/borrowing/interior-mutability.md
-#, fuzzy
 msgid "`RefCell`"
-msgstr "`RefCell<T>`"
+msgstr "`RefCell`"
 
 #: src/borrowing/interior-mutability.md
 msgid "\"graph: {root:#?}\""
-msgstr ""
+msgstr "\"gráfico: {root:#?}\""
 
 #: src/borrowing/interior-mutability.md
 msgid "\"graph sum: {}\""
-msgstr ""
+msgstr "\"suma de gráfico: {}\""
 
 #: src/borrowing/interior-mutability.md
-#, fuzzy
 msgid "`Cell`"
-msgstr "`Cell<T>`"
+msgstr "`Cell`"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9188,6 +9312,10 @@ msgid ""
 "shared reference to the `Cell`. However, it does not allow any references to "
 "the value. Since there are no references, borrowing rules cannot be broken."
 msgstr ""
+"`Cell` envuelve un valor y permite obtenerlo o definirlo, incluso con una "
+"referencia compartida a `Cell`. Sin embargo, no permite obtener referencias "
+"al valor. Como no hay referencias, las reglas de préstamos no pueden "
+"quebrantarse."
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9195,6 +9323,9 @@ msgid ""
 "ways to modify data behind a shared reference. There are a variety of ways "
 "to ensure that safety, and `RefCell` and `Cell` are two of them."
 msgstr ""
+"Lo más importante de esta diapositiva es que Rust ofrece formas _seguras_ de "
+"modificar los datos subyacentes a una referencia compartida. Hay varias "
+"formas de garantizar la seguridad, como `RefCell` y `Cell`."
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9203,6 +9334,11 @@ msgid ""
 "case, all borrows are very short and never overlap, so the checks always "
 "succeed."
 msgstr ""
+"`RefCell` implementa las reglas de préstamos habituales de Rust (varias "
+"referencias compartidas o una única referencia exclusiva) con una "
+"comprobación del tiempo de ejecución. En este caso, todos los préstamos son "
+"muy cortos y nunca se solapan, por lo que las comprobaciones siempre se "
+"llevan a cabo de forma correcta."
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9210,6 +9346,9 @@ msgid ""
 "purpose is to allow (and count) many references. But we want to modify the "
 "value, so we need interior mutability."
 msgstr ""
+"`Rc` solo permite el acceso compartido (de solo lectura) a su contenido, ya "
+"que su objetivo es permitir (y contar) muchas referencias. Ya que nuestro "
+"objetivo modificar el valor, necesitamos utilizar la mutabilidad interna."
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9217,15 +9356,18 @@ msgid ""
 "`&self`. This needs no runtime check, but requires moving values, which can "
 "have its own cost."
 msgstr ""
+"`Cell` es un medio más sencillo de garantizar la seguridad: tiene un método "
+"`set` que utiliza `&self`. No es necesario comprobar el tiempo de ejecución, "
+"pero sí es necesario transferir los valores, lo que puede tener su propio "
+"coste."
 
 #: src/borrowing/interior-mutability.md
-#, fuzzy
 msgid ""
 "Demonstrate that reference loops can be created by adding `root` to `subtree."
 "children`."
 msgstr ""
 "Demuestra que se pueden crear bucles de referencia añadiendo `root` a "
-"`subtree.children` (¡no intentes imprimirlo!)."
+"`subtree.children`."
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -9273,44 +9415,54 @@ msgid ""
 "\"Update a user's statistics based on measurements from a visit to the "
 "doctor\""
 msgstr ""
+"\"Actualiza las estadísticas de un usuario en función de las mediciones "
+"obtenidas durante una consulta médica\"."
 
 #: src/borrowing/exercise.md src/borrowing/solution.md
 #: src/android/build-rules/library.md src/android/aidl/client.md
 msgid "\"Bob\""
-msgstr ""
+msgstr "\"Bob\""
 
 #: src/borrowing/exercise.md src/borrowing/solution.md
 msgid "\"I'm {} and my age is {}\""
-msgstr ""
+msgstr "\"Me llamo {} y tengo {} años\""
 
 #: src/slices-and-lifetimes.md
 msgid "[Slices: &\\[T\\]](./slices-and-lifetimes/slices.md) (10 minutes)"
-msgstr ""
+msgstr "[Slices: &\\[T\\]](./slices-and-lifetimes/slices.md) (10 minutos)"
 
 #: src/slices-and-lifetimes.md
 msgid "[String References](./slices-and-lifetimes/str.md) (10 minutes)"
-msgstr ""
+msgstr "[Referencias de cadenas](./slices-and-lifetimes/str.md) (10 minutos)"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Lifetime Annotations](./slices-and-lifetimes/lifetime-annotations.md) (10 "
 "minutes)"
 msgstr ""
+"[Anotaciones de tiempos de vida](./slices-and-lifetimes/lifetime-annotations."
+"md) (10 minutos)"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Lifetime Elision](./slices-and-lifetimes/lifetime-elision.md) (5 minutes)"
 msgstr ""
+"[Omisión de tiempos de vida](./slices-and-lifetimes/lifetime-elision.md) (5 "
+"minutos)"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Struct Lifetimes](./slices-and-lifetimes/struct-lifetimes.md) (5 minutes)"
 msgstr ""
+"[Tiempos de vida de structs](./slices-and-lifetimes/struct-lifetimes.md) (5 "
+"minutos)"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Exercise: Protobuf Parsing](./slices-and-lifetimes/exercise.md) (30 minutes)"
 msgstr ""
+"[Ejercicio: análisis de Protobuf](./slices-and-lifetimes/exercise.md) (30 "
+"minutos)"
 
 #: src/slices-and-lifetimes/slices.md
 msgid "Slices"
@@ -9402,19 +9554,21 @@ msgid ""
 "We can now understand the two string types in Rust: `&str` is almost like "
 "`&[char]`, but with its data stored in a variable-length encoding (UTF-8)."
 msgstr ""
+"Ahora podemos entender los dos tipos de cadenas de Rust: `&str` es muy "
+"parecida a `&[char]`, pero almacena sus datos en una codificación de "
+"longitud variable (UTF-8)."
 
 #: src/slices-and-lifetimes/str.md
 msgid "\"s1: {s1}\""
-msgstr ""
+msgstr "\"s1: {s1}\""
 
 #: src/slices-and-lifetimes/str.md
-#, fuzzy
 msgid "\"Hello \""
-msgstr "¡Hola, mundo!"
+msgstr "\"¡Hola \""
 
 #: src/slices-and-lifetimes/str.md
 msgid "\"s3: {s3}\""
-msgstr ""
+msgstr "\"s3: {s3}\""
 
 #: src/slices-and-lifetimes/str.md
 msgid "Rust terminology:"
@@ -9477,6 +9631,11 @@ msgid ""
 "boundaries, the expression will panic. The `chars` iterator iterates over "
 "characters and is preferred over trying to get character boundaries right."
 msgstr ""
+"Puedes tomar prestados slices `&str` de `String` a través de `&` y, de forma "
+"opcional, la selección de intervalos. Si seleccionas un intervalo de bytes "
+"que no esté alineado con los límites de caracteres, la expresión activará un "
+"pánico. El iterador `chars` itera sobre los caracteres y se aconseja esta "
+"opción a intentar definir los límites de los caracteres correctamente."
 
 #: src/slices-and-lifetimes/str.md
 #, fuzzy
@@ -9502,6 +9661,9 @@ msgid ""
 "A reference has a _lifetime_, which must not \"outlive\" the value it refers "
 "to. This is verified by the borrow checker."
 msgstr ""
+"Una referencia tiene un valor de _tiempo de vida_ que no debe \"superar\" el "
+"valor al que hace referencia. El verificador de préstamos se encarga de "
+"comprobarlo."
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
@@ -9510,6 +9672,11 @@ msgid ""
 "`'` and `'a` is a typical default name. Read `&'a Point` as \"a borrowed "
 "`Point` which is valid for at least the lifetime `a`\"."
 msgstr ""
+"El tiempo de vida puede ser implícito, como hemos visto hasta ahora, pero "
+"también explícito, como es el caso de `&'a Point` y `&'document str`. Los "
+"tiempos de vida empiezan por `'` y `'a` es el nombre predeterminado que se "
+"suele usar. Lee `&'a Point` como \"un `Point` prestado que es válido al "
+"menos durante el tiempo de vida `a`\"."
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 #, fuzzy
@@ -9526,14 +9693,16 @@ msgid ""
 "Lifetimes become more complicated when considering passing values to and "
 "returning values from functions."
 msgstr ""
+"Los tiempos de vida se vuelven más complejos cuando se tiene en cuenta la "
+"transferencia y devolución de valores a las funciones."
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid "// What is the lifetime of p3?\n"
-msgstr ""
+msgstr "// ¿Cuál es el tiempo de vida de p3?\n"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid "\"p3: {p3:?}\""
-msgstr ""
+msgstr "\"p3: {p3:?}\""
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
@@ -9543,21 +9712,31 @@ msgid ""
 "Rust requires explicit annotations of lifetimes on function arguments and "
 "return values."
 msgstr ""
+"En este ejemplo, el compilador no conoce el tiempo de vida que se debe "
+"inferir para `p3`. Al examinar el cuerpo de la función, solo se puede "
+"suponer con seguridad que el tiempo de vida de `p3` es menor que`p1` y `p2`. "
+"Sin embargo, como sucede con los tipos, Rust requiere anotaciones explícitas "
+"de los tiempos de vida en los argumentos de las funciones y los valores "
+"devueltos."
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid "Add `'a` appropriately to `left_most`:"
-msgstr ""
+msgstr "Añade `'a` correctamente a `left_most`:"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
 "This says, \"given p1 and p2 which both outlive `'a`, the return value lives "
 "for at least `'a`."
 msgstr ""
+"Por tanto, \"dado p1 y p2, que superan el tiempo de vida de `'a`, el valor "
+"devuelto tiene una duración de al menos `'a`."
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
 "In common cases, lifetimes can be elided, as described on the next slide."
 msgstr ""
+"De forma habitual, los tiempos de vida se pueden omitir, tal como se "
+"describe en la siguiente diapositiva."
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "Lifetimes in Function Calls"
@@ -9579,32 +9758,44 @@ msgstr ""
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "Each argument which does not have a lifetime annotation is given one."
 msgstr ""
+"A cada argumento que no tenga una anotación de tiempo de vida se le "
+"proporciona uno."
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
 "If there is only one argument lifetime, it is given to all un-annotated "
 "return values."
 msgstr ""
+"Si solo hay un tiempo de vida de un argumento, se le asigna a todos los "
+"valores devueltos que no estén anotados."
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
 "If there are multiple argument lifetimes, but the first one is for `self`, "
 "that lifetime is given to all un-annotated return values."
 msgstr ""
+"Si existen varios tiempos de vida de argumentos, pero el primero es para "
+"`self`, ese tiempo de vida se asigna a todos los valores devueltos que no "
+"estén anotados."
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "In this example, `cab_distance` is trivially elided."
 msgstr ""
+"En este ejemplo, `cab_distance` se ha suprimido sin que suponga un problema."
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
 "The `nearest` function provides another example of a function with multiple "
 "references in its arguments that requires explicit annotation."
 msgstr ""
+"La función `nearest` proporciona otro ejemplo de una función con múltiples "
+"referencias en sus argumentos que requiere una anotación explícita."
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "Try adjusting the signature to \"lie\" about the lifetimes returned:"
 msgstr ""
+"Prueba a ajustar la firma para \"mentir\" sobre los tiempos de vida "
+"devueltos:"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
@@ -9612,6 +9803,10 @@ msgid ""
 "validity by the compiler. Note that this is not the case for raw pointers "
 "(unsafe), and this is a common source of errors with unsafe Rust."
 msgstr ""
+"No se hará la compilación, lo que demuestra que el compilador comprueba la "
+"validez de las anotaciones. Debes tener en cuenta que este no es el caso de "
+"los punteros sin formato (inseguros), y es uno de los motivos por los que se "
+"cometen errores con Rust inseguro."
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
@@ -9621,6 +9816,13 @@ msgid ""
 "help resolve ambiguity. Often, especially when prototyping, it's easier to "
 "just work with owned data by cloning values where necessary."
 msgstr ""
+"Puede que los participantes pregunten cuándo se deben usar los tiempos de "
+"vida. Los préstamos de Rust _siempre_ tienen tiempos de vida. En la mayoría "
+"de las ocasiones, la omisión y la inferencia de tipos hacen que no sea "
+"necesario escribirlos. En casos más complicados, las anotaciones de tiempos "
+"de vida pueden ayudar a resolver la ambigüedad. A menudo, sobre todo cuando "
+"se llevan a cabo prototipos, resulta más fácil trabajar únicamente con datos "
+"propios, clonando valores siempre que sea necesario."
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "Lifetimes in Data Structures"
@@ -9635,23 +9837,25 @@ msgstr ""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"Bye {text}!\""
-msgstr ""
+msgstr "\"¡Adiós, {text}!\""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"The quick brown fox jumps over the lazy dog.\""
 msgstr ""
+"\"El veloz murciélago hindú comía feliz cardillo y kiwi. La cigüeña tocaba "
+"el saxofón detrás del palenque de paja.\"."
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "// erase(text);\n"
-msgstr ""
+msgstr "// erase(text);\n"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"{fox:?}\""
-msgstr ""
+msgstr "\"{fox:?}\""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"{dog:?}\""
-msgstr ""
+msgstr "\"{dog:?}\""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid ""
@@ -9707,6 +9911,11 @@ msgid ""
 "simpler than it seems! This illustrates a common parsing pattern, passing "
 "slices of data. The underlying data itself is never copied."
 msgstr ""
+"En este ejercicio, vas a compilar un analizador para la [codificación "
+"binaria de protobuf](https://protobuf.dev/programming-guides/encoding/). No "
+"hay nada de lo que preocuparse, es más sencillo de lo que parece. En este "
+"ejemplo se muestra un patrón de análisis muy habitual que consiste en "
+"transferir fracciones de datos. Los datos subyacentes nunca se copian."
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
@@ -9715,6 +9924,11 @@ msgid ""
 "file. In this exercise, we'll encode that information into `match` "
 "statements in functions that get called for each field."
 msgstr ""
+"Para poder llevar a cabo un análisis completo de un mensaje de protobuf, es "
+"necesario conocer los tipos de campos, indexados por el número de campo. Se "
+"suelen proporcionar en un archivo `proto`. En este ejercicio, codificaremos "
+"esa información en declaraciones `match` en funciones a las que se llama "
+"para cada campo."
 
 #: src/slices-and-lifetimes/exercise.md
 #, fuzzy
@@ -9728,6 +9942,11 @@ msgid ""
 "number (e.g., `2` for the `id` field of a `Person` message) and a wire type "
 "defining how the payload should be determined from the byte stream."
 msgstr ""
+"Un mensaje proto se codifica como una serie de campos, uno detrás del otro. "
+"Cada uno se implementa como una \"etiqueta\" seguida del valor. La etiqueta "
+"contiene un número de campo (por ejemplo, `2` para el campo `id` de un "
+"mensaje de `Person`) y un tipo de wire que define cómo se debe definir la "
+"carga útil a partir del flujo de bytes."
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
@@ -9736,44 +9955,51 @@ msgid ""
 "code also defines callbacks to handle `Person` and `PhoneNumber` fields, and "
 "to parse a message into a series of calls to those callbacks."
 msgstr ""
+"Los números enteros, incluida la etiqueta, se representan con una "
+"codificación de longitud variable denominada VARINT. A continuación puedes "
+"consultar la definición de `parse_varint`. El código dado también define "
+"retrollamadas para gestionar los campos `Person` y `PhoneNumber`, así como "
+"analizar un mensaje en una serie de llamadas a dichas retrollamadas."
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
 "What remains for you is to implement the `parse_field` function and the "
 "`ProtoMessage` trait for `Person` and `PhoneNumber`."
 msgstr ""
+"Ahora solo tienes que implementar la función `parse_field` y el trait "
+"`ProtoMessage` para `Person` y `PhoneNumber`."
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid varint\""
-msgstr ""
+msgstr "\"Varint no válido\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid wire-type\""
-msgstr ""
+msgstr "\"Tipo de wire no válido\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Unexpected EOF\""
-msgstr ""
+msgstr "\"EOF inesperado\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid length\""
-msgstr ""
+msgstr "\"Longitud no válida\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Unexpected wire-type)\""
-msgstr ""
+msgstr "\"Tipo de wire inesperado)\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid string (not UTF-8)\""
-msgstr ""
+msgstr "\"Cadena no válida (no es UTF‐8)\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// A wire type as seen on the wire.\n"
-msgstr ""
+msgstr "/// Tipo de wire como se observa en el wire.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// The Varint WireType indicates the value is a single VARINT.\n"
-msgstr ""
+msgstr "/// Varint WireType indica que el valor es un único VARINT.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
@@ -9782,61 +10008,74 @@ msgid ""
 "a\n"
 "    /// VARINT followed by exactly that number of bytes.\n"
 msgstr ""
+"//I64,  -- no es necesario para este ejercicio\n"
+"    /// El Len WireType indica que el valor es una longitud representada "
+"como\n"
+"    /// VARINT seguida exactamente de ese número de bytes.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
 "/// The I32 WireType indicates that the value is precisely 4 bytes in\n"
 "    /// little-endian order containing a 32-bit signed integer.\n"
 msgstr ""
+"/// El WireType I32 indica que el valor es de 4 bytes en\n"
+"    /// el orden little endian que contiene un número entero con signo de 32 "
+"bits.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// A field's value, typed based on the wire type.\n"
-msgstr ""
+msgstr "/// Valor de un campo, escrito en función del tipo de wire.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "//I64(i64),  -- not needed for this exercise\n"
-msgstr ""
+msgstr "//I64(i64),  -- no es necesario para este ejercicio\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// A field, containing the field number and its value.\n"
-msgstr ""
+msgstr "/// Campo que contiene el número de campo y su valor.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "//1 => WireType::I64,  -- not needed for this exercise\n"
-msgstr ""
+msgstr "//1 => WireType::I64, no es necesario para este ejercicio\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
 "/// Parse a VARINT, returning the parsed value and the remaining bytes.\n"
 msgstr ""
+"/// Analiza un VARINT, que devuelve el valor analizado y los bytes "
+"restantes.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
 "// This is the last byte of the VARINT, so convert it to\n"
 "            // a u64 and return it.\n"
 msgstr ""
+"// Este es el último byte de VARINT, así que conviértelo en\n"
+"            // u64 y haz que lo devuelva.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "// More than 7 bytes is invalid.\n"
-msgstr ""
+msgstr "// Un número mayor de 7 bytes no es válido.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// Convert a tag into a field number and a WireType.\n"
-msgstr ""
+msgstr "/// Convierte una etiqueta en un número de campo y un WireType.\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// Parse a field, returning the remaining bytes\n"
-msgstr ""
+msgstr "/// Analiza un campo y haz que devuelva los bytes restantes.\n"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
 "\"Based on the wire type, build a Field, consuming as many bytes as "
 "necessary.\""
 msgstr ""
+"\"En función del tipo de wire, crea un campo que utilice todos los bytes "
+"necesarios.\""
 
 #: src/slices-and-lifetimes/exercise.md
 msgid "\"Return the field, and any un-consumed bytes.\""
-msgstr ""
+msgstr "\"Devuelve el campo y los bytes que no se hayan utilizado.\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
@@ -9846,22 +10085,27 @@ msgid ""
 "///\n"
 "/// The entire input is consumed.\n"
 msgstr ""
+"/// Analiza un mensaje de los datos proporcionados, llamando a `T::"
+"add_field` para cada campo\n"
+"/// del mensaje.\n"
+"///\n"
+"/// Se utilizan todos los datos introducidos.\n"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid "// TODO: Implement ProtoMessage for Person and PhoneNumber.\n"
-msgstr ""
+msgstr "// TAREA: implementar ProtoMessage para Person y PhoneNumber.\n"
 
 #: src/slices-and-lifetimes/solution.md
 msgid "// Unwrap error because `value` is definitely 4 bytes long.\n"
-msgstr ""
+msgstr "// Desenvuelve el error porque `value` tiene 4 bytes.\n"
 
 #: src/slices-and-lifetimes/solution.md
 msgid "// skip everything else\n"
-msgstr ""
+msgstr "// salta todos los demás pasos\n"
 
 #: src/slices-and-lifetimes/solution.md
 msgid "b\"hello\""
-msgstr ""
+msgstr "n\"hola\""
 
 #: src/welcome-day-4.md
 msgid "Welcome to Day 4"

--- a/po/es.po
+++ b/po/es.po
@@ -20921,11 +20921,11 @@ msgstr "Los hilos de Rust funcionan de forma similar a los de otros lenguajes:"
 
 #: src/concurrency/threads.md
 msgid "\"Count in thread: {i}!\""
-msgstr ""
+msgstr "\"Recuento en el hilo: {i}!\""
 
 #: src/concurrency/threads.md
 msgid "\"Main thread: {i}\""
-msgstr ""
+msgstr "\"Hilo principal: {i}\""
 
 #: src/concurrency/threads.md
 msgid "Threads are all daemon threads, the main thread does not wait for them."
@@ -20943,7 +20943,6 @@ msgstr ""
 "con `downcast_ref`."
 
 #: src/concurrency/threads.md
-#, fuzzy
 msgid ""
 "Notice that the thread is stopped before it reaches 10 --- the main thread "
 "is not waiting."
@@ -21013,7 +21012,7 @@ msgstr ""
 
 #: src/concurrency/channels.md
 msgid "\"Received: {:?}\""
-msgstr ""
+msgstr "\"Recibido: {:?}\""
 
 #: src/concurrency/channels.md
 msgid ""
@@ -21039,19 +21038,19 @@ msgstr "Se obtiene un canal asíncrono y sin límites con `mpsc::channel()`:"
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"Message {i}\""
-msgstr ""
+msgstr "\"Mensaje {i}\""
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"{thread_id:?}: sent Message {i}\""
-msgstr ""
+msgstr "\"{thread_id:?}: mensaje enviado {i}\""
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"{thread_id:?}: done\""
-msgstr ""
+msgstr "\"{thread_id:?}: completado\""
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"Main: got {msg}\""
-msgstr ""
+msgstr "\"Principal: ha recibido {msg}\""
 
 #: src/concurrency/channels/bounded.md
 msgid ""
@@ -21355,11 +21354,11 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md
 msgid "\"{thread_id:?}: {v:?}\""
-msgstr ""
+msgstr "\"{thread_id:?}: {v:?}\""
 
 #: src/concurrency/shared_state/arc.md src/concurrency/shared_state/example.md
 msgid "\"v: {v:?}\""
-msgstr ""
+msgstr "\"v: {v:?}\""
 
 #: src/concurrency/shared_state/arc.md
 msgid ""
@@ -21412,7 +21411,7 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md
 msgid "\"v: {:?}\""
-msgstr ""
+msgstr "\"v: {:?}\""
 
 #: src/concurrency/shared_state/mutex.md
 msgid ""
@@ -21489,7 +21488,7 @@ msgstr "Veamos cómo funcionan `Arc` y `Mutex`:"
 
 #: src/concurrency/shared_state/example.md
 msgid "// use std::sync::{Arc, Mutex};\n"
-msgstr ""
+msgstr "// usar std::sync::{Arc, Mutex};\n"
 
 #: src/concurrency/shared_state/example.md
 msgid "Possible solution:"
@@ -21590,26 +21589,29 @@ msgid ""
 "    // right_fork: ...\n"
 "    // thoughts: ...\n"
 msgstr ""
+"// left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // thoughts: ...\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Eureka! {} has a new idea!\""
-msgstr ""
+msgstr "\"¡Eureka! ¡{} tiene una nueva idea!\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Pick up forks...\n"
-msgstr ""
+msgstr "// Recoge los tenedores...\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"{} is eating...\""
-msgstr ""
+msgstr "\"{} está comiendo...\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
@@ -21624,50 +21626,50 @@ msgstr "Crates HAL"
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Hypatia\""
-msgstr ""
+msgstr "\"Hipatia\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Plato\""
-msgstr ""
+msgstr "\"Platón\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Aristotle\""
-msgstr ""
+msgstr "\"Aristóteles\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Pythagoras\""
-msgstr ""
+msgstr "\"Pitágoras\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Create forks\n"
-msgstr ""
+msgstr "// Crea tenedores\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Create philosophers\n"
-msgstr ""
+msgstr "// Crea filósofos\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid "// Make each of them think and eat 100 times\n"
-msgstr ""
+msgstr "// Haz que cada uno de ellos piense y coma 100 veces\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Output their thoughts\n"
-msgstr ""
+msgstr "// Expresa sus reflexiones\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid "You can use the following `Cargo.toml`:"
@@ -21682,6 +21684,12 @@ msgid ""
 "edition = \"2021\"\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"dining-philosophers\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"```"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
@@ -21780,40 +21788,40 @@ msgstr "El archivo `src/main.rs` debería tener un aspecto similar a este:"
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"request error: {0}\""
-msgstr ""
+msgstr "\"Error de solicitud: {0}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"bad http response: {0}\""
-msgstr ""
+msgstr "\"respuesta HTTP incorrecta: {0}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"Checking {:#}\""
-msgstr ""
+msgstr "\"Comprobando {:#}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"href\""
-msgstr ""
+msgstr "\"href\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
-msgstr ""
+msgstr "\"En {base_url:#}: {href:?} ignorado, no se puede analizar: {err}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"https://www.google.org\""
-msgstr ""
+msgstr "\"https://www.google.org\""
 
 #: src/exercises/concurrency/link-checker.md
 msgid "\"Links: {links:#?}\""
-msgstr ""
+msgstr "\"Enlaces: {links:#?}\""
 
 #: src/exercises/concurrency/link-checker.md
 msgid "\"Could not extract links: {err:#}\""
-msgstr ""
+msgstr "\"No se han podido extraer los enlaces: {err:#}\""
 
 #: src/exercises/concurrency/link-checker.md
 msgid "Run the code in `src/main.rs` with"
@@ -21847,7 +21855,7 @@ msgstr "([volver al ejercicio](dining-philosophers.md))"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"{} is trying to eat\""
-msgstr ""
+msgstr "\"{} está intentando comer\""
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid ""
@@ -21855,10 +21863,14 @@ msgid ""
 "        // somewhere. This will swap the forks without deinitializing\n"
 "        // either of them.\n"
 msgstr ""
+"// Para evitar un interbloqueo, tenemos que romper la simetría\n"
+"        // en algún lugar. De este modo, se cambiarán los tenedores sin "
+"desinicializar\n"
+"        // ninguno de ellos.\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"{thought}\""
-msgstr ""
+msgstr "\"{thought}\""
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "Link Checker"
@@ -21871,25 +21883,27 @@ msgstr "([volver al ejercicio](link-checker.md))"
 #: src/exercises/concurrency/solutions-morning.md
 msgid ""
 "/// Determine whether links within the given page should be extracted.\n"
-msgstr ""
+msgstr "/// Determina si se deben extraer los enlaces de la página indicada.\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid ""
 "/// Mark the given page as visited, returning false if it had already\n"
 "    /// been visited.\n"
 msgstr ""
+"/// Marca la página indicada como visitada y devuelve false si ya se había\n"
+"    /// visitado anteriormente.\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "// The sender got dropped. No more commands coming in.\n"
-msgstr ""
+msgstr "// Se ha descartado el remitente. No se enviarán más comandos.\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"Got crawling error: {:#}\""
-msgstr ""
+msgstr "\"Se ha producido un error de rastreo: {:#}\""
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"Bad URLs: {:#?}\""
-msgstr ""
+msgstr "\"URLs incorrectas: {:#?}\""
 
 #: src/async.md
 msgid "Async Rust"
@@ -21961,7 +21975,7 @@ msgstr ""
 
 #: src/async/async-await.md
 msgid "\"Count is: {i}!\""
-msgstr ""
+msgstr "\"El recuento es: ¡{i}!\""
 
 #: src/async/async-await.md
 msgid ""
@@ -22174,11 +22188,11 @@ msgstr "Un amplio ecosistema de bibliotecas."
 
 #: src/async/runtimes/tokio.md
 msgid "\"Count in task: {i}!\""
-msgstr ""
+msgstr "\"Recuento en la tarea: {i}\""
 
 #: src/async/runtimes/tokio.md
 msgid "\"Main task: {i}\""
-msgstr ""
+msgstr "\"Tarea principal: {i}\""
 
 #: src/async/runtimes/tokio.md
 msgid "With the `tokio::main` macro we can now make `main` async."
@@ -22236,27 +22250,27 @@ msgstr ""
 
 #: src/async/tasks.md
 msgid "\"127.0.0.1:0\""
-msgstr ""
+msgstr "\"127.0.0.1:0\""
 
 #: src/async/tasks.md
 msgid "\"listening on port {}\""
-msgstr ""
+msgstr "\"escuchando en el puerto {}\""
 
 #: src/async/tasks.md
 msgid "\"connection from {addr:?}\""
-msgstr ""
+msgstr "\"conexión de {addr:?}\""
 
 #: src/async/tasks.md
 msgid "b\"Who are you?\\n\""
-msgstr ""
+msgstr "b\"¿Quién eres?\\n\""
 
 #: src/async/tasks.md
 msgid "\"socket error\""
-msgstr ""
+msgstr "\"error de socket\""
 
 #: src/async/tasks.md
 msgid "\"Thanks for dialing in, {name}!\\n\""
-msgstr ""
+msgstr "\"¡Gracias por llamar, {name}!\\n\""
 
 #: src/async/tasks.md src/async/control-flow/join.md
 msgid ""
@@ -22271,6 +22285,9 @@ msgid ""
 "com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
 "telnet/)."
 msgstr ""
+"Prueba a conectarte mediante una herramienta de conexión TCP como [nc]"
+"(https://www.unix.com/man-page/linux/1/nc/) o [telnet](https://www.unix.com/"
+"man-page/linux/1/telnet/)."
 
 #: src/async/tasks.md
 msgid ""
@@ -22306,23 +22323,23 @@ msgstr "Varios crates admiten canales asíncronos. Por ejemplo, `tokio`:"
 
 #: src/async/channels.md
 msgid "\"Received {count} pings so far.\""
-msgstr ""
+msgstr "\"Se han recibido {count} pings hasta el momento.\""
 
 #: src/async/channels.md
 msgid "\"ping_handler complete\""
-msgstr ""
+msgstr "\"ping_handler completo\""
 
 #: src/async/channels.md
 msgid "\"Failed to send ping.\""
-msgstr ""
+msgstr "\"No se ha podido enviar el ping.\""
 
 #: src/async/channels.md
 msgid "\"Sent {} pings so far.\""
-msgstr ""
+msgstr "\"Se han enviado {} pings hasta ahora.\""
 
 #: src/async/channels.md
 msgid "\"Something went wrong in ping handler task.\""
-msgstr ""
+msgstr "\"Se ha producido un error en la tarea del controlador de ping.\""
 
 #: src/async/channels.md
 msgid "Change the channel size to `3` and see how it affects the execution."
@@ -22395,19 +22412,19 @@ msgstr ""
 
 #: src/async/control-flow/join.md
 msgid "\"https://google.com\""
-msgstr ""
+msgstr "\"https://google.com\""
 
 #: src/async/control-flow/join.md
 msgid "\"https://httpbin.org/ip\""
-msgstr ""
+msgstr "\"https://httpbin.org/ip\""
 
 #: src/async/control-flow/join.md
 msgid "\"https://play.rust-lang.org/\""
-msgstr ""
+msgstr "\"https://play.rust-lang.org/\""
 
 #: src/async/control-flow/join.md
 msgid "\"BAD_URL\""
-msgstr ""
+msgstr "\"BAD_URL\""
 
 #: src/async/control-flow/join.md
 msgid ""
@@ -22471,27 +22488,27 @@ msgstr ""
 
 #: src/async/control-flow/select.md
 msgid "\"Felix\""
-msgstr ""
+msgstr "\"Felix\""
 
 #: src/async/control-flow/select.md
 msgid "\"Failed to send cat.\""
-msgstr ""
+msgstr "\"No se ha podido enviar el gato.\""
 
 #: src/async/control-flow/select.md
 msgid "\"Rex\""
-msgstr ""
+msgstr "\"Rex\""
 
 #: src/async/control-flow/select.md
 msgid "\"Failed to send dog.\""
-msgstr ""
+msgstr "\"No se ha podido enviar el perro.\""
 
 #: src/async/control-flow/select.md
 msgid "\"Failed to receive winner\""
-msgstr ""
+msgstr "\"No se ha podido recibir el ganador\""
 
 #: src/async/control-flow/select.md
 msgid "\"Winner is {winner:?}\""
-msgstr ""
+msgstr "\"El ganador es {winner:?}\""
 
 #: src/async/control-flow/select.md
 msgid ""
@@ -22589,11 +22606,11 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md
 msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
-msgstr ""
+msgstr "\"future {id} ha dormido {duration_ms} min, terminó después de {} ms\""
 
 #: src/async/pitfalls/blocking-executor.md
 msgid "\"current_thread\""
-msgstr ""
+msgstr "\"current_thread\""
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
@@ -22660,6 +22677,10 @@ msgid ""
 "type returned is the result of a compiler transformation which turns local "
 "variables into data stored inside the future."
 msgstr ""
+"Los bloques y las funciones asíncronos devuelven tipos que implementan el "
+"trait `Future`. El tipo devuelto es el resultado de una transformación del "
+"compilador que convierte las variables locales en datos almacenados en el "
+"futuro."
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -22667,6 +22688,9 @@ msgid ""
 "of that, the future should never be moved to a different memory location, as "
 "it would invalidate those pointers."
 msgstr ""
+"Algunas de estas variables pueden dirigir punteros a otras variables "
+"locales. Por este motivo, el futuro nunca debería trasladarse a otra "
+"ubicación de memoria, ya que esta acción invalidaría esos punteros."
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -22675,44 +22699,51 @@ msgid ""
 "operations that would move the instance it points to into a different memory "
 "location."
 msgstr ""
+"Para evitar que el tipo futuro se mueva en la memoria, solo se puede sondear "
+"mediante un puntero fijado. `Pin` es un envoltorio que rodea a una "
+"referencia y que no permite todas las operaciones que moverían la instancia "
+"a la que apunta a otra ubicación de memoria."
 
 #: src/async/pitfalls/pin.md
 msgid ""
 "// A work item. In this case, just sleep for the given time and respond\n"
 "// with a message on the `respond_on` channel.\n"
 msgstr ""
+"// Un elemento de trabajo. En este caso, solo se duerme durante un tiempo "
+"determinado y responde\n"
+"// con un mensaje en el canal `respond_on`.\n"
 
 #: src/async/pitfalls/pin.md
 msgid "// A worker which listens for work on a queue and performs it.\n"
-msgstr ""
+msgstr "// Un trabajador que espera trabajo en una cola y lo ejecuta.\n"
 
 #: src/async/pitfalls/pin.md
 msgid "// Pretend to work.\n"
-msgstr ""
+msgstr "// Simula que trabaja.\n"
 
 #: src/async/pitfalls/pin.md
 msgid "\"failed to send response\""
-msgstr ""
+msgstr "\"no se ha podido enviar la respuesta\""
 
 #: src/async/pitfalls/pin.md
 msgid "// TODO: report number of iterations every 100ms\n"
-msgstr ""
+msgstr "// TODO: informar del número de iteraciones cada 100 ms\n"
 
 #: src/async/pitfalls/pin.md
 msgid "// A requester which requests work and waits for it to complete.\n"
-msgstr ""
+msgstr "// Un solicitante que pide trabajo y espera a que se complete.\n"
 
 #: src/async/pitfalls/pin.md
 msgid "\"failed to send on work queue\""
-msgstr ""
+msgstr "\"no se ha podido enviar en la cola de trabajo\""
 
 #: src/async/pitfalls/pin.md
 msgid "\"failed waiting for response\""
-msgstr ""
+msgstr "\"no se ha podido esperar la respuesta\""
 
 #: src/async/pitfalls/pin.md
 msgid "\"work result for iteration {i}: {resp}\""
-msgstr ""
+msgstr "\"resultado del trabajo de la iteración {i}: {resp}\""
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -22791,6 +22822,12 @@ msgid ""
 "code transformation for async blocks and functions is not verified by the "
 "borrow checker."
 msgstr ""
+"Los datos que contienen punteros a sí mismos se denominan autoreferenciales. "
+"Normalmente, el verificador de préstamos de Rust evitaría que se movieran "
+"los datos de autorreferencia, ya que las referencias no pueden tener una "
+"duración mayor que la de los datos a los que apuntan. Sin embargo, el "
+"verificador de préstamos no verifica la transformación del código de las "
+"funciones y los bloques asíncronos."
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -22798,6 +22835,9 @@ msgid ""
 "place using a pinned pointer. However, it can still be moved through an "
 "unpinned pointer."
 msgstr ""
+"`Pin` es un envoltorio que rodea a una referencia. No se puede mover un "
+"objeto desde su lugar mediante un puntero fijado. Sin embargo, sí se puede "
+"mover mediante un puntero no fijado."
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -22805,6 +22845,9 @@ msgid ""
 "`&mut Self` to refer to the instance. That's why it can only be called on a "
 "pinned pointer."
 msgstr ""
+"El método `poll` del trait `Future` utiliza `Pin<&mut Self>` en lugar de "
+"`&mut Self` para hacer referencia a la instancia. Por eso solo se puede "
+"llamar desde un puntero fijado."
 
 #: src/async/pitfalls/async-traits.md
 msgid ""
@@ -22828,11 +22871,11 @@ msgstr ""
 
 #: src/async/pitfalls/async-traits.md
 msgid "\"running all sleepers..\""
-msgstr ""
+msgstr "\"ejecutando todos los sleepers…\"."
 
 #: src/async/pitfalls/async-traits.md
 msgid "\"slept for {}ms\""
-msgstr ""
+msgstr "\"ha dormido {} ms\""
 
 #: src/async/pitfalls/async-traits.md
 msgid ""
@@ -22885,11 +22928,11 @@ msgstr "UTF-8"
 
 #: src/async/pitfalls/cancellation.md
 msgid "\"hi\\nthere\\n\""
-msgstr ""
+msgstr "\"hi\\nthere\\n\""
 
 #: src/async/pitfalls/cancellation.md
 msgid "\"tick!\""
-msgstr ""
+msgstr "\"tick!\""
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
@@ -22928,7 +22971,7 @@ msgstr ""
 
 #: src/async/pitfalls/cancellation.md
 msgid "// prefix buf and bytes with self.\n"
-msgstr ""
+msgstr "// prefijo buf y bytes con self.\n"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
@@ -22986,9 +23029,8 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
-#, fuzzy
 msgid "Dining Philosophers --- Async"
-msgstr "La Cena de Filósofos - Async"
+msgstr "La Cena de Filósofos --- Async"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 msgid ""
@@ -23012,7 +23054,7 @@ msgstr ""
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Make them think and eat\n"
-msgstr ""
+msgstr "// Hazles pensar y comer\n"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 msgid ""
@@ -23023,7 +23065,6 @@ msgstr ""
 "usar el siguiente `Cargo.toml`:"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
-#, fuzzy
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -23038,16 +23079,13 @@ msgid ""
 msgstr ""
 "```toml\n"
 "[package]\n"
-"name = \"link-checker\"\n"
+"name = \"dining-philosophers-async-dine\"\n"
 "version = \"0.1.0\"\n"
 "edition = \"2021\"\n"
-"publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
-"tls\"] }\n"
-"scraper = \"0.13.0\"\n"
-"thiserror = \"1.0.37\"\n"
+"tokio = { version = \"1.26.0\", features = [\"sync\", \"time\", \"macros\", "
+"\"rt-multi-thread\"] }\n"
 "```"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
@@ -23059,7 +23097,6 @@ msgstr ""
 "`mpsc` del crate `tokio`."
 
 #: src/exercises/concurrency/dining-philosophers-async.md
-#, fuzzy
 msgid "Can you make your implementation single-threaded?"
 msgstr "¿Puedes conseguir que tu implementación tenga un solo hilo? "
 
@@ -23078,7 +23115,6 @@ msgstr ""
 "servidor del chat transmite cada mensaje que recibe a todos los clientes."
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid ""
 "For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
 "sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
@@ -23087,20 +23123,18 @@ msgid ""
 msgstr ""
 "Para ello, usaremos \\[un canal en abierto](https://docs.rs/tokio/latest/"
 "tokio/sync/broadcast/fn.channel.html) en el servidor y [`tokio_websockets`]"
-"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) para la "
-"comunicación entre el cliente y el servidor."
+"(https://docs.rs/tokio-websockets/) para la comunicación entre el cliente y "
+"el servidor."
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Create a new Cargo project and add the following dependencies:"
 msgstr "Crea un proyecto de Cargo y añade las siguientes dependencias:"
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid "_Cargo.toml_:"
-msgstr "`Cargo.toml`:"
+msgstr "_Cargo.toml_:"
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -23118,16 +23152,16 @@ msgid ""
 msgstr ""
 "```toml\n"
 "[package]\n"
-"name = \"link-checker\"\n"
+"name = \"chat-async\"\n"
 "version = \"0.1.0\"\n"
 "edition = \"2021\"\n"
-"publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
-"tls\"] }\n"
-"scraper = \"0.13.0\"\n"
-"thiserror = \"1.0.37\"\n"
+"futures-util = { version = \"0.3.30\", features = [\"sink\"] }\n"
+"http = \"1.0.0\"\n"
+"tokio = { version = \"1.28.1\", features = [\"full\"] }\n"
+"tokio-websockets = { version = \"0.5.1\", features = [\"client\", "
+"\"fastrand\", \"server\", \"sha1_smol\"] }\n"
 "```"
 
 #: src/exercises/concurrency/chat-app.md
@@ -23135,29 +23169,26 @@ msgid "The required APIs"
 msgstr "Las APIs necesarias"
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid ""
 "You are going to need the following functions from `tokio` and "
 "[`tokio_websockets`](https://docs.rs/tokio-websockets/). Spend a few minutes "
 "to familiarize yourself with the API."
 msgstr ""
 "Necesitarás las siguientes funciones de `tokio` y [`tokio_websockets`]"
-"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/). Dedica unos "
-"minutos a familiarizarte con la API. "
+"(https://docs.rs/tokio-websockets/). Dedica unos minutos a familiarizarte "
+"con la API. "
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid ""
 "[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
 "trait.StreamExt.html#method.next) implemented by `WebSocketStream`: for "
 "asynchronously reading messages from a Websocket Stream."
 msgstr ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
-"trait.SinkExt.html#method.send) implementado por `WebsocketStream`: permite "
-"enviar mensajes de forma asíncrona a través de un flujo WebSocket."
+"[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
+"trait.StreamExt.html#method.next) implementado por `WebSocketStream`: "
+"permite enviar mensajes de forma asíncrona a través de un flujo Websocket."
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid ""
 "[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
 "trait.SinkExt.html#method.send) implemented by `WebSocketStream`: for "
@@ -23165,7 +23196,7 @@ msgid ""
 msgstr ""
 "[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
 "trait.SinkExt.html#method.send) implementado por `WebsocketStream`: permite "
-"enviar mensajes de forma asíncrona a través de un flujo WebSocket."
+"enviar mensajes de forma asíncrona a través de un flujo Websocket."
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -23190,7 +23221,6 @@ msgid "Two binaries"
 msgstr "Dos binarios"
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid ""
 "Normally in a Cargo project, you can have only one binary, and one `src/main."
 "rs` file. In this project, we need two binaries. One for the client, and one "
@@ -23209,7 +23239,6 @@ msgstr ""
 "doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries)). "
 
 #: src/exercises/concurrency/chat-app.md
-#, fuzzy
 msgid ""
 "Copy the following server and client code into `src/bin/server.rs` and `src/"
 "bin/client.rs`, respectively. Your task is to complete these files as "
@@ -23228,37 +23257,38 @@ msgstr "`src/bin/server.rs`:"
 #: src/exercises/concurrency/chat-app.md
 msgid "// TODO: For a hint, see the description of the task below.\n"
 msgstr ""
+"// TODO: Para obtener una pista, consulta la descripción de la tarea a "
+"continuación.\n"
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"127.0.0.1:2000\""
-msgstr ""
+msgstr "\"127.0.0.1:2000\""
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"listening on port 2000\""
-msgstr ""
+msgstr "\"escuchando en el puerto 2000\""
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"New connection from {addr:?}\""
-msgstr ""
+msgstr "\"Nueva conexión de {addr:?}\""
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Wrap the raw TCP stream into a websocket.\n"
-msgstr ""
+msgstr "// Envuelve el flujo TCP sin procesar en un websocket.\n"
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
-#, fuzzy
 msgid "_src/bin/client.rs_:"
-msgstr "`src/bin/client.rs`:"
+msgstr "_src/bin/client.rs_:"
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"ws://127.0.0.1:2000\""
-msgstr ""
+msgstr "\"ws://127.0.0.1:2000\""
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Running the binaries"
@@ -23323,10 +23353,13 @@ msgid ""
 "// Add a delay before picking the second fork to allow the execution\n"
 "        // to transfer to another task\n"
 msgstr ""
+"// Añade un retraso antes de elegir el segundo tenedor para permitir la "
+"ejecución\n"
+"        // para transferir a otra tarea\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// The locks are dropped here\n"
-msgstr ""
+msgstr "// Los bloqueos se eliminan aquí\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid ""
@@ -23334,14 +23367,20 @@ msgid ""
 "            // somewhere. This will swap the forks without deinitializing\n"
 "            // either of them.\n"
 msgstr ""
+"// Para evitar un interbloqueo, tenemos que romper la simetría\n"
+"            // en algún lugar. De este modo, se cambiarán los tenedores sin "
+"desinicializar\n"
+"            // ninguno de ellos.\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
 msgstr ""
+"// tx se elimina aquí, por lo que no tenemos que eliminarlo explícitamente "
+"más tarde.\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Here is a thought: {thought}\""
-msgstr ""
+msgstr "\"Aquí tienes una reflexión: {thought}\""
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "([back to exercise](chat-app.md))"
@@ -23349,7 +23388,7 @@ msgstr "([volver al ejercicio](chat-app.md))"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Welcome to chat! Type a message\""
-msgstr ""
+msgstr "\"Te damos la bienvenida al chat. Escribe un mensaje\""
 
 #: src/exercises/concurrency/solutions-afternoon.md
 #, fuzzy
@@ -23365,15 +23404,15 @@ msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"From client {addr:?} {text:?}\""
-msgstr ""
+msgstr "\"Del cliente {addr:?} {text:?}\""
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Continuous loop for concurrently sending and receiving messages.\n"
-msgstr ""
+msgstr "// Bucle continuo para enviar y recibir mensajes simultáneamente.\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"From server: {}\""
-msgstr ""
+msgstr "\"Del servidor: {}\""
 
 #: src/thanks.md
 msgid ""
@@ -23401,18 +23440,26 @@ msgid ""
 "Rust terms. For translations, this also serves to connect the term back to "
 "the English original."
 msgstr ""
+"A continuación, se incluye un glosario con el objetivo de ofrecer una breve "
+"definición de algunos términos de Rust. En el caso de las traducciones, "
+"también sirve para relacionar el término con el original en inglés."
 
 #: src/glossary.md
 msgid ""
 "allocate:  \n"
 "Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md)."
 msgstr ""
+"asignar:  \n"
+"Asignación dinámica de memoria en [el montículo](Memory-management/stack-vs-"
+"heap.md)."
 
 #: src/glossary.md
 msgid ""
 "argument:  \n"
 "Information that is passed into a function or method."
 msgstr ""
+"argumento:  \n"
+"Información que se transmite a una función o método."
 
 #: src/glossary.md
 msgid ""
@@ -23420,30 +23467,42 @@ msgid ""
 "Low-level Rust development, often deployed to a system without an operating "
 "system. See [Bare-metal Rust](bare-metal.md)."
 msgstr ""
+"Rust Bare-metal:  \n"
+"desarrollo de Rust de bajo nivel, a menudo desplegado en un sistema sin "
+"sistema operativo. Consulta [Bare-metal Rust](bare-metal.md)."
 
 #: src/glossary.md
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
 msgstr ""
+"bloque:  \n"
+"Consulta [bloques](control-flow/blocks.md) y _ámbito_."
 
 #: src/glossary.md
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
 msgstr ""
+"borrow (_omar prestado_):  \n"
+"Consulta [Borrowing (Préstamos)](ownership/borrowing.md)."
 
 #: src/glossary.md
 msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
 msgstr ""
+"borrow checker (_comprobador de préstamos_):  \n"
+"la parte del compilador de Rust que comprueba que todos los préstamos sean "
+"válidos."
 
 #: src/glossary.md
 msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
 msgstr ""
+"llave:  \n"
+"`{` and `}`. Delimitan _bloques_."
 
 #: src/glossary.md
 msgid ""
@@ -23451,42 +23510,59 @@ msgid ""
 "The process of converting source code into executable code or a usable "
 "program."
 msgstr ""
+"compilar  \n"
+"El proceso de conversión de código fuente en código ejecutable o en un "
+"programa utilizable."
 
 #: src/glossary.md
 msgid ""
 "call:  \n"
 "To invoke or execute a function or method."
 msgstr ""
+"Llamar:  \n"
+"invocar o ejecutar una función o método."
 
 #: src/glossary.md
 msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
 msgstr ""
+"Canal:  \n"
+"se utiliza para enviar mensajes [entre hilos](concurrency/channels.md) de "
+"forma segura."
 
 #: src/glossary.md
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
 msgstr ""
+"Comprehensive Rust 🦀:  \n"
+"el conjunto de cursos que se describen aquí se denomina Comprehensive Rust "
+"🦀."
 
 #: src/glossary.md
 msgid ""
 "concurrency:  \n"
 "The execution of multiple tasks or processes at the same time."
 msgstr ""
+"Simultaneidad:  \n"
+"ejecución de varias tareas o procesos al mismo tiempo."
 
 #: src/glossary.md
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
 msgstr ""
+"Simultaneidad en Rust:  \n"
+"consulta [Simultaneidad en Rust](concurrency.md)."
 
 #: src/glossary.md
 msgid ""
 "constant:  \n"
 "A value that does not change during the execution of a program."
 msgstr ""
+"Constante:  \n"
+" valor que no cambia durante la ejecución de un programa."
 
 #: src/glossary.md
 msgid ""
@@ -23494,12 +23570,16 @@ msgid ""
 "The order in which the individual statements or instructions are executed in "
 "a program."
 msgstr ""
+"Flujo de control:  \n"
+"el orden en el que se ejecutan las instrucciones individuales en un programa."
 
 #: src/glossary.md
 msgid ""
 "crash:  \n"
 "An unexpected and unhandled failure or termination of a program."
 msgstr ""
+"Fallo:  \n"
+"fallo o finalización de un programa de forma inesperada y sin gestionar."
 
 #: src/glossary.md
 msgid ""
@@ -23507,12 +23587,17 @@ msgid ""
 "A data type that holds one of several named constants, possibly with an "
 "associated tuple or struct."
 msgstr ""
+"Enumeración:  \n"
+"tipo de dato que contiene una de varias constantes con nombre, posiblemente "
+"con una tupla o estructura asociada."
 
 #: src/glossary.md
 msgid ""
 "error:  \n"
 "An unexpected condition or result that deviates from the expected behavior."
 msgstr ""
+"Error:  \n"
+"condición o resultado inesperado que se desvía del comportamiento esperado."
 
 #: src/glossary.md
 msgid ""
@@ -23520,18 +23605,26 @@ msgid ""
 "The process of managing and responding to errors that occur during program "
 "execution."
 msgstr ""
+"Gestión de errores:  \n"
+"el proceso de gestionar y responder a los errores que se producen durante la "
+"ejecución del programa."
 
 #: src/glossary.md
 msgid ""
 "exercise:  \n"
 "A task or problem designed to practice and test programming skills."
 msgstr ""
+"Ejercicio:  \n"
+"una tarea o problema diseñado para practicar y poner a prueba las "
+"habilidades de programación."
 
 #: src/glossary.md
 msgid ""
 "function:  \n"
 "A reusable block of code that performs a specific task."
 msgstr ""
+"Función:  \n"
+"bloque de código reutilizable que lleva a cabo una tarea específica."
 
 #: src/glossary.md
 msgid ""
@@ -23539,6 +23632,9 @@ msgid ""
 "A mechanism that automatically frees up memory occupied by objects that are "
 "no longer in use."
 msgstr ""
+"Recolector de elementos no utilizados:  \n"
+"mecanismo que libera automáticamente la memoria que ocupan objetos que ya no "
+"se utilizan."
 
 #: src/glossary.md
 msgid ""
@@ -23546,12 +23642,17 @@ msgid ""
 "A feature that allows writing code with placeholders for types, enabling "
 "code reuse with different data types."
 msgstr ""
+"Genéricos:  \n"
+"una función que permite escribir código con marcadores de posición para los "
+"tipos, lo que permite reutilizar código con distintos tipos de datos."
 
 #: src/glossary.md
 msgid ""
 "immutable:  \n"
 "Unable to be changed after creation."
 msgstr ""
+"Inmutable:  \n"
+"que no se puede cambiar después de crearse."
 
 #: src/glossary.md
 msgid ""
@@ -23559,6 +23660,9 @@ msgid ""
 "A type of test that verifies the interactions between different parts or "
 "components of a system."
 msgstr ""
+"Prueba de integración:  \n"
+"tipo de prueba que verifica las interacciones entre diferentes partes o "
+"componentes de un sistema."
 
 #: src/glossary.md
 msgid ""
@@ -23566,12 +23670,18 @@ msgid ""
 "A reserved word in a programming language that has a specific meaning and "
 "cannot be used as an identifier."
 msgstr ""
+"Palabra clave:  \n"
+"palabra reservada en un lenguaje de programación que tiene un significado "
+"específico y que no se puede utilizar como identificador."
 
 #: src/glossary.md
 msgid ""
 "library:  \n"
 "A collection of precompiled routines or code that can be used by programs."
 msgstr ""
+"Biblioteca:  \n"
+"una colección de rutinas o código precompilados que pueden utilizar los "
+"programas."
 
 #: src/glossary.md
 msgid ""
@@ -23580,12 +23690,19 @@ msgid ""
 "normal functions are not enough. A typical example is `format!`, which takes "
 "a variable number of arguments, which isn't supported by Rust functions."
 msgstr ""
+"Macro:  \n"
+"las macros de Rust se pueden reconocer por llevar `!` en el nombre. Las "
+"macros se utilizan cuando las funciones normales no son suficientes. Un "
+"ejemplo típico es `format!`, que utiliza un número variable de argumentos "
+"que no es compatible con las funciones de Rust."
 
 #: src/glossary.md
 msgid ""
 "`main` function:  \n"
 "Rust programs start executing with the `main` function."
 msgstr ""
+"Función `main`:  \n"
+"los programas de Rust empiezan a ejecutarse con la función `main`."
 
 #: src/glossary.md
 msgid ""
@@ -23593,6 +23710,9 @@ msgid ""
 "A control flow construct in Rust that allows for pattern matching on the "
 "value of an expression."
 msgstr ""
+"Coincidencia:  \n"
+"construcción de flujo de control en Rust que permite la coincidencia de "
+"patrones con el valor de una expresión."
 
 #: src/glossary.md
 msgid ""
@@ -23600,12 +23720,17 @@ msgid ""
 "A situation where a program fails to release memory that is no longer "
 "needed, leading to a gradual increase in memory usage."
 msgstr ""
+"Pérdida de memoria:  \n"
+"situación en la que un programa no libera memoria que ya no se necesita, lo "
+"que provoca un aumento gradual en el uso de memoria."
 
 #: src/glossary.md
 msgid ""
 "method:  \n"
 "A function associated with an object or a type in Rust."
 msgstr ""
+"Método:  \n"
+"una función asociada a un objeto o a un tipo en Rust."
 
 #: src/glossary.md
 msgid ""
@@ -23613,12 +23738,17 @@ msgid ""
 "A namespace that contains definitions, such as functions, types, or traits, "
 "to organize code in Rust."
 msgstr ""
+"Módulo:  \n"
+"espacio de nombres que contiene definiciones, como funciones, tipos o "
+"traits, para organizar el código en Rust."
 
 #: src/glossary.md
 msgid ""
 "move:  \n"
 "The transfer of ownership of a value from one variable to another in Rust."
 msgstr ""
+"Mover:  \n"
+"la transferencia de la propiedad de un valor de una variable a otra en Rust."
 
 #: src/glossary.md
 msgid ""
@@ -23626,6 +23756,9 @@ msgid ""
 "A property in Rust that allows variables to be modified after they have been "
 "declared."
 msgstr ""
+"Mutable:  \n"
+"una propiedad en Rust que permite que se modifiquen las variables después de "
+"que se hayan declarado."
 
 #: src/glossary.md
 msgid ""
@@ -23633,6 +23766,9 @@ msgid ""
 "The concept in Rust that defines which part of the code is responsible for "
 "managing the memory associated with a value."
 msgstr ""
+"Propiedad:  \n"
+"el concepto de Rust que define qué parte del código es responsable de "
+"gestionar la memoria asociada a un valor."
 
 #: src/glossary.md
 msgid ""
@@ -23640,12 +23776,17 @@ msgid ""
 "An unrecoverable error condition in Rust that results in the termination of "
 "the program."
 msgstr ""
+"Pánico:  \n"
+"condición de error irrecuperable en Rust que provoca la finalización del "
+"programa."
 
 #: src/glossary.md
 msgid ""
 "parameter:  \n"
 "A value that is passed into a function or method when it is called."
 msgstr ""
+"Parámetro:  \n"
+" valor que se transfiere a una función o método cuando se llama."
 
 #: src/glossary.md
 msgid ""
@@ -23653,12 +23794,18 @@ msgid ""
 "A combination of values, literals, or structures that can be matched against "
 "an expression in Rust."
 msgstr ""
+"Patrón:  \n"
+"una combinación de valores, literales o estructuras que se pueden comparar "
+"con una expresión de Rust."
 
 #: src/glossary.md
 msgid ""
 "payload:  \n"
 "The data or information carried by a message, event, or data structure."
 msgstr ""
+"Carga útil:  \n"
+"los datos o la información que transporta un mensaje, evento o estructura de "
+"datos."
 
 #: src/glossary.md
 msgid ""
@@ -23666,12 +23813,18 @@ msgid ""
 "A set of instructions that a computer can execute to perform a specific task "
 "or solve a particular problem."
 msgstr ""
+"Programa:  \n"
+"conjunto de instrucciones que un ordenador puede ejecutar para llevar a cabo "
+"una tarea específica o resolver un problema concreto."
 
 #: src/glossary.md
 msgid ""
 "programming language:  \n"
 "A formal system used to communicate instructions to a computer, such as Rust."
 msgstr ""
+"Lenguaje de programación:  \n"
+"un sistema formal que se utiliza para comunicar instrucciones a un "
+"ordenador, como Rust."
 
 #: src/glossary.md
 msgid ""
@@ -23679,6 +23832,9 @@ msgid ""
 "The first parameter in a Rust method that represents the instance on which "
 "the method is called."
 msgstr ""
+"Receptor:  \n"
+"el primer parámetro de un método de Rust que representa la instancia en la "
+"que se llama al método."
 
 #: src/glossary.md
 msgid ""
@@ -23686,12 +23842,18 @@ msgid ""
 "A memory management technique in which the number of references to an object "
 "is tracked, and the object is deallocated when the count reaches zero."
 msgstr ""
+"Recuento de referencias:  \n"
+"técnica de gestión de la memoria en la que se hace un seguimiento del número "
+"de referencias a un objeto y se desasigna cuando el recuento llega a cero."
 
 #: src/glossary.md
 msgid ""
 "return:  \n"
 "A keyword in Rust used to indicate the value to be returned from a function."
 msgstr ""
+"Retorno:  \n"
+"una palabra clave de Rust que se utiliza para indicar el valor que se "
+"devuelve de una función."
 
 #: src/glossary.md
 msgid ""
@@ -23699,24 +23861,33 @@ msgid ""
 "A systems programming language that focuses on safety, performance, and "
 "concurrency."
 msgstr ""
+"Rust:  \n"
+"lenguaje de programación de sistemas que se centra en la seguridad, el "
+"rendimiento y la simultaneidad."
 
 #: src/glossary.md
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 3 of this course."
 msgstr ""
+"Aspectos básicos de Rust:  \n"
+"contenido del día 1 al día 3 de este curso."
 
 #: src/glossary.md
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
 msgstr ""
+"Rust en Android:  \n"
+"consulta [Rust en Android](android.md)."
 
 #: src/glossary.md
 msgid ""
 "Rust in Chromium:  \n"
 "See [Rust in Chromium](chromium.md)."
 msgstr ""
+"Rust en Chromium:  \n"
+"consulta [Rust en Chromium](chromium.md)."
 
 #: src/glossary.md
 msgid ""
@@ -23724,18 +23895,26 @@ msgid ""
 "Refers to code that adheres to Rust's ownership and borrowing rules, "
 "preventing memory-related errors."
 msgstr ""
+"Seguro:  \n"
+"se refiere al código que cumple las reglas de propiedad y préstamos de Rust, "
+"lo que evita errores relacionados con la memoria."
 
 #: src/glossary.md
 msgid ""
 "scope:  \n"
 "The region of a program where a variable is valid and can be used."
 msgstr ""
+"Ámbito:  \n"
+"la región de un programa en la que una variable es válida y se puede "
+"utilizar."
 
 #: src/glossary.md
 msgid ""
 "standard library:  \n"
 "A collection of modules providing essential functionality in Rust."
 msgstr ""
+"Biblioteca estándar:  \n"
+"una colección de módulos que proporcionan funciones esenciales en Rust."
 
 #: src/glossary.md
 msgid ""
@@ -23743,6 +23922,9 @@ msgid ""
 "A keyword in Rust used to define static variables or items with a `'static` "
 "lifetime."
 msgstr ""
+"Static:  \n"
+"una palabra clave de Rust que se utiliza para definir variables o elementos "
+"estáticos con un tiempo de vida `'static`."
 
 #: src/glossary.md
 msgid ""
@@ -23750,6 +23932,9 @@ msgid ""
 "A data type storing textual data. See [`String` vs `str`](basic-syntax/"
 "string-slices.html) for more."
 msgstr ""
+"String o cadena:  \n"
+"tipo de datos que almacena datos de texto. Consulta [`String` vs `str`]"
+"(basic-syntax/string-slices.html) para obtener más información."
 
 #: src/glossary.md
 msgid ""
@@ -23757,6 +23942,9 @@ msgid ""
 "A composite data type in Rust that groups together variables of different "
 "types under a single name."
 msgstr ""
+"Struct:  \n"
+"tipo de datos compuestos de Rust que agrupa variables de diferentes tipos "
+"bajo un mismo nombre."
 
 #: src/glossary.md
 msgid ""
@@ -23764,12 +23952,18 @@ msgid ""
 "A Rust module containing functions that test the correctness of other "
 "functions."
 msgstr ""
+"Prueba:  \n"
+"módulo de Rust que contiene funciones que comprueban que otras funciones "
+"sean correctas."
 
 #: src/glossary.md
 msgid ""
 "thread:  \n"
 "A separate sequence of execution in a program, allowing concurrent execution."
 msgstr ""
+"Hilo:  \n"
+"una secuencia de ejecución independiente en un programa que permite la "
+"ejecución simultánea."
 
 #: src/glossary.md
 msgid ""
@@ -23777,6 +23971,9 @@ msgid ""
 "The property of a program that ensures correct behavior in a multithreaded "
 "environment."
 msgstr ""
+"Seguridad en hilos:  \n"
+"la propiedad de un programa que asegura un comportamiento correcto en un "
+"entorno multihilo."
 
 #: src/glossary.md
 msgid ""
@@ -23784,6 +23981,9 @@ msgid ""
 "A collection of methods defined for an unknown type, providing a way to "
 "achieve polymorphism in Rust."
 msgstr ""
+"Trait:  \n"
+"conjunto de métodos definidos para un tipo desconocido que proporciona una "
+"forma de lograr el polimorfismo en Rust."
 
 #: src/glossary.md
 msgid ""
@@ -23791,6 +23991,9 @@ msgid ""
 "An abstraction where you can require types to implement some traits of your "
 "interest."
 msgstr ""
+"Límite del trait:  \n"
+"una abstracción en la que puedes requerir que los tipos implementen algunos "
+"traits de tu interés."
 
 #: src/glossary.md
 msgid ""
@@ -23798,6 +24001,10 @@ msgid ""
 "A composite data type that contains variables of different types. Tuple "
 "fields have no names, and are accessed by their ordinal numbers."
 msgstr ""
+"Tupla:  \n"
+"tipo de datos compuestos que contiene variables de diferentes tipos. Los "
+"campos de tuplas no tienen nombre y se accede a ellos por sus números "
+"ordinales."
 
 #: src/glossary.md
 msgid ""
@@ -23805,6 +24012,9 @@ msgid ""
 "A classification that specifies which operations can be performed on values "
 "of a particular kind in Rust."
 msgstr ""
+"Tipo:  \n"
+"una clasificación que especifica qué operaciones se pueden llevar a cabo en "
+"valores de una clase concreta en Rust."
 
 #: src/glossary.md
 msgid ""
@@ -23812,6 +24022,9 @@ msgid ""
 "The ability of the Rust compiler to deduce the type of a variable or "
 "expression."
 msgstr ""
+"Inferencia de tipos:  \n"
+"capacidad del compilador de Rust para deducir el tipo de una variable o "
+"expresión."
 
 #: src/glossary.md
 msgid ""
@@ -23819,12 +24032,18 @@ msgid ""
 "Actions or conditions in Rust that have no specified result, often leading "
 "to unpredictable program behavior."
 msgstr ""
+"Comportamiento indefinido:  \n"
+"acciones o condiciones en Rust que no tienen ningún resultado especificado, "
+"lo que a menudo provoca un comportamiento impredecible del programa."
 
 #: src/glossary.md
 msgid ""
 "union:  \n"
 "A data type that can hold values of different types but only one at a time."
 msgstr ""
+"Unión:  \n"
+"tipo de datos que puede contener valores de distintos tipos, pero solo de "
+"uno en uno."
 
 #: src/glossary.md
 msgid ""
@@ -23832,12 +24051,18 @@ msgid ""
 "Rust comes with built-in support for running small unit tests and larger "
 "integration tests. See [Unit Tests](testing/unit-tests.html)."
 msgstr ""
+"Prueba unitaria:  \n"
+"Rust incluye asistencia integrada para llevar a cabo pruebas unitarias de "
+"pequeño tamaño y pruebas de integración de mayor tamaño. Consulta la página "
+"[Pruebas unitarias](testing/unit-tests.html)."
 
 #: src/glossary.md
 msgid ""
 "unit type:  \n"
 "Type that holds no data, written as a tuple with no members."
 msgstr ""
+"Tipo de unidad:  \n"
+"tipo que no contiene datos, escrito como una tupla sin miembros."
 
 #: src/glossary.md
 msgid ""
@@ -23845,12 +24070,18 @@ msgid ""
 "The subset of Rust which allows you to trigger _undefined behavior_. See "
 "[Unsafe Rust](unsafe.html)."
 msgstr ""
+"Inseguro:  \n"
+"el subconjunto de Rust que te permite activar un _comportamiento "
+"indefinido_. Consulta [Rust inseguro](unsafe.html)."
 
 #: src/glossary.md
 msgid ""
 "variable:  \n"
 "A memory location storing data. Variables are valid in a _scope_."
 msgstr ""
+"Variable:  \n"
+"una ubicación de la memoria que almacena datos. Las variables son válidas en "
+"un _ámbito_"
 
 #: src/other-resources.md
 msgid "Other Rust Resources"

--- a/po/es.po
+++ b/po/es.po
@@ -12117,30 +12117,40 @@ msgid ""
 "The speaker may mention any of the following given the increased use of Rust "
 "in Android:"
 msgstr ""
+"El orador puede mencionar cualquiera de los siguientes aspectos, debido al "
+"aumento del uso de Rust en Android:"
 
 #: src/android.md
 msgid ""
 "Service example: [DNS over HTTP](https://security.googleblog.com/2022/07/dns-"
 "over-http3-in-android.html)"
 msgstr ""
+"Ejemplo de servicio: [DNS over HTTP](https://security.googleblog.com/2022/07/"
+"dns-over-http3-in-android.html)"
 
 #: src/android.md
 msgid ""
 "Libraries: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
 "appendix/rutabaga_gfx.html)"
 msgstr ""
+"Bibliotecas: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
+"appendix/rutabaga_gfx.html)"
 
 #: src/android.md
 msgid ""
 "Kernel Drivers: [Binder](https://lore.kernel.org/rust-for-linux/20231101-"
 "rust-binder-v1-0-08ba9197f637@google.com/)"
 msgstr ""
+"Controladores de kernel: [Binder](https://lore.kernel.org/rust-for-"
+"linux/20231101-rust-binder-v1-0-08ba9197f637@google.com/)"
 
 #: src/android.md
 msgid ""
 "Firmware: [pKVM firmware](https://security.googleblog.com/2023/10/bare-metal-"
 "rust-in-android.html)"
 msgstr ""
+"Firmware: [firmware de pKVM](https://security.googleblog.com/2023/10/bare-"
+"metal-rust-in-android.html)"
 
 #: src/android/setup.md
 #, fuzzy
@@ -12164,12 +12174,18 @@ msgid ""
 "Cuttlefish is a reference Android device designed to work on generic Linux "
 "desktops. MacOS support is also planned."
 msgstr ""
+"Cuttlefish es un dispositivo Android de referencia diseñado para funcionar "
+"en ordenadores genéricos Linux. También tenemos previsto ofrecer "
+"compatibilidad con MacOS."
 
 #: src/android/setup.md
 msgid ""
 "The Cuttlefish system image maintains high fidelity to real devices, and is "
 "the ideal emulator to run many Rust use cases."
 msgstr ""
+"La imagen del sistema de Cuttlefish mantiene una alta fidelidad a los "
+"dispositivos reales y es el emulador ideal para ejecutar muchos casos "
+"prácticos de Rust."
 
 #: src/android/build-rules.md
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
@@ -12274,25 +12290,32 @@ msgstr "A continuación, hablaremos de `rust_binary` y `rust_library`."
 
 #: src/android/build-rules.md
 msgid "Additional items speaker may mention:"
-msgstr ""
+msgstr "Otros elementos que puede mencionar el orador:"
 
 #: src/android/build-rules.md
 msgid ""
 "Cargo is not optimized for multi-language repos, and also downloads packages "
 "from the internet."
 msgstr ""
+"Cargo no está optimizado para los repositorios en varios lenguajes y también "
+"descarga paquetes de Internet."
 
 #: src/android/build-rules.md
 msgid ""
 "For compliance and performance, Android must have crates in-tree. It must "
 "also interop with C/C++/Java code. Soong fills that gap."
 msgstr ""
+"Por razones de cumplimiento y rendimiento, Android debe tener crates en "
+"estructura de árbol. También debe existir interoperabilidad con el código C, "
+"C++ y Java. Soong cumple estos requisitos."
 
 #: src/android/build-rules.md
 msgid ""
 "Soong has many similarities to Bazel, which is the open-source variant of "
 "Blaze (used in google3)."
 msgstr ""
+"Soong tiene muchas similitudes con Bazel, que es la variante de código "
+"abierto de Blaze (se utiliza en google3)."
 
 #: src/android/build-rules.md
 msgid ""
@@ -12301,14 +12324,20 @@ msgid ""
 "com/chromiumos/bazel/), and [Fuchsia](https://source.android.com/docs/setup/"
 "build/bazel/introduction) to Bazel."
 msgstr ""
+"Está previsto hacer la transición de [Android](https://source.android.com/"
+"docs/setup/build/bazel/introduction), [ChromeOS](https://chromium."
+"googlesource.com/chromiumos/bazel/) y [Fuchsia](https://source.android.com/"
+"docs/setup/build/bazel/introduction) a Bazel."
 
 #: src/android/build-rules.md
 msgid "Learning Bazel-like build rules is useful for all Rust OS developers."
 msgstr ""
+"Aprender reglas de compilación similares a Bazel es útil para todos los "
+"desarrolladores del SO de Rust."
 
 #: src/android/build-rules.md
 msgid "Fun fact: Data from Star Trek is a Soong-type Android."
-msgstr ""
+msgstr "Dato curioso: los datos de Star Trek son un Android de tipo Soong."
 
 #: src/android/build-rules/binary.md
 msgid "Rust Binaries"
@@ -12328,13 +12357,12 @@ msgstr "_hello_rust/Android.bp_:"
 
 #: src/android/build-rules/binary.md
 msgid "\"hello_rust\""
-msgstr ""
+msgstr "\"hello_rust\""
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 #: src/android/logging.md
-#, fuzzy
 msgid "\"src/main.rs\""
-msgstr "`src/main.rs`:"
+msgstr "\"src/main.rs\""
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "_hello_rust/src/main.rs_:"
@@ -12342,22 +12370,21 @@ msgstr "_hello_rust/src/main.rs_:"
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "//! Rust demo.\n"
-msgstr ""
+msgstr "//! Demo de Rust.\n"
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "/// Prints a greeting to standard output.\n"
-msgstr ""
+msgstr "/// Imprime un saludo en una salida estándar.\n"
 
 #: src/android/build-rules/binary.md src/exercises/chromium/build-rules.md
 msgid "\"Hello from Rust!\""
-msgstr ""
+msgstr "\"¡Saludos de parte Rust!\""
 
 #: src/android/build-rules/binary.md
 msgid "You can now build, push, and run the binary:"
 msgstr "Ahora puedes compilar, insertar y ejecutar el binario:"
 
 #: src/android/build-rules/binary.md
-#, fuzzy
 msgid ""
 "```shell\n"
 "m hello_rust\n"
@@ -12366,10 +12393,9 @@ msgid ""
 "```"
 msgstr ""
 "```shell\n"
-"m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
-"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"m hello_rust\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust\" /data/local/tmp\n"
+"adb shell /data/local/tmp/hello_rust\n"
 "```"
 
 #: src/android/build-rules/library.md
@@ -12400,29 +12426,28 @@ msgstr ""
 
 #: src/android/build-rules/library.md
 msgid "\"hello_rust_with_dep\""
-msgstr ""
+msgstr "\"hello_rust_with_dep\""
 
 #: src/android/build-rules/library.md
 msgid "\"libgreetings\""
-msgstr ""
+msgstr "\"libgreetings\""
 
 #: src/android/build-rules/library.md
 msgid "\"libtextwrap\""
-msgstr ""
+msgstr "\"libtextwrap\""
 
 #: src/android/build-rules/library.md
 msgid "// Need this to avoid dynamic link error.\n"
-msgstr ""
+msgstr "// Es necesario para evitar errores de enlace dinámico.\n"
 
 #: src/android/build-rules/library.md
 msgid "\"greetings\""
-msgstr ""
+msgstr "\"greetings\""
 
 #: src/android/build-rules/library.md src/android/aidl/implementation.md
 #: src/android/interoperability/java.md
-#, fuzzy
 msgid "\"src/lib.rs\""
-msgstr "`src/main.rs`:"
+msgstr "\"src/lib.rs\""
 
 #: src/android/build-rules/library.md
 msgid "_hello_rust/src/lib.rs_:"
@@ -12430,11 +12455,11 @@ msgstr "_hello_rust/src/lib.rs_:"
 
 #: src/android/build-rules/library.md
 msgid "//! Greeting library.\n"
-msgstr ""
+msgstr "//! Biblioteca de saludos.\n"
 
 #: src/android/build-rules/library.md
 msgid "/// Greet `name`.\n"
-msgstr ""
+msgstr "/// Saluda a `name`.\n"
 
 #: src/android/build-rules/library.md
 #, fuzzy
@@ -12450,7 +12475,6 @@ msgid "You build, push, and run the binary like before:"
 msgstr "Puedes compilar, insertar y ejecutar el binario como antes:"
 
 #: src/android/build-rules/library.md
-#, fuzzy
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
@@ -12461,8 +12485,8 @@ msgid ""
 msgstr ""
 "```shell\n"
 "m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep\" /data/local/"
+"tmp\n"
 "adb shell /data/local/tmp/hello_rust_with_dep\n"
 "```"
 
@@ -12499,11 +12523,11 @@ msgstr ""
 
 #: src/android/aidl/interface.md src/android/aidl/changing.md
 msgid "/** Birthday service interface. */"
-msgstr ""
+msgstr "/** Birthday service interface. */"
 
 #: src/android/aidl/interface.md src/android/aidl/changing.md
 msgid "/** Generate a Happy Birthday message. */"
-msgstr ""
+msgstr "/** Generate a Happy Birthday message. */"
 
 #: src/android/aidl/interface.md
 msgid "_birthday_service/aidl/Android.bp_:"
@@ -12511,17 +12535,15 @@ msgstr "_birthday_service/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md
 msgid "\"com.example.birthdayservice\""
-msgstr ""
+msgstr "\"com.example.birthdayservice\""
 
 #: src/android/aidl/interface.md
-#, fuzzy
 msgid "\"com/example/birthdayservice/*.aidl\""
-msgstr ""
-"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
+msgstr "\"com/example/birthdayservice/*.aidl\""
 
 #: src/android/aidl/interface.md
 msgid "// Rust is not enabled by default\n"
-msgstr ""
+msgstr "// Rust no está habilitado de forma predeterminada\n"
 
 #: src/android/aidl/interface.md
 msgid ""
@@ -12545,16 +12567,16 @@ msgstr "_birthday_service/src/lib.rs_:"
 
 #: src/android/aidl/implementation.md
 msgid "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-msgstr ""
+msgstr "//! Implementación de la interfaz de AIDL de `IBirthdayService`.\n"
 
 #: src/android/aidl/implementation.md
 #, fuzzy
 msgid "/// The `IBirthdayService` implementation.\n"
-msgstr "Implementación del servicio"
+msgstr "/// Implementación del método HelloWorld::hello.\n"
 
 #: src/android/aidl/implementation.md
 msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
-msgstr ""
+msgstr "\"Feliz cumpleaños, {name}, te han caído {years} años\"."
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
@@ -12562,25 +12584,23 @@ msgid "_birthday_service/Android.bp_:"
 msgstr "_birthday_service/Android.bp_:"
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
-#, fuzzy
 msgid "\"libbirthdayservice\""
-msgstr "_birthday_service/src/lib.rs_:"
+msgstr "\"libbirthdayservice\""
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
-#, fuzzy
 msgid "\"birthdayservice\""
-msgstr "_birthday_service/src/lib.rs_:"
+msgstr "\"birthdayservice\""
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
 msgid "\"com.example.birthdayservice-rust\""
-msgstr ""
+msgstr "\"com.example.birthdayservice-rust\""
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
 msgid "\"libbinder_rs\""
-msgstr ""
+msgstr "\"libbinder_rs\""
 
 #: src/android/aidl/server.md
 msgid "AIDL Server"
@@ -12596,36 +12616,33 @@ msgstr "_birthday_service/src/server.rs_:"
 
 #: src/android/aidl/server.md src/android/aidl/client.md
 msgid "//! Birthday service.\n"
-msgstr ""
+msgstr "//! Servicio de felicitación cumpleaños.\n"
 
 #: src/android/aidl/server.md
 msgid "/// Entry point for birthday service.\n"
-msgstr ""
+msgstr "/// Punto de entrada del servicio de felicitación cumpleaños.\n"
 
 #: src/android/aidl/server.md
 msgid "\"Failed to register service\""
-msgstr ""
+msgstr "\"No se ha podido registrar el servicio\""
 
 #: src/android/aidl/server.md
-#, fuzzy
 msgid "\"birthday_server\""
-msgstr "_birthday_service/src/lib.rs_:"
+msgstr "\"birthday_server\""
 
 #: src/android/aidl/server.md
-#, fuzzy
 msgid "\"src/server.rs\""
-msgstr "`src/bin/server.rs`:"
+msgstr "\"src/server.rs\""
 
 #: src/android/aidl/server.md src/android/aidl/client.md
 msgid "// To avoid dynamic link error.\n"
-msgstr ""
+msgstr "// Para evitar errores de enlaces dinámicos.\n"
 
 #: src/android/aidl/deploy.md
 msgid "We can now build, push, and start the service:"
 msgstr "Ahora podemos crear, insertar e iniciar el servicio:"
 
 #: src/android/aidl/deploy.md
-#, fuzzy
 msgid ""
 "```shell\n"
 "m birthday_server\n"
@@ -12636,10 +12653,11 @@ msgid ""
 "```"
 msgstr ""
 "```shell\n"
-"m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
-"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"m birthday_server\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server\" /data/local/"
+"tmp\n"
+"adb root\n"
+"adb shell /data/local/tmp/birthday_server\n"
 "```"
 
 #: src/android/aidl/deploy.md
@@ -12665,29 +12683,28 @@ msgstr "_birthday_service/src/client.rs_:"
 
 #: src/android/aidl/client.md
 msgid "/// Connect to the BirthdayService.\n"
-msgstr ""
+msgstr "/// Conecta con el servicio de felicitación de cumpleaños.\n"
 
 #: src/android/aidl/client.md
 msgid "/// Call the birthday service.\n"
-msgstr ""
+msgstr "/// Llama al servicio de felicitación cumpleaños.\n"
 
 #: src/android/aidl/client.md
 msgid "\"Failed to connect to BirthdayService\""
 msgstr ""
+"\"No se ha podido conectar con el servicio de felicitación de cumpleaños.\""
 
 #: src/android/aidl/client.md
 msgid "\"{msg}\""
-msgstr ""
+msgstr "\"{msg}\""
 
 #: src/android/aidl/client.md
-#, fuzzy
 msgid "\"birthday_client\""
-msgstr "_birthday_service/src/client.rs_:"
+msgstr "\"birthday_client\""
 
 #: src/android/aidl/client.md
-#, fuzzy
 msgid "\"src/client.rs\""
-msgstr "`src/bin/client.rs`:"
+msgstr "\"src/client.rs\""
 
 #: src/android/aidl/client.md
 msgid "Notice that the client does not depend on `libbirthdayservice`."
@@ -12698,7 +12715,6 @@ msgid "Build, push, and run the client on your device:"
 msgstr "Compila, inserta y ejecuta el cliente en tu dispositivo:"
 
 #: src/android/aidl/client.md
-#, fuzzy
 msgid ""
 "```shell\n"
 "m birthday_client\n"
@@ -12708,10 +12724,10 @@ msgid ""
 "```"
 msgstr ""
 "```shell\n"
-"m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
-"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"m birthday_client\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/birthday_client Charlie 60\n"
 "```"
 
 #: src/android/aidl/changing.md
@@ -12735,17 +12751,16 @@ msgid "_hello_rust_logs/Android.bp_:"
 msgstr "_hello_rust_logs/Android.bp_:"
 
 #: src/android/logging.md
-#, fuzzy
 msgid "\"hello_rust_logs\""
-msgstr "_hello_rust_logs/Android.bp_:"
+msgstr "\"hello_rust_logs\""
 
 #: src/android/logging.md
 msgid "\"liblog_rust\""
-msgstr ""
+msgstr "\"liblog_rust\""
 
 #: src/android/logging.md
 msgid "\"liblogger\""
-msgstr ""
+msgstr "\"liblogger\""
 
 #: src/android/logging.md
 msgid "_hello_rust_logs/src/main.rs_:"
@@ -12753,27 +12768,27 @@ msgstr "_hello_rust_logs/src/main.rs_:"
 
 #: src/android/logging.md
 msgid "//! Rust logging demo.\n"
-msgstr ""
+msgstr "//! Demo de registros de Rust.\n"
 
 #: src/android/logging.md
 msgid "/// Logs a greeting.\n"
-msgstr ""
+msgstr "/// Registra un saludo.\n"
 
 #: src/android/logging.md
 msgid "\"rust\""
-msgstr ""
+msgstr "\"rust\""
 
 #: src/android/logging.md
 msgid "\"Starting program.\""
-msgstr ""
+msgstr "\"Iniciando programa.\""
 
 #: src/android/logging.md
 msgid "\"Things are going fine.\""
-msgstr ""
+msgstr "\"Todo es correcto.\""
 
 #: src/android/logging.md
 msgid "\"Something went wrong!\""
-msgstr ""
+msgstr "\"Se ha producido un error.\""
 
 #: src/android/logging.md src/android/interoperability/with-c/bindgen.md
 #: src/android/interoperability/with-c/rust.md
@@ -12781,7 +12796,6 @@ msgid "Build, push, and run the binary on your device:"
 msgstr "Compila, inserta y ejecuta el binario en tu dispositivo:"
 
 #: src/android/logging.md
-#, fuzzy
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
@@ -12791,10 +12805,10 @@ msgid ""
 "```"
 msgstr ""
 "```shell\n"
-"m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
-"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"m hello_rust_logs\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 
 #: src/android/logging.md
@@ -12843,7 +12857,7 @@ msgstr "Si quieres, puedes hacerlo de forma manual:"
 
 #: src/android/interoperability/with-c.md
 msgid "\"{x}, {abs_x}\""
-msgstr ""
+msgstr "\"{x}, {abs_x}\""
 
 #: src/android/interoperability/with-c.md
 msgid ""
@@ -12892,23 +12906,23 @@ msgstr "_interoperability/bindgen/libbirthday.c_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "<stdio.h>"
-msgstr ""
+msgstr "<stdio.h>"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday.h\""
-msgstr ""
+msgstr "\"libbirthday.h\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"+--------------\\n\""
-msgstr ""
+msgstr "\"+--------------\\n\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"| Happy Birthday %s!\\n\""
-msgstr ""
+msgstr "\"| ¡Feliz cumpleaños, %s!\\n\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"| Congratulations with the %i years!\\n\""
-msgstr ""
+msgstr "\"| ¡Enhorabuena por cumplir %i años!\\n\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "Add this to your `Android.bp` file:"
@@ -12916,15 +12930,15 @@ msgstr "Añade lo siguiente a tu archivo `Android.bp`:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/Android.bp_:"
-msgstr ""
+msgstr "_interoperability/bindgen/Android.bp_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday\""
-msgstr ""
+msgstr "\"libbirthday\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday.c\""
-msgstr ""
+msgstr "\"libbirthday.c\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid ""
@@ -12944,20 +12958,19 @@ msgstr "Ahora puedes generar automáticamente los enlaces:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_bindgen\""
-msgstr ""
+msgstr "\"libbirthday_bindgen\""
 
 #: src/android/interoperability/with-c/bindgen.md
-#, fuzzy
 msgid "\"birthday_bindgen\""
-msgstr "`rust_bindgen`"
+msgstr "\"birthday_bindgen\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_wrapper.h\""
-msgstr ""
+msgstr "\"libbirthday_wrapper.h\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"bindings\""
-msgstr ""
+msgstr "\"bindings\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "Finally, we can use the bindings in our Rust program:"
@@ -12965,12 +12978,11 @@ msgstr "Por último, podemos utilizar los enlaces de nuestro programa de Rust:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"print_birthday_card\""
-msgstr ""
+msgstr "\"print_birthday_card\""
 
 #: src/android/interoperability/with-c/bindgen.md
-#, fuzzy
 msgid "\"main.rs\""
-msgstr "`main.rs`:"
+msgstr "\"main.rs\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/main.rs_:"
@@ -12978,14 +12990,14 @@ msgstr "_interoperability/bindgen/main.rs_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "//! Bindgen demo.\n"
-msgstr ""
+msgstr "//! Demo de Bindgen.\n"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "// SAFETY: `print_card` is safe to call with a valid `card` pointer.\n"
 msgstr ""
+"// SEGURIDAD: es seguro llamar a `print_card` con un puntero `card` válido.\n"
 
 #: src/android/interoperability/with-c/bindgen.md
-#, fuzzy
 msgid ""
 "```shell\n"
 "m print_birthday_card\n"
@@ -12995,10 +13007,10 @@ msgid ""
 "```"
 msgstr ""
 "```shell\n"
-"m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
-"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"m print_birthday_card\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 
 #: src/android/interoperability/with-c/bindgen.md
@@ -13009,23 +13021,23 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_bindgen_test\""
-msgstr ""
+msgstr "\"libbirthday_bindgen_test\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\":libbirthday_bindgen\""
-msgstr ""
+msgstr "\":libbirthday_bindgen\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"general-tests\""
-msgstr ""
+msgstr "\"general-tests\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"none\""
-msgstr ""
+msgstr "\"ninguno\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "// Generated file, skip linting\n"
-msgstr ""
+msgstr "// Archivo generado, se omite la ejecución de lint\n"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "Calling Rust"
@@ -13041,19 +13053,19 @@ msgstr "_interoperability/rust/libanalyze/analyze.rs_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "//! Rust FFI demo.\n"
-msgstr ""
+msgstr "//! Demo de FFI de Rust.\n"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "/// Analyze the numbers.\n"
-msgstr ""
+msgstr "/// Analiza los números.\n"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"x ({x}) is smallest!\""
-msgstr ""
+msgstr "¡\"x ({x}) es el menor!\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"y ({y}) is probably larger than x ({x})\""
-msgstr ""
+msgstr "\"y ({y}) probablemente sea mayor que x ({x})\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/libanalyze/analyze.h_"
@@ -13065,15 +13077,15 @@ msgstr "_interoperability/rust/libanalyze/Android.bp_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"libanalyze_ffi\""
-msgstr ""
+msgstr "\"libanalyze_ffi\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze_ffi\""
-msgstr ""
+msgstr "\"analyze_ffi\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze.rs\""
-msgstr ""
+msgstr "\"analyze.rs\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "We can now call this from a C binary:"
@@ -13085,7 +13097,7 @@ msgstr "_interoperability/rust/analyze/main.c_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze.h\""
-msgstr ""
+msgstr "\"analyze.h\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/analyze/Android.bp_"
@@ -13093,11 +13105,11 @@ msgstr "_interoperability/rust/analyze/Android.bp_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze_numbers\""
-msgstr ""
+msgstr "\"analyze_numbers\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"main.c\""
-msgstr ""
+msgstr "\"main.c\""
 
 #: src/android/interoperability/with-c/rust.md
 #, fuzzy
@@ -13110,10 +13122,10 @@ msgid ""
 "```"
 msgstr ""
 "```shell\n"
-"m hello_rust_with_dep\n"
-"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
-"tmp\"\n"
-"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"m analyze_numbers\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/analyze_numbers\n"
 "```"
 
 #: src/android/interoperability/with-c/rust.md
@@ -13145,19 +13157,23 @@ msgid ""
 "from each language to the other. You provide this description using extern "
 "blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
+"CXX se basa en una descripción de las firmas de la función que se mostrarán "
+"de un lenguaje a otro. Proporcionas esta descripción mediante bloques "
+"externos en un módulo de Rust anotado con la macro de atributo `#[cxx::"
+"bridge]`."
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "\"org::blobstore\""
-msgstr ""
+msgstr "\"org::blobstore\""
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "// Shared structs with fields visible to both languages.\n"
-msgstr ""
+msgstr "// Estructuras compartidas con campos visibles para ambos lenguajes.\n"
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/generated-cpp.md
 msgid "// Rust types and signatures exposed to C++.\n"
-msgstr ""
+msgstr "// Tipos y firmas de Rust expuestos a C++.\n"
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/rust-bridge.md
@@ -13166,30 +13182,29 @@ msgstr ""
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
-#, fuzzy
 msgid "\"Rust\""
-msgstr "Rustdoc"
+msgstr "\"Rust\""
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "// C++ types and signatures exposed to Rust.\n"
-msgstr ""
+msgstr "// Tipos y firmas de C++ y expuestos a Rust.\n"
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 #: src/android/interoperability/cpp/cpp-exception.md
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "\"C++\""
-msgstr ""
+msgstr "\"C++\""
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"include/blobstore.h\""
-msgstr ""
+msgstr "\"include/blobstore.h\""
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "The bridge is generally declared in an `ffi` module within your crate."
-msgstr ""
+msgstr "Bridge se declara generalmente en un módulo `ffi` dentro del crate."
 
 #: src/android/interoperability/cpp/bridge.md
 msgid ""
@@ -13197,6 +13212,9 @@ msgid ""
 "Rust and C++ type/function definitions in order to expose those items to "
 "both languages."
 msgstr ""
+"A partir de las declaraciones que se han hecho en el módulo bridge, CXX "
+"generará definiciones de funciones o tipos de Rust y C++ que coincidan para "
+"exponer esos elementos a ambos lenguajes."
 
 #: src/android/interoperability/cpp/bridge.md
 msgid ""
@@ -13205,22 +13223,27 @@ msgid ""
 "examples you would use `cargo expand ::ffi` to expand just the `ffi` module "
 "(though this doesn't apply for Android projects)."
 msgstr ""
+"Para ver el código de Rust generado, usa [cargo-expand](https://github.com/"
+"dtolnay/cargo-expand) para ver la macro de procedimiento desplegada. En la "
+"mayoría de los ejemplos, se utilizaría `cargo expand ::ffi` para desplegar "
+"únicamente el módulo `ffi` (aunque esta acción no se aplica a los proyectos "
+"de Android)."
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "To view the generated C++ code, look in `target/cxxbridge`."
-msgstr ""
+msgstr "Para ver el código C++ generado, consulta `target/cxxbridge`."
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid "Rust Bridge Declarations"
-msgstr ""
+msgstr "Declaraciones Bridge en Rust"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid "// Opaque type\n"
-msgstr ""
+msgstr "// Tipo opaco\n"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid "// Method on `MyType`\n"
-msgstr ""
+msgstr "// Método en `MyType`\n"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 #, fuzzy
@@ -13232,6 +13255,8 @@ msgid ""
 "Items declared in the `extern \"Rust\"` reference items that are in scope in "
 "the parent module."
 msgstr ""
+"Elementos declarados en los elementos de referencia `extern de \"Rust\" que "
+"se encuentran dentro del ámbito del módulo superior."
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid ""
@@ -13240,26 +13265,35 @@ msgid ""
 "header has the same path as the Rust source file containing the bridge, "
 "except with a .rs.h file extension."
 msgstr ""
+"El generador de código CXX utiliza las secciones `extern de \"Rust\"` para "
+"generar un archivo de encabezado de C++ que contenga las declaraciones de C+"
+"+ correspondientes. El encabezado generado tiene la misma ruta que el "
+"archivo de origen de Rust que contiene el patrón bridge, excepto con la "
+"extensión de archivo .rs.h."
 
 #: src/android/interoperability/cpp/generated-cpp.md
 msgid "Results in (roughly) the following C++:"
 msgstr ""
+"Los resultados son (aproximadamente) los que se muestran a continuación en C+"
+"+:"
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "C++ Bridge Declarations"
-msgstr ""
+msgstr "Declaraciones Bridge en C++"
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "Results in (roughly) the following Rust:"
 msgstr ""
+"Los resultados son (aproximadamente) los que se muestran a continuación en "
+"Rust:"
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
-msgstr ""
+msgstr "\"org$blobstore$cxxbridge1$new_blobstore_client\""
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
-msgstr ""
+msgstr "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid ""
@@ -13267,20 +13301,25 @@ msgid ""
 "in are accurate. CXX performs static assertions that the signatures exactly "
 "correspond with what is declared in C++."
 msgstr ""
+"El programador no tiene que asegurar que las firmas que ha introducido son "
+"precisas. CXX lleva a cabo aserciones estáticas en las que las firmas se "
+"corresponden exactamente con lo que se declara en C++."
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid ""
 "`unsafe extern` blocks allow you to declare C++ functions that are safe to "
 "call from Rust."
 msgstr ""
+"Los bloques `unsafe extern` permiten declarar funciones de C++ que se pueden "
+"llamar de forma segura desde Rust."
 
 #: src/android/interoperability/cpp/shared-types.md
 msgid "// A=1, J=11, Q=12, K=13\n"
-msgstr ""
+msgstr "// A=1, J=11, Q=12, K=13\n"
 
 #: src/android/interoperability/cpp/shared-types.md
 msgid "Only C-like (unit) enums are supported."
-msgstr ""
+msgstr "Solo se admiten enums tipo C (unidad)."
 
 #: src/android/interoperability/cpp/shared-types.md
 msgid ""
@@ -13289,15 +13328,18 @@ msgid ""
 "derive `Hash` also generates an implementation of `std::hash` for the "
 "corresponding C++ type."
 msgstr ""
+"Un número limitado de traits es compatible con `#[derive()]` en los tipos "
+"compartidos. La función correspondiente también se genera para el código C+"
+"+; por ejemplo, si derivas `Hash`, también genera una implementación de "
+"`std::hash` para el tipo de C++ correspondiente."
 
 #: src/android/interoperability/cpp/shared-enums.md
-#, fuzzy
 msgid "Generated Rust:"
-msgstr "Unsafe Rust"
+msgstr "Rust generado:"
 
 #: src/android/interoperability/cpp/shared-enums.md
 msgid "Generated C++:"
-msgstr ""
+msgstr "C++ generado:"
 
 #: src/android/interoperability/cpp/shared-enums.md
 msgid ""
@@ -13306,20 +13348,27 @@ msgid ""
 "class to hold a value different from all of the listed variants, and our "
 "Rust representation needs to have the same behavior."
 msgstr ""
+"En Rust, el código generado para las enums compartidas es en realidad una "
+"estructura que envuelve un valor numérico. Esto se debe a que no es un "
+"comportamiento indefinido en C++ para que una clase de enum contenga un "
+"valor distinto de todas las variantes enumeradas y nuestra representación en "
+"Rust debe tener el mismo comportamiento."
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid "\"fallible1 requires depth > 0\""
-msgstr ""
+msgstr "\"fallible1 requiere una profundidad > 0\""
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid "\"Success!\""
-msgstr ""
+msgstr "\"Correcto.\""
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid ""
 "Rust functions that return `Result` are translated to exceptions on the C++ "
 "side."
 msgstr ""
+"Las funciones de Rust que devuelven `Result` se convierten en excepciones en "
+"C++."
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid ""
@@ -13327,26 +13376,34 @@ msgid ""
 "exposes a way to get the error message string. The error message will come "
 "from the error type's `Display` impl."
 msgstr ""
+"La excepción que se genera siempre será del tipo `rust::Error`, que muestra "
+"principalmente una forma de obtener la cadena del mensaje de error. El "
+"mensaje de error procede de la implementación `Display` del tipo de error."
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid ""
 "A panic unwinding from Rust to C++ will always cause the process to "
 "immediately terminate."
 msgstr ""
+"Si un pánico pasa de Rust a C++, el proceso siempre finalizará "
+"inmediatamente."
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid "\"example/include/example.h\""
-msgstr ""
+msgstr "\"example/include/example.h\""
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid "\"Error: {}\""
-msgstr ""
+msgstr "\"Error: {}\""
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid ""
 "C++ functions declared to return a `Result` will catch any thrown exception "
 "on the C++ side and return it as an `Err` value to the calling Rust function."
 msgstr ""
+"Las funciones de C++ declaradas para devolver un `Result` detectarán "
+"cualquier excepción en C++ y la devolverán como un valor `Err` a la función "
+"de llamada de Rust."
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid ""
@@ -13355,6 +13412,10 @@ msgid ""
 "terminate`. The behavior is equivalent to the same exception being thrown "
 "through a `noexcept` C++ function."
 msgstr ""
+"Si se produce una excepción desde una función externa de \"C++\" no "
+"declarada por el bridge de CXX para devolver `Result`, el programa llamará a "
+"`std::terminate` de C++. El comportamiento equivale a la misma excepción que "
+"se genera mediante una función `noexcept`de C++."
 
 #: src/android/interoperability/cpp/type-mapping.md
 #, fuzzy
@@ -13369,95 +13430,98 @@ msgstr "Ejemplo en C++"
 #: src/android/interoperability/cpp/type-mapping.md
 #, fuzzy
 msgid "`rust::String`"
-msgstr "`rust_bindgen`"
+msgstr "`std::string`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`&str`"
-msgstr ""
+msgstr "`&str`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`rust::Str`"
-msgstr "`rust_test`"
+msgstr "`rust::Str`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`CxxString`"
-msgstr "String"
+msgstr "CxxString"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`std::string`"
-msgstr ""
+msgstr "`std::string`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`&[T]`/`&mut [T]`"
-msgstr ""
+msgstr "`&[T]`/`&mut [T]`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`rust::Slice`"
-msgstr "`rust_ffi`"
+msgstr "`rust::Slice`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Box<T>`"
-msgstr ""
+msgstr "`rust::Box<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`UniquePtr<T>`"
-msgstr ""
+msgstr "`UniquePtr<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`std::unique_ptr<T>`"
-msgstr ""
+msgstr "`std::unique_ptr<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`Vec<T>`"
-msgstr "`Vec`"
+msgstr "`Vec<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`rust::Vec<T>`"
-msgstr "`mpsc::Receiver<T>`"
+msgstr "`rust::Vec<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`CxxVector<T>`"
-msgstr "`Cell<T>`"
+msgstr "`CxxVector<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`std::vector<T>`"
-msgstr "`mpsc::Receiver<T>`"
+msgstr "`std::vector<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "These types can be used in the fields of shared structs and the arguments "
 "and returns of extern functions."
 msgstr ""
+"Estos tipos se pueden utilizar en los campos de estructura compartidas y en "
+"los argumentos e instrucciones de retorno de las funciones externas."
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "Note that Rust's `String` does not map directly to `std::string`. There are "
 "a few reasons for this:"
 msgstr ""
+"Ten en cuenta que `String` de Rust no se cruza directamente con `std::"
+"string`. Puede haber varios motivos:"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "`std::string` does not uphold the UTF-8 invariant that `String` requires."
 msgstr ""
+"`std::string` no mantiene la invariante de UTF-8 que requiere `String`."
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "The two types have different layouts in memory and so can't be passed "
 "directly between languages."
 msgstr ""
+"Los dos tipos tienen diseños diferentes en la memoria y, por lo tanto, no se "
+"pueden transferir directamente entre lenguajes."
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "`std::string` requires move constructors that don't match Rust's move "
 "semantics, so a `std::string` can't be passed by value to Rust."
 msgstr ""
+"`std::string` requiere constructores de movimiento que no coincidan con la "
+"semántica de movimiento de Rust, por lo que `std::string` no se puede "
+"transferir a Rust mediante un valor."
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-cpp-genrules.md
@@ -13471,29 +13535,31 @@ msgid ""
 "Create a `cc_library_static` to build the C++ library, including the CXX "
 "generated header and source file."
 msgstr ""
+"Crea un `cc_library_static` para compilar la biblioteca de C++, incluidos el "
+"encabezado y el archivo de origen generados por CXX."
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"libcxx_test_cpp\""
-msgstr ""
+msgstr "\"libcxx_test_cpp\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid "\"cxx_test.cpp\""
-msgstr ""
+msgstr "\"cxx_test.cpp\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid "\"cxx-bridge-header\""
-msgstr ""
+msgstr "\"cxx-bridge-header\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"libcxx_test_bridge_header\""
-msgstr ""
+msgstr "\"libcxx_test_bridge_header\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"libcxx_test_bridge_code\""
-msgstr ""
+msgstr "\"libcxx_test_bridge_code\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
@@ -13501,12 +13567,17 @@ msgid ""
 "the dependencies for the CXX-generated C++ bindings. We'll show how these "
 "are setup on the next slide."
 msgstr ""
+"Señala que `libcxx_test_bridge_header` y `libcxx_test_bridge_code` son las "
+"dependencias de los enlaces de C++ generados por CXX. En la siguiente "
+"diapositiva veremos cómo se configuran."
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
 "Note that you also need to depend on the `cxx-bridge-header` library in "
 "order to pull in common CXX definitions."
 msgstr ""
+"Ten en cuenta que también debes depender de la biblioteca `cxx-bridge-"
+"header` para obtener definiciones de CXX habituales."
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
@@ -13516,53 +13587,66 @@ msgid ""
 "that link with the class so that students know where they can find these "
 "instructions again in the future."
 msgstr ""
+"Los documentos completos sobre el uso de CXX en Android se pueden encontrar "
+"en [los documentos de Android](https://source.android.com/docs/setup/build/"
+"rust/building-rust-modules/android-rust-patterns#rust-cpp-interop-using-"
+"cxx). Puedes compartir ese enlace con la clase para que los participantes "
+"sepan dónde pueden buscar estas instrucciones de ahora en adelante."
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "Create two genrules: One to generate the CXX header, and one to generate the "
 "CXX source file. These are then used as inputs to the `cc_library_static`."
 msgstr ""
+"Crea dos genrule, una para generar el encabezado de CXX y otra para generar "
+"el archivo de origen de CXX. Luego se usarán como entradas a "
+"`cc_library_static`."
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "// Generate a C++ header containing the C++ bindings\n"
 "// to the Rust exported functions in lib.rs.\n"
 msgstr ""
+"// Genera un encabezado de C++ que contenga los enlaces de C++\n"
+"// a las funciones exportadas de Rust en lib.rs.\n"
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"cxxbridge\""
-msgstr ""
+msgstr "\"cxxbridge\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
-msgstr ""
+msgstr "\"$(location cxxbridge) $(in) --header > $(out)\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"lib.rs\""
-msgstr ""
+msgstr "\"lib.rs\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"lib.rs.h\""
-msgstr ""
+msgstr "\"lib.rs.h\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "// Generate the C++ code that Rust calls into.\n"
-msgstr ""
+msgstr "// Genera el código C++ al que llama Rust.\n"
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"$(location cxxbridge) $(in) > $(out)\""
-msgstr ""
+msgstr "\"$(location cxxbridge) $(in) > $(out)\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"lib.rs.cc\""
-msgstr ""
+msgstr "\"lib.rs.cc\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
 "bridge module. It is included in Android and available as a Soong tool."
 msgstr ""
+"La herramienta `cxxbridge` es una herramienta independiente que genera el "
+"lado C++ del módulo de bridge. Se incluye en Android y está disponible como "
+"herramienta de Soong."
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
@@ -13570,19 +13654,23 @@ msgid ""
 "named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
 "convention isn't enforced, though."
 msgstr ""
+"Por convención, si el archivo de origen de Rust es `lib.rs`, el archivo de "
+"encabezado se llamará `lib.rs.h` y el archivo de origen, `lib.rs.cc`. Sin "
+"embargo, esta convención en cuanto a la nomenclatura no es obligatoria."
 
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid ""
 "Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
 msgstr ""
+"Crea un `rust_binary` que dependa de `libcxx` y de tu `cc_library_static`."
 
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"cxx_test\""
-msgstr ""
+msgstr "\"cxx_test\""
 
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"libcxx\""
-msgstr ""
+msgstr "\"libcxx\""
 
 #: src/android/interoperability/java.md
 msgid "Interoperability with Java"
@@ -13608,19 +13696,19 @@ msgstr "_interoperability/java/src/lib.rs_:"
 
 #: src/android/interoperability/java.md
 msgid "//! Rust <-> Java FFI demo.\n"
-msgstr ""
+msgstr "//! Rust <-> Demo de FFI de Java.\n"
 
 #: src/android/interoperability/java.md
 msgid "/// HelloWorld::hello method implementation.\n"
-msgstr ""
+msgstr "/// Implementación del método HelloWorld::hello.\n"
 
 #: src/android/interoperability/java.md
 msgid "\"system\""
-msgstr ""
+msgstr "\"system\""
 
 #: src/android/interoperability/java.md
 msgid "\"Hello, {input}!\""
-msgstr ""
+msgstr "\"¡Hola, {input}!\""
 
 #: src/android/interoperability/java.md
 msgid "_interoperability/java/Android.bp_:"
@@ -13628,15 +13716,15 @@ msgstr "_interoperability/java/Android.bp_:"
 
 #: src/android/interoperability/java.md
 msgid "\"libhello_jni\""
-msgstr ""
+msgstr "\"libhello_jni\""
 
 #: src/android/interoperability/java.md
 msgid "\"hello_jni\""
-msgstr ""
+msgstr "\"hello_jni\""
 
 #: src/android/interoperability/java.md
 msgid "\"libjni\""
-msgstr ""
+msgstr "\"libjni\""
 
 #: src/android/interoperability/java.md
 #, fuzzy
@@ -13649,17 +13737,15 @@ msgstr "_interoperability/java/HelloWorld.java_:"
 
 #: src/android/interoperability/java.md
 msgid "\"helloworld_jni\""
-msgstr ""
+msgstr "\"helloworld_jni\""
 
 #: src/android/interoperability/java.md
-#, fuzzy
 msgid "\"HelloWorld.java\""
-msgstr "¡Hola, mundo!"
+msgstr "\"HelloWorld.java\""
 
 #: src/android/interoperability/java.md
-#, fuzzy
 msgid "\"HelloWorld\""
-msgstr "¡Hola, mundo!"
+msgstr "\"HelloWorld\""
 
 #: src/android/interoperability/java.md
 msgid "Finally, you can build, sync, and run the binary:"

--- a/po/es.po
+++ b/po/es.po
@@ -67,15 +67,15 @@ msgstr "¿Qué es Rust?"
 
 #: src/SUMMARY.md src/hello-world/benefits.md
 msgid "Benefits of Rust"
-msgstr ""
+msgstr "Ventajas de Rust"
 
 #: src/SUMMARY.md src/hello-world/playground.md
 msgid "Playground"
-msgstr ""
+msgstr "Playground"
 
 #: src/SUMMARY.md src/types-and-values.md
 msgid "Types and Values"
-msgstr ""
+msgstr "Tipos y valores"
 
 #: src/SUMMARY.md src/types-and-values/variables.md
 msgid "Variables"
@@ -83,11 +83,11 @@ msgstr "Variables"
 
 #: src/SUMMARY.md src/types-and-values/values.md
 msgid "Values"
-msgstr ""
+msgstr "Valores"
 
 #: src/SUMMARY.md src/types-and-values/arithmetic.md
 msgid "Arithmetic"
-msgstr ""
+msgstr "Aritmética"
 
 #: src/SUMMARY.md src/types-and-values/strings.md
 msgid "Strings"
@@ -99,7 +99,7 @@ msgstr "Inferencia de tipos"
 
 #: src/SUMMARY.md src/types-and-values/exercise.md
 msgid "Exercise: Fibonacci"
-msgstr ""
+msgstr "Ejercicio: Fibonacci"
 
 #: src/SUMMARY.md src/types-and-values/solution.md
 #: src/control-flow-basics/solution.md src/tuples-and-arrays/solution.md
@@ -122,7 +122,7 @@ msgstr "Control de Flujo"
 
 #: src/SUMMARY.md src/control-flow-basics/conditionals.md
 msgid "Conditionals"
-msgstr ""
+msgstr "Condicionales"
 
 #: src/SUMMARY.md src/control-flow-basics/loops.md
 #, fuzzy
@@ -135,7 +135,7 @@ msgstr "`break` y `continue`"
 
 #: src/SUMMARY.md src/control-flow-basics/blocks-and-scopes.md
 msgid "Blocks and Scopes"
-msgstr ""
+msgstr "Bloques y ámbitos"
 
 #: src/SUMMARY.md src/control-flow-basics/functions.md
 msgid "Functions"
@@ -143,11 +143,11 @@ msgstr "Funciones"
 
 #: src/SUMMARY.md src/control-flow-basics/macros.md
 msgid "Macros"
-msgstr ""
+msgstr "Macros"
 
 #: src/SUMMARY.md src/control-flow-basics/exercise.md
 msgid "Exercise: Collatz Sequence"
-msgstr ""
+msgstr "Ejercicio: secuencia de Collatz"
 
 #: src/SUMMARY.md
 msgid "Day 1: Afternoon"
@@ -156,7 +156,7 @@ msgstr "Día 1: Tarde"
 #: src/SUMMARY.md src/tuples-and-arrays.md
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Tuples and Arrays"
-msgstr ""
+msgstr "Tuplas y arrays"
 
 #: src/SUMMARY.md src/tuples-and-arrays/iteration.md
 #, fuzzy
@@ -175,7 +175,7 @@ msgstr "Desestructurando Enums"
 
 #: src/SUMMARY.md src/tuples-and-arrays/exercise.md
 msgid "Exercise: Nested Arrays"
-msgstr ""
+msgstr "Ejercicio: arrays anidados"
 
 #: src/SUMMARY.md src/references.md
 msgid "References"
@@ -184,7 +184,7 @@ msgstr "Referencias"
 #: src/SUMMARY.md src/references/shared.md
 #, fuzzy
 msgid "Shared References"
-msgstr "Referencias"
+msgstr "Enums compartidas"
 
 #: src/SUMMARY.md src/references/exclusive.md
 #, fuzzy
@@ -193,11 +193,11 @@ msgstr "Referencias colgantes"
 
 #: src/SUMMARY.md src/references/exercise.md
 msgid "Exercise: Geometry"
-msgstr ""
+msgstr "Ejercicio: geometría"
 
 #: src/SUMMARY.md src/user-defined-types.md
 msgid "User-Defined Types"
-msgstr ""
+msgstr "Tipos definidos por el usuario"
 
 #: src/SUMMARY.md src/user-defined-types/named-structs.md
 #, fuzzy
@@ -211,7 +211,7 @@ msgstr "Estructuras de tuplas"
 #: src/SUMMARY.md src/user-defined-types/enums.md
 #: src/pattern-matching/destructuring.md
 msgid "Enums"
-msgstr ""
+msgstr "Enumeraciones"
 
 #: src/SUMMARY.md src/user-defined-types/static-and-const.md
 #, fuzzy
@@ -220,11 +220,11 @@ msgstr "static y const"
 
 #: src/SUMMARY.md src/user-defined-types/aliases.md
 msgid "Type Aliases"
-msgstr ""
+msgstr "Alias de tipo"
 
 #: src/SUMMARY.md src/user-defined-types/exercise.md
 msgid "Exercise: Elevator Events"
-msgstr ""
+msgstr "Ejercicio: eventos de ascensor"
 
 #: src/SUMMARY.md
 msgid "Day 2: Morning"
@@ -237,7 +237,7 @@ msgstr "Control de Flujo"
 
 #: src/SUMMARY.md src/pattern-matching/exercise.md
 msgid "Exercise: Expression Evaluation"
-msgstr ""
+msgstr "Ejercicio: evaluación de expresiones"
 
 #: src/SUMMARY.md src/methods-and-traits.md
 #, fuzzy
@@ -263,7 +263,7 @@ msgstr "Objetos Trait"
 
 #: src/SUMMARY.md src/methods-and-traits/exercise.md
 msgid "Exercise: Generic Logger"
-msgstr ""
+msgstr "Ejercicio: registro genérico"
 
 #: src/SUMMARY.md src/generics.md
 msgid "Generics"
@@ -288,7 +288,7 @@ msgstr "`impl Trait`"
 
 #: src/SUMMARY.md src/generics/exercise.md
 msgid "Exercise: Generic `min`"
-msgstr ""
+msgstr "Ejercicio: `min` genérico"
 
 #: src/SUMMARY.md
 msgid "Day 2: Afternoon"
@@ -306,22 +306,19 @@ msgstr "Biblioteca estándar"
 #: src/SUMMARY.md src/std-types/docs.md
 #, fuzzy
 msgid "Documentation"
-msgstr "Pruebas de Documentación"
+msgstr "Documentación"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "`Option`"
-msgstr "`Duration`"
+msgstr "`Option`"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "`Result`"
-msgstr "`Option`, `Result`"
+msgstr "`Result`"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`String`"
-msgstr "String"
+msgstr "`String`"
 
 #: src/SUMMARY.md src/std-types/vec.md
 msgid "`Vec`"
@@ -334,7 +331,7 @@ msgstr "`HashMap`"
 #: src/SUMMARY.md src/std-types/exercise.md
 #, fuzzy
 msgid "Exercise: Counter"
-msgstr "Ejercicios"
+msgstr "Ejercicio: Contador"
 
 #: src/SUMMARY.md src/std-traits.md
 #, fuzzy
@@ -346,9 +343,8 @@ msgid "Comparisons"
 msgstr "Comparaciones"
 
 #: src/SUMMARY.md src/std-traits/operators.md
-#, fuzzy
 msgid "Operators"
-msgstr "Iteradores"
+msgstr "Operadores"
 
 #: src/SUMMARY.md src/std-traits/from-and-into.md
 msgid "`From` and `Into`"
@@ -365,16 +361,15 @@ msgstr "`Read` y `Write`"
 
 #: src/SUMMARY.md
 msgid "`Default`, struct update syntax"
-msgstr ""
+msgstr "`Default`, sintaxis de actualización de structs"
 
 #: src/SUMMARY.md src/std-traits/closures.md
 msgid "Closures"
 msgstr "Cierres"
 
 #: src/SUMMARY.md src/std-traits/exercise.md
-#, fuzzy
 msgid "Exercise: ROT13"
-msgstr "Ejercicios"
+msgstr "Ejercicio: ROT13"
 
 #: src/SUMMARY.md
 msgid "Day 3: Morning"
@@ -386,7 +381,7 @@ msgstr "Manejo de Memoria"
 
 #: src/SUMMARY.md src/memory-management/review.md
 msgid "Review of Program Memory"
-msgstr ""
+msgstr "Revisión de la memoria de programas"
 
 #: src/SUMMARY.md src/memory-management/approaches.md
 #, fuzzy
@@ -403,7 +398,7 @@ msgstr "Semántica de movimiento"
 
 #: src/SUMMARY.md
 msgid "`Clone`"
-msgstr ""
+msgstr "Trait `Clone`"
 
 #: src/SUMMARY.md src/memory-management/copy-types.md
 #, fuzzy
@@ -412,21 +407,20 @@ msgstr "Tipos compuestos"
 
 #: src/SUMMARY.md
 msgid "`Drop`"
-msgstr ""
+msgstr "Trait `Drop`"
 
 #: src/SUMMARY.md src/memory-management/exercise.md
 msgid "Exercise: Builder Type"
-msgstr ""
+msgstr "Ejercicio: Constructores"
 
 #: src/SUMMARY.md src/smart-pointers.md
 msgid "Smart Pointers"
-msgstr ""
+msgstr "Punteros inteligentes"
 
 #: src/SUMMARY.md src/smart-pointers/box.md
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`Box<T>`"
-msgstr "`Box`"
+msgstr "`Box<T>`"
 
 #: src/SUMMARY.md src/smart-pointers/rc.md
 msgid "`Rc`"
@@ -434,7 +428,7 @@ msgstr "`Rc`"
 
 #: src/SUMMARY.md src/smart-pointers/exercise.md
 msgid "Exercise: Binary Tree"
-msgstr ""
+msgstr "Ejercicio: Árbol binario"
 
 #: src/SUMMARY.md
 msgid "Day 3: Afternoon"
@@ -460,9 +454,8 @@ msgid "Interior Mutability"
 msgstr "Interoperabilidad"
 
 #: src/SUMMARY.md src/borrowing/exercise.md
-#, fuzzy
 msgid "Exercise: Health Statistics"
-msgstr "Estadísticas de salud"
+msgstr "Ejercicio: Estadísticas de Salud"
 
 #: src/SUMMARY.md src/slices-and-lifetimes.md
 #, fuzzy
@@ -470,9 +463,8 @@ msgid "Slices and Lifetimes"
 msgstr "Tiempos de vida"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Slices: `&[T]`"
-msgstr "Slices"
+msgstr "Slices: `&[T]`"
 
 #: src/SUMMARY.md src/slices-and-lifetimes/str.md
 #, fuzzy
@@ -496,7 +488,7 @@ msgstr "Tiempos de vida"
 
 #: src/SUMMARY.md src/slices-and-lifetimes/exercise.md
 msgid "Exercise: Protobuf Parsing"
-msgstr ""
+msgstr "Ejercicio: Análisis de Protobuf"
 
 #: src/SUMMARY.md
 msgid "Day 4: Morning"
@@ -521,7 +513,7 @@ msgstr "FromIterator"
 
 #: src/SUMMARY.md src/iterators/exercise.md
 msgid "Exercise: Iterator Method Chaining"
-msgstr ""
+msgstr "Ejercicio: Encadenamiento de métodos del iterador"
 
 #: src/SUMMARY.md src/modules.md src/modules/modules.md
 msgid "Modules"
@@ -537,11 +529,11 @@ msgstr "Visibilidad"
 
 #: src/SUMMARY.md
 msgid "`use`, `super`, `self`"
-msgstr ""
+msgstr "`use`, `super`, `self`"
 
 #: src/SUMMARY.md src/modules/exercise.md
 msgid "Exercise: Modules for a GUI Library"
-msgstr ""
+msgstr "Ejercicio: Módulos para una biblioteca GUI"
 
 #: src/SUMMARY.md src/testing.md src/chromium/testing.md
 msgid "Testing"
@@ -562,15 +554,15 @@ msgstr "Crates útiles"
 
 #: src/SUMMARY.md src/testing/googletest.md
 msgid "GoogleTest"
-msgstr ""
+msgstr "GoogleTest"
 
 #: src/SUMMARY.md src/testing/mocking.md
 msgid "Mocking"
-msgstr ""
+msgstr "Simulaciones"
 
 #: src/SUMMARY.md src/testing/lints.md
 msgid "Compiler Lints and Clippy"
-msgstr ""
+msgstr "Lints de compiladores y Clippy"
 
 #: src/SUMMARY.md src/testing/exercise.md
 #, fuzzy
@@ -587,7 +579,7 @@ msgstr "Manejo de Errores"
 
 #: src/SUMMARY.md src/error-handling/panics.md
 msgid "Panics"
-msgstr ""
+msgstr "Pánicos"
 
 #: src/SUMMARY.md src/error-handling/try.md
 #, fuzzy
@@ -646,13 +638,12 @@ msgid "Unsafe Traits"
 msgstr "Implementación de Traits Unsafe (Inseguras) "
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Exercise: FFI Wrapper"
-msgstr "Envoltorio de FFI Seguro"
+msgstr "Ejercicio: Envoltorio de FFI"
 
 #: src/SUMMARY.md src/bare-metal/android.md
 msgid "Android"
-msgstr ""
+msgstr "Android"
 
 #: src/SUMMARY.md src/android/setup.md src/chromium/setup.md
 msgid "Setup"
@@ -672,7 +663,7 @@ msgstr "Biblioteca"
 
 #: src/SUMMARY.md src/android/aidl.md
 msgid "AIDL"
-msgstr ""
+msgstr "AIDL"
 
 #: src/SUMMARY.md
 msgid "Interface"
@@ -728,54 +719,48 @@ msgid "The Bridge Module"
 msgstr "Módulos de Pruebas"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Rust Bridge"
-msgstr "Binarios de Rust"
+msgstr "Rust Bridge"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/generated-cpp.md
 msgid "Generated C++"
-msgstr ""
+msgstr "C++ generado"
 
 #: src/SUMMARY.md
 msgid "C++ Bridge"
-msgstr ""
+msgstr "Bridge en C++"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/shared-types.md
-#, fuzzy
 msgid "Shared Types"
-msgstr "Tipos escalares"
+msgstr "Tipos de datos compartidos"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/shared-enums.md
 msgid "Shared Enums"
-msgstr ""
+msgstr "Enums compartidas"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/rust-result.md
-#, fuzzy
 msgid "Rust Error Handling"
-msgstr "Manejo de Errores"
+msgstr "Manejo de Errores en Rust"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/cpp-exception.md
-#, fuzzy
 msgid "C++ Error Handling"
-msgstr "Manejo de Errores"
+msgstr "Manejo de Errores en C++"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
 msgid "Additional Types"
-msgstr ""
+msgstr "Tipos adicionales"
 
 #: src/SUMMARY.md
 msgid "Building for Android: C++"
-msgstr ""
+msgstr "Compilar en Android: C++"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Building for Android: Genrules"
-msgstr "Construir componentes en Rust."
+msgstr "Compilar en Android: Genrules"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Building for Android: Rust"
-msgstr "Construir componentes en Rust."
+msgstr "Compilar en Android: Rust"
 
 #: src/SUMMARY.md
 msgid "With Java"
@@ -789,15 +774,15 @@ msgstr "Ejercicios"
 
 #: src/SUMMARY.md
 msgid "Chromium"
-msgstr ""
+msgstr "Chromium"
 
 #: src/SUMMARY.md src/chromium/cargo.md
 msgid "Comparing Chromium and Cargo Ecosystems"
-msgstr ""
+msgstr "Comparación de los ecosistemas de Chromium y Cargo"
 
 #: src/SUMMARY.md
 msgid "Policy"
-msgstr ""
+msgstr "Política"
 
 #: src/SUMMARY.md
 #, fuzzy
@@ -806,28 +791,27 @@ msgstr "Unsafe Rust"
 
 #: src/SUMMARY.md src/chromium/build-rules/depending.md
 msgid "Depending on Rust Code from Chromium C++"
-msgstr ""
+msgstr "Depender de código de Rust desde Chromium C++"
 
 #: src/SUMMARY.md src/chromium/build-rules/vscode.md
 msgid "Visual Studio Code"
-msgstr ""
+msgstr "Visual Studio Code"
 
 #: src/SUMMARY.md src/exercises/chromium/third-party.md
-#, fuzzy
 msgid "Exercise"
-msgstr "Ejercicios"
+msgstr "Ejercicio"
 
 #: src/SUMMARY.md src/chromium/testing/rust-gtest-interop.md
 msgid "`rust_gtest_interop` Library"
-msgstr ""
+msgstr "Biblioteca `rust_gtest_interop`"
 
 #: src/SUMMARY.md src/chromium/testing/build-gn.md
 msgid "GN Rules for Rust Tests"
-msgstr ""
+msgstr "Reglas GN para pruebas de Rust"
 
 #: src/SUMMARY.md src/chromium/testing/chromium-import-macro.md
 msgid "`chromium::import!` Macro"
-msgstr ""
+msgstr "Macro `chromium::import!`"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp.md
 #, fuzzy
@@ -841,88 +825,86 @@ msgstr "Ejemplos"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "Limitations of CXX"
-msgstr ""
+msgstr "Limitaciones de CXX"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/error-handling.md
-#, fuzzy
 msgid "CXX Error Handling"
-msgstr "Manejo de Errores"
+msgstr "Manejo de Errores en CXX"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Error Handling: QR Example"
-msgstr "Manejo de Errores"
+msgstr "Manejo de Errores: Ejemplo QR"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Error Handling: PNG Example"
-msgstr "Manejo de Errores"
+msgstr "Manejo de Errores: Ejemplo PNG"
 
 #: src/SUMMARY.md
 msgid "Using CXX in Chromium"
-msgstr ""
+msgstr "Usar CXX en Chromium"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates.md
 msgid "Adding Third Party Crates"
-msgstr ""
+msgstr "Añadir crates de terceros"
 
 #: src/SUMMARY.md
 msgid "Configuring Cargo.toml"
-msgstr ""
+msgstr "Configurar Cargo.toml"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid "Configuring `gnrt_config.toml`"
-msgstr ""
+msgstr "Configurar `gnrt_config.toml`"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "Downloading Crates"
-msgstr ""
+msgstr "Descargar crates"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid "Generating `gn` Build Rules"
-msgstr ""
+msgstr "Generar reglas de compilación `gn`"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Resolving Problems"
-msgstr ""
+msgstr "Resolución de problemas"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid "Build Scripts Which Generate Code"
-msgstr ""
+msgstr "Compilar secuencias de comandos que generan código"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "Build Scripts Which Build C++ or Take Arbitrary Actions"
 msgstr ""
+"Compilar secuencias de comandos que compilan C++ o llevan a cabo acciones "
+"arbitrarias"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid "Depending on a Crate"
-msgstr ""
+msgstr "Depender de un crate"
 
 #: src/SUMMARY.md
 msgid "Reviews and Audits"
-msgstr ""
+msgstr "Revisiones y auditorías"
 
 #: src/SUMMARY.md
 msgid "Checking into Chromium Source Code"
-msgstr ""
+msgstr "Comprobaciones en el código fuente de Chromium"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates/keeping-up-to-date.md
 msgid "Keeping Crates Up to Date"
-msgstr ""
+msgstr "Mantener los crates actualizados"
 
 #: src/SUMMARY.md
 msgid "Bringing It Together - Exercise"
-msgstr ""
+msgstr "Poner en práctica todo lo aprendido: ejercicio"
 
 #: src/SUMMARY.md src/exercises/chromium/solutions.md
-#, fuzzy
 msgid "Exercise Solutions"
-msgstr "Soluciones"
+msgstr "Soluciones de Ejercicios"
 
 #: src/SUMMARY.md
 msgid "Bare Metal: Morning"
@@ -1193,7 +1175,7 @@ msgstr "Bloqueo del ejecutor"
 
 #: src/SUMMARY.md src/async/pitfalls/pin.md
 msgid "`Pin`"
-msgstr ""
+msgstr "`Pin`"
 
 #: src/SUMMARY.md src/async/pitfalls/async-traits.md
 msgid "Async Traits"
@@ -1218,7 +1200,7 @@ msgstr "Gracias."
 
 #: src/SUMMARY.md src/glossary.md
 msgid "Glossary"
-msgstr ""
+msgstr "Glosario"
 
 #: src/SUMMARY.md
 msgid "Other Resources"
@@ -1239,6 +1221,14 @@ msgid ""
 "io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
 "com/google/comprehensive-rust/stargazers)"
 msgstr ""
+"[![Crear flujo de trabajo](https://img.shields.io/github/actions/workflow/"
+"status/google/comprehensive-rust/build.yml?style=flat-square)](https://"
+"github.com/google/comprehensive-rust/actions/workflows/build.yml?"
+"query=branch%3Amain) [![Colaboradores de GitHub](https://img.shields.io/"
+"github/contributors/google/comprehensive-rust?style=flat-square)](https://"
+"github.com/google/comprehensive-rust/graphs/contributors) [![Estrellas de "
+"GitHub](https://img.shields.io/github/stars/google/comprehensive-rust?"
+"style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
 
 #: src/index.md
 msgid ""
@@ -1309,9 +1299,10 @@ msgid ""
 "based browsers. This includes interoperability with C++ and how to include "
 "third-party crates in Chromium."
 msgstr ""
-"[Android](android.md): un curso de medio día sobre el uso de Rust en el "
-"desarrollo de la plataforma Android (AOSP). En él se incluye la "
-"interoperabilidad con C, C++ y Java."
+"[Rust en Chromium](../chromium.md) es una clase en profundidad de medio día "
+"sobre el uso de Rust como parte del navegador Chromium. Incluye el uso de "
+"Rust en el sistema de compilación `gn` de Chromium e incorpora bibliotecas "
+"de terceros (\"crates\") e interoperabilidad en C++."
 
 #: src/index.md
 msgid ""
@@ -1541,142 +1532,143 @@ msgstr ""
 "md). Los días son muy intensos y cubrimos mucho terreno:"
 
 #: src/running-the-course/course-structure.md
-#, fuzzy
 msgid "Course schedule:"
-msgstr "Estructura del curso"
+msgstr "Horario del curso:"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 1 Morning (3 hours, including breaks)"
-msgstr ""
+msgstr "Día 1 por la mañana (3 horas, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-1.md) (5 minutes)"
-msgstr ""
+msgstr "[Bienvenida](../welcome-day-1.md) (5 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Hello, World](../hello-world.md) (20 minutes)"
-msgstr ""
+msgstr "[Hola, mundo](../hello-world.md) (20 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Types and Values](../types-and-values.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[Tipos y valores](../types-and-values.md) (1 hora y 5 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Control Flow Basics](../control-flow-basics.md) (1 hour)"
 msgstr ""
+"[Aspectos básicos del flujo de control](../control-flow-basics.md) (1 hora)"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 1 Afternoon (2 hours and 55 minutes, including breaks)"
-msgstr ""
+msgstr "Día 1 por la tarde (2 horas y 55 minutos, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Tuples and Arrays](../tuples-and-arrays.md) (1 hour)"
-msgstr ""
+msgstr "[Tuplas y arrays](../tuples-and-arrays.md) (1 hora)"
 
 #: src/running-the-course/course-structure.md
 msgid "[References](../references.md) (50 minutes)"
-msgstr ""
+msgstr "[Referencias](../references.md) (50 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[User-Defined Types](../user-defined-types.md) (50 minutes)"
 msgstr ""
+"[Tipos definidos por el usuario](../user-definition-types.md) (50 minutos)"
 
 #: src/running-the-course/course-structure.md
+#, fuzzy
 msgid "Day 2 Morning (3 hours and 5 minutes, including breaks)"
-msgstr ""
+msgstr "Día 4 por la mañana (3 horas y 5 minutos, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-2.md) (3 minutes)"
-msgstr ""
+msgstr "[Bienvenida](../welcome-day-2.md) (3 minutos)"
 
 #: src/running-the-course/course-structure.md
-#, fuzzy
 msgid "[Pattern Matching](../pattern-matching.md) (50 minutes)"
-msgstr ""
-"Consulta de nuevo la sección de [coincidencia de patrones](../pattern-"
-"matching.md) para obtener más información sobre los patrones de Rust."
+msgstr "[Coincidencia de patrones](../pattern-matching.md) (50 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Methods and Traits](../methods-and-traits.md) (55 minutes)"
-msgstr ""
+msgstr "[Métodos y traits](../methods-and-traits.md) (55 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Generics](../generics.md) (45 minutes)"
-msgstr ""
+msgstr "[Genéricos](../generics.md) (45 minutos)"
 
 #: src/running-the-course/course-structure.md
-#, fuzzy
 msgid "Day 2 Afternoon (3 hours, including breaks)"
-msgstr "Día 2: Ejercicios de la tarde"
+msgstr "Día 2 por la tarde (3 horas, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Standard Library Types](../std-types.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[Tipos de bibliotecas estándar](../std-types.md) (1 hora y 10 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Standard Library Traits](../std-traits.md) (1 hour and 40 minutes)"
 msgstr ""
+"[Traits de biblioteca estándar](../std-traits.md) (1 hora y 40 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 3 Morning (2 hours and 15 minutes, including breaks)"
-msgstr ""
+msgstr "Día 3 por la mañana (2 horas y 15 minutos, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-3.md) (3 minutes)"
-msgstr ""
+msgstr "[Bienvenida](../welcome-day-3.md) (3 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Memory Management](../memory-management.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[Gestión de la memoria](../memory-management.md) (1 hora y 10 minutos)"
 
 #: src/running-the-course/course-structure.md
+#, fuzzy
 msgid "[Smart Pointers](../smart-pointers.md) (45 minutes)"
-msgstr ""
+msgstr "[Iteradores](../iterators.md) (45 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 3 Afternoon (2 hours and 20 minutes, including breaks)"
-msgstr ""
+msgstr "Día 3 por la tarde (2 horas y 20 minutos, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Borrowing](../borrowing.md) (1 hour)"
-msgstr ""
+msgstr "[Préstamos](../borrowing.md) (1 hora)"
 
 #: src/running-the-course/course-structure.md
 msgid ""
 "[Slices and Lifetimes](../slices-and-lifetimes.md) (1 hour and 10 minutes)"
 msgstr ""
+"[Slices y tiempos de vida](../slices-and-lifetimes.md) (1 hora y 10 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 4 Morning (3 hours and 5 minutes, including breaks)"
-msgstr ""
+msgstr "Día 4 por la mañana (3 horas y 5 minutos, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-4.md) (3 minutes)"
-msgstr ""
+msgstr "[Bienvenida](../welcome-day-4.md) (3 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Iterators](../iterators.md) (45 minutes)"
-msgstr ""
+msgstr "[Iteradores](../iterators.md) (45 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Modules](../modules.md) (40 minutes)"
-msgstr ""
+msgstr "[Módulos](../modules.md) (40 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Testing](../testing.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[Pruebas](../testing.md) (1 hora y 5 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 4 Afternoon (2 hours, including breaks)"
-msgstr ""
+msgstr "Día 4 por la tarde (2 horas, incluidos los descansos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Error Handling](../error-handling.md) (45 minutes)"
-msgstr ""
+msgstr "[Gestión de errores](../error-handling.md) (45 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "[Unsafe Rust](../unsafe-rust.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[Rust inseguro](../unsafe-rust.md) (1 hora y 5 minutos)"
 
 #: src/running-the-course/course-structure.md
 msgid "Deep Dives"
@@ -1731,9 +1723,8 @@ msgstr ""
 "que funcionan cuando lo corres a mano."
 
 #: src/running-the-course/course-structure.md
-#, fuzzy
 msgid "Rust in Chromium"
-msgstr "Rust en Android"
+msgstr "Rust en Chromium"
 
 #: src/running-the-course/course-structure.md
 msgid ""
@@ -1742,6 +1733,10 @@ msgid ""
 "Chromium's `gn` build system, bringing in third-party libraries (\"crates\") "
 "and C++ interoperability."
 msgstr ""
+"[Rust en Chromium](../chromium.md) es una clase en profundidad de medio día "
+"sobre el uso de Rust como parte del navegador Chromium. Incluye el uso de "
+"Rust en el sistema de compilación `gn` de Chromium e incorpora bibliotecas "
+"de terceros (\"crates\") e interoperabilidad en C++."
 
 #: src/running-the-course/course-structure.md
 msgid ""
@@ -1749,10 +1744,14 @@ msgid ""
 "[recommended](../chromium/setup.md) for speed but any build will work. "
 "Ensure that you can run the Chromium browser that you've built."
 msgstr ""
+"Deberás poder compilar Chromium: [recomendamos] una compilación de "
+"depuración de componentes (../chromium/setup.md) por cuestiones de "
+"velocidad, pero cualquier compilación funcionará de forma correcta. "
+"Asegúrate de que puedes ejecutar el navegador Chromium que has compilado."
 
 #: src/running-the-course/course-structure.md
 msgid "Bare-Metal Rust"
-msgstr ""
+msgstr "Bare Metal Rust"
 
 #: src/running-the-course/course-structure.md
 msgid ""
@@ -1861,6 +1860,10 @@ msgid ""
 "com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), and "
 "[@henrif75](https://github.com/henrif75)."
 msgstr ""
+"[Portugués de Brasil](https://google.github.io/comprehensive-rust/pt-BR/) "
+"por [@rastringer](https://github.com/rastringer), [@hugojacob](https://"
+"github.com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes) y "
+"[@henrif75](https://github.com/henrif75)."
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1871,6 +1874,12 @@ msgid ""
 "github.com/superwhd), [@SketchK](https://github.com/SketchK), and [@nodmp]"
 "(https://github.com/nodmp)."
 msgstr ""
+"[Chino (simplificado)](https://google.github.io/comprehensive-rust/zh-CN/) "
+"por [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
+"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
+"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
+"github.com/superwhd), [@SketchK](https://github.com/SketchK) y [@nodmp]"
+"(https://github.com/nodmp)."
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1880,6 +1889,11 @@ msgid ""
 "github.com/kuanhungchen), and [@johnathan79717](https://github.com/"
 "johnathan79717)."
 msgstr ""
+"[Chino (tradicional)](https://google.github.io/comprehensive-rust/zh-TW/) "
+"por [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
+"victorhsieh), [@mingyc](https://github.com/mingyc), [@kuanhungchen](https://"
+"github.com/kuanhungchen) y [@johnathan79717](https://github.com/"
+"johnathan79717)."
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1887,12 +1901,17 @@ msgid ""
 "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
+"[Coreano](https://google.github.io/comprehensive-rust/ko/) por [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) y "
+"[@jooyunghan](https://github.com/jooyunghan)."
 
 #: src/running-the-course/translations.md
 msgid ""
 "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
 "(https://github.com/deavid)."
 msgstr ""
+"[Español](https://google.github.io/comprehensive-rust/es/) por [@deavid]"
+"(https://github.com/deavid)."
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1917,18 +1936,24 @@ msgid ""
 "[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
 "(https://github.com/raselmandol)."
 msgstr ""
+"[Bengalí](https://google.github.io/comprehensive-rust/bn/) por [@raselmandol]"
+"(https://github.com/raselmandol)."
 
 #: src/running-the-course/translations.md
 msgid ""
 "[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
 "(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
+"[Francés](https://google.github.io/comprehensive-rust/fr/) por [@KookaS]"
+"(https://github.com/KookaS) y [@vcaen](https://github.com/vcaen)."
 
 #: src/running-the-course/translations.md
 msgid ""
 "[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
 "(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
 msgstr ""
+"[Alemán](https://google.github.io/comprehensive-rust/de/) por [@Throvn]"
+"(https://github.com/Throvn) y [@ronaldfw](https://github.com/ronaldfw)."
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1936,6 +1961,9 @@ msgid ""
 "(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
 "momotaro1105)."
 msgstr ""
+"[Japonés](https://google.github.io/comprehensive-rust/ja/) por [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) y [@momotaro1105](https://github.com/"
+"momotaro1105)."
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1943,6 +1971,9 @@ msgid ""
 "[@henrythebuilder](https://github.com/henrythebuilder) and [@detro](https://"
 "github.com/detro)."
 msgstr ""
+"[Italiano](https://google.github.io/comprehensive-rust/it/) por "
+"[@henrythebuilder](https://github.com/henrythebuilder) y [@detro](https://"
+"github.com/detro)."
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -2001,6 +2032,13 @@ msgid ""
 "analyzer.github.io/manual.html#vimneovim), and many others. There is also a "
 "different IDE available called [RustRover](https://www.jetbrains.com/rust/)."
 msgstr ""
+"Después de instalar Rust, debes configurar tu editor o IDE para utilizar "
+"Rust. La mayoría de los editores lo hacen con [rust-analyzer](https://rust-"
+"analyzer.github.io/), que ofrece funciones de autocompletado y salto a la "
+"definición para [VS Code](https://code.visualstudio.com/), [Emacs](https://"
+"rust-analyzer.github.io/manual.html#emacs) y [Vim/Neovim](https://rust-"
+"analyzer.github.io/manual.html#vimneovim), entre otros. También hay "
+"disponible otro IDE denominado [RustRover](https://www.jetbrains.com/rust/)."
 
 #: src/cargo.md
 #, fuzzy
@@ -2169,18 +2207,21 @@ msgid "Dev Dependencies and Runtime Dependency management/caching"
 msgstr "Manejo/Caché de Dependencias de Desarrollo y de Runtime "
 
 #: src/cargo/rust-ecosystem.md
+#, fuzzy
 msgid ""
 "[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
 "html)"
 msgstr ""
-"Consulta el libro [Rust Reference](https://doc.rust-lang.org/reference/type-"
-"layout.html)."
+"[Instalación global](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
 
 #: src/cargo/rust-ecosystem.md
 msgid ""
 "[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
 "html)"
 msgstr ""
+"[Instalación global](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
 
 #: src/cargo/rust-ecosystem.md
 msgid ""
@@ -2192,6 +2233,8 @@ msgstr "Consulta más información en el \\[libro oficial de Cargo\\]."
 msgid ""
 "Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
 msgstr ""
+"Consulta más información en el [libro oficial de Cargo](https://doc.rust-"
+"lang.org/cargo/)"
 
 #: src/cargo/code-samples.md
 msgid "Code Samples in This Training"
@@ -2223,7 +2266,7 @@ msgstr "Los bloques de código de este curso son totalmente interactivos:"
 
 #: src/cargo/code-samples.md src/cargo/running-locally.md
 msgid "\"Edit me!\""
-msgstr ""
+msgstr "\"¡Edítame!\""
 
 #: src/cargo/code-samples.md
 msgid "You can use "
@@ -2284,6 +2327,8 @@ msgid ""
 "You can use any later version too since Rust maintains backwards "
 "compatibility."
 msgstr ""
+"También puedes usar cualquier versión posterior, ya que Rust mantiene la "
+"retrocompatibilidad."
 
 #: src/cargo/running-locally.md
 msgid ""
@@ -2382,11 +2427,11 @@ msgstr "Inferencia de tipos"
 
 #: src/welcome-day-1.md
 msgid "Control flow constructs: loops, conditionals, and so on."
-msgstr ""
+msgstr "Construcciones de flujos de control: bucles, condicionales, etc."
 
 #: src/welcome-day-1.md
 msgid "User-defined types: structs and enums."
-msgstr ""
+msgstr "Tipos definidos por el usuario: estructuras y enumeraciones."
 
 #: src/welcome-day-1.md
 msgid "Pattern matching: destructuring enums, structs, and arrays."
@@ -2396,34 +2441,37 @@ msgstr ""
 #: src/welcome-day-1.md src/welcome-day-2.md src/welcome-day-3.md
 #: src/welcome-day-4.md
 msgid "Schedule"
-msgstr ""
+msgstr "Horario"
 
 #: src/welcome-day-1.md src/welcome-day-1-afternoon.md src/welcome-day-2.md
 #: src/welcome-day-2-afternoon.md src/welcome-day-3.md
 #: src/welcome-day-3-afternoon.md src/welcome-day-4.md
 #: src/welcome-day-4-afternoon.md
 msgid "In this session:"
-msgstr ""
+msgstr "En esta sesión:"
 
 #: src/welcome-day-1.md
 msgid "[Welcome](./welcome-day-1.md) (5 minutes)"
-msgstr ""
+msgstr "[Bienvenida](./welcome-day-1.md) (5 minutos)"
 
 #: src/welcome-day-1.md
 msgid "[Hello, World](./hello-world.md) (20 minutes)"
-msgstr ""
+msgstr "[Hola, mundo](./hello-world.md) (20 minutos)"
 
 #: src/welcome-day-1.md
 msgid "[Types and Values](./types-and-values.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[Tipos y valores](./types-and-values.md) (1 hora y 5 minutos)"
 
 #: src/welcome-day-1.md
 msgid "[Control Flow Basics](./control-flow-basics.md) (1 hour)"
 msgstr ""
+"[Aspectos básicos del flujo de control](./control-flow-basics.md) (1 hora)"
 
 #: src/welcome-day-1.md src/welcome-day-2-afternoon.md
 msgid "Including 10 minute breaks, this session should take about 3 hours"
 msgstr ""
+"Contando con los descansos de 10 minutos, la duración prevista de la sesión "
+"es de unas 3 horas."
 
 #: src/welcome-day-1.md
 msgid "Please remind the students that:"
@@ -2478,6 +2526,9 @@ msgid ""
 "should have immediate parallels in other languages. The more advanced parts "
 "of Rust come on the subsequent days."
 msgstr ""
+"El objetivo del primer día es mostrar los aspectos \"básicos\" de Rust que "
+"podrían tener paralelismos inmediatos con otros lenguajes de programación. A "
+"lo largo del curso se estudiarán los aspectos más avanzados de Rust."
 
 #: src/welcome-day-1.md
 msgid ""
@@ -2487,6 +2538,12 @@ msgid ""
 "The times listed here are a suggestion in order to keep the course on "
 "schedule. Feel free to be flexible and adjust as necessary!"
 msgstr ""
+"Si estás impartiendo el curso en un aula, este un buen lugar para repasar el "
+"calendario. Debes tener en cuenta que hay un ejercicio al final de cada "
+"parte, seguido de una pausa. Organiza las sesiones de forma que se explique "
+"la solución del ejercicio después de la pausa. Las horas que se indican son "
+"una sugerencia para que el curso se ciña al horario establecido. No dudes en "
+"modificar el calendario y hacer los cambios que consideres necesarios."
 
 #: src/hello-world.md src/types-and-values.md src/control-flow-basics.md
 #: src/tuples-and-arrays.md src/references.md src/user-defined-types.md
@@ -2496,27 +2553,27 @@ msgstr ""
 #: src/iterators.md src/modules.md src/testing.md src/error-handling.md
 #: src/unsafe-rust.md
 msgid "In this segment:"
-msgstr ""
+msgstr "En esta parte se abordarán los siguientes temas:"
 
 #: src/hello-world.md
 msgid "[What is Rust?](./hello-world/what-is-rust.md) (10 minutes)"
-msgstr ""
+msgstr "[¿Qué es Rust?](./hello-world/what-is-rust.md) (10 minutos)"
 
 #: src/hello-world.md
 msgid "[Hello, World](./hello-world/hello-world.md) (5 minutes)"
-msgstr ""
+msgstr "[Hola, mundo](./hello-world/hello-world.md) (5 minutos)"
 
 #: src/hello-world.md
 msgid "[Benefits of Rust](./hello-world/benefits.md) (3 minutes)"
-msgstr ""
+msgstr "[Ventajas de Rust](./hello-world/benefits.md) (3 minutos)"
 
 #: src/hello-world.md
 msgid "[Playground](./hello-world/playground.md) (2 minutes)"
-msgstr ""
+msgstr "[Playground](./hello-world/playground.md) (2 minutos)"
 
 #: src/hello-world.md
 msgid "This segment should take about 20 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 20 minutos."
 
 #: src/hello-world/what-is-rust.md
 msgid ""
@@ -2610,7 +2667,7 @@ msgstr "Vamos a hablar del programa Rust más simple, un clásico Hola Mundo:"
 
 #: src/hello-world/hello-world.md
 msgid "\"Hello 🌍!\""
-msgstr ""
+msgstr "\"Hola, 🌍\""
 
 #: src/hello-world/hello-world.md
 msgid "What you see:"
@@ -2705,6 +2762,8 @@ msgid ""
 "_Compile time memory safety_ - whole classes of memory bugs are prevented at "
 "compile time"
 msgstr ""
+"_Seguridad de la memoria durante el tiempo de compilación:_ se evitan clases "
+"completas de errores de memoria durante el tiempo de compilación"
 
 #: src/hello-world/benefits.md
 msgid "No uninitialized variables."
@@ -2739,6 +2798,8 @@ msgid ""
 "_No undefined runtime behavior_ - what a Rust statement does is never left "
 "unspecified"
 msgstr ""
+"_No hay comportamientos indefinidos en el tiempo de ejecución:_ es decir, "
+"una instrucción de Rust nunca queda sin especificar"
 
 #: src/hello-world/benefits.md
 msgid "Array access is bounds checked."
@@ -2753,6 +2814,8 @@ msgid ""
 "_Modern language features_ - as expressive and ergonomic as higher-level "
 "languages"
 msgstr ""
+"_Características de los lenguajes modernos:_ es tan expresivo y ergonómico "
+"como los lenguajes de nivel superior"
 
 #: src/hello-world/benefits.md
 msgid "Enums and pattern matching."
@@ -2791,6 +2854,8 @@ msgid ""
 "Do not spend much time here. All of these points will be covered in more "
 "depth later."
 msgstr ""
+"No le dediques mucho tiempo a este punto. Todos estos aspectos se tratarán "
+"de forma más detallada más adelante."
 
 #: src/hello-world/benefits.md
 msgid ""
@@ -2834,12 +2899,18 @@ msgid ""
 "this course. Try running the \"hello-world\" program it starts with. It "
 "comes with a few handy features:"
 msgstr ""
+"El [playground de Rust](https://play.rust-lang.org/) ofrece una forma "
+"sencilla de ejecutar programas cortos de Rust y es la base de los ejemplos y "
+"ejercicios de este curso. Prueba a ejecutar el programa \"hello-world\" con "
+"el que empieza. Incluye algunas funciones útiles:"
 
 #: src/hello-world/playground.md
 msgid ""
 "Under \"Tools\", use the `rustfmt` option to format your code in the "
 "\"standard\" way."
 msgstr ""
+"En \"Tools\", usa la opción `rustfmt` para dar formato al código de forma "
+"\"estándar\"."
 
 #: src/hello-world/playground.md
 msgid ""
@@ -2847,12 +2918,18 @@ msgid ""
 "checks, less optimization) and Release (fewer runtime checks, lots of "
 "optimization). These are accessible under \"Debug\" at the top."
 msgstr ""
+"Rust cuenta con dos \"perfiles\" principales para generar código: Debug "
+"(comprobaciones adicionales del tiempo de ejecución, menor optimización) y "
+"Release (menos comprobaciones del tiempo de ejecución y mayor optimización). "
+"Puedes acceder a ellos haciendo clic en \"Debug\", en la parte superior."
 
 #: src/hello-world/playground.md
 msgid ""
 "If you're interested, use \"ASM\" under \"...\" to see the generated "
 "assembly code."
 msgstr ""
+"Si te interesa, utiliza la opción \"ASM\" en \"...\" para ver el código de "
+"ensamblado que se ha generado."
 
 #: src/hello-world/playground.md
 msgid ""
@@ -2862,34 +2939,40 @@ msgid ""
 "students who want to know more about Rust's optimizations or generated "
 "assembly."
 msgstr ""
+"Cuando sea la hora del descanso, anima a los asistentes a abrir el "
+"playground para que experimenten un poco. Hazles saber que pueden mantener "
+"la pestaña abierta y probar cosas durante el resto del curso. Resulta "
+"especialmente útil para los participantes con un nivel avanzado que quieran "
+"obtener más información sobre las optimizaciones o el ensamblaje generado de "
+"Rust."
 
 #: src/types-and-values.md
 msgid "[Variables](./types-and-values/variables.md) (5 minutes)"
-msgstr ""
+msgstr "[Variables](./types-and-values/variables.md) (5 minutos)"
 
 #: src/types-and-values.md
 msgid "[Values](./types-and-values/values.md) (10 minutes)"
-msgstr ""
+msgstr "[Valores](./types-and-values/values.md) (10 minutos)"
 
 #: src/types-and-values.md
 msgid "[Arithmetic](./types-and-values/arithmetic.md) (5 minutes)"
-msgstr ""
+msgstr "[Aritmética](./types-and-values/arithmetic.md) (5 minutos)"
 
 #: src/types-and-values.md
 msgid "[Strings](./types-and-values/strings.md) (10 minutes)"
-msgstr ""
+msgstr "[Cadenas](./types-and-values/strings.md) (10 minutos)"
 
 #: src/types-and-values.md
 msgid "[Type Inference](./types-and-values/inference.md) (5 minutes)"
-msgstr ""
+msgstr "[Inferencia de tipos](./types-and-values/inference.md) (5 minutos)"
 
 #: src/types-and-values.md
 msgid "[Exercise: Fibonacci](./types-and-values/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[Ejercicio: Fibonacci](./types-and-values/exercise.md) (30 minutos)"
 
 #: src/types-and-values.md src/testing.md src/unsafe-rust.md
 msgid "This segment should take about 1 hour and 5 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 1 hora y 5 minutos."
 
 #: src/types-and-values/variables.md
 #, fuzzy
@@ -2904,19 +2987,24 @@ msgstr ""
 #: src/control-flow-basics/break-continue.md
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"x: {x}\""
-msgstr ""
+msgstr "\"x: {x}\""
 
 #: src/types-and-values/variables.md
 msgid ""
 "// x = 20;\n"
 "    // println!(\"x: {x}\");\n"
 msgstr ""
+"// x = 20;\n"
+"    // println!(\"x: {x}\");\n"
 
 #: src/types-and-values/variables.md
 msgid ""
 "Uncomment the `x = 20` to demonstrate that variables are immutable by "
 "default. Add the `mut` keyword to allow changes."
 msgstr ""
+"Elimina el comentario de `x = 20` para demostrar que las variables son "
+"inmutables de forma predeterminada. Añade la palabra clave `mut` para que se "
+"puedan hacer cambios."
 
 #: src/types-and-values/variables.md
 msgid ""
@@ -2924,12 +3012,17 @@ msgid ""
 "time, but type inference (covered later) allows the programmer to omit it in "
 "many cases."
 msgstr ""
+"En este ejemplo, `i32` es el tipo de la variable. Se debe conocer durante el "
+"tiempo de compilación, pero la inferencia de tipos (véase más adelante) "
+"permite al programador omitirla en muchos casos."
 
 #: src/types-and-values/values.md
 msgid ""
 "Here are some basic built-in types, and the syntax for literal values of "
 "each type."
 msgstr ""
+"A continuación, se muestran algunos tipos integrados básicos, así como la "
+"sintaxis de los valores literales de cada tipo."
 
 #: src/types-and-values/values.md src/tuples-and-arrays/tuples-and-arrays.md
 #: src/unsafe-rust/exercise.md
@@ -2946,11 +3039,11 @@ msgstr "Enteros con signo"
 
 #: src/types-and-values/values.md
 msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
-msgstr ""
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
 
 #: src/types-and-values/values.md
 msgid "`-10`, `0`, `1_000`, `123_i64`"
-msgstr ""
+msgstr "`-10`, `0`, `1_000`, `123_i64`"
 
 #: src/types-and-values/values.md
 msgid "Unsigned integers"
@@ -2958,11 +3051,11 @@ msgstr "Enteros sin signo"
 
 #: src/types-and-values/values.md
 msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
-msgstr ""
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
 
 #: src/types-and-values/values.md
 msgid "`0`, `123`, `10_u16`"
-msgstr ""
+msgstr "`0`, `123`, `10_u16`"
 
 #: src/types-and-values/values.md
 msgid "Floating point numbers"
@@ -2970,11 +3063,11 @@ msgstr "Números de coma flotante"
 
 #: src/types-and-values/values.md
 msgid "`f32`, `f64`"
-msgstr ""
+msgstr "`f32`, `f64`"
 
 #: src/types-and-values/values.md
 msgid "`3.14`, `-10.0e20`, `2_f32`"
-msgstr ""
+msgstr "`3.14`, `-10.0e20`, `2_f32`"
 
 #: src/types-and-values/values.md
 msgid "Unicode scalar values"
@@ -2982,11 +3075,11 @@ msgstr "Valores escalares Unicode"
 
 #: src/types-and-values/values.md
 msgid "`char`"
-msgstr ""
+msgstr "`char`"
 
 #: src/types-and-values/values.md
 msgid "`'a'`, `'α'`, `'∞'`"
-msgstr ""
+msgstr "`'a'`, `'α'`, `'∞'`"
 
 #: src/types-and-values/values.md
 msgid "Booleans"
@@ -2994,11 +3087,11 @@ msgstr "Booleanos"
 
 #: src/types-and-values/values.md
 msgid "`bool`"
-msgstr ""
+msgstr "`bool`"
 
 #: src/types-and-values/values.md
 msgid "`true`, `false`"
-msgstr ""
+msgstr "`true`, `false`"
 
 #: src/types-and-values/values.md
 msgid "The types have widths as follows:"
@@ -3036,7 +3129,7 @@ msgstr ""
 
 #: src/types-and-values/arithmetic.md
 msgid "\"result: {}\""
-msgstr ""
+msgstr "\"resultado: {}\""
 
 #: src/types-and-values/arithmetic.md
 msgid ""
@@ -3044,10 +3137,14 @@ msgid ""
 "meaning should be clear: it takes three integers, and returns an integer. "
 "Functions will be covered in more detail later."
 msgstr ""
+"Es la primera vez que vemos una función distinta a `main`, pero el "
+"significado debería quedar claro: utiliza tres números enteros y devuelve "
+"uno. Más adelante, hablaremos sobre las funciones con más profundidad."
 
 #: src/types-and-values/arithmetic.md
 msgid "Arithmetic is very similar to other languages, with similar precedence."
 msgstr ""
+"La aritmética es muy similar a otros idiomas, al igual que su precedencia."
 
 #: src/types-and-values/arithmetic.md
 msgid ""
@@ -3055,6 +3152,10 @@ msgid ""
 "actually undefined, and might do different things on different platforms or "
 "compilers. In Rust, it's defined."
 msgstr ""
+"¿Qué pasa con el desbordamiento de enteros? En C y C++, el desbordamiento de "
+"números enteros _con signo_ no está definido y se pueden llevar a cabo "
+"distintas acciones en diferentes plataformas o compiladores. En Rust sí está "
+"definido."
 
 #: src/types-and-values/arithmetic.md
 msgid ""
@@ -3064,18 +3165,29 @@ msgid ""
 "with method syntax, e.g., `(a * b).saturating_add(b * c).saturating_add(c * "
 "a)`."
 msgstr ""
+"Cambia el `i32` a `i16` para observar un desbordamiento de un número entero, "
+"lo que da error (pánico) en una versión de depuración, pero lo envuelve en "
+"una compilación de lanzamiento. Hay otras opciones disponibles, como el "
+"desbordamiento, la saturación y el acarreo, a las que se accede mediante la "
+"sintaxis del método, por ejemplo, `(a * b).saturating_add(b * c)."
+"saturating_add(c * a)`."
 
 #: src/types-and-values/arithmetic.md
 msgid ""
 "In fact, the compiler will detect overflow of constant expressions, which is "
 "why the example requires a separate function."
 msgstr ""
+"De hecho, el compilador detectará si existe un desbordamiento de expresiones "
+"constantes, por ello el ejemplo requiere una función independiente."
 
 #: src/types-and-values/strings.md
 msgid ""
 "Rust has two types to represent strings, both of which will be covered in "
 "more depth later. Both _always_ store UTF-8 encoded strings."
 msgstr ""
+"En Rust hay dos tipos para representar cadenas, de los que hablaremos con "
+"detenimiento más adelante. Ambos tipos _siempre_ almacenan cadenas "
+"codificadas en UTF-8."
 
 #: src/types-and-values/strings.md
 #, fuzzy
@@ -3085,46 +3197,56 @@ msgstr "`String` es un búfer de cadena mutable."
 #: src/types-and-values/strings.md
 msgid "`&str` - a read-only string. String literals have this type."
 msgstr ""
+"`&str`: es una cadena de solo lectura. Los literales de cadena son de este "
+"tipo."
 
 #: src/types-and-values/strings.md
 msgid "\"Greetings\""
-msgstr ""
+msgstr "\"Saludos\""
 
 #: src/types-and-values/strings.md
 msgid "\"🪐\""
-msgstr ""
+msgstr "\"🪐\""
 
 #: src/types-and-values/strings.md
 msgid "\", \""
-msgstr ""
+msgstr "\", \""
 
 #: src/types-and-values/strings.md
 msgid "\"final sentence: {}\""
-msgstr ""
+msgstr "\"frase final: {}\""
 
 #: src/types-and-values/strings.md src/async/control-flow/join.md
 msgid "\"{:?}\""
-msgstr ""
+msgstr "\"{:?}\""
 
 #: src/types-and-values/strings.md
 msgid "//println!(\"{:?}\", &sentence[12..13]);\n"
-msgstr ""
+msgstr "//println!(\"{:?}\", &sentence[12..13]);\n"
 
 #: src/types-and-values/strings.md
 msgid ""
 "This slide introduces strings. Everything here will be covered in more depth "
 "later, but this is enough for subsequent slides and exercises to use strings."
 msgstr ""
+"En esta diapositiva se presentan las cadenas. Más adelante hablaremos de "
+"todo lo relacionado con este tema, pero esta información es suficiente para "
+"que se puedan usar cadenas en las diapositivas y ejercicios que vienen a "
+"continuación."
 
 #: src/types-and-values/strings.md
 msgid "Invalid UTF-8 in a string is UB, and this not allowed in safe Rust."
 msgstr ""
+"La codificación UTF-8 no válida en una cadena tiene comportamiento "
+"indefinido y no es compatible con Rust seguro."
 
 #: src/types-and-values/strings.md
 msgid ""
 "`String` is a user-defined type with a constructor (`::new()`) and methods "
 "like `s.push_str(..)`."
 msgstr ""
+"`String` es un tipo definido por el usuario con un constructor (`::new()`) y "
+"métodos como `s.push_str(..)`."
 
 #: src/types-and-values/strings.md
 msgid ""
@@ -3132,6 +3254,9 @@ msgid ""
 "references later, so for now just think of `&str` as a unit meaning \"a read-"
 "only string\"."
 msgstr ""
+"La `&` en `&str` indica que se trata de una referencia. Más adelante "
+"hablaremos de las referencias, por el momento solo es necesario saber que "
+"`&str` es una unidad que significa \"cadena de solo lectura\"."
 
 #: src/types-and-values/strings.md
 msgid ""
@@ -3139,6 +3264,9 @@ msgid ""
 "`12..13` does not end on a character boundary, so the program panics. Adjust "
 "it to a range that does, based on the error message."
 msgstr ""
+"La línea marcada como comentario se indexa en la cadena por posición de "
+"byte. `12..13` no termina en el límite de un carácter, por lo que el "
+"programa da error. Ajusta el intervalo en función del mensaje de error."
 
 #: src/types-and-values/strings.md
 msgid ""
@@ -3182,10 +3310,14 @@ msgid ""
 "`i32`. This sometimes appears as `{integer}` in error messages. Similarly, "
 "floating-point literals default to `f64`."
 msgstr ""
+"Cuando ningún elemento restringe el tipo de un literal entero, Rust lo "
+"define de forma predeterminada como `i32`. A veces aparece como `{integer}` "
+"en los mensajes de error. Del mismo modo, los literales de punto flotante se "
+"definen como `f64` de forma predeterminada."
 
 #: src/types-and-values/inference.md
 msgid "// ERROR: no implementation for `{float} == {integer}`\n"
-msgstr ""
+msgstr "// ERROR: no hay implementación para `{float} == {integer}`\n"
 
 #: src/types-and-values/exercise.md
 msgid ""
@@ -3193,64 +3325,73 @@ msgid ""
 "Fibonacci number is calculated recursively as the sum of the n-1'th and "
 "n-2'th Fibonacci numbers."
 msgstr ""
+"El primer número de Fibonacci y el segundo son `1`. Para n>2, el número de "
+"Fibonacci en la posición n se calcula de forma recursiva como la suma de los "
+"números de Fibonacci n-1 y n-2'"
 
 #: src/types-and-values/exercise.md
 msgid ""
 "Write a function `fib(n)` that calculates the n'th Fibonacci number. When "
 "will this function panic?"
 msgstr ""
+"Escribe una función `fib(n)` que calcule el número n de Fibonacci. ¿Cuándo "
+"da error pánico esta función?"
 
 #: src/types-and-values/exercise.md
 msgid "// The base case.\n"
-msgstr ""
+msgstr "// El caso base.\n"
 
 #: src/types-and-values/exercise.md src/control-flow-basics/exercise.md
-#, fuzzy
 msgid "\"Implement this\""
-msgstr "Implementación"
+msgstr "\"Implementar esto\""
 
 #: src/types-and-values/exercise.md
 msgid "// The recursive case.\n"
-msgstr ""
+msgstr "// El caso recursivo.\n"
 
 #: src/types-and-values/exercise.md src/types-and-values/solution.md
 msgid "\"fib(n) = {}\""
-msgstr ""
+msgstr "\"fib(n) = {}\""
 
 #: src/control-flow-basics.md
 msgid "[Conditionals](./control-flow-basics/conditionals.md) (5 minutes)"
-msgstr ""
+msgstr "[Condicionales](./control-flow-basics/conditionals.md) (5 minutos)"
 
 #: src/control-flow-basics.md
 msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
-msgstr ""
+msgstr "[Bucles](./control-flow-basics/loops.md) (5 minutos)"
 
 #: src/control-flow-basics.md
 msgid ""
 "[break and continue](./control-flow-basics/break-continue.md) (5 minutes)"
 msgstr ""
+"[break y continue](./control-flow-basics/break-continue.md) (5 minutos)"
 
 #: src/control-flow-basics.md
 msgid ""
 "[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (10 minutes)"
 msgstr ""
+"[Bloques y ámbitos (scopes)](./control-flow-basics/blocks-and-scopes.md) (10 "
+"minutos)"
 
 #: src/control-flow-basics.md
 msgid "[Functions](./control-flow-basics/functions.md) (3 minutes)"
-msgstr ""
+msgstr "[Funciones](./control-flow-basics/functions.md) (3 minutos)"
 
 #: src/control-flow-basics.md
 msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
-msgstr ""
+msgstr "[Macros](./control-flow-basics/macros.md) (2 minutos)"
 
 #: src/control-flow-basics.md
 msgid ""
 "[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (30 minutes)"
 msgstr ""
+"[Ejercicio: secuencia de Collatz](./control-flow-basics/exercise.md) (30 "
+"minutos)"
 
 #: src/control-flow-basics.md src/tuples-and-arrays.md src/borrowing.md
 msgid "This segment should take about 1 hour"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 1 hora"
 
 #: src/control-flow-basics/conditionals.md
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
@@ -3258,9 +3399,8 @@ msgstr ""
 "Gran parte de la sintaxis de Rust te resultará familiar de C, C++ o Java:"
 
 #: src/control-flow-basics/conditionals.md
-#, fuzzy
 msgid "Blocks are delimited by curly braces."
-msgstr "Los bloques y ámbitos están delimitados por llaves."
+msgstr "Los bloques están delimitados por llaves."
 
 #: src/control-flow-basics/conditionals.md
 msgid ""
@@ -3294,15 +3434,15 @@ msgstr ""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"small\""
-msgstr ""
+msgstr "\"pequeño\""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"biggish\""
-msgstr ""
+msgstr "\"muy grande\""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"huge\""
-msgstr ""
+msgstr "\"enorme\""
 
 #: src/control-flow-basics/conditionals.md
 msgid ""
@@ -3314,11 +3454,11 @@ msgstr ""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"large\""
-msgstr ""
+msgstr "\"grande\""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"number size: {}\""
-msgstr ""
+msgstr "\"tamaño del número: {}\""
 
 #: src/control-flow-basics/conditionals.md
 #, fuzzy
@@ -3337,10 +3477,13 @@ msgid ""
 "separate it from the next statement. Remove the `;` before `println!` to see "
 "the compiler error."
 msgstr ""
+"Cuando se utiliza `if` en una expresión, esta debe tener un `;` para "
+"separarla de la siguiente instrucción. Elimina `;` antes de `println!` para "
+"ver el error del compilador."
 
 #: src/control-flow-basics/loops.md
 msgid "There are three looping keywords in Rust: `while`, `loop`, and `for`:"
-msgstr ""
+msgstr "Hay tres palabras clave de bucle en Rust: `while`, `loop` y `for`:"
 
 #: src/control-flow-basics/loops.md
 #, fuzzy
@@ -3359,7 +3502,7 @@ msgstr ""
 
 #: src/control-flow-basics/loops.md
 msgid "\"Final x: {x}\""
-msgstr ""
+msgstr "\"x final: {x}\""
 
 #: src/control-flow-basics/loops.md
 #, fuzzy
@@ -3377,7 +3520,7 @@ msgstr ""
 
 #: src/control-flow-basics/loops.md
 msgid "`loop`"
-msgstr ""
+msgstr "`loop`"
 
 #: src/control-flow-basics/loops.md
 #, fuzzy
@@ -3390,18 +3533,22 @@ msgstr ""
 
 #: src/control-flow-basics/loops.md
 msgid "\"{i}\""
-msgstr ""
+msgstr "\"{i}\""
 
 #: src/control-flow-basics/loops.md
 msgid ""
 "We will discuss iteration later; for now, just stick to range expressions."
 msgstr ""
+"Hablaremos de la iteración más adelante. Por el momento, céntrate en las "
+"expresiones de intervalo."
 
 #: src/control-flow-basics/loops.md
 msgid ""
 "Note that the `for` loop only iterates to `4`. Show the `1..=5` syntax for "
 "an inclusive range."
 msgstr ""
+"Ten en cuenta que el bucle `for` solo se itera en `4`. Muestra la sintaxis "
+"`1..=5` para un intervalo inclusivo."
 
 #: src/control-flow-basics/break-continue.md
 #, fuzzy
@@ -3425,7 +3572,7 @@ msgstr ""
 
 #: src/control-flow-basics/break-continue.md
 msgid "\"{result}\""
-msgstr ""
+msgstr "\"{result}\""
 
 #: src/control-flow-basics/break-continue.md
 msgid ""
@@ -3437,7 +3584,7 @@ msgstr ""
 
 #: src/control-flow-basics/break-continue.md
 msgid "\"x: {x}, i: {i}\""
-msgstr ""
+msgstr "\"x: {x}, i: {i}\""
 
 #: src/control-flow-basics/break-continue.md
 msgid ""
@@ -3472,7 +3619,7 @@ msgstr ""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"y: {y}\""
-msgstr ""
+msgstr "\"y: {y}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
@@ -3488,7 +3635,7 @@ msgstr "Ámbitos y _Shadowing_"
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "A variable's scope is limited to the enclosing block."
-msgstr ""
+msgstr "El ámbito de una variable se limita al bloque que la contiene."
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
@@ -3500,24 +3647,24 @@ msgstr ""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"before: {a}\""
-msgstr ""
+msgstr "\"antes: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md src/std-traits/from-and-into.md
 #: src/slices-and-lifetimes/solution.md
 msgid "\"hello\""
-msgstr ""
+msgstr "\"hola\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"inner scope: {a}\""
-msgstr ""
+msgstr "\"ámbito interno: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"shadowed in inner scope: {a}\""
-msgstr ""
+msgstr "\"sombreado en el ámbito interno: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"after: {a}\""
-msgstr ""
+msgstr "\"después: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
@@ -3532,6 +3679,9 @@ msgid ""
 "Show that a variable's scope is limited by adding a `b` in the inner block "
 "in the last example, and then trying to access it outside that block."
 msgstr ""
+"Para demostrar que el ámbito de una variable está limitado, añade una `b` en "
+"el bloque interno del último ejemplo y, a continuación, intenta acceder a "
+"ella desde fuera de ese bloque."
 
 #: src/control-flow-basics/blocks-and-scopes.md
 #, fuzzy
@@ -3598,6 +3748,9 @@ msgid ""
 "Always takes a fixed number of parameters. Default arguments are not "
 "supported. Macros can be used to support variadic functions."
 msgstr ""
+"Siempre toma un número fijo de parámetros. No se admiten argumentos "
+"predeterminados. Las macros se pueden utilizar para admitir funciones "
+"variádicas."
 
 #: src/control-flow-basics/functions.md
 #, fuzzy
@@ -3612,6 +3765,10 @@ msgid ""
 "variable number of arguments. They are distinguished by a `!` at the end. "
 "The Rust standard library includes an assortment of useful macros."
 msgstr ""
+"Las macros se amplían a código de Rust durante la compilación y pueden "
+"adoptar un número variable de argumentos. Se distinguen por utilizar un "
+"símbolo `!` al final. La biblioteca estándar de Rust incluye una serie de "
+"macros útiles."
 
 #: src/control-flow-basics/macros.md
 #, fuzzy
@@ -3627,26 +3784,32 @@ msgid ""
 "`format!(format, ..)` works just like `println!` but returns the result as a "
 "string."
 msgstr ""
+"`format!(format, ..)` funciona igual que `println!`, pero devuelve el "
+"resultado en forma de cadena."
 
 #: src/control-flow-basics/macros.md
 msgid "`dbg!(expression)` logs the value of the expression and returns it."
-msgstr ""
+msgstr "`dbg!(expression)` registra el valor de la expresión y lo devuelve."
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "`todo!()` marks a bit of code as not-yet-implemented. If executed, it will "
 "panic."
 msgstr ""
+"`todo!()` marca un fragmento de código como no implementado todavía. Si se "
+"ejecuta, activará un error pánico."
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "`unreachable!()` marks a bit of code as unreachable. If executed, it will "
 "panic."
 msgstr ""
+"`unreachable!()` marca un fragmento de código como inaccesible. Si se "
+"ejecuta, activará un error pánico."
 
 #: src/control-flow-basics/macros.md
 msgid "\"{n}! = {}\""
-msgstr ""
+msgstr "\"{n}! = {}\""
 
 #: src/control-flow-basics/macros.md
 msgid ""
@@ -3654,18 +3817,25 @@ msgid ""
 "how to use them. Why they are defined as macros, and what they expand to, is "
 "not especially critical."
 msgstr ""
+"El objetivo de esta sección es mostrar que existen estos elementos útiles y "
+"cómo usarlos. Por qué se definen como macros y a qué se expanden no es muy "
+"importante."
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "The course does not cover defining macros, but a later section will describe "
 "use of derive macros."
 msgstr ""
+"En el curso no se imparte la definición de macros, pero en una sección "
+"posterior se describirá el uso de las macros de derivación."
 
 #: src/control-flow-basics/exercise.md
 msgid ""
 "The [Collatz Sequence](https://en.wikipedia.org/wiki/Collatz_conjecture) is "
 "defined as follows, for an arbitrary n"
 msgstr ""
+"La [secuencia de Collatz](https://es.wikipedia.org/wiki/"
+"Conjetura_de_Collatz) se define de la siguiente manera, para n arbitrario"
 
 #: src/control-flow-basics/exercise.md
 #, fuzzy
@@ -3674,63 +3844,63 @@ msgstr "12"
 
 #: src/control-flow-basics/exercise.md
 msgid " greater than zero:"
-msgstr ""
+msgstr " mayor que cero:"
 
 #: src/control-flow-basics/exercise.md
 msgid "If _n"
-msgstr ""
+msgstr "Si _n"
 
 #: src/control-flow-basics/exercise.md
 msgid "i"
-msgstr ""
+msgstr "i"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ is 1, then the sequence terminates at _n"
-msgstr ""
+msgstr "_ es 1, la secuencia termina en _n"
 
 #: src/control-flow-basics/exercise.md
 msgid "_."
-msgstr ""
+msgstr "_."
 
 #: src/control-flow-basics/exercise.md
 msgid "_ is even, then _n"
-msgstr ""
+msgstr "_ es par, entonces _n"
 
 #: src/control-flow-basics/exercise.md
 msgid "i+1"
-msgstr ""
+msgstr "i+1"
 
 #: src/control-flow-basics/exercise.md
 msgid " = n"
-msgstr ""
+msgstr " = n"
 
 #: src/control-flow-basics/exercise.md
 msgid " / 2_."
-msgstr ""
+msgstr " / 2_."
 
 #: src/control-flow-basics/exercise.md
 msgid "_ is odd, then _n"
-msgstr ""
+msgstr "_ es impar, entonces _n"
 
 #: src/control-flow-basics/exercise.md
 msgid " = 3 * n"
-msgstr ""
+msgstr " = 3 * n"
 
 #: src/control-flow-basics/exercise.md
 msgid " + 1_."
-msgstr ""
+msgstr " + 1_."
 
 #: src/control-flow-basics/exercise.md
 msgid "For example, beginning with _n"
-msgstr ""
+msgstr "Por ejemplo, si empieza por _n"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 3:"
-msgstr ""
+msgstr "_ = 3:"
 
 #: src/control-flow-basics/exercise.md
 msgid "3 is odd, so _n"
-msgstr ""
+msgstr "3 es impar, por lo que _n"
 
 #: src/control-flow-basics/exercise.md
 #, fuzzy
@@ -3739,11 +3909,11 @@ msgstr "12"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 3 * 3 + 1 = 10;"
-msgstr ""
+msgstr "_ = 3 * 3 + 1 = 10;"
 
 #: src/control-flow-basics/exercise.md
 msgid "10 is even, so _n"
-msgstr ""
+msgstr "10 es par, por lo que _n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "3"
@@ -3751,11 +3921,11 @@ msgstr "3"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 10 / 2 = 5;"
-msgstr ""
+msgstr "_ = 10 / 2 = 5;"
 
 #: src/control-flow-basics/exercise.md
 msgid "5 is odd, so _n"
-msgstr ""
+msgstr "5 es impar, por lo que _n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "4"
@@ -3763,23 +3933,23 @@ msgstr "4"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 3 * 5 + 1 = 16;"
-msgstr ""
+msgstr "_ = 3 * 5 + 1 = 16;"
 
 #: src/control-flow-basics/exercise.md
 msgid "16 is even, so _n"
-msgstr ""
+msgstr "16 es par, por lo que _n"
 
 #: src/control-flow-basics/exercise.md
 msgid "5"
-msgstr ""
+msgstr "5"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 16 / 2 = 8;"
-msgstr ""
+msgstr "_ = 16 / 2 = 8;"
 
 #: src/control-flow-basics/exercise.md
 msgid "8 is even, so _n"
-msgstr ""
+msgstr "8 es par, por lo que _n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "6"
@@ -3787,23 +3957,23 @@ msgstr "6"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 8 / 2 = 4;"
-msgstr ""
+msgstr "_ = 8 / 2 = 4;"
 
 #: src/control-flow-basics/exercise.md
 msgid "4 is even, so _n"
-msgstr ""
+msgstr "4 es par, por lo que _n"
 
 #: src/control-flow-basics/exercise.md
 msgid "7"
-msgstr ""
+msgstr "7"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 4 / 2 = 2;"
-msgstr ""
+msgstr "_ = 4 / 2 = 2;"
 
 #: src/control-flow-basics/exercise.md
 msgid "2 is even, so _n"
-msgstr ""
+msgstr "2 es par, por lo que _n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "8"
@@ -3811,25 +3981,28 @@ msgstr "8"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 1; and"
-msgstr ""
+msgstr "_ = 1; y"
 
 #: src/control-flow-basics/exercise.md
 msgid "the sequence terminates."
-msgstr ""
+msgstr "la secuencia finaliza."
 
 #: src/control-flow-basics/exercise.md
 msgid ""
 "Write a function to calculate the length of the collatz sequence for a given "
 "initial `n`."
 msgstr ""
+"Escribe una función para calcular la longitud de la secuencia de Collatz "
+"para un número `n` inicial dado."
 
 #: src/control-flow-basics/exercise.md src/control-flow-basics/solution.md
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
+"/// Determina la longitud de la secuencia de Collatz que empieza por `n`.\n"
 
 #: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
 msgid "\"Length: {}\""
-msgstr ""
+msgstr "\"Longitud: {}\""
 
 #: src/welcome-day-1-afternoon.md src/welcome-day-2-afternoon.md
 #: src/welcome-day-3-afternoon.md src/welcome-day-4-afternoon.md
@@ -3839,42 +4012,47 @@ msgstr "Te damos la bienvenida"
 
 #: src/welcome-day-1-afternoon.md
 msgid "[Tuples and Arrays](./tuples-and-arrays.md) (1 hour)"
-msgstr ""
+msgstr "[Tuplas y arrays](./tuples-and-arrays.md) (1 hora)"
 
 #: src/welcome-day-1-afternoon.md
 msgid "[References](./references.md) (50 minutes)"
-msgstr ""
+msgstr "[Referencias](./references.md) (50 minutos)"
 
 #: src/welcome-day-1-afternoon.md
 msgid "[User-Defined Types](./user-defined-types.md) (50 minutes)"
 msgstr ""
+"[Tipos definidos por el usuario](./user-definition-types.md) (50 minutos)"
 
 #: src/welcome-day-1-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 55 "
 "minutes"
 msgstr ""
+"Contando con los descansos de 10 minutos, la duración prevista de la sesión "
+"es de unas 2 horas y 55 minutos."
 
 #: src/tuples-and-arrays.md
 msgid ""
 "[Tuples and Arrays](./tuples-and-arrays/tuples-and-arrays.md) (10 minutes)"
 msgstr ""
+"[Tuplas y arrays](./tuples-and-arrays/tuples-and-arrays.md) (10 minutos)"
 
 #: src/tuples-and-arrays.md
 msgid "[Array Iteration](./tuples-and-arrays/iteration.md) (3 minutes)"
-msgstr ""
+msgstr "[Iteración de arrays](./tuples-and-arrays/iteration.md) (3 minutos)"
 
 #: src/tuples-and-arrays.md
 msgid "[Pattern Matching](./tuples-and-arrays/match.md) (10 minutes)"
-msgstr ""
+msgstr "[Coincidencia de patrones](./tuples-and-arrays/match.md) (10 minutos)"
 
 #: src/tuples-and-arrays.md
 msgid "[Destructuring](./tuples-and-arrays/destructuring.md) (5 minutes)"
-msgstr ""
+msgstr "[Desestructuración](./tuples-and-arrays/destructuring.md) (5 minutos)"
 
 #: src/tuples-and-arrays.md
 msgid "[Exercise: Nested Arrays](./tuples-and-arrays/exercise.md) (30 minutes)"
 msgstr ""
+"[Ejercicio: Arrays anidados](./tuples-and-arrays/exercise.md) (30 minutos)"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
@@ -3882,6 +4060,10 @@ msgid ""
 "elements of an array have the same type, while tuples can accommodate "
 "different types. Both types have a size fixed at compile time."
 msgstr ""
+"Las tuplas y los arrays son los primeros tipos \"compuestos\" que hemos "
+"estudiado. Todos los elementos de un array tienen el mismo tipo, mientras "
+"que las tuplas admiten distintos tipos. Ambos tipos tienen un tamaño fijo "
+"durante el tiempo de compilación."
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 #: src/tuples-and-arrays/destructuring.md
@@ -3890,11 +4072,11 @@ msgstr "Arrays"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`[T; N]`"
-msgstr ""
+msgstr "`[T; N]`"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`[20, 30, 40]`, `[0; 3]`"
-msgstr ""
+msgstr "`[20, 30, 40]`, `[0; 3]`"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 #: src/tuples-and-arrays/destructuring.md
@@ -3903,11 +4085,11 @@ msgstr "Tuplas"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`()`, `(T,)`, `(T1, T2)`, ..."
-msgstr ""
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
-msgstr ""
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Array assignment and access:"
@@ -3941,6 +4123,9 @@ msgid ""
 "runtime. Rust can usually optimize these checks away, and they can be "
 "avoided using unsafe Rust."
 msgstr ""
+"Prueba a acceder a un array que esté fuera de los límites. Los accesos a los "
+"arrays se comprueban en el tiempo de ejecución. Rust suele optimizar estas "
+"comprobaciones y se pueden evitar utilizando Rust inseguro."
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "We can use literals to assign values to arrays."
@@ -4015,12 +4200,14 @@ msgstr ""
 #: src/tuples-and-arrays/iteration.md
 msgid "The `for` statement supports iterating over arrays (but not tuples)."
 msgstr ""
+"La instrucción `for` permite iterar sobre arrays, pero no sobre tuplas."
 
 #: src/tuples-and-arrays/iteration.md
 msgid ""
 "This functionality uses the `IntoIterator` trait, but we haven't covered "
 "that yet."
 msgstr ""
+"Esta función usa el trait `IntoIterator`, pero aún no lo hemos estudiado."
 
 #: src/tuples-and-arrays/iteration.md
 msgid ""
@@ -4028,6 +4215,10 @@ msgid ""
 "` macros. These are always checked while, debug-only variants like "
 "`debug_assert!` compile to nothing in release builds."
 msgstr ""
+"La macro `assert_ne!` es nueva. También existen las macros `assert_eq!` y "
+"`assert!`. Estas variantes siempre se comprueban mientras las variantes de "
+"solo depuración, como `debug_assert!`, no compilan nada en las compilaciones "
+"de lanzamiento."
 
 #: src/tuples-and-arrays/match.md
 #, fuzzy
@@ -4047,58 +4238,58 @@ msgstr ""
 
 #: src/tuples-and-arrays/match.md
 msgid "'x'"
-msgstr ""
+msgstr "'x'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'q'"
-msgstr ""
+msgstr "'q'"
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Quitting\""
-msgstr ""
+msgstr "\"Salir\""
 
 #: src/tuples-and-arrays/match.md src/std-traits/solution.md
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'a'"
-msgstr ""
+msgstr "'a'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'s'"
-msgstr ""
+msgstr "'s'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'w'"
-msgstr ""
+msgstr "'w'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'d'"
-msgstr ""
+msgstr "'d'"
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Moving around\""
-msgstr ""
+msgstr "\"Desplazarse\""
 
 #: src/tuples-and-arrays/match.md src/error-handling/exercise.md
 #: src/error-handling/solution.md
 msgid "'0'"
-msgstr ""
+msgstr "'0'"
 
 #: src/tuples-and-arrays/match.md src/error-handling/exercise.md
 #: src/error-handling/solution.md
 msgid "'9'"
-msgstr ""
+msgstr "'9'"
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Number input\""
-msgstr ""
+msgstr "\"Introducción de números\""
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Lowercase: {key}\""
-msgstr ""
+msgstr "\"Minúscula: {key}\""
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Something else\""
-msgstr ""
+msgstr "\"Otro\""
 
 #: src/tuples-and-arrays/match.md
 msgid ""
@@ -4106,6 +4297,9 @@ msgid ""
 "expressions _must_ be irrefutable, meaning that it covers every possibility, "
 "so `_` is often used as the final catch-all case."
 msgstr ""
+"`_` es un patrón comodín que coincide con cualquier valor. Las expresiones "
+"_deben_ ser irrefutables, lo que significa que deben tener en cuenta todas "
+"las posibilidades, por lo que `_` a menudo se usa como caso que atrapa todo."
 
 #: src/tuples-and-arrays/match.md
 #, fuzzy
@@ -4123,10 +4317,14 @@ msgid ""
 "A variable in the pattern (`key` in this example) will create a binding that "
 "can be used within the match arm."
 msgstr ""
+"Una variable del patrón (en este ejemplo, `key`) creará un enlace que se "
+"puede usar dentro del brazo de coincidencia."
 
 #: src/tuples-and-arrays/match.md
 msgid "A match guard causes the arm to match only if the condition is true."
 msgstr ""
+"Un protección de coincidencia hace que la expresión coincida únicamente si "
+"se cumple la condición."
 
 #: src/tuples-and-arrays/match.md src/user-defined-types/named-structs.md
 #: src/user-defined-types/enums.md src/methods-and-traits/methods.md
@@ -4192,6 +4390,9 @@ msgid ""
 "pattern that is matched up to the data structure, binding variables to "
 "subcomponents of the data structure."
 msgstr ""
+"La desestructuración es una forma de extraer datos de una estructura de "
+"datos al escribir un patrón que coincida con la estructura de datos, es "
+"decir, enlazando variables a los subcomponentes de dicha estructura."
 
 #: src/tuples-and-arrays/destructuring.md
 #, fuzzy
@@ -4202,39 +4403,39 @@ msgstr ""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"on Y axis\""
-msgstr ""
+msgstr "\"en el eje Y\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"on X axis\""
-msgstr ""
+msgstr "\"en el eje X\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"left of Y axis\""
-msgstr ""
+msgstr "\"a la izquierda del eje Y\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"below X axis\""
-msgstr ""
+msgstr "\"debajo del eje X\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"first quadrant\""
-msgstr ""
+msgstr "\"primer cuadrante\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"Tell me about {triple:?}\""
-msgstr ""
+msgstr "\"Dame información sobre {triple:?}\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"First is 0, y = {y}, and z = {z}\""
-msgstr ""
+msgstr "\"El primero es 0, y = {y}, z = {z}\"."
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"First is 1 and the rest were ignored\""
-msgstr ""
+msgstr "\"El primero es 1 y el resto se ha ignorado\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"All elements were ignored\""
-msgstr ""
+msgstr "\"Se han ignorado todos los elementos\""
 
 #: src/tuples-and-arrays/destructuring.md
 #, fuzzy
@@ -4260,7 +4461,7 @@ msgstr ""
 
 #: src/tuples-and-arrays/exercise.md
 msgid "Arrays can contain other arrays:"
-msgstr ""
+msgstr "Los arrays pueden contener otros arrays:"
 
 #: src/tuples-and-arrays/exercise.md
 #, fuzzy
@@ -4301,35 +4502,35 @@ msgstr ""
 
 #: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "// <-- the comment makes rustfmt add a newline\n"
-msgstr ""
+msgstr "// <-- el comentario hace que rustfmt añada una nueva línea\n"
 
 #: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "\"matrix: {:#?}\""
-msgstr ""
+msgstr "\"matriz: {:#?}\""
 
 #: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "\"transposed: {:#?}\""
-msgstr ""
+msgstr "\"traspuesto: {:#?}\""
 
 #: src/tuples-and-arrays/solution.md
 msgid "//\n"
-msgstr ""
+msgstr "//\n"
 
 #: src/references.md
 msgid "[Shared References](./references/shared.md) (10 minutes)"
-msgstr ""
+msgstr "[Referencias compartidas](./references/shared.md) (10 minutos)"
 
 #: src/references.md
 msgid "[Exclusive References](./references/exclusive.md) (10 minutes)"
-msgstr ""
+msgstr "[Referencias exclusivas](./references/included.md) (10 minutos)"
 
 #: src/references.md
 msgid "[Exercise: Geometry](./references/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[Ejercicio: geometría](./references/exercise.md) (30 minutos)"
 
 #: src/references.md src/user-defined-types.md src/pattern-matching.md
 msgid "This segment should take about 50 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 50 minutos."
 
 #: src/references/shared.md
 msgid ""
@@ -4337,6 +4538,10 @@ msgid ""
 "responsibility for the value, and is also called \"borrowing\". Shared "
 "references are read-only, and the referenced data cannot change."
 msgstr ""
+"Una referencia ofrece una forma de acceder a otro valor sin asumir la "
+"responsabilidad del valor. También se denomina \"préstamo\". Las referencias "
+"compartidas son de solo lectura y los datos a los que se hace referencia no "
+"pueden cambiar."
 
 #: src/references/shared.md
 msgid ""
@@ -4344,6 +4549,9 @@ msgid ""
 "with the `&` operator. The `*` operator \"dereferences\" a reference, "
 "yielding its value."
 msgstr ""
+"Una referencia compartida a un tipo `T` tiene el tipo `&T`. Se crea un valor "
+"de referencia con el operador `&`. El operador `*` \"desreferencia\" una "
+"referencia, dando lugar a su valor."
 
 #: src/references/shared.md
 msgid "Rust will statically forbid dangling references:"
@@ -4356,6 +4564,12 @@ msgid ""
 "access the value, but is still \"owned\" by the original variable. The "
 "course will get into more detail on ownership in day 3."
 msgstr ""
+"Se dice que una referencia \"toma prestado\" el valor al que hace "
+"referencia. Este es un buen modelo para los estudiantes que no están "
+"familiarizados con los punteros, ya que el código puede usar la referencia "
+"para acceder al valor, pero este sigue \"perteneciendo\" a la variable "
+"original. En el curso hablaremos con más profundidad sobre la propiedad el "
+"tercer día."
 
 #: src/references/shared.md
 msgid ""
@@ -4365,12 +4579,17 @@ msgid ""
 "cover how Rust prevents the memory-safety bugs that come from using raw "
 "pointers."
 msgstr ""
+"Las referencias se implementan como punteros y una ventaja clave es que "
+"pueden ser mucho más pequeñas del elemento al que apuntan. Los participantes "
+"que estén familiarizados con C o C++ reconocerán las referencias como "
+"punteros. A lo largo del curso, hablaremos sobre cómo Rust evita los errores "
+"de seguridad en la memoria derivados del uso de punteros sin formato."
 
 #: src/references/shared.md
 msgid ""
 "Rust does not automatically create references for you - the `&` is always "
 "required."
-msgstr ""
+msgstr "Rust no crea referencias automáticamente, `&` siempre es obligatorio."
 
 #: src/references/shared.md
 #, fuzzy
@@ -4389,12 +4608,18 @@ msgid ""
 "different from C++, where assignment to a reference changes the referenced "
 "value."
 msgstr ""
+"En este ejemplo, `r` es mutable para que se pueda reasignar (`r = &b`). "
+"Debes tener en cuenta que se vuelve a enlazar `r` para que haga referencia a "
+"otro elemento. Es distinto de C++, donde la asignación a una referencia "
+"modifica el valor referenciado."
 
 #: src/references/shared.md
 msgid ""
 "A shared reference does not allow modifying the value it refers to, even if "
 "that value was mutable. Try `*r = 'X'`."
 msgstr ""
+"Una referencia compartida no permite modificar el valor al que hace "
+"referencia, incluso aunque el valor sea mutable. Prueba con `*r = 'X'`."
 
 #: src/references/shared.md
 msgid ""
@@ -4403,6 +4628,10 @@ msgid ""
 "a reference to `point`, but `point` will be deallocated when the function "
 "returns, so this will not compile."
 msgstr ""
+"Rust hace un seguimiento del tiempo de vida de todas las referencias para "
+"asegurarse de que duran lo suficiente. En Rust seguro no se dan referencias "
+"colgantes. `x_axis` devolvería una referencia a `point`, pero `point` se "
+"desasignará cuando se devuelva la función, por lo que no se compilará."
 
 #: src/references/shared.md
 msgid "We will talk more about borrowing when we get to ownership."
@@ -4415,6 +4644,8 @@ msgid ""
 "Exclusive references, also known as mutable references, allow changing the "
 "value they refer to. They have type `&mut T`."
 msgstr ""
+"Las referencias exclusivas, también denominadas referencias mutables, "
+"permiten cambiar el valor al que hacen referencia. Tienen el tipo `&mut T`."
 
 #: src/references/exclusive.md
 msgid ""
@@ -4424,6 +4655,11 @@ msgid ""
 "exists. Try making an `&point.0` or changing `point.0` while `x_coord` is "
 "alive."
 msgstr ""
+"\"Exclusivo\" significa que solo se puede utilizar esta referencia para "
+"acceder al valor. No pueden existir otras referencias (compartidas o "
+"exclusivas) al mismo tiempo y no se puede acceder al valor de referencia "
+"mientras exista la referencia exclusiva. Prueba a ejecutar un `&point.0` o a "
+"cambiar `point.0` mientras `x_coord` está activo."
 
 #: src/references/exclusive.md
 #, fuzzy
@@ -4444,6 +4680,9 @@ msgid ""
 "representing a point as `[f64;3]`. It is up to you to determine the function "
 "signatures."
 msgstr ""
+"Crearemos algunas funciones de utilidad para la geometría tridimensional "
+"representando un punto como `[f64;3]`. Debes decidir las firmas de las "
+"funciones."
 
 #: src/references/exercise.md
 msgid ""
@@ -4453,64 +4692,79 @@ msgid ""
 "square\n"
 "// root, like `v.sqrt()`.\n"
 msgstr ""
+"// Calcula la magnitud de un vector sumando los cuadrados de sus "
+"coordenadas\n"
+"// y sacando la raíz cuadrada. Usa el método `sqrt()` para calcular la raíz "
+"cuadrada\n"
+"//, como `v.sqrt()`.\n"
 
 #: src/references/exercise.md
 msgid ""
 "// Normalize a vector by calculating its magnitude and dividing all of its\n"
 "// coordinates by that magnitude.\n"
 msgstr ""
+"// Normaliza un vector calculando su magnitud y dividiendo todas\n"
+"// sus coordenadas entre esa magnitud.\n"
 
 #: src/references/exercise.md
 msgid "// Use the following `main` to test your work.\n"
-msgstr ""
+msgstr "// Usa `main` para comprobar lo que has hecho.\n"
 
 #: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of a unit vector: {}\""
-msgstr ""
+msgstr "\"Magnitud de un vector unitario: {}\""
 
 #: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of {v:?}: {}\""
-msgstr ""
+msgstr "\"Magnitud de {v:?}: {}\""
 
 #: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of {v:?} after normalization: {}\""
-msgstr ""
+msgstr "\"Magnitud de {v:?} después de la normalización: {}\""
 
 #: src/references/solution.md
 msgid "/// Calculate the magnitude of the given vector.\n"
-msgstr ""
+msgstr "/// Calcula la magnitud del vector dado.\n"
 
 #: src/references/solution.md
 msgid ""
 "/// Change the magnitude of the vector to 1.0 without changing its "
 "direction.\n"
-msgstr ""
+msgstr "/// Cambia la magnitud del vector a 1.0 sin cambiar su dirección.\n"
 
 #: src/user-defined-types.md
 msgid "[Named Structs](./user-defined-types/named-structs.md) (10 minutes)"
 msgstr ""
+"[Estructuras con nombre](./user-undefined-types/named-structs.md) (10 "
+"minutos)"
 
 #: src/user-defined-types.md
 msgid "[Tuple Structs](./user-defined-types/tuple-structs.md) (10 minutes)"
 msgstr ""
+"[Estructuras de tuplas](./user-definition-types/tuple-structs.md) (10 "
+"minutos)"
 
 #: src/user-defined-types.md
 msgid "[Enums](./user-defined-types/enums.md) (5 minutes)"
-msgstr ""
+msgstr "[Enums](./user-undefined-types/enums.md) (5 minutos)"
 
 #: src/user-defined-types.md
 msgid ""
 "[Static and Const](./user-defined-types/static-and-const.md) (5 minutes)"
 msgstr ""
+"[Variables Static y Const](./user-definition-types/static-and-const.md) (5 "
+"minutos)"
 
 #: src/user-defined-types.md
 msgid "[Type Aliases](./user-defined-types/aliases.md) (2 minutes)"
-msgstr ""
+msgstr "[Alias de tipo](./user-definition-types/aliases.md) (2 minutos)"
 
 #: src/user-defined-types.md
 msgid ""
 "[Exercise: Elevator Events](./user-defined-types/exercise.md) (15 minutes)"
 msgstr ""
+"[Ejercicio: Eventos de ascensor](./user-definition-types/exercise.md) (15 "
+"minutos)"
 
 #: src/user-defined-types/named-structs.md
 msgid "Like C and C++, Rust has support for custom structs:"
@@ -4518,20 +4772,20 @@ msgstr "Al igual que C y C++, Rust admite estructuras (struct) personalizadas:"
 
 #: src/user-defined-types/named-structs.md
 msgid "\"{} is {} years old\""
-msgstr ""
+msgstr "\"{} tiene {} años\""
 
 #: src/user-defined-types/named-structs.md
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"Peter\""
-msgstr ""
+msgstr "\"Peter\""
 
 #: src/user-defined-types/named-structs.md
 msgid "\"Avery\""
-msgstr ""
+msgstr "\"Avery\""
 
 #: src/user-defined-types/named-structs.md
 msgid "\"Jackie\""
-msgstr ""
+msgstr "\"Jackie\""
 
 #: src/user-defined-types/named-structs.md
 msgid "Structs work like in C or C++."
@@ -4603,7 +4857,7 @@ msgstr ""
 
 #: src/user-defined-types/tuple-structs.md
 msgid "\"({}, {})\""
-msgstr ""
+msgstr "\"({}, {})\""
 
 #: src/user-defined-types/tuple-structs.md
 msgid "This is often used for single-field wrappers (called newtypes):"
@@ -4613,14 +4867,14 @@ msgstr ""
 
 #: src/user-defined-types/tuple-structs.md
 msgid "\"Ask a rocket scientist at NASA\""
-msgstr ""
+msgstr "\"Pregunta a un científico aeroespacial de la NASA\""
 
 #: src/user-defined-types/tuple-structs.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 #: src/bare-metal/microcontrollers/type-state.md
 #: src/async/pitfalls/cancellation.md
 msgid "// ...\n"
-msgstr ""
+msgstr "// ...\n"
 
 #: src/user-defined-types/tuple-structs.md
 msgid ""
@@ -4682,19 +4936,19 @@ msgstr ""
 
 #: src/user-defined-types/enums.md
 msgid "// Simple variant\n"
-msgstr ""
+msgstr "// Variante simple\n"
 
 #: src/user-defined-types/enums.md
 msgid "// Tuple variant\n"
-msgstr ""
+msgstr "// Variante de tupla\n"
 
 #: src/user-defined-types/enums.md
 msgid "// Struct variant\n"
-msgstr ""
+msgstr "// Variante de struct\n"
 
 #: src/user-defined-types/enums.md
 msgid "\"On this turn: {:?}\""
-msgstr ""
+msgstr "\"En este turno: {:?}\""
 
 #: src/user-defined-types/enums.md
 #, fuzzy
@@ -4707,6 +4961,8 @@ msgid ""
 "`Direction` is a type with variants. There are two values of `Direction`: "
 "`Direction::Left` and `Direction::Right`."
 msgstr ""
+"`Direction` es un tipo con variantes. Hay dos valores de `Direction`: "
+"`Direction::Left` y `Direction::Right`."
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4714,6 +4970,9 @@ msgid ""
 "Rust will store a discriminant so that it knows at runtime which variant is "
 "in a `PlayerMove` value."
 msgstr ""
+"`PlayerMove` es un tipo con tres variantes. Además de las cargas útiles, "
+"Rust almacenará un discriminante para saber qué variante se encuentra en un "
+"valor `PlayerMove` en el tiempo de ejecución."
 
 #: src/user-defined-types/enums.md
 #, fuzzy
@@ -4743,11 +5002,12 @@ msgstr ""
 
 #: src/user-defined-types/enums.md
 msgid "Rust uses minimal space to store the discriminant."
-msgstr ""
+msgstr "Rust usa muy poco espacio para almacenar el discriminante."
 
 #: src/user-defined-types/enums.md
 msgid "If necessary, it stores an integer of the smallest required size"
 msgstr ""
+"Si es necesario, almacena un número entero del tamaño más pequeño requerido."
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4756,6 +5016,10 @@ msgid ""
 "optimization\"). For example, `Option<&u8>` stores either a pointer to an "
 "integer or `NULL` for the `None` variant."
 msgstr ""
+"Si los valores de la variante permitidos no cubren todos los patrones de "
+"bits, se utilizarán patrones de bits no válidos para codificar el "
+"discriminante (la \"optimización de nicho\"). Por ejemplo, `Option<&u8>` "
+"almacena un puntero en un número entero o `NULL` para la variante `None`."
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4776,13 +5040,15 @@ msgstr ""
 #: src/memory-management/review.md src/memory-management/move.md
 #: src/smart-pointers/box.md src/borrowing/shared.md
 msgid "More to Explore"
-msgstr ""
+msgstr "Más información"
 
 #: src/user-defined-types/enums.md
 msgid ""
 "Rust has several optimizations it can employ to make enums take up less "
 "space."
 msgstr ""
+"Rust cuenta con varias optimizaciones que puede utilizar para hacer que las "
+"enums ocupen menos espacio."
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4865,7 +5131,7 @@ msgstr "Te damos la bienvenida al Día 1"
 
 #: src/user-defined-types/static-and-const.md
 msgid "\"{BANNER}\""
-msgstr ""
+msgstr "\"{BANNER}\""
 
 #: src/user-defined-types/static-and-const.md
 #, fuzzy
@@ -4998,14 +5264,16 @@ msgid ""
 "A type alias creates a name for another type. The two types can be used "
 "interchangeably."
 msgstr ""
+"Un alias de tipo crea un nombre para otro tipo. Ambos tipos se pueden "
+"utilizar indistintamente."
 
 #: src/user-defined-types/aliases.md
 msgid "// Aliases are more useful with long, complex types:\n"
-msgstr ""
+msgstr "// Los alias resultan de más utilidad con tipos largos y complejos:\n"
 
 #: src/user-defined-types/aliases.md
 msgid "C programmers will recognize this as similar to a `typedef`."
-msgstr ""
+msgstr "Los programadores de C verán un parecido con `typedef`."
 
 #: src/user-defined-types/exercise.md
 msgid ""
@@ -5014,6 +5282,10 @@ msgid ""
 "various events. Use `#[derive(Debug)]` to allow the types to be formatted "
 "with `{:?}`."
 msgstr ""
+"Crearemos una estructura de datos para representar un evento en un sistema "
+"de control de ascensores. Debes definir los tipos y las funciones para crear "
+"varios eventos. Usa `#[derive(Debug)]` para permitir que se aplique el "
+"formato `{:?}` a los tipos."
 
 #: src/user-defined-types/exercise.md
 msgid ""
@@ -5021,97 +5293,106 @@ msgid ""
 "`main` runs without errors. The next part of the course will cover getting "
 "data out of these structures."
 msgstr ""
+"Para hacer este ejercicio solo es necesario crear y rellenar estructuras de "
+"datos de forma que `main` se ejecute sin errores. En la siguiente parte del "
+"curso veremos cómo extraer datos de estas estructuras."
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid ""
 "/// An event in the elevator system that the controller must react to.\n"
 msgstr ""
+"/// Un evento en el sistema de ascensores al que debe reaccionar el "
+"controlador.\n"
 
 #: src/user-defined-types/exercise.md
 msgid "// TODO: add required variants\n"
-msgstr ""
+msgstr "// TAREAS: añadir variantes obligatorias\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// A direction of travel.\n"
-msgstr ""
+msgstr "/// Un sentido de la marcha.\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car has arrived on the given floor.\n"
-msgstr ""
+msgstr "/// El ascensor ha llegado a la planta indicada.\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car doors have opened.\n"
-msgstr ""
+msgstr "/// Las puertas del ascensor se han abierto.\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car doors have closed.\n"
-msgstr ""
+msgstr "/// Las puertas del ascensor se han cerrado.\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid ""
 "/// A directional button was pressed in an elevator lobby on the given "
 "floor.\n"
 msgstr ""
+"/// Se ha pulsado el botón direccional de un ascensor en la planta "
+"indicada.\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// A floor button was pressed in the elevator car.\n"
-msgstr ""
+msgstr "/// Se ha pulsado el botón de una planta en el ascensor.\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"A ground floor passenger has pressed the up button: {:?}\""
 msgstr ""
+"\"Un pasajero de la planta baja ha pulsado el botón para ir hacia arriba: "
+"{:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car has arrived on the ground floor: {:?}\""
-msgstr ""
+msgstr "\"El ascensor ha llegado a la planta baja: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car door opened: {:?}\""
-msgstr ""
+msgstr "\"Las puertas del ascensor se han abierto: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"A passenger has pressed the 3rd floor button: {:?}\""
-msgstr ""
+msgstr "\"Un pasajero ha pulsado el botón de la tercera planta: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car door closed: {:?}\""
-msgstr ""
+msgstr "\"Las puertas del ascensor se han cerrado: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car has arrived on the 3rd floor: {:?}\""
-msgstr ""
+msgstr "\"El ascensor ha llegado a la tercera planta: {:?}\""
 
 #: src/user-defined-types/solution.md
 msgid "/// A button was pressed.\n"
-msgstr ""
+msgstr "/// Se ha pulsado un botón.\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// The car has arrived at the given floor.\n"
-msgstr ""
+msgstr "/// El ascensor ha llegado a la planta indicada.\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// The car's doors have opened.\n"
-msgstr ""
+msgstr "/// Las puertas del ascensor se han abierto.\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// The car's doors have closed.\n"
-msgstr ""
+msgstr "/// Las puertas del ascensor se han cerrado.\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A floor is represented as an integer.\n"
-msgstr ""
+msgstr "/// Una planta se representa como un número entero.\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A user-accessible button.\n"
-msgstr ""
+msgstr "/// Un botón accesible para el usuario.\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A button in the elevator lobby on the given floor.\n"
-msgstr ""
+msgstr "/// Un botón para el ascensor en la planta indicada.\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A floor button within the car.\n"
-msgstr ""
+msgstr "/// Un botón de planta de la cabina del ascensor.\n"
 
 #: src/welcome-day-2.md
 msgid "Welcome to Day 2"

--- a/po/es.po
+++ b/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2024-01-24T15:37:30-08:00\n"
+"POT-Creation-Date: 2024-01-25T15:03:24-08:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17771,14 +17771,18 @@ msgstr ""
 msgid ""
 "// Safe because `HEAP` is only used here and `entry` is only called once.\n"
 msgstr ""
+"// Es seguro porque `HEAP` solo se usa aquí y solo se llama una vez a "
+"`entry`.\n"
 
 #: src/bare-metal/alloc.md
 msgid "// Give the allocator some memory to allocate.\n"
-msgstr ""
+msgstr "// Proporciona al asignador algo de memoria para asignar.\n"
 
 #: src/bare-metal/alloc.md
 msgid "// Now we can do things that require heap allocation.\n"
 msgstr ""
+"// Ahora podemos llevar a cabo acciones que requieran la asignación de "
+"montículo.\n"
 
 #: src/bare-metal/alloc.md
 #, fuzzy
@@ -17867,33 +17871,36 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md
 msgid "/// GPIO port 0 peripheral address\n"
-msgstr ""
+msgstr "/// Dirección de periférico del puerto GPIO 0\n"
 
 #: src/bare-metal/microcontrollers/mmio.md
 msgid "// GPIO peripheral offsets\n"
-msgstr ""
+msgstr "// Offset de periféricos GPIO\n"
 
 #: src/bare-metal/microcontrollers/mmio.md
 msgid "// PIN_CNF fields\n"
-msgstr ""
+msgstr "// Campos PIN_CNF\n"
 
 #: src/bare-metal/microcontrollers/mmio.md
 #: src/bare-metal/microcontrollers/pacs.md
 #: src/bare-metal/microcontrollers/hals.md
 msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-msgstr ""
+msgstr "// Configura los pines 21 y 28 de GPIO 0 como salidas push-pull.\n"
 
 #: src/bare-metal/microcontrollers/mmio.md
 msgid ""
 "// Safe because the pointers are to valid peripheral control registers, and\n"
 "    // no aliases exist.\n"
 msgstr ""
+"// Es seguro porque los punteros dirigen a registros de control de "
+"periféricos válidos y\n"
+"    // no existe ningún alias.\n"
 
 #: src/bare-metal/microcontrollers/mmio.md
 #: src/bare-metal/microcontrollers/pacs.md
 #: src/bare-metal/microcontrollers/hals.md
 msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
-msgstr ""
+msgstr "// Define el pin 28 bajo y 21 alto para encender el LED.\n"
 
 #: src/bare-metal/microcontrollers/mmio.md
 msgid ""
@@ -17982,7 +17989,7 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md
 msgid "// Create HAL wrapper for GPIO port 0.\n"
-msgstr ""
+msgstr "// Crea un envoltorio HAL para el puerto GPIO 0.\n"
 
 #: src/bare-metal/microcontrollers/hals.md
 msgid ""
@@ -18036,11 +18043,11 @@ msgstr "El patrón de tipo de estado"
 
 #: src/bare-metal/microcontrollers/type-state.md
 msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
-msgstr ""
+msgstr "// let gpio0_01_again = gpio0.p0_01; // Error, se ha movido.\n"
 
 #: src/bare-metal/microcontrollers/type-state.md
 msgid "// pin_input.is_high(); // Error, moved.\n"
-msgstr ""
+msgstr "// pin_input.is_high(); // Error, se ha movido.\n"
 
 #: src/bare-metal/microcontrollers/type-state.md
 msgid ""
@@ -18162,6 +18169,8 @@ msgstr " y JTAG a través de comprobaciones CMSIS-DAP, ST-Link y J-Link"
 #: src/bare-metal/microcontrollers/probe-rs.md
 msgid "GDB stub and Microsoft DAP (Debug Adapter Protocol) server"
 msgstr ""
+"Stub de GDB y servidor de Microsoft DAP (protocolo de adaptador de "
+"depuración)"
 
 #: src/bare-metal/microcontrollers/probe-rs.md
 msgid "Cargo integration"
@@ -18251,7 +18260,7 @@ msgstr "En otro terminal del mismo directorio:"
 
 #: src/bare-metal/microcontrollers/debugging.md
 msgid "On gLinux or Debian:"
-msgstr ""
+msgstr "En gLinux o Debian:"
 
 #: src/bare-metal/microcontrollers/debugging.md
 msgid "In GDB, try running:"
@@ -18457,29 +18466,33 @@ msgstr "`src/main.rs`:"
 #: src/exercises/bare-metal/compass.md
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "// Configure serial port.\n"
-msgstr ""
+msgstr "// Configura el puerto serie.\n"
 
 #: src/exercises/bare-metal/compass.md
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "// Use the system timer as a delay provider.\n"
-msgstr ""
+msgstr "// Usa el temporizador del sistema como proveedor de retrasos.\n"
 
 #: src/exercises/bare-metal/compass.md
 msgid ""
 "// Set up the I2C controller and Inertial Measurement Unit.\n"
 "    // TODO\n"
 msgstr ""
+"// Configura el controlador I2C y la unidad de medición inercial.\n"
+"    // TAREA\n"
 
 #: src/exercises/bare-metal/compass.md
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "\"Ready.\""
-msgstr ""
+msgstr "\"Listo.\""
 
 #: src/exercises/bare-metal/compass.md
 msgid ""
 "// Read compass data and log it to the serial port.\n"
 "        // TODO\n"
 msgstr ""
+"// Lee datos de la brújula y regístralos en el puerto serie.\n"
+"        // TAREA\n"
 
 #: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
 #, fuzzy
@@ -18521,23 +18534,23 @@ msgstr "([volver al ejercicio](compass.md))"
 
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
-msgstr ""
+msgstr "// Configura el controlador de I2C y la unidad de medición inercial.\n"
 
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "\"Setting up IMU...\""
-msgstr ""
+msgstr "\"Configurando IMU...\""
 
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "// Set up display and timer.\n"
-msgstr ""
+msgstr "// Configura la pantalla y el temporizador.\n"
 
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "// Read compass data and log it to the serial port.\n"
-msgstr ""
+msgstr "// Lee los datos de la brújula y regístralos en el puerto serie.\n"
 
 #: src/exercises/bare-metal/solutions-morning.md
 msgid "\"{},{},{}\\t{},{},{}\""
-msgstr ""
+msgstr "\"{},{},{}\\t{},{},{}\""
 
 #: src/exercises/bare-metal/solutions-morning.md
 msgid ""
@@ -18545,6 +18558,9 @@ msgid ""
 "LEDs\n"
 "        // on.\n"
 msgstr ""
+"// Si se pulsa el botón A, cambia al siguiente modo y haz que parpadeen "
+"brevemente todos los LED\n"
+"        // activados.\n"
 
 #: src/bare-metal/aps.md
 msgid "Application processors"
@@ -18664,6 +18680,78 @@ msgid ""
 "    b 2b\n"
 "```"
 msgstr ""
+"```armasm\n"
+".section .init.entry, \"ax\"\n"
+".global entry\n"
+"entry:\n"
+"    /*\n"
+"     * Load and apply the memory management configuration, ready to enable "
+"MMU and\n"
+"     * caches.\n"
+"     */\n"
+"    adrp x30, idmap\n"
+"    msr ttbr0_el1, x30\n"
+"\n"
+"    mov_i x30, .Lmairval\n"
+"    msr mair_el1, x30\n"
+"\n"
+"    mov_i x30, .Ltcrval\n"
+"    /* Copy the supported PA range into TCR_EL1.IPS. */\n"
+"    mrs x29, id_aa64mmfr0_el1\n"
+"    bfi x30, x29, #32, #4\n"
+"\n"
+"    msr tcr_el1, x30\n"
+"\n"
+"    mov_i x30, .Lsctlrval\n"
+"\n"
+"    /*\n"
+"     * Ensure everything before this point has completed, then invalidate "
+"any\n"
+"     * potentially stale local TLB entries before they start being used.\n"
+"     */\n"
+"    isb\n"
+"    tlbi vmalle1\n"
+"    ic iallu\n"
+"    dsb nsh\n"
+"    isb\n"
+"\n"
+"    /*\n"
+"     * Configure sctlr_el1 to enable MMU and cache and don't proceed until "
+"this\n"
+"     * has completed.\n"
+"     */\n"
+"    msr sctlr_el1, x30\n"
+"    isb\n"
+"\n"
+"    /* Disable trapping floating point access in EL1. */\n"
+"    mrs x30, cpacr_el1\n"
+"    orr x30, x30, #(0x3 << 20)\n"
+"    msr cpacr_el1, x30\n"
+"    isb\n"
+"\n"
+"    /* Zero out the bss section. */\n"
+"    adr_l x29, bss_begin\n"
+"    adr_l x30, bss_end\n"
+"0:  cmp x29, x30\n"
+"    b.hs 1f\n"
+"    stp xzr, xzr, [x29], #16\n"
+"    b 0b\n"
+"\n"
+"1:  /* Prepare the stack. */\n"
+"    adr_l x30, boot_stack_end\n"
+"    mov sp, x30\n"
+"\n"
+"    /* Set up exception vector. */\n"
+"    adr x30, vector_table_el1\n"
+"    msr vbar_el1, x30\n"
+"\n"
+"    /* Call into Rust code. */\n"
+"    bl main\n"
+"\n"
+"    /* Loop forever waiting for interrupts. */\n"
+"2:  wfi\n"
+"    b 2b\n"
+"```"
 
 #: src/bare-metal/aps/entry-point.md
 msgid ""
@@ -18783,42 +18871,44 @@ msgid ""
 "// Safe because this only uses the declared registers and doesn't do\n"
 "    // anything with memory.\n"
 msgstr ""
+"// Es seguro porque solo utiliza los registros declarados y no\n"
+"    // hace nada con la memoria.\n"
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"hvc #0\""
-msgstr ""
+msgstr "\"hvc #0\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w0\""
-msgstr ""
+msgstr "\"w0\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w1\""
-msgstr ""
+msgstr "\"w1\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w2\""
-msgstr ""
+msgstr "\"w2\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w3\""
-msgstr ""
+msgstr "\"w3\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w4\""
-msgstr ""
+msgstr "\"w4\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w5\""
-msgstr ""
+msgstr "\"w5\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w6\""
-msgstr ""
+msgstr "\"w6\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid "\"w7\""
-msgstr ""
+msgstr "\"w7\""
 
 #: src/bare-metal/aps/inline-assembly.md
 msgid ""
@@ -18956,7 +19046,7 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md
 msgid "/// Minimal driver for a PL011 UART.\n"
-msgstr ""
+msgstr "/// Controlador mínimo para un UART PL011.\n"
 
 #: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 msgid ""
@@ -18971,32 +19061,46 @@ msgid ""
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
+"/// Construye una instancia nueva del controlador de UART para un "
+"dispositivo PL011 en la\n"
+"    /// dirección base proporcionada.\n"
+"    ///\n"
+"    /// # Seguridad\n"
+"    ///\n"
+"    /// La dirección base debe apuntar a los 8 registros de control MMIO de "
+"un \n"
+"    /// dispositivo PL011, que debe asignarse al espacio de direcciones del "
+"proceso\n"
+"    /// como memoria del dispositivo y no tener ningún otro alias.\n"
 
 #: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 #: src/exercises/bare-metal/rtc.md
 msgid "/// Writes a single byte to the UART.\n"
-msgstr ""
+msgstr "/// Escribe un solo byte en el UART.\n"
 
 #: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 #: src/exercises/bare-metal/rtc.md
 msgid "// Wait until there is room in the TX buffer.\n"
-msgstr ""
+msgstr "// Espera hasta que haya espacio en el búfer de TX.\n"
 
 #: src/bare-metal/aps/uart.md
 msgid ""
 "// Safe because we know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
 msgstr ""
+"// Es seguro porque sabemos que la dirección base apunta a los registros\n"
+"        // de control de un dispositivo PL011 que está asignado "
+"correctamente.\n"
 
 #: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 #: src/exercises/bare-metal/rtc.md
 msgid "// Write to the TX buffer.\n"
-msgstr ""
+msgstr "// Escribe en el búfer de TX.\n"
 
 #: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 #: src/exercises/bare-metal/rtc.md
 msgid "// Wait until the UART is no longer busy.\n"
-msgstr ""
+msgstr "// Espera hasta que el UART esté libre.\n"
 
 #: src/bare-metal/aps/uart.md
 msgid ""
@@ -19053,6 +19157,8 @@ msgid ""
 "// Safe because it just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
 msgstr ""
+"// Es seguro porque solo contiene un puntero a la memoria del dispositivo,\n"
+"// a la que se puede acceder desde cualquier contexto.\n"
 
 #: src/bare-metal/aps/uart/traits.md
 msgid ""
@@ -19242,43 +19348,43 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Flags from the UART flag register.\n"
-msgstr ""
+msgstr "/// Marcas del registro de marcas de UART.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Clear to send.\n"
-msgstr ""
+msgstr "/// Borra para enviar.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Data set ready.\n"
-msgstr ""
+msgstr "/// Conjunto de datos listo.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Data carrier detect.\n"
-msgstr ""
+msgstr "/// Detección del portador de datos.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// UART busy transmitting data.\n"
-msgstr ""
+msgstr "/// UART está transmitiendo datos.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Receive FIFO is empty.\n"
-msgstr ""
+msgstr "/// El FIFO de recepción está vacío\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Transmit FIFO is full.\n"
-msgstr ""
+msgstr "/// El FIFO de transmisión está completo.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Receive FIFO is full.\n"
-msgstr ""
+msgstr "/// El FIFO de recepción está completo.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Transmit FIFO is empty.\n"
-msgstr ""
+msgstr "/// El FIFO de transmisión está vacío.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
 msgid "/// Ring indicator.\n"
-msgstr ""
+msgstr "/// Indicador de anillo.\n"
 
 #: src/bare-metal/aps/better-uart/bitflags.md
 msgid ""
@@ -19322,23 +19428,28 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md
 msgid "/// Driver for a PL011 UART.\n"
-msgstr ""
+msgstr "/// Controlador para un UART PL011.\n"
 
 #: src/bare-metal/aps/better-uart/driver.md src/exercises/bare-metal/rtc.md
 msgid ""
 "// Safe because we know that self.registers points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
 msgstr ""
+"// Es seguro porque sabemos que self.registers apunta\n"
+"        // a los registros de control de un dispositivo PL011 que está "
+"asignado correctamente.\n"
 
 #: src/bare-metal/aps/better-uart/driver.md src/exercises/bare-metal/rtc.md
 msgid ""
 "/// Reads and returns a pending byte, or `None` if nothing has been\n"
 "    /// received.\n"
 msgstr ""
+"/// Lee y devuelve un byte pendiente o `None` si no se ha recibido nada\n"
+"    ///.\n"
 
 #: src/bare-metal/aps/better-uart/driver.md src/exercises/bare-metal/rtc.md
 msgid "// TODO: Check for error conditions in bits 8-11.\n"
-msgstr ""
+msgstr "// TAREA: Comprueba si hay condiciones de error en los bits 8 a 11.\n"
 
 #: src/bare-metal/aps/better-uart/driver.md
 msgid ""
@@ -19365,7 +19476,7 @@ msgstr ""
 #: src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Base address of the primary PL011 UART.\n"
-msgstr ""
+msgstr "/// Dirección base del UART de PL011 principal.\n"
 
 #: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
 #: src/exercises/bare-metal/rtc.md
@@ -19374,26 +19485,29 @@ msgid ""
 "// Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
 "    // and nothing else accesses that address range.\n"
 msgstr ""
+"// Es seguro porque `PL011_BASE_ADDRESS` es la dirección base de un "
+"dispositivo PL011\n"
+"    // y ninguna más accede a ese intervalo de direcciones.\n"
 
 #: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
 msgid "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
-msgstr ""
+msgstr "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
 
 #: src/bare-metal/aps/better-uart/using.md
 msgid "b'\\r'"
-msgstr ""
+msgstr "b'\\r'"
 
 #: src/bare-metal/aps/better-uart/using.md src/async/pitfalls/cancellation.md
 msgid "b'\\n'"
-msgstr ""
+msgstr "b'\\n'"
 
 #: src/bare-metal/aps/better-uart/using.md
 msgid "b'q'"
-msgstr ""
+msgstr "b'q'"
 
 #: src/bare-metal/aps/better-uart/using.md
 msgid "\"Bye!\""
-msgstr ""
+msgstr "\"¡Adiós!\""
 
 #: src/bare-metal/aps/better-uart/using.md
 msgid ""
@@ -19422,11 +19536,11 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md src/exercises/bare-metal/rtc.md
 msgid "\"[{}] {}\""
-msgstr ""
+msgstr "\"[{}] {}\""
 
 #: src/bare-metal/aps/logging.md src/exercises/bare-metal/rtc.md
 msgid "/// Initialises UART logger.\n"
-msgstr ""
+msgstr "/// Inicia el registro de UART.\n"
 
 #: src/bare-metal/aps/logging.md
 msgid ""
@@ -19443,7 +19557,7 @@ msgstr "Debemos inicializar el registrador antes de utilizarlo."
 #: src/bare-metal/aps/logging/using.md src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"{info}\""
-msgstr ""
+msgstr "\"{info}\""
 
 #: src/bare-metal/aps/logging/using.md
 msgid "Note that our panic handler can now log details of panics."
@@ -19683,15 +19797,15 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md
 msgid "// Create a new page table with identity mapping.\n"
-msgstr ""
+msgstr "// Crea una tabla de páginas con mapeado de identidades.\n"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md
 msgid "// Map a 2 MiB region of memory as read-only.\n"
-msgstr ""
+msgstr "// Asigna una región de 2 MiB de memoria como de solo lectura.\n"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md
 msgid "// Set `TTBR0_EL1` to activate the page table.\n"
-msgstr ""
+msgstr "// Configura `TTBR0_EL1` para activar la tabla de páginas.\n"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md
 msgid ""
@@ -19970,12 +20084,12 @@ msgstr ""
 #: src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Base addresses of the GICv3.\n"
-msgstr ""
+msgstr "/// Direcciones base de GICv3.\n"
 
 #: src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
-msgstr ""
+msgstr "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
 
 #: src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
@@ -19984,14 +20098,21 @@ msgid ""
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
 msgstr ""
+"// Es seguro porque `GICD_BASE_ADDRESS` y `GICR_BASE_ADDRESS` son las "
+"direcciones base\n"
+"    // de un distribuidor y un redistribuidor GICv3 respectivamente,\n"
+"    // y ningún otro elemento tiene acceso a esos intervalos de "
+"direcciones.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// TODO: Create instance of RTC driver and print current time.\n"
 msgstr ""
+"// TAREA: crear una instancia del controlador RTC e imprimir la hora "
+"actual.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// TODO: Wait for 3 seconds.\n"
-msgstr ""
+msgstr "// TAREA: esperar 3 segundos.\n"
 
 #: src/exercises/bare-metal/rtc.md
 #, fuzzy
@@ -20018,103 +20139,121 @@ msgid ""
 "// See the License for the specific language governing permissions and\n"
 "// limitations under the License.\n"
 msgstr ""
+"// Copyright 2023 Google LLC\n"
+"//\n"
+"// Con licencia Apache, versión 2.0 (la \"Licencia\");\n"
+"// Este archivo solo se puede utilizar según lo estipulado en la Licencia.\n"
+"// Puedes obtener una copia de la Licencia en\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Salvo que lo exija la legislación aplicable o se haya acordado por "
+"escrito, el software\n"
+"// distribuido bajo la Licencia se distribuye \"TAL CUAL\",\n"
+"// SIN GARANTÍAS NI CONDICIONES DE NINGÚN TIPO, ya sean explícitas o "
+"implícitas.\n"
+"// Consulta la Licencia para saber los permisos y las limitaciones "
+"aplicables a cada idioma\n"
+"//.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"sync_exception_current\""
-msgstr ""
+msgstr "\"sync_exception_current\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"irq_current\""
-msgstr ""
+msgstr "\"irq_current\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"No pending interrupt\""
-msgstr ""
+msgstr "\"No hay interrupciones pendientes\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"IRQ {intid:?}\""
-msgstr ""
+msgstr "\"IRQ {intid:?}\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"fiq_current\""
-msgstr ""
+msgstr "\"fiq_current\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"serr_current\""
-msgstr ""
+msgstr "\"serr_current\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"sync_lower\""
-msgstr ""
+msgstr "\"sync_lower\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"irq_lower\""
-msgstr ""
+msgstr "\"irq_lower\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"fiq_lower\""
-msgstr ""
+msgstr "\"fiq_lower\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"serr_lower\""
-msgstr ""
+msgstr "\"serr_lower\""
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
-msgstr "`src/logger.rs` (no debería ser necesario cambiarlo):"
+msgstr "_src/logger.rs_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// ANCHOR: main\n"
-msgstr ""
+msgstr "// ANCHOR: main\n"
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
-msgstr "`src/pl011.rs` (no debería ser necesario cambiarlo):"
+msgstr "_src/pl011.rs_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// ANCHOR: Flags\n"
-msgstr ""
+msgstr "// ANCHOR: Flags\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// ANCHOR_END: Flags\n"
-msgstr ""
+msgstr "// ANCHOR_END: Flags\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid ""
 "/// Flags from the UART Receive Status Register / Error Clear Register.\n"
 msgstr ""
+"/// Marcas del registro de estado de recepción de UART/Registro de borrado "
+"de errores.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "/// Framing error.\n"
-msgstr ""
+msgstr "/// Error de encuadre.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "/// Parity error.\n"
-msgstr ""
+msgstr "/// Error de paridad.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "/// Break error.\n"
-msgstr ""
+msgstr "/// Error de break.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "/// Overrun error.\n"
-msgstr ""
+msgstr "/// Error de desbordamiento.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// ANCHOR: Registers\n"
-msgstr ""
+msgstr "// ANCHOR: Registers\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// ANCHOR_END: Registers\n"
-msgstr ""
+msgstr "// ANCHOR_END: Registers\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid ""
 "// ANCHOR: Uart\n"
 "/// Driver for a PL011 UART.\n"
 msgstr ""
+"// ANCHOR: Uart\n"
+"/// Controlador para un UART PL011.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid ""
@@ -20129,54 +20268,60 @@ msgid ""
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
+"/// Crea una instancia nueva del controlador UART para un dispositivo PL011 "
+"en la\n"
+"    /// dirección base proporcionada.\n"
+"    ///\n"
+"    /// # Seguridad\n"
+"    ///\n"
+"    /// El objeto la dirección base debe apuntar a los registros de control "
+"MMIO de un dispositivo\n"
+"    /// PL011, que debe asignarse al espacio de direcciones del proceso\n"
+"    /// como memoria del dispositivo y no tener ningún otro alias.\n"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "// ANCHOR_END: Uart\n"
-msgstr ""
+msgstr "// ANCHOR_END: Uart\n"
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_build.rs_ (you shouldn't need to change this):"
-msgstr "`build.rs` (no debería ser necesario cambiarlo):"
+msgstr "_build.rs_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"linux\""
-msgstr ""
+msgstr "\"linux\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"CROSS_COMPILE\""
-msgstr ""
+msgstr "\"CROSS_COMPILE\""
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "\"aarch64-linux-gnu\""
-msgstr "aarch64-paging"
+msgstr "\"aarch64-linux-gnu\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"aarch64-none-elf\""
-msgstr ""
+msgstr "\"aarch64-none-elf\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"entry.S\""
-msgstr ""
+msgstr "\"entry.S\""
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "\"exceptions.S\""
-msgstr "Excepciones"
+msgstr "\"exceptions.S\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"idmap.S\""
-msgstr ""
+msgstr "\"idmap.S\""
 
 #: src/exercises/bare-metal/rtc.md
 msgid "\"empty\""
-msgstr ""
+msgstr "\"empty\""
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_entry.S_ (you shouldn't need to change this):"
-msgstr "`entry.S` (no debería ser necesario cambiarlo):"
+msgstr "_entry.S_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid ""
@@ -20339,11 +20484,168 @@ msgid ""
 "\tb 2b\n"
 "```"
 msgstr ""
+"```armasm\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+".macro adr_l, reg:req, sym:req\n"
+"\tadrp \\reg, \\sym\n"
+"\tadd \\reg, \\reg, :lo12:\\sym\n"
+".endm\n"
+"\n"
+".macro mov_i, reg:req, imm:req\n"
+"\tmovz \\reg, :abs_g3:\\imm\n"
+"\tmovk \\reg, :abs_g2_nc:\\imm\n"
+"\tmovk \\reg, :abs_g1_nc:\\imm\n"
+"\tmovk \\reg, :abs_g0_nc:\\imm\n"
+".endm\n"
+"\n"
+".set .L_MAIR_DEV_nGnRE,\t0x04\n"
+".set .L_MAIR_MEM_WBWA,\t0xff\n"
+".set .Lmairval, .L_MAIR_DEV_nGnRE | (.L_MAIR_MEM_WBWA << 8)\n"
+"\n"
+"/* 4 KiB granule size for TTBR0_EL1. */\n"
+".set .L_TCR_TG0_4KB, 0x0 << 14\n"
+"/* 4 KiB granule size for TTBR1_EL1. */\n"
+".set .L_TCR_TG1_4KB, 0x2 << 30\n"
+"/* Disable translation table walk for TTBR1_EL1, generating a translation "
+"fault instead. */\n"
+".set .L_TCR_EPD1, 0x1 << 23\n"
+"/* Translation table walks for TTBR0_EL1 are inner sharable. */\n"
+".set .L_TCR_SH_INNER, 0x3 << 12\n"
+"/*\n"
+" * Translation table walks for TTBR0_EL1 are outer write-back read-allocate "
+"write-allocate\n"
+" * cacheable.\n"
+" */\n"
+".set .L_TCR_RGN_OWB, 0x1 << 10\n"
+"/*\n"
+" * Translation table walks for TTBR0_EL1 are inner write-back read-allocate "
+"write-allocate\n"
+" * cacheable.\n"
+" */\n"
+".set .L_TCR_RGN_IWB, 0x1 << 8\n"
+"/* Size offset for TTBR0_EL1 is 2**39 bytes (512 GiB). */\n"
+".set .L_TCR_T0SZ_512, 64 - 39\n"
+".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | ."
+"L_TCR_RGN_OWB\n"
+".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | ."
+"L_TCR_T0SZ_512\n"
+"\n"
+"/* Stage 1 instruction access cacheability is unaffected. */\n"
+".set .L_SCTLR_ELx_I, 0x1 << 12\n"
+"/* SP alignment fault if SP is not aligned to a 16 byte boundary. */\n"
+".set .L_SCTLR_ELx_SA, 0x1 << 3\n"
+"/* Stage 1 data access cacheability is unaffected. */\n"
+".set .L_SCTLR_ELx_C, 0x1 << 2\n"
+"/* EL0 and EL1 stage 1 MMU enabled. */\n"
+".set .L_SCTLR_ELx_M, 0x1 << 0\n"
+"/* Privileged Access Never is unchanged on taking an exception to EL1. */\n"
+".set .L_SCTLR_EL1_SPAN, 0x1 << 23\n"
+"/* SETEND instruction disabled at EL0 in aarch32 mode. */\n"
+".set .L_SCTLR_EL1_SED, 0x1 << 8\n"
+"/* Various IT instructions are disabled at EL0 in aarch32 mode. */\n"
+".set .L_SCTLR_EL1_ITD, 0x1 << 7\n"
+".set .L_SCTLR_EL1_RES1, (0x1 << 11) | (0x1 << 20) | (0x1 << 22) | (0x1 << "
+"28) | (0x1 << 29)\n"
+".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | ."
+"L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
+".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | ."
+"L_SCTLR_EL1_RES1\n"
+"\n"
+"/**\n"
+" * Es un punto de entrada genérico para una imagen. It carries out the "
+"operations required to prepare the\n"
+" * loaded image to be run. Specifically, it zeroes the bss section using "
+"registers x25 and above,\n"
+" * prepares the stack, enables floating point, and sets up the exception "
+"vector. It preserves x0-x3\n"
+" * for the Rust entry point, as these may contain boot parameters.\n"
+" */\n"
+".section .init.entry, \"ax\"\n"
+".global entry\n"
+"entry:\n"
+"\t/* Load and apply the memory management configuration, ready to enable MMU "
+"and caches. */\n"
+"\tadrp x30, idmap\n"
+"\tmsr ttbr0_el1, x30\n"
+"\n"
+"\tmov_i x30, .Lmairval\n"
+"\tmsr mair_el1, x30\n"
+"\n"
+"\tmov_i x30, .Ltcrval\n"
+"\t/* Copy the supported PA range into TCR_EL1.IPS. */\n"
+"\tmrs x29, id_aa64mmfr0_el1\n"
+"\tbfi x30, x29, #32, #4\n"
+"\n"
+"\tmsr tcr_el1, x30\n"
+"\n"
+"\tmov_i x30, .Lsctlrval\n"
+"\n"
+"\t/*\n"
+"\t * Ensure everything before this point has completed, then invalidate any "
+"potentially stale\n"
+"\t * local TLB entries before they start being used.\n"
+"\t */\n"
+"\tisb\n"
+"\ttlbi vmalle1\n"
+"\tic iallu\n"
+"\tdsb nsh\n"
+"\tisb\n"
+"\n"
+"\t/*\n"
+"\t * Configure sctlr_el1 to enable MMU and cache and don't proceed until "
+"this has completed.\n"
+"\t */\n"
+"\tmsr sctlr_el1, x30\n"
+"\tisb\n"
+"\n"
+"\t/* Disable trapping floating point access in EL1. */\n"
+"\tmrs x30, cpacr_el1\n"
+"\torr x30, x30, #(0x3 << 20)\n"
+"\tmsr cpacr_el1, x30\n"
+"\tisb\n"
+"\n"
+"\t/* Zero out the bss section. */\n"
+"\tadr_l x29, bss_begin\n"
+"\tadr_l x30, bss_end\n"
+"0:\tcmp x29, x30\n"
+"\tb.hs 1f\n"
+"\tstp xzr, xzr, [x29], #16\n"
+"\tb 0b\n"
+"\n"
+"1:\t/* Prepare the stack. */\n"
+"\tadr_l x30, boot_stack_end\n"
+"\tmov sp, x30\n"
+"\n"
+"\t/* Set up exception vector. */\n"
+"\tadr x30, vector_table_el1\n"
+"\tmsr vbar_el1, x30\n"
+"\n"
+"\t/* Call into Rust code. */\n"
+"\tbl main\n"
+"\n"
+"\t/* Loop forever waiting for interrupts. */\n"
+"2:\twfi\n"
+"\tb 2b\n"
+"```"
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_exceptions.S_ (you shouldn't need to change this):"
-msgstr "`exceptions.S` (no debería ser necesario cambiarlo):"
+msgstr "_exceptions.S_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid ""
@@ -20538,11 +20840,200 @@ msgid ""
 "\tcurrent_exception_spx serr_lower\n"
 "```"
 msgstr ""
+"```armasm\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+"/**\n"
+" * Saves the volatile registers onto the stack. This currently takes 14\n"
+" * instructions, so it can be used in exception handlers with 18 "
+"instructions\n"
+" * left.\n"
+" *\n"
+" * On return, x0 and x1 are initialised to elr_el2 and spsr_el2 "
+"respectively,\n"
+" * which can be used as the first and second arguments of a subsequent "
+"call.\n"
+" */\n"
+".macro save_volatile_to_stack\n"
+"\t/* Reserve stack space and save registers x0-x18, x29 & x30. */\n"
+"\tstp x0, x1, [sp, #-(8 * 24)]!\n"
+"\tstp x2, x3, [sp, #8 * 2]\n"
+"\tstp x4, x5, [sp, #8 * 4]\n"
+"\tstp x6, x7, [sp, #8 * 6]\n"
+"\tstp x8, x9, [sp, #8 * 8]\n"
+"\tstp x10, x11, [sp, #8 * 10]\n"
+"\tstp x12, x13, [sp, #8 * 12]\n"
+"\tstp x14, x15, [sp, #8 * 14]\n"
+"\tstp x16, x17, [sp, #8 * 16]\n"
+"\tstr x18, [sp, #8 * 18]\n"
+"\tstp x29, x30, [sp, #8 * 20]\n"
+"\n"
+"\t/*\n"
+"\t * Save elr_el1 & spsr_el1. This such that we can take nested exception\n"
+"\t * and still be able to unwind.\n"
+"\t */\n"
+"\tmrs x0, elr_el1\n"
+"\tmrs x1, spsr_el1\n"
+"\tstp x0, x1, [sp, #8 * 22]\n"
+".endm\n"
+"\n"
+"/**\n"
+" * Restores the volatile registers from the stack. This currently takes 14\n"
+" * instructions, so it can be used in exception handlers while still leaving "
+"18\n"
+" * instructions left; if paired with save_volatile_to_stack, there are 4\n"
+" * instructions to spare.\n"
+" */\n"
+".macro restore_volatile_from_stack\n"
+"\t/* Restore registers x2-x18, x29 & x30. */\n"
+"\tldp x2, x3, [sp, #8 * 2]\n"
+"\tldp x4, x5, [sp, #8 * 4]\n"
+"\tldp x6, x7, [sp, #8 * 6]\n"
+"\tldp x8, x9, [sp, #8 * 8]\n"
+"\tldp x10, x11, [sp, #8 * 10]\n"
+"\tldp x12, x13, [sp, #8 * 12]\n"
+"\tldp x14, x15, [sp, #8 * 14]\n"
+"\tldp x16, x17, [sp, #8 * 16]\n"
+"\tldr x18, [sp, #8 * 18]\n"
+"\tldp x29, x30, [sp, #8 * 20]\n"
+"\n"
+"\t/* Restore registers elr_el1 & spsr_el1, using x0 & x1 as scratch. */\n"
+"\tldp x0, x1, [sp, #8 * 22]\n"
+"\tmsr elr_el1, x0\n"
+"\tmsr spsr_el1, x1\n"
+"\n"
+"\t/* Restore x0 & x1, and release stack space. */\n"
+"\tldp x0, x1, [sp], #8 * 24\n"
+".endm\n"
+"\n"
+"/**\n"
+" * This is a generic handler for exceptions taken at the current EL while "
+"using\n"
+" * SP0. It behaves similarly to the SPx case by first switching to SPx, "
+"doing\n"
+" * the work, then switching back to SP0 before returning.\n"
+" *\n"
+" * Switching to SPx and calling the Rust handler takes 16 instructions. To\n"
+" * restore and return we need an additional 16 instructions, so we can "
+"implement\n"
+" * the whole handler within the allotted 32 instructions.\n"
+" */\n"
+".macro current_exception_sp0 handler:req\n"
+"\tmsr spsel, #1\n"
+"\tsave_volatile_to_stack\n"
+"\tbl \\handler\n"
+"\trestore_volatile_from_stack\n"
+"\tmsr spsel, #0\n"
+"\teret\n"
+".endm\n"
+"\n"
+"/**\n"
+" * This is a generic handler for exceptions taken at the current EL while "
+"using\n"
+" * SPx. It saves volatile registers, calls the Rust handler, restores "
+"volatile\n"
+" * registers, then returns.\n"
+" *\n"
+" * This also works for exceptions taken from EL0, if we don't care about\n"
+" * non-volatile registers.\n"
+" *\n"
+" * Saving state and jumping to the Rust handler takes 15 instructions, and\n"
+" * restoring and returning also takes 15 instructions, so we can fit the "
+"whole\n"
+" * handler in 30 instructions, under the limit of 32.\n"
+" */\n"
+".macro current_exception_spx handler:req\n"
+"\tsave_volatile_to_stack\n"
+"\tbl \\handler\n"
+"\trestore_volatile_from_stack\n"
+"\teret\n"
+".endm\n"
+"\n"
+".section .text.vector_table_el1, \"ax\"\n"
+".global vector_table_el1\n"
+".balign 0x800\n"
+"vector_table_el1:\n"
+"sync_cur_sp0:\n"
+"\tcurrent_exception_sp0 sync_exception_current\n"
+"\n"
+".balign 0x80\n"
+"irq_cur_sp0:\n"
+"\tcurrent_exception_sp0 irq_current\n"
+"\n"
+".balign 0x80\n"
+"fiq_cur_sp0:\n"
+"\tcurrent_exception_sp0 fiq_current\n"
+"\n"
+".balign 0x80\n"
+"serr_cur_sp0:\n"
+"\tcurrent_exception_sp0 serr_current\n"
+"\n"
+".balign 0x80\n"
+"sync_cur_spx:\n"
+"\tcurrent_exception_spx sync_exception_current\n"
+"\n"
+".balign 0x80\n"
+"irq_cur_spx:\n"
+"\tcurrent_exception_spx irq_current\n"
+"\n"
+".balign 0x80\n"
+"fiq_cur_spx:\n"
+"\tcurrent_exception_spx fiq_current\n"
+"\n"
+".balign 0x80\n"
+"serr_cur_spx:\n"
+"\tcurrent_exception_spx serr_current\n"
+"\n"
+".balign 0x80\n"
+"sync_lower_64:\n"
+"\tcurrent_exception_spx sync_lower\n"
+"\n"
+".balign 0x80\n"
+"irq_lower_64:\n"
+"\tcurrent_exception_spx irq_lower\n"
+"\n"
+".balign 0x80\n"
+"fiq_lower_64:\n"
+"\tcurrent_exception_spx fiq_lower\n"
+"\n"
+".balign 0x80\n"
+"serr_lower_64:\n"
+"\tcurrent_exception_spx serr_lower\n"
+"\n"
+".balign 0x80\n"
+"sync_lower_32:\n"
+"\tcurrent_exception_spx sync_lower\n"
+"\n"
+".balign 0x80\n"
+"irq_lower_32:\n"
+"\tcurrent_exception_spx irq_lower\n"
+"\n"
+".balign 0x80\n"
+"fiq_lower_32:\n"
+"\tcurrent_exception_spx fiq_lower\n"
+"\n"
+".balign 0x80\n"
+"serr_lower_32:\n"
+"\tcurrent_exception_spx serr_lower\n"
+"```"
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_idmap.S_ (you shouldn't need to change this):"
-msgstr "`idmap.S` (no debería ser necesario cambiarlo):"
+msgstr "_idmap.S_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid ""
@@ -20592,11 +21083,55 @@ msgid ""
 "\t.fill\t\t255, 8, 0x0\t\t\t// 255 GiB of remaining VA space\n"
 "```"
 msgstr ""
+"```armasm\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+".set .L_TT_TYPE_BLOCK, 0x1\n"
+".set .L_TT_TYPE_PAGE,  0x3\n"
+".set .L_TT_TYPE_TABLE, 0x3\n"
+"\n"
+"/* Access flag. */\n"
+".set .L_TT_AF, 0x1 << 10\n"
+"/* Not global. */\n"
+".set .L_TT_NG, 0x1 << 11\n"
+".set .L_TT_XN, 0x3 << 53\n"
+"\n"
+".set .L_TT_MT_DEV, 0x0 << 2\t\t\t// MAIR #0 (DEV_nGnRE)\n"
+".set .L_TT_MT_MEM, (0x1 << 2) | (0x3 << 8)\t// MAIR #1 (MEM_WBWA), inner "
+"shareable\n"
+"\n"
+".set .L_BLOCK_DEV, .L_TT_TYPE_BLOCK | .L_TT_MT_DEV | .L_TT_AF | .L_TT_XN\n"
+".set .L_BLOCK_MEM, .L_TT_TYPE_BLOCK | .L_TT_MT_MEM | .L_TT_AF | .L_TT_NG\n"
+"\n"
+".section \".rodata.idmap\", \"a\", %progbits\n"
+".global idmap\n"
+".align 12\n"
+"idmap:\n"
+"\t/* level 1 */\n"
+"\t.quad\t\t.L_BLOCK_DEV | 0x0\t\t    // 1 GiB of device mappings\n"
+"\t.quad\t\t.L_BLOCK_MEM | 0x40000000\t// 1 GiB of DRAM\n"
+"\t.fill\t\t254, 8, 0x0\t\t\t// 254 GiB of unmapped VA space\n"
+"\t.quad\t\t.L_BLOCK_DEV | 0x4000000000 // 1 GiB of device mappings\n"
+"\t.fill\t\t255, 8, 0x0\t\t\t// 255 GiB of remaining VA space\n"
+"```"
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_image.ld_ (you shouldn't need to change this):"
-msgstr "`image.ld` (no debería ser necesario cambiarlo):"
+msgstr "_image.ld_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid ""
@@ -20708,32 +21243,137 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
+"```ld\n"
+"/*\n"
+" * Copyright 2023 Google LLC\n"
+" *\n"
+" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+" * you may not use this file except in compliance with the License.\n"
+" * You may obtain a copy of the License at\n"
+" *\n"
+" *     https://www.apache.org/licenses/LICENSE-2.0\n"
+" *\n"
+" * Unless required by applicable law or agreed to in writing, software\n"
+" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+" * See the License for the specific language governing permissions and\n"
+" * limitations under the License.\n"
+" */\n"
+"\n"
+"/*\n"
+" * Code will start running at this symbol which is placed at the start of "
+"the\n"
+" * image.\n"
+" */\n"
+"ENTRY(entry)\n"
+"\n"
+"MEMORY\n"
+"{\n"
+"\timage : ORIGIN = 0x40080000, LENGTH = 2M\n"
+"}\n"
+"\n"
+"SECTIONS\n"
+"{\n"
+"\t/*\n"
+"\t * Collect together the code.\n"
+"\t */\n"
+"\t.init : ALIGN(4096) {\n"
+"\t\ttext_begin = .;\n"
+"\t\t*(.init.entry)\n"
+"\t\t*(.init.*)\n"
+"\t} >image\n"
+"\t.text : {\n"
+"\t\t*(.text.*)\n"
+"\t} >image\n"
+"\ttext_end = .;\n"
+"\n"
+"\t/*\n"
+"\t * Collect together read-only data.\n"
+"\t */\n"
+"\t.rodata : ALIGN(4096) {\n"
+"\t\trodata_begin = .;\n"
+"\t\t*(.rodata.*)\n"
+"\t} >image\n"
+"\t.got : {\n"
+"\t\t*(.got)\n"
+"\t} >image\n"
+"\trodata_end = .;\n"
+"\n"
+"\t/*\n"
+"\t * Collect together the read-write data including .bss at the end which\n"
+"\t * will be zero'd by the entry code.\n"
+"\t */\n"
+"\t.data : ALIGN(4096) {\n"
+"\t\tdata_begin = .;\n"
+"\t\t*(.data.*)\n"
+"\t\t/*\n"
+"\t\t * The entry point code assumes that .data is a multiple of 32\n"
+"\t\t * bytes long.\n"
+"\t\t */\n"
+"\t\t. = ALIGN(32);\n"
+"\t\tdata_end = .;\n"
+"\t} >image\n"
+"\n"
+"\t/* Everything beyond this point will not be included in the binary. */\n"
+"\tbin_end = .;\n"
+"\n"
+"\t/* The entry point code assumes that .bss is 16-byte aligned. */\n"
+"\t.bss : ALIGN(16)  {\n"
+"\t\tbss_begin = .;\n"
+"\t\t*(.bss.*)\n"
+"\t\t*(COMMON)\n"
+"\t\t. = ALIGN(16);\n"
+"\t\tbss_end = .;\n"
+"\t} >image\n"
+"\n"
+"\t.stack (NOLOAD) : ALIGN(4096) {\n"
+"\t\tboot_stack_begin = .;\n"
+"\t\t. += 40 * 4096;\n"
+"\t\t. = ALIGN(4096);\n"
+"\t\tboot_stack_end = .;\n"
+"\t} >image\n"
+"\n"
+"\t. = ALIGN(4K);\n"
+"\tPROVIDE(dma_region = .);\n"
+"\n"
+"\t/*\n"
+"\t * Remove unused sections from the image.\n"
+"\t */\n"
+"\t/DISCARD/ : {\n"
+"\t\t/* The image loads itself so doesn't need these sections. */\n"
+"\t\t*(.gnu.hash)\n"
+"\t\t*(.hash)\n"
+"\t\t*(.interp)\n"
+"\t\t*(.eh_frame_hdr)\n"
+"\t\t*(.eh_frame)\n"
+"\t\t*(.note.gnu.build-id)\n"
+"\t}\n"
+"}\n"
+"```"
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "_Makefile_ (you shouldn't need to change this):"
-msgstr "`Makefile` (no debería ser necesario cambiarlo):"
+msgstr "_Makefile_ (no debería ser necesario cambiarlo):"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "# Copyright 2023 Google LLC"
-msgstr ""
+msgstr "# Copyright 2023 Google LLC"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "$(shell uname -s)"
-msgstr ""
+msgstr "$(shell uname -s)"
 
 #: src/exercises/bare-metal/rtc.md
-#, fuzzy
 msgid "aarch64-linux-gnu"
-msgstr "aarch64-paging"
+msgstr "aarch64-linux-gnu"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "stdio -display none -kernel $< -s"
-msgstr ""
+msgstr "stdio -display none -kernel $< -s"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "cargo clean"
-msgstr ""
+msgstr "cargo clean"
 
 #: src/exercises/bare-metal/rtc.md
 msgid "Run the code in QEMU with `make qemu`."
@@ -20741,98 +21381,96 @@ msgstr "Ejecuta el código en QEMU con `make qemu`."
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "Bare Metal Rust Afternoon"
-msgstr "Rust Bare Metal: tarde"
+msgstr "Rust Bare Metal: Tarde"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "([back to exercise](rtc.md))"
 msgstr "([volver al ejercicio](rtc.md))"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
-#, fuzzy
 msgid "_main.rs_:"
-msgstr "`main.rs`:"
+msgstr "_main.rs_:"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Base address of the PL031 RTC.\n"
-msgstr ""
+msgstr "/// Dirección base de PL031 RTC.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// The IRQ used by the PL031 RTC.\n"
-msgstr ""
+msgstr "/// IRQ que utiliza PL031 RTC.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
 "    // and nothing else accesses that address range.\n"
 msgstr ""
+"// Es seguro porque `PL031_BASE_ADDRESS` es la dirección base de un "
+"dispositivo PL031\n"
+"    // y ningún otro elemento puede acceder a ese intervalo de direcciones.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"RTC: {time}\""
-msgstr ""
+msgstr "\"RTC: {time}\""
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "// Wait for 3 seconds, without interrupts.\n"
-msgstr ""
+msgstr "// Espera 3 segundos, sin interrupciones.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"Waiting for {}\""
-msgstr ""
+msgstr "\"Esperando a {}\""
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"matched={}, interrupt_pending={}\""
-msgstr ""
+msgstr "\"matched={}, interrupt_pending={}\""
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"Finished waiting\""
-msgstr ""
+msgstr "\"Espera finalizada\""
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "// Wait another 3 seconds for an interrupt.\n"
-msgstr ""
+msgstr "// Espera otros 3 segundos a que se produzca una interrupción.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
-#, fuzzy
 msgid "_pl031.rs_:"
-msgstr "`pl031.rs`:"
+msgstr "_pl031.rs_:"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Data register\n"
-msgstr ""
+msgstr "/// Registro de datos\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Match register\n"
-msgstr ""
+msgstr "/// Registro de coincidencias\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Load register\n"
-msgstr ""
+msgstr "/// Registro de cargas\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Control register\n"
-msgstr ""
+msgstr "/// Registro de control\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Interrupt Mask Set or Clear register\n"
-msgstr ""
+msgstr "/// Interrumpe Mask Set o Clear register\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Raw Interrupt Status\n"
-msgstr ""
+msgstr "/// Estado de interrupción sin procesar\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Masked Interrupt Status\n"
-msgstr ""
+msgstr "/// Estado de interrupción enmascarada\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Interrupt Clear Register\n"
-msgstr ""
+msgstr "/// Interrumpir registro de limpieza\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
-#, fuzzy
 msgid "/// Driver for a PL031 real-time clock.\n"
-msgstr ""
-"Escribiremos un controlador para el dispositivo de reloj en tiempo real "
-"PL031."
+msgstr "/// Controlador para un reloj en tiempo real PL031.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
@@ -20847,22 +21485,38 @@ msgid ""
 "process\n"
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
+"/// Crea una instancia nueva del controlador RTC para un dispositivo PL031 "
+"en la\n"
+"    /// dirección base proporcionada.\n"
+"    ///\n"
+"    /// # Seguridad\n"
+"    ///\n"
+"    /// El objeto la dirección base debe apuntar a los registros de control "
+"MMIO de un dispositivo\n"
+"    /// PL031, que debe asignarse al espacio de direcciones del proceso\n"
+"    /// como memoria del dispositivo y no tener ningún otro alias.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Reads the current RTC value.\n"
-msgstr ""
+msgstr "/// Lee el valor de RTC actual.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "// Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
 msgstr ""
+"// Es seguro porque sabemos que self.registers apunta\n"
+"        // a los registros de control de un dispositivo PL031 que está "
+"asignado correctamente.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "/// Writes a match value. When the RTC value matches this then an interrupt\n"
 "    /// will be generated (if it is enabled).\n"
 msgstr ""
+"/// Escribe un valor de coincidencia. Cuando el valor de RTC coincida, se "
+"generará una interrupción\n"
+"    /// (si está habilitada).\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
@@ -20870,6 +21524,9 @@ msgid ""
 "not\n"
 "    /// the interrupt is enabled.\n"
 msgstr ""
+"/// Devuelve en función de si el registro de coincidencias coincide con el "
+"valor de RTC,\n"
+"    /// si la interrupción está habilitada o no.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
@@ -20878,6 +21535,10 @@ msgid ""
 "    /// This should be true if and only if `matched` returns true and the\n"
 "    /// interrupt is masked.\n"
 msgstr ""
+"/// Devuelve si hay una interrupción pendiente.\n"
+"    ///\n"
+"    /// Solo debe ser true si `matched` devuelve true y\n"
+"    /// la interrupción está enmascarada.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
@@ -20887,10 +21548,14 @@ msgid ""
 "the\n"
 "    /// interrupt is disabled.\n"
 msgstr ""
+"/// Define o borra la máscara de interrupción.\n"
+"    ///\n"
+"    /// Si la máscara es true, se habilita la interrupción; Si es false,\n"
+"    /// se inhabilita la interrupción.\n"
 
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Clears a pending interrupt, if any.\n"
-msgstr ""
+msgstr "/// Borra una interrupción pendiente, si la hubiera.\n"
 
 #: src/concurrency.md
 msgid "Welcome to Concurrency in Rust"

--- a/po/es.po
+++ b/po/es.po
@@ -5414,63 +5414,70 @@ msgstr ""
 
 #: src/welcome-day-2.md
 msgid "Methods: associating functions with types."
-msgstr ""
+msgstr "Métodos: asociar funciones a tipos."
 
 #: src/welcome-day-2.md
 msgid "Traits: behaviors shared by multiple types."
-msgstr ""
+msgstr "Traits: comportamientos que comparten varios tipos."
 
 #: src/welcome-day-2.md
 msgid "Generics: parameterizing types on other types."
-msgstr ""
+msgstr "Genéricos: parametrizar tipos en otros tipos."
 
 #: src/welcome-day-2.md
 msgid ""
 "Standard library types and traits: a tour of Rust's rich standard library."
 msgstr ""
+"Tipos y traits de bibliotecas estándar: un recorrido por la amplia "
+"biblioteca estándar de Rust."
 
 #: src/welcome-day-2.md
 msgid "[Welcome](./welcome-day-2.md) (3 minutes)"
-msgstr ""
+msgstr "[Bienvenida](./welcome-day-2.md) (3 minutos)"
 
 #: src/welcome-day-2.md
-#, fuzzy
 msgid "[Pattern Matching](./pattern-matching.md) (50 minutes)"
-msgstr ""
-"Consulta de nuevo la sección de [coincidencia de patrones](../pattern-"
-"matching.md) para obtener más información sobre los patrones de Rust."
+msgstr "[Coincidencia de patrones](./pattern-matching.md) (50 minutos)"
 
 #: src/welcome-day-2.md
 msgid "[Methods and Traits](./methods-and-traits.md) (55 minutes)"
-msgstr ""
+msgstr "[Métodos y traits](./methods-and-traits.md) (55 minutos)"
 
 #: src/welcome-day-2.md
 msgid "[Generics](./generics.md) (45 minutes)"
-msgstr ""
+msgstr "[Genéricos](./generics.md) (45 minutos)"
 
 #: src/welcome-day-2.md src/welcome-day-4.md
 msgid ""
 "Including 10 minute breaks, this session should take about 3 hours and 5 "
 "minutes"
 msgstr ""
+"Incluyendo descansos de 10 minutos, esta sesión debería durar unas 3 horas y "
+"5 minutos"
 
 #: src/pattern-matching.md
 msgid "[Destructuring](./pattern-matching/destructuring.md) (10 minutes)"
-msgstr ""
+msgstr "[Desestructuración](./pattern-matching/destructuring.md) (10 minutos)"
 
 #: src/pattern-matching.md
 msgid "[Let Control Flow](./pattern-matching/let-control-flow.md) (10 minutes)"
 msgstr ""
+"[Control de Flujo con `let`](./pattern-matching/let-control-flow.md) (10 "
+"minutos)"
 
 #: src/pattern-matching.md
 msgid ""
 "[Exercise: Expression Evaluation](./pattern-matching/exercise.md) (30 "
 "minutes)"
 msgstr ""
+"[Ejercicio: evaluación de expresiones](./pattern-matching/exercise.md) (30 "
+"minutos)"
 
 #: src/pattern-matching/destructuring.md
 msgid "Like tuples, structs and enums can also be destructured by matching:"
 msgstr ""
+"Al igual que las tuplas, las estructuras y las enumeraciones también se "
+"pueden desestructurar con la coincidencia:"
 
 #: src/pattern-matching/destructuring.md
 msgid "Structs"
@@ -5478,15 +5485,15 @@ msgstr "Structs"
 
 #: src/pattern-matching/destructuring.md
 msgid "\"x.0 = 1, b = {b}, y = {y}\""
-msgstr ""
+msgstr "\"x.0 = 1, b = {b}, y = {y}\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"y = 2, x = {i:?}\""
-msgstr ""
+msgstr "\"y = 2, x = {i:?}\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"y = {y}, other fields were ignored\""
-msgstr ""
+msgstr "\"y = {y}, se han ignorado otros campos\""
 
 #: src/pattern-matching/destructuring.md
 msgid ""
@@ -5500,15 +5507,15 @@ msgstr ""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"cannot divide {n} into two equal parts\""
-msgstr ""
+msgstr "\"no se puede dividir {n} en dos partes iguales\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"{n} divided in two is {half}\""
-msgstr ""
+msgstr "\"{n} dividido entre dos es {half}\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"sorry, an error happened: {msg}\""
-msgstr ""
+msgstr "\"se ha producido un error: {msg}\""
 
 #: src/pattern-matching/destructuring.md
 msgid ""
@@ -5589,6 +5596,14 @@ msgid ""
 "io/rfcs/2005-match-ergonomics.html) appeared in Rust 2018. If you want to "
 "support older Rust, replace `msg` with `ref msg` in the pattern."
 msgstr ""
+"Guarda el resultado de `divide_in_two` en la variable `result` y hazlo "
+"coincidir mediante `match` en un bucle. No se compilará porque se utilizará "
+"`msg` cuando coincida. Para solucionarlo, haz coincidir `&result` en lugar "
+"de `result`. De esta forma, `msg` se convertirá en una referencia y no se "
+"utilizará. Esta [\"ergonomía de coincidencia\"](https://rust-lang.github.io/"
+"rfcs/2005-match-ergonomics.html) apareció en Rust 2018. Si quieres que sea "
+"compatible con las versiones anteriores de Rust, sustituye `msg` por `ref "
+"msg` en el patrón."
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5622,12 +5637,11 @@ msgstr ""
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"slept for {:?}\""
-msgstr ""
+msgstr "\"Horas de sueño: {:?}\""
 
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "`let else` expressions"
-msgstr "Expresiones `while let`"
+msgstr "Expresiones `let else`"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5636,28 +5650,32 @@ msgid ""
 "let_else.html). The \"else\" case must diverge (`return`, `break`, or panic "
 "- anything but falling off the end of the block)."
 msgstr ""
+"En el caso habitual de coincidencia con un patrón y retorno de la función, "
+"utiliza [`let else`](https://doc.rust-lang.org/rust-by-example/flow_control/"
+"let_else.html). El caso \"else\" debe divergir (`return`, `break` o pánico; "
+"cualquier acción es válida menos colocarlo al final del bloque)."
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"got None\""
-msgstr ""
+msgstr "\"se ha obtenido None\""
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"got empty string\""
-msgstr ""
+msgstr "\"se ha encontrado una cadena vacía\""
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"not a hex digit\""
-msgstr ""
+msgstr "\"no es un dígito hexadecimal\""
 
 #: src/pattern-matching/let-control-flow.md src/pattern-matching/solution.md
 msgid "\"result: {:?}\""
-msgstr ""
+msgstr "\"resultado: {:?}\""
 
 #: src/pattern-matching/let-control-flow.md src/generics/trait-bounds.md
 #: src/smart-pointers/solution.md src/testing/googletest.md
 #: src/testing/solution.md
 msgid "\"foo\""
-msgstr ""
+msgstr "\"foo\""
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5684,7 +5702,7 @@ msgstr ""
 
 #: src/pattern-matching/let-control-flow.md
 msgid "if-let"
-msgstr ""
+msgstr "if-let"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5709,7 +5727,7 @@ msgstr ""
 
 #: src/pattern-matching/let-control-flow.md
 msgid "let-else"
-msgstr ""
+msgstr "let-else"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5717,15 +5735,17 @@ msgid ""
 "flattening this nested code. Rewrite the awkward version for students, so "
 "they can see the transformation."
 msgstr ""
+"Las instrucciones `if-let` se pueden apilar, tal y como se muestra. La "
+"construcción `let-else` permite aplanar este código anidado. Reescribe esta "
+"rara versión para que los participantes puedan ver la transformación."
 
 #: src/pattern-matching/let-control-flow.md
 msgid "The rewritten version is:"
-msgstr ""
+msgstr "La versión reescrita es la siguiente:"
 
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "while-let"
-msgstr "Bucles `while let`"
+msgstr "while-let"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5750,6 +5770,7 @@ msgstr ""
 #: src/pattern-matching/exercise.md
 msgid "Let's write a simple recursive evaluator for arithmetic expressions."
 msgstr ""
+"Vamos a escribir un sencillo evaluador recursivo de expresiones aritméticas."
 
 #: src/pattern-matching/exercise.md
 msgid ""
@@ -5758,6 +5779,11 @@ msgid ""
 "tests. To evaluate a boxed expression, use the deref operator (`*`) to "
 "\"unbox\" it: `eval(*boxed_expr)`."
 msgstr ""
+"El tipo `Box` es un puntero inteligente y lo veremos con detalle más "
+"adelante en el curso. Una expresión puede \"estar delimitada\" con `Box::"
+"new`, tal como se observa en las pruebas. Para evaluar una expresión "
+"delimitada, usa el operador de desreferencia (`*`) para \"eliminar la "
+"delimitación\": `eval(*boxed_expr)`."
 
 #: src/pattern-matching/exercise.md
 msgid ""
@@ -5767,6 +5793,11 @@ msgid ""
 "(`Ok(Value)`) or an error (`Err(String)`). We will cover this type in detail "
 "later."
 msgstr ""
+"Algunas expresiones no se pueden evaluar y devuelven un error. El tipo "
+"estándar [`Result<Value, String>`](https://doc.rust-lang.org/std/result/enum."
+"Result.html) es una enumeración que representa un valor correcto "
+"(`Ok(Value)`) o un error (`Err(String)`). Más adelante hablaremos de este "
+"tipo en profundidad."
 
 #: src/pattern-matching/exercise.md
 msgid ""
@@ -5775,61 +5806,71 @@ msgid ""
 "`todo!()` and get the tests to pass one-by-one. You can also skip a test "
 "temporarily with `#[ignore]`:"
 msgstr ""
+"Copia y pega el código en el playground de Rust y comienza a implementar "
+"`eval`. El producto final debe superar las pruebas. Recomendamos utilizar "
+"`todo!()` y hacer las pruebas para superar todas las pruebas de forma "
+"individual. También puedes saltarte una prueba de forma temporal con "
+"`#[ignore]`:"
 
 #: src/pattern-matching/exercise.md
 msgid ""
 "If you finish early, try writing a test that results in division by zero or "
 "integer overflow. How could you handle this with `Result` instead of a panic?"
 msgstr ""
+"Si terminas antes, prueba a escribir una prueba que dé como resultado la "
+"división entre cero o un desbordamiento de números enteros. ¿Cómo podrías "
+"gestionarlo con `Result` en vez de con un pánico?"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An operation to perform on two subexpressions.\n"
-msgstr ""
+msgstr "/// Operación que se puede llevar a cabo en dos subexpresiones.\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An expression, in tree form.\n"
-msgstr ""
+msgstr "/// Una expresión en forma de árbol.\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An operation on two subexpressions.\n"
-msgstr ""
+msgstr "/// Operación en dos subexpresiones.\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// A literal value\n"
-msgstr ""
+msgstr "/// Un valor literal\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "\"division by zero\""
-msgstr ""
+msgstr "\"división entre cero\""
 
 #: src/pattern-matching/solution.md
 msgid "\"expr: {:?}\""
-msgstr ""
+msgstr "\"expr: {:?}\""
 
 #: src/methods-and-traits.md
 msgid "[Methods](./methods-and-traits/methods.md) (10 minutes)"
-msgstr ""
+msgstr "[Métodos](./methods-and-traits/methods.md) (10 minutos)"
 
 #: src/methods-and-traits.md
 msgid "[Traits](./methods-and-traits/traits.md) (10 minutes)"
-msgstr ""
+msgstr "[Traits](./methods-and-traits/traits.md) (10 minutos)"
 
 #: src/methods-and-traits.md
 msgid "[Deriving](./methods-and-traits/deriving.md) (5 minutes)"
-msgstr ""
+msgstr "[Derivación](./methods-and-traits/deriving.md) (5 minutos)"
 
 #: src/methods-and-traits.md
 msgid "[Trait Objects](./methods-and-traits/trait-objects.md) (10 minutes)"
-msgstr ""
+msgstr "[Objetos de Trait](./methods-and-traits/trait-objects.md) (10 minutos)"
 
 #: src/methods-and-traits.md
 msgid ""
 "[Exercise: Generic Logger](./methods-and-traits/exercise.md) (20 minutes)"
 msgstr ""
+"[Ejercicio: registrador genérico](./methods-and-traits/exercise.md) (20 "
+"minutos)"
 
 #: src/methods-and-traits.md
 msgid "This segment should take about 55 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 55 minutos."
 
 #: src/methods-and-traits/methods.md
 msgid ""
@@ -5841,39 +5882,39 @@ msgstr ""
 
 #: src/methods-and-traits/methods.md
 msgid "// No receiver, a static method\n"
-msgstr ""
+msgstr "// No hay receptor, método estático\n"
 
 #: src/methods-and-traits/methods.md
 msgid "// Exclusive borrowed read-write access to self\n"
-msgstr ""
+msgstr "// Acceso exclusivo de lectura/escritura prestado a self\n"
 
 #: src/methods-and-traits/methods.md
 msgid "// Shared and read-only borrowed access to self\n"
-msgstr ""
+msgstr "// Acceso compartido y de solo lectura prestado a self\n"
 
 #: src/methods-and-traits/methods.md
 msgid "\"Recorded {} laps for {}:\""
-msgstr ""
+msgstr "\"Se han registrado {} vueltas de {}:\""
 
 #: src/methods-and-traits/methods.md
 msgid "\"Lap {idx}: {lap} sec\""
-msgstr ""
+msgstr "\"Vuelta {idx}: {lap} s\""
 
 #: src/methods-and-traits/methods.md
 msgid "// Exclusive ownership of self\n"
-msgstr ""
+msgstr "// Propiedad exclusiva de self\n"
 
 #: src/methods-and-traits/methods.md
 msgid "\"Race {} is finished, total lap time: {}\""
-msgstr ""
+msgstr "\"La carrera {} ha terminado. Duración total de la vuelta: {}.\""
 
 #: src/methods-and-traits/methods.md
 msgid "\"Monaco Grand Prix\""
-msgstr ""
+msgstr "\"Gran Premio de Mónaco\""
 
 #: src/methods-and-traits/methods.md
 msgid "// race.add_lap(42);\n"
-msgstr ""
+msgstr "// race.add_lap(42);\n"
 
 #: src/methods-and-traits/methods.md
 #, fuzzy
@@ -6007,29 +6048,32 @@ msgstr ""
 
 #: src/methods-and-traits/traits.md
 msgid "\"Oh you're a cutie! What's your name? {}\""
-msgstr ""
+msgstr "\"¡Eres una monada! ¿Cómo te llamas? {}\""
 
 #: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
 msgid "\"Woof, my name is {}!\""
-msgstr ""
+msgstr "\"¡Guau, me llamo {}!\""
 
 #: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
 msgid "\"Miau!\""
-msgstr ""
+msgstr "\"¡Miau!\""
 
 #: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
 msgid "\"Fido\""
-msgstr ""
+msgstr "\"Fido\""
 
 #: src/methods-and-traits/traits.md
 msgid ""
 "A trait defines a number of methods that types must have in order to "
 "implement the trait."
 msgstr ""
+"Un trait define una serie de métodos que los tipos deben tener para "
+"implementar el trait."
 
 #: src/methods-and-traits/traits.md
 msgid "Traits are implemented in an `impl <trait> for <type> { .. }` block."
 msgstr ""
+"Los traits se implementan en un bloque `impl <trait> for <type> { .. }`."
 
 #: src/methods-and-traits/traits.md
 #, fuzzy
@@ -6048,26 +6092,29 @@ msgid ""
 "Supported traits can be automatically implemented for your custom types, as "
 "follows:"
 msgstr ""
+"Los traits compatibles se pueden implementar de forma automática en los "
+"tipos personalizados de la siguiente manera:"
 
 #: src/methods-and-traits/deriving.md
 msgid "// Default trait adds `default` constructor.\n"
-msgstr ""
+msgstr "// El trait predeterminado añade el constructor `default`.\n"
 
 #: src/methods-and-traits/deriving.md
 msgid "// Clone trait adds `clone` method.\n"
-msgstr ""
+msgstr "// El trait clonado añade el método `clone`.\n"
 
 #: src/methods-and-traits/deriving.md
 msgid "\"EldurScrollz\""
-msgstr ""
+msgstr "\"EldurScrollz\""
 
 #: src/methods-and-traits/deriving.md
 msgid "// Debug trait adds support for printing with `{:?}`.\n"
 msgstr ""
+"// El trait Debug permite que sea compatible con imprimir con `{:?}`.\n"
 
 #: src/methods-and-traits/deriving.md
 msgid "\"{:?} vs. {:?}\""
-msgstr ""
+msgstr "\"{:?} contra {:?}\""
 
 #: src/methods-and-traits/deriving.md
 msgid ""
@@ -6075,6 +6122,10 @@ msgid ""
 "macros to add useful functionality. For example, `serde` can derive "
 "serialization support for a struct using `#[derive(Serialize)]`."
 msgstr ""
+"La derivación se implementa con macros y muchos crates ofrecen macros de "
+"derivación útiles para añadir funciones. Por ejemplo, `serde` puede derivar "
+"la compatibilidad con la serialización para una struct con "
+"`#[derive(Serialize)]`."
 
 #: src/methods-and-traits/trait-objects.md
 msgid ""
@@ -6251,7 +6302,7 @@ msgstr "Compara estas salidas en el ejemplo anterior:"
 
 #: src/methods-and-traits/trait-objects.md src/std-traits/closures.md
 msgid "\"{} {}\""
-msgstr ""
+msgstr "\"{} {}\""
 
 #: src/methods-and-traits/trait-objects.md src/std-traits/exercise.md
 #: src/std-traits/solution.md src/modules/exercise.md src/modules/solution.md
@@ -6259,7 +6310,7 @@ msgstr ""
 #: src/android/interoperability/cpp/rust-bridge.md
 #: src/async/pitfalls/cancellation.md
 msgid "\"{}\""
-msgstr ""
+msgstr "\"{}\""
 
 #: src/methods-and-traits/exercise.md
 msgid ""
@@ -6268,6 +6319,11 @@ msgid ""
 "In testing, this might put messages in the test logfile, while in a "
 "production build it would send messages to a log server."
 msgstr ""
+"Vamos a diseñar una sencilla utilidad de registro mediante un trait `Logger` "
+"con un método `log`. El código que podría registrar su progreso puede usar "
+"`&impl Logger`. En las pruebas, esta acción colocaría mensajes en el archivo "
+"de registro de la prueba, mientras que en una compilación de producción "
+"enviaría los mensajes a un servidor de registro."
 
 #: src/methods-and-traits/exercise.md
 msgid ""
@@ -6275,6 +6331,10 @@ msgid ""
 "verbosity. Your task is to write a `VerbosityFilter` type that will ignore "
 "messages above a maximum verbosity."
 msgstr ""
+"Sin embargo, el elemento `StderrLogger` que aparece a continuación registra "
+"todos los mensajes, independientemente de su verbosidad. Tu tarea es "
+"escribir un tipo `VerbosityFilter` que ignore los mensajes que superen el "
+"máximo de verbosidad."
 
 #: src/methods-and-traits/exercise.md
 msgid ""
@@ -6282,54 +6342,60 @@ msgid ""
 "implementing that same trait, adding behavior in the process. What other "
 "kinds of wrappers might be useful in a logging utility?"
 msgstr ""
+"Este es un patrón común: una struct que envuelve una implementación de "
+"traits e implementa ese mismo trait, añadiendo comportamiento en el proceso. "
+"¿Qué otros tipos de envoltorios pueden ser útiles en una utilidad de "
+"registro?"
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "/// Log a message at the given verbosity level.\n"
-msgstr ""
+msgstr "/// Registra un mensaje con el nivel de verbosidad determinado.\n"
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"verbosity={verbosity}: {message}\""
-msgstr ""
+msgstr "\"verbosidad={verbosity}: {message}\""
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"FYI\""
-msgstr ""
+msgstr "\"Para tu información\""
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"Uhoh\""
-msgstr ""
+msgstr "\"Oh, oh\""
 
 #: src/methods-and-traits/exercise.md
 msgid "// TODO: Define and implement `VerbosityFilter`.\n"
-msgstr ""
+msgstr "// TAREA: Define e implementa `VerbosityFilter`.\n"
 
 #: src/methods-and-traits/solution.md
 msgid "/// Only log messages up to the given verbosity level.\n"
 msgstr ""
+"/// Registra solo los mensajes que cumplan el nivel de verbosidad "
+"determinado.\n"
 
 #: src/generics.md
 msgid "[Generic Functions](./generics/generic-functions.md) (5 minutes)"
-msgstr ""
+msgstr "[Funciones genéricas](./generics/generic-functions.md) (5 minutos)"
 
 #: src/generics.md
 msgid "[Generic Data Types](./generics/generic-data.md) (15 minutes)"
-msgstr ""
+msgstr "[Tipos de datos genéricos](./generics/generic-data.md) (15 minutos)"
 
 #: src/generics.md
 msgid "[Trait Bounds](./generics/trait-bounds.md) (10 minutes)"
-msgstr ""
+msgstr "[Límites de traits](./generics/trait-bounds.md) (10 minutos)"
 
 #: src/generics.md
 msgid "[impl Trait](./generics/impl-trait.md) (5 minutes)"
-msgstr ""
+msgstr "[impl Trait](./generics/impl-trait.md) (5 minutos)"
 
 #: src/generics.md
 msgid "[Exercise: Generic min](./generics/exercise.md) (10 minutes)"
-msgstr ""
+msgstr "[Ejercicio: min genérico](./generics/exercise.md) (10 minutos)"
 
 #: src/generics.md src/smart-pointers.md src/iterators.md src/error-handling.md
 msgid "This segment should take about 45 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 45 minutos."
 
 #: src/generics/generic-functions.md
 #, fuzzy
@@ -6343,29 +6409,31 @@ msgstr ""
 
 #: src/generics/generic-functions.md
 msgid "/// Pick `even` or `odd` depending on the value of `n`.\n"
-msgstr ""
+msgstr "/// Elige `even` u `odd` en función de si `n` es par o impar.\n"
 
 #: src/generics/generic-functions.md
 msgid "\"picked a number: {:?}\""
-msgstr ""
+msgstr "\"número elegido: {:?}\""
 
 #: src/generics/generic-functions.md
 msgid "\"picked a tuple: {:?}\""
-msgstr ""
+msgstr "\"tupla elegida: {:?}\""
 
 #: src/generics/generic-functions.md
 msgid "\"dog\""
-msgstr ""
+msgstr "\"perro\""
 
 #: src/generics/generic-functions.md
 msgid "\"cat\""
-msgstr ""
+msgstr "\"gato\""
 
 #: src/generics/generic-functions.md
 msgid ""
 "Rust infers a type for T based on the types of the arguments and return "
 "value."
 msgstr ""
+"Rust infiere un tipo para T en función de los tipos de los argumentos y del "
+"valor devuelto."
 
 #: src/generics/generic-functions.md
 msgid ""
@@ -6375,6 +6443,12 @@ msgid ""
 "`n == 0`. Even if only the `pick` instantiation with integers is used, Rust "
 "still considers it invalid. C++ would let you do this."
 msgstr ""
+"Es similar a las plantillas de C++, pero Rust compila de forma parcial la "
+"función genérica de forma inmediata, por lo que debe ser válida para todos "
+"los tipos que coincidan con las restricciones. Por ejemplo, prueba a "
+"modificar `pick` para que devuelva `even + odd` si `n == 0`. Aunque solo se "
+"use la instanciación `pick` con números enteros, Rust seguirá considerando "
+"que no es válida. En cambio, C++ lo permitiría."
 
 #: src/generics/generic-functions.md
 #, fuzzy
@@ -6393,15 +6467,15 @@ msgstr "Puedes usar genéricos para abstraer el tipo de campo concreto:"
 
 #: src/generics/generic-data.md
 msgid "// fn set_x(&mut self, x: T)\n"
-msgstr ""
+msgstr "// fn set_x(&mut self, x: T)\n"
 
 #: src/generics/generic-data.md
 msgid "\"{integer:?} and {float:?}\""
-msgstr ""
+msgstr "\"{integer:?} y {float:?}\""
 
 #: src/generics/generic-data.md
 msgid "\"coords: {:?}\""
-msgstr ""
+msgstr "\"coordenadas: {:?}\""
 
 #: src/generics/generic-data.md
 msgid ""
@@ -6442,6 +6516,9 @@ msgid ""
 "code to allow points that have elements of different types, by using two "
 "type variables, e.g., `T` and `U`."
 msgstr ""
+"Prueba a declarar una nueva variable `let p = Punto { x: 5, y: 10.0 };`. "
+"Actualiza el código para permitir que haya puntos que tengan elementos de "
+"diferentes tipos con dos variables de tipo, por ejemplo, `T` y `U`."
 
 #: src/generics/trait-bounds.md
 msgid ""
@@ -6458,19 +6535,19 @@ msgstr "Puedes hacerlo con `T: Trait` o `impl Trait`:"
 
 #: src/generics/trait-bounds.md
 msgid "// struct NotClonable;\n"
-msgstr ""
+msgstr "// struct NotClonable;\n"
 
 #: src/generics/trait-bounds.md
 msgid "\"{pair:?}\""
-msgstr ""
+msgstr "\"{pair:?}\""
 
 #: src/generics/trait-bounds.md
 msgid "Try making a `NonClonable` and passing it to `duplicate`."
-msgstr ""
+msgstr "Prueba a crear un `NonClonable` y pásalo a `duplicable`."
 
 #: src/generics/trait-bounds.md
 msgid "When multiple traits are necessary, use `+` to join them."
-msgstr ""
+msgstr "Si se necesitan varios traits, usa `+` para unirlos."
 
 #: src/generics/trait-bounds.md
 msgid "Show a `where` clause, students will encounter it when reading code."
@@ -6499,6 +6576,9 @@ msgid ""
 "Note that Rust does not (yet) support specialization. For example, given the "
 "original `duplicate`, it is invalid to add a specialized `duplicate(a: u32)`."
 msgstr ""
+"Ten en cuenta que Rust (todavía) no admite especialización. Por ejemplo, "
+"dado el `duplicate`, original, no es válido añadir un `duplicate(a: u32)` "
+"especializado."
 
 #: src/generics/impl-trait.md
 msgid ""
@@ -6513,18 +6593,20 @@ msgid ""
 "// Syntactic sugar for:\n"
 "//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
 msgstr ""
+"// Azúcar sintáctico para:\n"
+"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
 
 #: src/generics/impl-trait.md
 msgid "\"{many}\""
-msgstr ""
+msgstr "\"{many}\""
 
 #: src/generics/impl-trait.md
 msgid "\"{many_more}\""
-msgstr ""
+msgstr "\"{many_more}\""
 
 #: src/generics/impl-trait.md
 msgid "\"debuggable: {debuggable:?}\""
-msgstr ""
+msgstr "\"depurable: {debuggable:?}\""
 
 #: src/generics/impl-trait.md
 #, fuzzy
@@ -6572,78 +6654,85 @@ msgid ""
 "What is the type of `debuggable`? Try `let debuggable: () = ..` to see what "
 "the error message shows."
 msgstr ""
+"¿Cuál es el tipo de `debuggable`? Prueba con `let debuggable: () = ..` para "
+"ver lo que muestra el mensaje de error."
 
 #: src/generics/exercise.md
 msgid ""
 "In this short exercise, you will implement a generic `min` function that "
 "determines the minimum of two values, using a `LessThan` trait."
 msgstr ""
+"En este breve ejercicio, implementarás una función `min` genérica que "
+"determina el mínimo de dos valores mediante un trait `lessThan`."
 
 #: src/generics/exercise.md src/generics/solution.md
 msgid "/// Return true if self is less than other.\n"
-msgstr ""
+msgstr "/// Devuelve true si el valor de self es menor que el de other.\n"
 
 #: src/generics/exercise.md
 msgid "// TODO: implement the `min` function used in `main`.\n"
-msgstr ""
+msgstr "// TAREA: implementar la función `min` usada en `main`.\n"
 
 #: src/generics/exercise.md src/generics/solution.md
 msgid "\"Shapiro\""
-msgstr ""
+msgstr "\"Shapiro\""
 
 #: src/generics/exercise.md src/generics/solution.md
 msgid "\"Baumann\""
-msgstr ""
+msgstr "\"Baumann\""
 
 #: src/welcome-day-2-afternoon.md
 msgid "[Standard Library Types](./std-types.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[Tipos de bibliotecas estándar](./std-types.md) (1 hora y 10 minutos)"
 
 #: src/welcome-day-2-afternoon.md
 msgid "[Standard Library Traits](./std-traits.md) (1 hour and 40 minutes)"
-msgstr ""
+msgstr "[Traits de biblioteca estándar](./std-traits.md) (1 hora y 40 minutos)"
 
 #: src/std-types.md
 msgid "[Standard Library](./std-types/std.md) (3 minutes)"
-msgstr ""
+msgstr "[Biblioteca estándar](./std-types/std.md) (3 minutos)"
 
 #: src/std-types.md
 msgid "[Documentation](./std-types/docs.md) (5 minutes)"
-msgstr ""
+msgstr "[Documentación](./std-types/docs.md) (5 minutos)"
 
 #: src/std-types.md
 msgid "[Option](./std-types/option.md) (10 minutes)"
-msgstr ""
+msgstr "[Option (Opción)](./std-types/option.md) (10 minutos)"
 
 #: src/std-types.md
 msgid "[Result](./std-types/result.md) (10 minutes)"
-msgstr ""
+msgstr "[Result (Resultado)](./std-types/result.md) (10 minutos)"
 
 #: src/std-types.md
 msgid "[String](./std-types/string.md) (10 minutes)"
-msgstr ""
+msgstr "[String (Cadena de texto)](./std-types/string.md) (10 minutos)"
 
 #: src/std-types.md
 msgid "[Vec](./std-types/vec.md) (10 minutes)"
-msgstr ""
+msgstr "[Vec (Vectores)](./std-types/vec.md) (10 minutos)"
 
 #: src/std-types.md
 msgid "[HashMap](./std-types/hashmap.md) (10 minutes)"
-msgstr ""
+msgstr "[HashMap](./std-types/hashmap.md) (10 minutos)"
 
 #: src/std-types.md
 msgid "[Exercise: Counter](./std-types/exercise.md) (10 minutes)"
-msgstr ""
+msgstr "[Ejercicio: contador](./std-types/exercise.md) (10 minutos)"
 
 #: src/std-types.md src/memory-management.md src/slices-and-lifetimes.md
 msgid "This segment should take about 1 hour and 10 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 1 hora y 10 minutos."
 
 #: src/std-types.md
 msgid ""
 "For each of the slides in this section, spend some time reviewing the "
 "documentation pages, highlighting some of the more common methods."
 msgstr ""
+"Dedica un tiempo a revisar las páginas de la documentación de cada una de "
+"las diapositivas de esta sección para destacar algunos de los métodos que "
+"más se usan."
 
 #: src/std-types/std.md
 #, fuzzy
@@ -6693,7 +6782,7 @@ msgstr ""
 
 #: src/std-types/docs.md
 msgid "Rust comes with extensive documentation. For example:"
-msgstr ""
+msgstr "Rust incluye una amplia documentación. Por ejemplo:"
 
 #: src/std-types/docs.md
 #, fuzzy
@@ -6709,6 +6798,8 @@ msgid ""
 "Primitive types like [`u8`](https://doc.rust-lang.org/stable/std/primitive."
 "u8.html)."
 msgstr ""
+"Tipos primitivos como [`u8`](https://doc.rust-lang.org/stable/std/primitive."
+"u8.html)."
 
 #: src/std-types/docs.md
 #, fuzzy
@@ -6722,7 +6813,7 @@ msgstr ""
 
 #: src/std-types/docs.md
 msgid "In fact, you can document your own code:"
-msgstr ""
+msgstr "De hecho, puedes documentar tu propio código:"
 
 #: src/std-types/docs.md
 msgid ""
@@ -6731,6 +6822,9 @@ msgid ""
 "///\n"
 "/// If the second argument is zero, the result is false.\n"
 msgstr ""
+"/// Determina si el primer argumento es divisible por el segundo argumento.\n"
+"///\n"
+"/// Si el segundo es cero, el resultado será false.\n"
 
 #: src/std-types/docs.md
 msgid ""
@@ -6751,12 +6845,17 @@ msgid ""
 "To document an item from inside the item (such as inside a module), use `//!"
 "` or `/*! .. */`, called \"inner doc comments\":"
 msgstr ""
+"Para documentar un elemento desde dentro (por ejemplo, dentro de un módulo), "
+"utiliza `//!` o `/*! .. */`, denominado como \"comentarios internos del "
+"documento\":"
 
 #: src/std-types/docs.md
 msgid ""
 "//! This module contains functionality relating to divisibility of "
 "integers.\n"
 msgstr ""
+"//! Este módulo contiene funciones relacionadas con la divisibilidad de "
+"números enteros.\n"
 
 #: src/std-types/docs.md
 #, fuzzy
@@ -6778,26 +6877,29 @@ msgid ""
 "type `T` or nothing. For example, [`String::find`](https://doc.rust-lang.org/"
 "stable/std/string/struct.String.html#method.find) returns an `Option<usize>`."
 msgstr ""
+"Ya hemos visto algunos usos de `Option<T>`. Almacena un valor de tipo `T` o "
+"nada. Por ejemplo, [`String::find`](https://doc.rust-lang.org/stable/std/"
+"string/struct.String.html#method.find) devuelve un `Option<usize>`."
 
 #: src/std-types/option.md
 msgid "\"Löwe 老虎 Léopard Gepardi\""
-msgstr ""
+msgstr "\"Löwe 老虎 Léopard Gepardi\""
 
 #: src/std-types/option.md
 msgid "'é'"
-msgstr ""
+msgstr "'é'"
 
 #: src/std-types/option.md
 msgid "\"find returned {position:?}\""
-msgstr ""
+msgstr "\"buscar {position:?} devuelto\""
 
 #: src/std-types/option.md
 msgid "'Z'"
-msgstr ""
+msgstr "'Z'"
 
 #: src/std-types/option.md
 msgid "\"Character not found\""
-msgstr ""
+msgstr "\"No se ha encontrado el carácter\""
 
 #: src/std-types/option.md
 #, fuzzy
@@ -6809,28 +6911,36 @@ msgid ""
 "`unwrap` will return the value in an `Option`, or panic. `expect` is similar "
 "but takes an error message."
 msgstr ""
+"`unwrap` devolverá el valor en un elemento `Option` o un error pánico. "
+"`expect` funciona de forma similar, pero muestra un mensaje de error."
 
 #: src/std-types/option.md
 msgid ""
 "You can panic on None, but you can't \"accidentally\" forget to check for "
 "None."
 msgstr ""
+"Puedes obtener un pánico en None, pero no puedes olvidarte \"de forma "
+"accidental\" de seleccionar None."
 
 #: src/std-types/option.md
 msgid ""
 "It's common to `unwrap`/`expect` all over the place when hacking something "
 "together, but production code typically handles `None` in a nicer fashion."
 msgstr ""
+"Es habitual usar `unwrap`/`expect` por todas partes, pero el código de "
+"producción suele gestionar `None` de una forma más adecuada."
 
 #: src/std-types/option.md
 msgid ""
 "The niche optimization means that `Option<T>` often has the same size in "
 "memory as `T`."
 msgstr ""
+"La \"optimización de nicho\" significa que `Option<T>` a menudo tiene el "
+"mismo tamaño en memoria que `T`."
 
 #: src/std-types/result.md
 msgid "Result"
-msgstr ""
+msgstr "Resultado"
 
 #: src/std-types/result.md
 msgid ""
@@ -6839,22 +6949,27 @@ msgid ""
 "in the expression exercise, but generic: `Result<T, E>` where `T` is used in "
 "the `Ok` variant and `E` appears in the `Err` variant."
 msgstr ""
+"`Result` es similar a `Option`, pero indica si una operación se ha "
+"completado de forma correcta o ha fallado, cada una con un tipo diferente. "
+"Es similar a `Res`, que se definió en el ejercicio de expresiones, pero "
+"genérico: `Result<T, E>`, donde `T` se usa en la variante `Ok` y `E` aparece "
+"en la variante `Err`."
 
 #: src/std-types/result.md
 msgid "\"diary.txt\""
-msgstr ""
+msgstr "\"diary.txt\""
 
 #: src/std-types/result.md
 msgid "\"Dear diary: {contents} ({bytes} bytes)\""
-msgstr ""
+msgstr "\"Querido diario: {contents} ({bytes} bytes)\""
 
 #: src/std-types/result.md
 msgid "\"Could not read file content\""
-msgstr ""
+msgstr "\"No se ha podido leer el contenido del archivo\""
 
 #: src/std-types/result.md
 msgid "\"The diary could not be opened: {err}\""
-msgstr ""
+msgstr "\"No se ha podido abrir el diario: {err}\""
 
 #: src/std-types/result.md
 msgid ""
@@ -6904,27 +7019,27 @@ msgstr ""
 #: src/memory-management/review.md src/testing/unit-tests.md
 #: src/concurrency/scoped-threads.md
 msgid "\"Hello\""
-msgstr ""
+msgstr "\"Hola\""
 
 #: src/std-types/string.md
 msgid "\"s1: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"s1: longitud = {}, capacidad = {}\""
 
 #: src/std-types/string.md
 msgid "'!'"
-msgstr ""
+msgstr "'!'"
 
 #: src/std-types/string.md
 msgid "\"s2: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"s2: longitud= {}, capacidad = {}\""
 
 #: src/std-types/string.md
 msgid "\"🇨🇭\""
-msgstr ""
+msgstr "\"🇨🇭\""
 
 #: src/std-types/string.md
 msgid "\"s3: len = {}, number of chars = {}\""
-msgstr ""
+msgstr "\"s3: longitud = {}, número de caracteres = {}\""
 
 #: src/std-types/string.md
 msgid ""
@@ -6984,6 +7099,8 @@ msgid ""
 "We haven't discussed the `Deref` trait yet, so at this point this mostly "
 "explains the structure of the sidebar in the documentation."
 msgstr ""
+"Todavía no hemos abordado el trait `Deref`, por lo que en este momento esto "
+"explica principalmente la estructura de la barra lateral de la documentación."
 
 #: src/std-types/string.md
 msgid ""
@@ -7038,27 +7155,27 @@ msgstr ""
 
 #: src/std-types/vec.md
 msgid "\"v1: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"v1: longitud= {}, capacidad = {}\""
 
 #: src/std-types/vec.md
 msgid "\"v2: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"v2: longitud= {}, capacidad = {}\""
 
 #: src/std-types/vec.md
 msgid "// Canonical macro to initialize a vector with elements.\n"
-msgstr ""
+msgstr "// Macro canónica para inicializar un vector con elementos.\n"
 
 #: src/std-types/vec.md
 msgid "// Retain only the even elements.\n"
-msgstr ""
+msgstr "// Conserva solo los elementos pares.\n"
 
 #: src/std-types/vec.md
 msgid "\"{v3:?}\""
-msgstr ""
+msgstr "\"{v3:?}\""
 
 #: src/std-types/vec.md
 msgid "// Remove consecutive duplicates.\n"
-msgstr ""
+msgstr "// Elimina los duplicados consecutivos.\n"
 
 #: src/std-types/vec.md
 msgid ""
@@ -7115,6 +7232,9 @@ msgid ""
 "Slices are covered on day 3. For now, students only need to know that a "
 "value of type `Vec` gives access to all of the documented slice methods, too."
 msgstr ""
+"Se estudiarán los slices el tercer día del curso. Por ahora, los "
+"participantes solo necesitan saber que un valor del tipo `Vec` también da "
+"acceso a todos los métodos de slice documentados."
 
 #: src/std-types/hashmap.md
 msgid "Standard hash map with protection against HashDoS attacks:"
@@ -7122,43 +7242,46 @@ msgstr "Mapa hash estándar con protección frente a ataques HashDoS:"
 
 #: src/std-types/hashmap.md
 msgid "\"Adventures of Huckleberry Finn\""
-msgstr ""
+msgstr "\"Las aventuras de Huckleberry Finn\""
 
 #: src/std-types/hashmap.md
 msgid "\"Grimms' Fairy Tales\""
-msgstr ""
+msgstr "\"Los cuentos de los hermanos Grimm\""
 
 #: src/std-types/hashmap.md
 msgid "\"Pride and Prejudice\""
-msgstr ""
+msgstr "\"Orgullo y prejuicio\""
 
 #: src/std-types/hashmap.md
 msgid "\"Les Misérables\""
-msgstr ""
+msgstr "\"Los miserables\""
 
 #: src/std-types/hashmap.md
 msgid "\"We know about {} books, but not Les Misérables.\""
 msgstr ""
+"\"Tenemos información acerca de {} libros, pero no de Los miserables\"."
 
 #: src/std-types/hashmap.md
 msgid "\"Alice's Adventure in Wonderland\""
-msgstr ""
+msgstr "\"Las aventuras de Alicia en el país de las maravillas\""
 
 #: src/std-types/hashmap.md
 msgid "\"{book}: {count} pages\""
-msgstr ""
+msgstr "\"{book}: {count} páginas\""
 
 #: src/std-types/hashmap.md
 msgid "\"{book} is unknown.\""
-msgstr ""
+msgstr "\"{book} es desconocido.\""
 
 #: src/std-types/hashmap.md
 msgid "// Use the .entry() method to insert a value if nothing is found.\n"
 msgstr ""
+"// Utiliza el método .entry() para insertar un valor si no se encuentra "
+"ningún resultado.\n"
 
 #: src/std-types/hashmap.md
 msgid "\"{page_counts:#?}\""
-msgstr ""
+msgstr "\"{page_counts:#?}\""
 
 #: src/std-types/hashmap.md
 msgid ""
@@ -7178,11 +7301,11 @@ msgstr ""
 
 #: src/std-types/hashmap.md
 msgid "\"Harry Potter and the Sorcerer's Stone\""
-msgstr ""
+msgstr "\"Harry Potter y la piedra filosofal\""
 
 #: src/std-types/hashmap.md
 msgid "\"The Hunger Games\""
-msgstr ""
+msgstr "\"Los juegos del hambre\""
 
 #: src/std-types/hashmap.md
 msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
@@ -7248,6 +7371,11 @@ msgid ""
 "stable/std/collections/struct.HashMap.html) to keep track of which values "
 "have been seen and how many times each one has appeared."
 msgstr ""
+"En este ejercicio habrá una estructura de datos muy sencilla y la "
+"convertirás en genérica. Utiliza un [`std::collections::HashMap`](https://"
+"doc.rust-lang.org/stable/std/collections/struct.HashMap.html) para hacer un "
+"seguimiento de los valores se han visto y cuántas veces ha aparecido cada "
+"uno."
 
 #: src/std-types/exercise.md
 msgid ""
@@ -7255,6 +7383,10 @@ msgid ""
 "values. Make the struct and its methods generic over the type of value being "
 "tracked, that way `Counter` can track any type of value."
 msgstr ""
+"La versión inicial de `Counter` está codificada para que solo funcione con "
+"los valores `u32`. Haz que struct y sus métodos sean genéricos sobre el tipo "
+"de valor del que se está haciendo un seguimiento, de manera que `Counter` "
+"pueda hacer el seguimiento de cualquier tipo de valor."
 
 #: src/std-types/exercise.md
 msgid ""
@@ -7262,101 +7394,117 @@ msgid ""
 "stable/std/collections/struct.HashMap.html#method.entry) method to halve the "
 "number of hash lookups required to implement the `count` method."
 msgstr ""
+"Si te sobra tiempo, prueba a usar el método [`entry`](https://doc.rust-lang."
+"org/stable/std/collections/struct.HashMap.html#method.entry) para reducir a "
+"la mitad el número de búsquedas de hash que se necesita para implementar el "
+"método `count`."
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid ""
 "/// Counter counts the number of times each value of type T has been seen.\n"
 msgstr ""
+"/// Counter cuenta el número de veces que se ha visto cada valor de tipo T.\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Create a new Counter.\n"
-msgstr ""
+msgstr "/// Crea un nuevo Counter.\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Count an occurrence of the given value.\n"
-msgstr ""
+msgstr "/// Cuenta una repetición del valor dado.\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Return the number of times the given value has been seen.\n"
-msgstr ""
+msgstr "/// Devuelve el número de veces que se ha visto el valor dado.\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"saw {} values equal to {}\""
-msgstr ""
+msgstr "\"se han visto {} valores iguales a {}\""
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"apple\""
-msgstr ""
+msgstr "\"manzana\""
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"orange\""
-msgstr ""
+msgstr "\"naranja\""
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"got {} apples\""
-msgstr ""
+msgstr "\"se han visto {} manzanas\""
 
 #: src/std-traits.md
 msgid "[Comparisons](./std-traits/comparisons.md) (10 minutes)"
-msgstr ""
+msgstr "[Comparaciones](./std-traits/comparisons.md) (10 minutos)"
 
 #: src/std-traits.md
 msgid "[Operators](./std-traits/operators.md) (10 minutes)"
-msgstr ""
+msgstr "[Operadores](./std-traits/operators.md) (10 minutos)"
 
 #: src/std-traits.md
 msgid "[From and Into](./std-traits/from-and-into.md) (10 minutes)"
-msgstr ""
+msgstr "[From e Into](./std-traits/from-and-into.md) (10 minutos)"
 
 #: src/std-traits.md
 msgid "[Casting](./std-traits/casting.md) (5 minutes)"
-msgstr ""
+msgstr "[Conversiones](./std-traits/casting.md) (5 minutos)"
 
 #: src/std-traits.md
 msgid "[Read and Write](./std-traits/read-and-write.md) (10 minutes)"
-msgstr ""
+msgstr "[Read y Write](./std-traits/read-and-write.md) (10 minutos)"
 
 #: src/std-traits.md
 msgid "[Default, struct update syntax](./std-traits/default.md) (5 minutes)"
 msgstr ""
+"[Default, sintaxis de actualización de structs](./std-traits/default.md) (5 "
+"minutos)"
 
 #: src/std-traits.md
 msgid "[Closures](./std-traits/closures.md) (20 minutes)"
-msgstr ""
+msgstr "[Cierres](./std-traits/closures.md) (20 minutos)"
 
 #: src/std-traits.md
 msgid "[Exercise: ROT13](./std-traits/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[Ejercicio: ROT13](./std-traits/exercise.md) (30 minutos)"
 
 #: src/std-traits.md
 msgid "This segment should take about 1 hour and 40 minutes"
-msgstr ""
+msgstr "Esta sección tiene una duración aproximada de 1 hora y 40 minutos."
 
 #: src/std-traits.md
 msgid ""
 "As with the standard-library types, spend time reviewing the documentation "
 "for each trait."
 msgstr ""
+"Al igual que con los tipos de biblioteca estándar, dedica tiempo a revisar "
+"la documentación de cada trait."
 
 #: src/std-traits.md
 msgid "This section is long. Take a break midway through."
 msgstr ""
+"Esta parte es larga, por lo que recomendamos tomar un descanso al llegar a "
+"la mitad."
 
 #: src/std-traits/comparisons.md
 msgid ""
 "These traits support comparisons between values. All traits can be derived "
 "for types containing fields that implement these traits."
 msgstr ""
+"Estos traits permiten comparar valores. Se pueden derivar todos los traits "
+"de los tipos que contengan campos que implementen estos traits."
 
 #: src/std-traits/comparisons.md
 msgid "`PartialEq` and `Eq`"
-msgstr ""
+msgstr "`PartialEq` y `Eq`"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "`PartialEq` is a partial equivalence relation, with required method `eq` and "
 "provided method `ne`. The `==` and `!=` operators will call these methods."
 msgstr ""
+"`PartialEq` es una relación de equivalencia parcial, con el método requerido "
+"`eq` y el método proporcionado `ne`. Los operadores `==` y `!=` llamarán a "
+"estos métodos."
 
 #: src/std-traits/comparisons.md
 msgid ""
@@ -7364,33 +7512,42 @@ msgid ""
 "and implies `PartialEq`. Functions that require full equivalence will use "
 "`Eq` as a trait bound."
 msgstr ""
+"`Eq` es una relación de equivalencia completa (reflexiva, simétrica y "
+"transitiva) e implica `PartialEq`. Las funciones que requieren una "
+"equivalencia total usan `Eq` como límite del trait."
 
 #: src/std-traits/comparisons.md
 #, fuzzy
 msgid "`PartialOrd` and `Ord`"
-msgstr "`Read` y `Write`"
+msgstr "`PartialEq` y `Eq`"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "`PartialOrd` defines a partial ordering, with a `partial_cmp` method. It is "
 "used to implement the `<`, `<=`, `>=`, and `>` operators."
 msgstr ""
+"`PartialOrd` define un orden parcial, con un método `partial_cmp`. Se usa "
+"para implementar los operadores `<`, `<=`, `>=` y `>`."
 
 #: src/std-traits/comparisons.md
 msgid "`Ord` is a total ordering, with `cmp` returning `Ordering`."
-msgstr ""
+msgstr "`Ord` es un orden total en el que `cmp` devuelve `Ordering`."
 
 #: src/std-traits/comparisons.md
 msgid ""
 "`PartialEq` can be implemented between different types, but `Eq` cannot, "
 "because it is reflexive:"
 msgstr ""
+"`PartialEq` se puede implementar entre diferentes tipos, pero `Eq` no, ya "
+"que es reflexivo:"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "In practice, it's common to derive these traits, but uncommon to implement "
 "them."
 msgstr ""
+"En la práctica, es habitual derivar estos traits, aunque no se suelen "
+"implementar."
 
 #: src/std-traits/operators.md
 msgid ""
@@ -7402,7 +7559,7 @@ msgstr ""
 
 #: src/std-traits/operators.md
 msgid "\"{:?} + {:?} = {:?}\""
-msgstr ""
+msgstr "\"{:?} + {:?} = {:?}\""
 
 #: src/std-traits/operators.md src/memory-management/drop.md
 msgid "Discussion points:"
@@ -7464,7 +7621,7 @@ msgstr ""
 
 #: src/std-traits/from-and-into.md
 msgid "\"{s}, {addr}, {one}, {bigger}\""
-msgstr ""
+msgstr "\"{s}, {addr}, {one}, {bigger}\""
 
 #: src/std-traits/from-and-into.md
 msgid ""
@@ -7501,18 +7658,20 @@ msgid ""
 "Rust has no _implicit_ type conversions, but does support explicit casts "
 "with `as`. These generally follow C semantics where those are defined."
 msgstr ""
+"Rust no tiene conversiones de tipo _implícitas_, pero admite conversiones "
+"explícitas con `as`. Por lo general, se definen según la semántica de C."
 
 #: src/std-traits/casting.md
 msgid "\"as u16: {}\""
-msgstr ""
+msgstr "\"ya que u16: {}\""
 
 #: src/std-traits/casting.md
 msgid "\"as i16: {}\""
-msgstr ""
+msgstr "\"ya que i16: {}\""
 
 #: src/std-traits/casting.md
 msgid "\"as u8: {}\""
-msgstr ""
+msgstr "\"ya que u8: {}\""
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7520,6 +7679,10 @@ msgid ""
 "platforms. This might not match your intuition for changing sign or casting "
 "to a smaller type -- check the docs, and comment for clarity."
 msgstr ""
+"Los resultados de `as` se definen _siempre_ en Rust y son coherentes en "
+"todas las plataformas. Es posible que no coincida con tu idea de cambiar el "
+"signo o convertirlo a otro de menor tamaño. Consulta los documentos y/o "
+"pregunta si tienes cualquier duda."
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7530,6 +7693,13 @@ msgid ""
 "selecting the bottom 32 bits of a `u64` with `as u32`, regardless of what "
 "was in the high bits)."
 msgstr ""
+"La conversión con `as` es una herramienta relativamente precisa y fácil de "
+"usar de forma incorrecta. Puede ser una fuente de pequeños errores, ya que "
+"los futuros trabajos de mantenimiento cambian los tipos que se usan o los "
+"intervalos de valores de los tipos. Las conversiones se utilizan únicamente "
+"cuando se quiere indicar un truncamiento incondicional (por ejemplo, "
+"seleccionando los 32 bits inferiores de un `u64` con `as u32`, "
+"independientemente del elemento que se encontrase en los bits altos)."
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7538,10 +7708,16 @@ msgid ""
 "casts, `TryFrom` and `TryInto` are available when you want to handle casts "
 "that fit differently from those that don't."
 msgstr ""
+"En el caso de las conversiones que no sean falibles (por ejemplo, `u32` a "
+"`u64`), se recomienda utilizar `From` o `Into` en lugar de `as` para "
+"confirmar que la conversión es precisamente infalible. En el caso de las "
+"conversiones falibles, `TryFrom` y `TryInto` están disponibles cuando "
+"necesitas gestionar conversiones que se ajustan de forma diferente a las que "
+"no lo hacen."
 
 #: src/std-traits/casting.md
 msgid "Consider taking a break after this slide."
-msgstr ""
+msgstr "Plantéate hacer una pausa después de esta diapositiva."
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7549,10 +7725,15 @@ msgid ""
 "be lost is generally discouraged, or at least deserves an explanatory "
 "comment."
 msgstr ""
+"`as` es similar a una conversión estática de C++. En general, se desaconseja "
+"el uso de `as` en los casos en los que puedan perderse datos, o al menos se "
+"recomienda dejar un comentario explicativo."
 
 #: src/std-traits/casting.md
 msgid "This is common in casting integers to `usize` for use as an index."
 msgstr ""
+"Esto es habitual al convertir números enteros a `usize` para usarlos como "
+"índice."
 
 #: src/std-traits/read-and-write.md
 msgid ""
@@ -7566,15 +7747,15 @@ msgstr ""
 
 #: src/std-traits/read-and-write.md
 msgid "b\"foo\\nbar\\nbaz\\n\""
-msgstr ""
+msgstr "b\"foo\\nbar\\nbaz\\n\""
 
 #: src/std-traits/read-and-write.md
 msgid "\"lines in slice: {}\""
-msgstr ""
+msgstr "\"líneas en el slice: {}\""
 
 #: src/std-traits/read-and-write.md
 msgid "\"lines in file: {}\""
-msgstr ""
+msgstr "\"líneas en el archivo: {}\""
 
 #: src/std-traits/read-and-write.md
 msgid ""
@@ -7586,15 +7767,15 @@ msgstr ""
 
 #: src/std-traits/read-and-write.md
 msgid "\"\\n\""
-msgstr ""
+msgstr "\"\\n\""
 
 #: src/std-traits/read-and-write.md src/slices-and-lifetimes/str.md
 msgid "\"World\""
-msgstr ""
+msgstr "\"mundo\""
 
 #: src/std-traits/read-and-write.md
 msgid "\"Logged: {:?}\""
-msgstr ""
+msgstr "\"Registrado: {:?}\""
 
 #: src/std-traits/default.md
 msgid "The `Default` Trait"
@@ -7610,24 +7791,24 @@ msgstr ""
 
 #: src/std-traits/default.md
 msgid "\"John Smith\""
-msgstr ""
+msgstr "\"John Smith\""
 
 #: src/std-traits/default.md
 msgid "\"{default_struct:#?}\""
-msgstr ""
+msgstr "\"{default_struct:#?}\""
 
 #: src/std-traits/default.md
 msgid "\"Y is set!\""
-msgstr ""
+msgstr "\"Ya está configurado.\""
 
 #: src/std-traits/default.md
 msgid "\"{almost_default_struct:#?}\""
-msgstr ""
+msgstr "\"{almost_default_struct:#?}\""
 
 #: src/std-traits/default.md src/slices-and-lifetimes/exercise.md
 #: src/slices-and-lifetimes/solution.md
 msgid "\"{:#?}\""
-msgstr ""
+msgstr "\"{:#?}\""
 
 #: src/std-traits/default.md
 msgid ""
@@ -7706,15 +7887,15 @@ msgstr "Llamar Funciones Unsafe (Inseguras)"
 
 #: src/std-traits/closures.md
 msgid "\"add_3: {}\""
-msgstr ""
+msgstr "\"add_3: {}\""
 
 #: src/std-traits/closures.md
 msgid "\"accumulate: {}\""
-msgstr ""
+msgstr "\"accumulate: {}\""
 
 #: src/std-traits/closures.md
 msgid "\"multiply_sum: {}\""
-msgstr ""
+msgstr "\"multiply_sum: {}\""
 
 #: src/std-traits/closures.md
 msgid ""
@@ -7759,12 +7940,19 @@ msgid ""
 "you can (i.e. you call it once), or `FnMut` else, and last `Fn`. This allows "
 "the most flexibility for the caller."
 msgstr ""
+"Cuando defines una función que admite un closure, debes usar `FnOnce` si es "
+"posible (es decir, se llama una vez) o, en su defecto, `FnMut`. En último "
+"lugar estaría `Fn`. De esta forma, se ofrece la máxima flexibilidad al "
+"llamador."
 
 #: src/std-traits/closures.md
 msgid ""
 "In contrast, when you have a closure, the most flexible you can have is `Fn` "
 "(it can be passed everywhere), then `FnMut`, and lastly `FnOnce`."
 msgstr ""
+"Por el contrario, cuando tienes un cierre (closure), lo más flexible que "
+"puedes tener es `Fn` (se puede transmitir en todas partes), a continuación "
+"`FnMut` y, por último, `FnOnce`."
 
 #: src/std-traits/closures.md
 msgid ""
@@ -7784,11 +7972,11 @@ msgstr ""
 
 #: src/std-traits/closures.md
 msgid "\"Hi\""
-msgstr ""
+msgstr "\"¿Qué\""
 
 #: src/std-traits/closures.md
 msgid "\"there\""
-msgstr ""
+msgstr "\"pasa?\""
 
 #: src/std-traits/exercise.md
 msgid ""
@@ -7797,28 +7985,34 @@ msgid ""
 "implement the missing bits. Only rotate ASCII alphabetic characters, to "
 "ensure the result is still valid UTF-8."
 msgstr ""
+"En este ejemplo, implementaremos el algoritmo de cifrado clásico [\"ROT13\"]"
+"(https://en.wikipedia.org/wiki/ROT13). Copia este código en el playground e "
+"implementa los bits que faltan. Rota únicamente los caracteres alfabéticos "
+"ASCII para asegurarte de que el resultado sigue siendo válido en UTF-8."
 
 #: src/std-traits/exercise.md
 msgid "// Implement the `Read` trait for `RotDecoder`.\n"
-msgstr ""
+msgstr "// Implementa el trait `Read` para `RotDecoder`.\n"
 
 #: src/std-traits/exercise.md src/std-traits/solution.md
 msgid "\"Gb trg gb gur bgure fvqr!\""
-msgstr ""
+msgstr "\"Gb trg gb gur bgure fvqr!\""
 
 #: src/std-traits/exercise.md src/std-traits/solution.md
 msgid "\"To get to the other side!\""
-msgstr ""
+msgstr "\"To get to the other side!\""
 
 #: src/std-traits/exercise.md
 msgid ""
 "What happens if you chain two `RotDecoder` instances together, each rotating "
 "by 13 characters?"
 msgstr ""
+"¿Qué ocurre si encadenas dos instancias `RotDecoder` y cada una de ellas "
+"rota 13 posiciones?"
 
 #: src/std-traits/solution.md
 msgid "'A'"
-msgstr ""
+msgstr "'A'"
 
 #: src/welcome-day-3.md
 msgid "Welcome to Day 3"


### PR DESCRIPTION
This PR merges the Spanish (es) v.2 translation back to main.
This requires just a syntactical review, as the partial PRs into this branch were reviewed already.

You can skim this PR with the [GitHub CLI](https://cli.github.com/):

gh pr diff 1846 | bat -l patch

#1463 #284