### PR TITLE
Uncomment setter in generics example

### DIFF
--- a/src/generics/generic-data.md
+++ b/src/generics/generic-data.md
@@ -18,7 +18,9 @@ impl<T> Point<T> {
         (&self.x, &self.y)
     }
 
-    // fn set_x(&mut self, x: T)
+    fn set_x(&mut self, x: T) {
+        self.x = x;
+    }
 }
 
 fn main() {


### PR DESCRIPTION
I don't think it helps to have the example of a setter commented out in the example. Uncommenting it and implementing it normally is more clear.