### PR TITLE
Remove redundant trait bounds from counter exercise

### DIFF
--- a/src/std-types/exercise.rs
+++ b/src/std-types/exercise.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 /// Counter counts the number of times each value of type T has been seen.
-struct Counter<T: Eq + Hash> {
+struct Counter<T> {
     values: HashMap<T, u64>,
 }
 


### PR DESCRIPTION
The trait bounds aren't needed on the struct definition, only the impl block. I think it'd be useful to show the difference here in order to show students how trait bounds for collection types are usually on the impl blocks rather than the type itself.