### PR TITLE
Temporarily disable saving playground state

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -48,9 +48,6 @@ urlcolor = "red"
 curly-quotes = true
 additional-js = [
   "theme/speaker-notes.js",
-  "theme/redbox.js",
-  "theme/save-playgrounds.js",
-  "theme/instructor-menu.js",
 ]
 additional-css = [
   "theme/css/svgbob.css",


### PR DESCRIPTION
When browing around on https://google.github.io/comprehensive-rust/, I sooner or later end up in a state where the local storage has `[]` stored for a page with one or more playgrounds. The effect of this is that the code is removed from the page!

I am not sure why this happens, but I’m afraid the code here needs more testing. I’m teaching a class Monday morning, so I’ll disable the code from #1917 for now.