### PR TITLE
Use larger GitHub runners for build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
         uses: dprint/check@v2.2
 
   typos:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04-64core
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
         run: cargo test
 
   bare-metal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-16core
     strategy:
       matrix:
         include:
@@ -95,7 +95,7 @@ jobs:
         run: cargo build
 
   find-languages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       languages: ${{ steps.find-languages.outputs.languages }}
     steps:
@@ -113,7 +113,7 @@ jobs:
           json.dump(sorted(languages), github_output)
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-64core
     needs:
       - find-languages
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,11 @@
 name: Publish
 
 on:
+  pull_request:
   push:
     branches:
       - main
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment
-concurrency:
-  group: pages
-  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,10 +14,7 @@ env:
 
 jobs:
   publish:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-64core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,7 +44,3 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: book/html
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
We apparently have access to larger runners on the GitHub Enterprise plan.