### PR TITLE
Removed destructuring about struct

### DIFF
--- a/src/tuples-and-arrays/destructuring.md
+++ b/src/tuples-and-arrays/destructuring.md
@@ -26,7 +26,6 @@ fn print_tuple(tuple: (i32, i32)) {
 }
 ```
 
-
 <details>
 
 - The patterns used here are "irrefutable", meaning that the compiler can

--- a/src/tuples-and-arrays/destructuring.md
+++ b/src/tuples-and-arrays/destructuring.md
@@ -26,19 +26,6 @@ fn print_tuple(tuple: (i32, i32)) {
 }
 ```
 
-This works with any kind of structured value:
-
-```rust,editable
-struct Foo {
-    a: i32,
-    b: bool,
-}
-
-fn print_foo(foo: Foo) {
-    let Foo { a, b } = foo;
-    println!("a: {a}, b: {b}");
-}
-```
 
 <details>
 


### PR DESCRIPTION
#1464 issue . Let's limit this section to arrays and tuples. Destructuring in structs explained in [Day-2  Morning]((https://google.github.io/comprehensive-rust/pattern-matching/destructuring.html)).