### PR TITLE
Remove generics from logger exercise

### DIFF
--- a/src/methods-and-traits/exercise.md
+++ b/src/methods-and-traits/exercise.md
@@ -2,7 +2,7 @@
 minutes: 20
 ---
 
-# Exercise: Generic Logger
+# Exercise: Logger Trait
 
 Let's design a simple logging utility, using a trait `Logger` with a `log`
 method. Code which might log its progress can then take an `&impl Logger`. In

--- a/src/methods-and-traits/exercise.rs
+++ b/src/methods-and-traits/exercise.rs
@@ -36,12 +36,12 @@ fn do_things(logger: &impl Logger) {
 // ANCHOR_END: setup
 
 /// Only log messages up to the given verbosity level.
-struct VerbosityFilter<L: Logger> {
+struct VerbosityFilter {
     max_verbosity: u8,
-    inner: L,
+    inner: StderrLogger,
 }
 
-impl<L: Logger> Logger for VerbosityFilter<L> {
+impl Logger for VerbosityFilter {
     fn log(&self, verbosity: u8, message: impl Display) {
         if verbosity <= self.max_verbosity {
             self.inner.log(verbosity, message);


### PR DESCRIPTION
The logger exercise comes before the section on generics, and the purpose of the exercise is for students to get practice writing a trait implementation, so using generics in the solution is a source of confusion for students. I've removed the generic and made `VerbosityFilter` directly hold a `StderrLogger`.