### PR TITLE
Fix typo in associated-types.md

### DIFF
--- a/src/methods-and-traits/traits/associated-types.md
+++ b/src/methods-and-traits/traits/associated-types.md
@@ -1,6 +1,6 @@
 # Associated Types
 
-Associated types allow are placeholder types which are filled in by the trait
+Associated types are placeholder types which are filled in by the trait
 implementation.
 
 ```rust,editable


### PR DESCRIPTION
A minor nitpick, but as someone new to the language I did spend a bit more time than I'd like to admit trying to understand the meaning of `allow` before realizing this is likely a typo. Maybe I still don't understand, and in that case I'd appreciate a correction!