### PR TITLE
Move generics to day 2 afternoon

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -89,6 +89,10 @@
   - [Deriving](methods-and-traits/deriving.md)
   - [Exercise: Generic Logger](methods-and-traits/exercise.md)
     - [Solution](methods-and-traits/solution.md)
+
+# Day 2: Afternoon
+
+- [Welcome](welcome-day-2-afternoon.md)
 - [Generics](generics.md)
   - [Generic Functions](generics/generic-functions.md)
   - [Generic Data Types](generics/generic-data.md)
@@ -97,10 +101,6 @@
   - [`impl Trait`](generics/impl-trait.md)
   - [Exercise: Generic `min`](generics/exercise.md)
     - [Solution](generics/solution.md)
-
-# Day 2: Afternoon
-
-- [Welcome](welcome-day-2-afternoon.md)
 - [Standard Library Types](std-types.md)
   - [Standard Library](std-types/std.md)
   - [Documentation](std-types/docs.md)


### PR DESCRIPTION
I'm consistently finding that pattern matching and methods/traits section fills up the morning, and I don't get to generics until the afternoon. This just moves the generics section to the afternoon to be a bit more accurate. This makes the estimated times a bit wonky, but I think the std types and traits sections are a bit over-estimated currently, and I find I have enough time in the afternoon to cover those and generics. At some point I'd like to go through and make those sections a bit more structured and make the time estimates more accurate.