### PR TITLE
Add missing import for try-conversions.md example

### DIFF
--- a/src/error-handling/try-conversions.md
+++ b/src/error-handling/try-conversions.md
@@ -29,7 +29,7 @@ higher-level errors.
 ```rust,editable
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, Read};
 
 #[derive(Debug)]

--- a/src/error-handling/try-conversions.md
+++ b/src/error-handling/try-conversions.md
@@ -29,7 +29,7 @@ higher-level errors.
 ```rust,editable
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{self, Read};
 
 #[derive(Debug)]
@@ -65,7 +65,7 @@ fn read_username(path: &str) -> Result<String, ReadUsernameError> {
 }
 
 fn main() {
-    //fs::write("config.dat", "").unwrap();
+    //std::fs::write("config.dat", "").unwrap();
     let username = read_username("config.dat");
     println!("username or error: {username:?}");
 }


### PR DESCRIPTION
Uncommenting the "write" line causes the example to fail compilation because the compiler can't find `fs`.