### PR TITLE
Simplify if-let example

### DIFF
--- a/src/pattern-matching/let-control-flow.md
+++ b/src/pattern-matching/let-control-flow.md
@@ -18,14 +18,13 @@ The
 lets you execute different code depending on whether a value matches a pattern:
 
 ```rust,editable
+use std::time::Duration;
+
 fn sleep_for(secs: f32) {
-    let dur = if let Ok(dur) = std::time::Duration::try_from_secs_f32(secs) {
-        dur
-    } else {
-        std::time::Duration::from_millis(500)
-    };
-    std::thread::sleep(dur);
-    println!("slept for {:?}", dur);
+    if let Ok(dur) = Duration::try_from_secs_f32(secs) {
+        std::thread::sleep(dur);
+        println!("slept for {:?}", dur);
+    }
 }
 
 fn main() {


### PR DESCRIPTION
I find that `if let` makes the most sense to use when you don't have an `else` case, otherwise it's generally clearer to express the same thing with a `match`. This changes the `if let` example to be (arguably) a bit more idiomatic and less verbose.