### PR TITLE
Remove `to_string` from `HashMap` example

### DIFF
--- a/src/std-types/hashmap.md
+++ b/src/std-types/hashmap.md
@@ -11,9 +11,9 @@ use std::collections::HashMap;
 
 fn main() {
     let mut page_counts = HashMap::new();
-    page_counts.insert("Adventures of Huckleberry Finn".to_string(), 207);
-    page_counts.insert("Grimms' Fairy Tales".to_string(), 751);
-    page_counts.insert("Pride and Prejudice".to_string(), 303);
+    page_counts.insert("Adventures of Huckleberry Finn", 207);
+    page_counts.insert("Grimms' Fairy Tales", 751);
+    page_counts.insert("Pride and Prejudice", 303);
 
     if !page_counts.contains_key("Les Misérables") {
         println!(
@@ -31,7 +31,7 @@ fn main() {
 
     // Use the .entry() method to insert a value if nothing is found.
     for book in ["Pride and Prejudice", "Alice's Adventure in Wonderland"] {
-        let page_count: &mut i32 = page_counts.entry(book.to_string()).or_insert(0);
+        let page_count: &mut i32 = page_counts.entry(book).or_insert(0);
         *page_count += 1;
     }
 


### PR DESCRIPTION
While it's generally better in Rust code to use `String` as the key type for a `HashMap` than `&str`, for the purposes of our examples having the extra `to_string` calls makes the example more verbose and confusing for students. The simple example will work as-is without the `to_string` calls, so I think it's better to just remove them.