### PR TITLE
Tweak solution to iter exercise

### DIFF
--- a/src/iterators/exercise.rs
+++ b/src/iterators/exercise.rs
@@ -27,7 +27,7 @@ where
     // ANCHOR_END: offset_differences
     let a = (&values).into_iter();
     let b = (&values).into_iter().cycle().skip(offset);
-    a.zip(b).map(|(a, b)| *b - *a).take(values.len()).collect()
+    a.zip(b).map(|(a, b)| *b - *a).collect()
 }
 
 // ANCHOR: unit-tests


### PR DESCRIPTION
Because `.zip()` is limited to the shorter length, the `.take()` call here is unnecessary. When explaining this solution I don't want to have to explain a call to a method that, used as it is, does nothing.