### PR TITLE
Only save CI cache on `main` branch

### DIFF
--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -8,4 +8,7 @@ runs:
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2
       with:
-        save-if: ${{ github.ref == 'refs/heads/main' }}
+        # Only save the cache on the main branch to avoid PRs filling
+        # up the cache. Further, only save it if we are working on the
+        # English source (or if no language has been set).
+        save-if: ${{ github.ref == 'refs/heads/main' && (matrix.language == 'en' || matrix.language == '') }}

--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -7,3 +7,5 @@ runs:
   steps:
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
When a PR restores the cache, it will find the most recent cache from the `main` branch. This cache should be mostly up to date.

We are constantly at the 10 GB limit for our CI caches, so removing the extra caches from the many PR branches should ensure that we always have space for the `main` branch caches.