### PR TITLE
vi: control-flow-basics.md translations

### DIFF
--- a/po/vi.po
+++ b/po/vi.po
@@ -3084,34 +3084,31 @@ msgstr ""
 
 #: src/control-flow-basics.md
 msgid "[if Expressions](./control-flow-basics/if.md) (4 minutes)"
-msgstr ""
+msgstr "[Lệnh if](./control-flow-basics/if.md) (4 phút)"
 
 #: src/control-flow-basics.md
 msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
-msgstr ""
+msgstr "[Vòng lặp](./control-flow-basics/loops.md) (5 phút)"
 
 #: src/control-flow-basics.md
-msgid ""
-"[break and continue](./control-flow-basics/break-continue.md) (4 minutes)"
-msgstr ""
+msgid "[break and continue](./control-flow-basics/break-continue.md) (4 minutes)"
+msgstr "[Lệnh break và lệnh continue](./control-flow-basics/break-continue.md) (4 phút)"
 
 #: src/control-flow-basics.md
-msgid ""
-"[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (5 minutes)"
-msgstr ""
+msgid "[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (5 minutes)"
+msgstr "[Khối và phạm vi](./control-flow-basics/blocks-and-scopes.md) (5 phút)"
 
 #: src/control-flow-basics.md
 msgid "[Functions](./control-flow-basics/functions.md) (3 minutes)"
-msgstr ""
+msgstr "[Hàm](./control-flow-basics/functions.md) (3 phút)"
 
 #: src/control-flow-basics.md
 msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
-msgstr ""
+msgstr "[Macros](./control-flow-basics/macros.md) (2 phút)"
 
 #: src/control-flow-basics.md
-msgid ""
-"[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (15 minutes)"
-msgstr ""
+msgid "[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (15 minutes)"
+msgstr "[Bài tập: Chuỗi Collatz](./control-flow-basics/exercise.md) (15 phút)"
 
 #: src/control-flow-basics/if.md
 msgid "`if` expressions"

--- a/po/vi.po
+++ b/po/vi.po
@@ -3091,11 +3091,15 @@ msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
 msgstr "[Vòng lặp](./control-flow-basics/loops.md) (5 phút)"
 
 #: src/control-flow-basics.md
-msgid "[break and continue](./control-flow-basics/break-continue.md) (4 minutes)"
-msgstr "[Lệnh break và lệnh continue](./control-flow-basics/break-continue.md) (4 phút)"
+msgid ""
+"[break and continue](./control-flow-basics/break-continue.md) (4 minutes)"
+msgstr ""
+"[Lệnh break và lệnh continue](./control-flow-basics/break-continue.md) (4 "
+"phút)"
 
 #: src/control-flow-basics.md
-msgid "[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (5 minutes)"
+msgid ""
+"[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (5 minutes)"
 msgstr "[Khối và phạm vi](./control-flow-basics/blocks-and-scopes.md) (5 phút)"
 
 #: src/control-flow-basics.md
@@ -3107,7 +3111,8 @@ msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
 msgstr "[Macros](./control-flow-basics/macros.md) (2 phút)"
 
 #: src/control-flow-basics.md
-msgid "[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (15 minutes)"
+msgid ""
+"[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (15 minutes)"
 msgstr "[Bài tập: Chuỗi Collatz](./control-flow-basics/exercise.md) (15 phút)"
 
 #: src/control-flow-basics/if.md

--- a/po/vi.po
+++ b/po/vi.po
@@ -3117,43 +3117,48 @@ msgstr "[Bài tập: Chuỗi Collatz](./control-flow-basics/exercise.md) (15 ph�
 
 #: src/control-flow-basics/if.md
 msgid "`if` expressions"
-msgstr ""
+msgstr "Lệnh `if`"
 
 #: src/control-flow-basics/if.md
 msgid ""
 "You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
 "if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
+"Học viên sử dụng [lệnh `if`](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) giống hệt như lệnh `if` ở những ngôn ngữ lập "
+"trình khác"
 
 #: src/control-flow-basics/if.md
 msgid "\"zero!\""
-msgstr ""
+msgstr "\"số không\""
 
 #: src/control-flow-basics/if.md
 msgid "\"biggish\""
-msgstr ""
+msgstr "\"số lớn\""
 
 #: src/control-flow-basics/if.md
 msgid "\"huge\""
-msgstr ""
+msgstr "\"số rất hơn\""
 
 #: src/control-flow-basics/if.md
 msgid ""
 "In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
+"Ngoài ra, học viên có thể sử dụng `if` như một biểu thức. Biểu thức cuối "
+"cùng của mỗi khối lệnh sẽ trở thành giá trị của biểu thức `if` đó"
 
 #: src/control-flow-basics/if.md
 msgid "\"small\""
-msgstr ""
+msgstr "\"nhỏ\""
 
 #: src/control-flow-basics/if.md
 msgid "\"large\""
-msgstr ""
+msgstr "\"lớn\""
 
 #: src/control-flow-basics/if.md
 msgid "\"number size: {}\""
-msgstr ""
+msgstr "\"kích thước số: {}\""
 
 #: src/control-flow-basics/if.md
 msgid ""
@@ -3161,6 +3166,9 @@ msgid ""
 "branch blocks must have the same type. Show what happens if you add `;` "
 "after `\"small\"` in the second example."
 msgstr ""
+"Bởi vì `if` là một biểu thức và phải có một kiểu dữ liệu nhất định, mỗi "
+"nhánh khối lệnh phải có cùng một kiểu dữ liểu. Hãy trình bày nếu học viên "
+"thêm dấu `;` vào sau `\"nhỏ\"` ở ví dụ thứ hai"
 
 #: src/control-flow-basics/if.md
 msgid ""
@@ -3168,6 +3176,9 @@ msgid ""
 "separate it from the next statement. Remove the `;` before `println!` to see "
 "the compiler error."
 msgstr ""
+"Khi `if` được sử dụng cho một biểu thức, biểu thức đó phải có dấu `;` để "
+"tách biệt nó khỏi lệnh tiếp theo. Loại bỏ dấu `;` sau `println!` để thấy "
+"được lỗi biên dịch"
 
 #: src/control-flow-basics/loops.md
 msgid "There are three looping keywords in Rust: `while`, `loop`, and `for`:"


### PR DESCRIPTION
Doing a small translations and making sure that I am creating PRs correctly

I leave `Macros` as-is because there isn't an actual translations for `Macros` in Vietnamese. It looks like they just use `macros` directly in any vietnamese docs

see:
* https://rust-tieng-viet.github.io/basic/macro/
* https://vi.linux-console.net/?p=28497#google_vignette
