### PR TITLE
zh-CN: glossary translation

### DIFF
--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -22167,24 +22167,24 @@ msgid ""
 "Rust terms. For translations, this also serves to connect the term back to "
 "the English original."
 msgstr ""
-"以下为术语表，旨在提供针对许多 Rust 术语的简要定义。此外，翻译过程中也可结合"
-"该术语定义来理解英语原文。"
+"本页面的词汇表提供了许多 Rust 术语的简要定义。同时提供翻译版本和英语原文的对"
+"应。"
 
 #: src/glossary.md
 msgid ""
 "allocate:  \n"
 "Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md)."
 msgstr ""
-"分配：\n"
-"指在 [堆](memory-management/stack-vs-heap.md) 上进行动态内存分配。"
+"分配（allocate）：  \n"
+"在 [堆](memory-management/stack-vs-heap.md) 上进行动态内存分配。"
 
 #: src/glossary.md
 msgid ""
 "argument:  \n"
 "Information that is passed into a function or method."
 msgstr ""
-"参数：\n"
-"指传入某个函数或方法中的信息。"
+"参数（argument）：  \n"
+"传入某个函数或方法中的信息。"
 
 #: src/glossary.md
 msgid ""
@@ -22192,24 +22192,24 @@ msgid ""
 "Low-level Rust development, often deployed to a system without an operating "
 "system. See [Bare-metal Rust](bare-metal.md)."
 msgstr ""
-"裸机 Rust：\n"
-"一种低级别的 Rust 开发方式，通常部署于没有操作系统的系统。请参阅 [裸机 Rust]"
-"(bare-metal.md)。"
+"裸机 Rust（Bare-metal Rust）：  \n"
+"底层 Rust 开发方式，通常部署于没有操作系统的系统。请参阅 [裸机 Rust](bare-"
+"metal.md)。"
 
 #: src/glossary.md
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
 msgstr ""
-"代码块：\n"
-"请参阅 [代码块](control-flow/blocks.md) 和 _作用域_。"
+"代码块（block）：  \n"
+"请参阅 [代码块](control-flow/blocks.md) 和 **作用域**。"
 
 #: src/glossary.md
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
 msgstr ""
-"借用：\n"
+"借用（borrow）：  \n"
 "请参阅 [借用](ownership/borrowing.md)。"
 
 #: src/glossary.md
@@ -22217,7 +22217,7 @@ msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
 msgstr ""
-"借用检查器：\n"
+"借用检查器（borrow checker）：  \n"
 "Rust 编译器的一部分，用于检查所有借用操作是否有效。"
 
 #: src/glossary.md
@@ -22225,8 +22225,8 @@ msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
 msgstr ""
-"括号：\n"
-"`{` and `}`。也称为 _大括号_，用于分隔 _代码块_。"
+"大括号（brace）：  \n"
+"`{` 和 `}`。也称为 **花括号**，用于分隔 **代码块**。"
 
 #: src/glossary.md
 msgid ""
@@ -22234,7 +22234,7 @@ msgid ""
 "The process of converting source code into executable code or a usable "
 "program."
 msgstr ""
-"build：\n"
+"构建（build）：  \n"
 " 将源代码转换为可执行代码或可用程序的过程。"
 
 #: src/glossary.md
@@ -22242,7 +22242,7 @@ msgid ""
 "call:  \n"
 "To invoke or execute a function or method."
 msgstr ""
-"调用：\n"
+"调用（call）：  \n"
 "调用或执行某个函数或方法。"
 
 #: src/glossary.md
@@ -22250,38 +22250,40 @@ msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
 msgstr ""
-"通道：\n"
+"通道（channel）：  \n"
 "用于安全地 [在线程之间](concurrency/channels.md) 传递消息。"
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
-msgstr "欢迎来到 Comprehensive Rust 🦀"
+msgstr ""
+"Comprehensive Rust 🦀：  \n"
+"本课程统称为 Comprehensive Rust 🦀。"
 
 #: src/glossary.md
 msgid ""
 "concurrency:  \n"
 "The execution of multiple tasks or processes at the same time."
 msgstr ""
-"并发：\n"
+"并发（concurrency）：  \n"
 "同时执行多个任务或进程。"
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
-msgstr "欢迎了解 Rust 中的并发"
+msgstr ""
+"Rust 中的并发（Concurrency in Rust）：  \n"
+"请参阅 [Rust 中的并发](concurrency.md)."
 
 #: src/glossary.md
 msgid ""
 "constant:  \n"
 "A value that does not change during the execution of a program."
 msgstr ""
-"常量：\n"
-"在程序执行期间不会发生的值。"
+"常量（constant）：  \n"
+"在程序执行期间不会改变的值。"
 
 #: src/glossary.md
 msgid ""
@@ -22289,7 +22291,7 @@ msgid ""
 "The order in which the individual statements or instructions are executed in "
 "a program."
 msgstr ""
-"控制流：\n"
+"控制流（control flow）：  \n"
 "程序中各个语句或指令的执行顺序。"
 
 #: src/glossary.md
@@ -22297,25 +22299,25 @@ msgid ""
 "crash:  \n"
 "An unexpected and unhandled failure or termination of a program."
 msgstr ""
-"崩溃：\n"
-"未处理的意外故障或程序终止。"
+"崩溃（crash）：  \n"
+"程序出现意外的、未处理的故障或终止。"
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "enumeration:  \n"
 "A data type that holds one of several named constants, possibly with an "
 "associated tuple or struct."
 msgstr ""
-"枚举：\n"
-"一种由命名常量值组成的数据类型。"
+"枚举（enumeration）：  \n"
+"一种用于保存多个已命名常量中的一个的数据类型，可能还有一个相关的元组或结构"
+"体。"
 
 #: src/glossary.md
 msgid ""
 "error:  \n"
 "An unexpected condition or result that deviates from the expected behavior."
 msgstr ""
-"错误：\n"
+"错误（error）：  \n"
 "与预期行为存在偏差的意外情况或结果。"
 
 #: src/glossary.md
@@ -22324,7 +22326,7 @@ msgid ""
 "The process of managing and responding to errors that occur during program "
 "execution."
 msgstr ""
-"错误处理：\n"
+"错误处理（error handling）：  \n"
 "对程序执行期间发生的错误进行管理和响应的过程。"
 
 #: src/glossary.md
@@ -22332,7 +22334,7 @@ msgid ""
 "exercise:  \n"
 "A task or problem designed to practice and test programming skills."
 msgstr ""
-"练习：\n"
+"练习（exercise）：  \n"
 "专为练习和测试编程技能而设计的任务或问题。"
 
 #: src/glossary.md
@@ -22340,7 +22342,7 @@ msgid ""
 "function:  \n"
 "A reusable block of code that performs a specific task."
 msgstr ""
-"函数：\n"
+"函数（function）：  \n"
 "用于执行特定任务且可重复使用的代码块。"
 
 #: src/glossary.md
@@ -22349,7 +22351,7 @@ msgid ""
 "A mechanism that automatically frees up memory occupied by objects that are "
 "no longer in use."
 msgstr ""
-"垃圾回收器：\n"
+"垃圾回收器（garbage collector）：  \n"
 "一种自动释放不再使用的对象所占内存的机制。"
 
 #: src/glossary.md
@@ -22358,7 +22360,7 @@ msgid ""
 "A feature that allows writing code with placeholders for types, enabling "
 "code reuse with different data types."
 msgstr ""
-"泛型：\n"
+"泛型（generics）：  \n"
 "这项功能支持使用类型占位符编写代码，支持对不同数据类型的代码进行重复使用。"
 
 #: src/glossary.md
@@ -22366,7 +22368,7 @@ msgid ""
 "immutable:  \n"
 "Unable to be changed after creation."
 msgstr ""
-"不可变：\n"
+"不可变（immutable）：  \n"
 "创建后无法再进行更改。"
 
 #: src/glossary.md
@@ -22375,8 +22377,8 @@ msgid ""
 "A type of test that verifies the interactions between different parts or "
 "components of a system."
 msgstr ""
-"集成测试：\n"
-"一种测试，用于验证系统的不同部分或组件之间是否能够交互。"
+"集成测试（integration test）：  \n"
+"一种验证系统不同部分或组件之间交互的测试类型。"
 
 #: src/glossary.md
 msgid ""
@@ -22384,7 +22386,7 @@ msgid ""
 "A reserved word in a programming language that has a specific meaning and "
 "cannot be used as an identifier."
 msgstr ""
-"关键字：\n"
+"关键字（keyword）：  \n"
 "编程语言中的保留字，具有特定含义且不能用作标识符。"
 
 #: src/glossary.md
@@ -22392,7 +22394,7 @@ msgid ""
 "library:  \n"
 "A collection of precompiled routines or code that can be used by programs."
 msgstr ""
-"库：\n"
+"库（library）：  \n"
 "程序可以使用的一组预编译例程或代码。"
 
 #: src/glossary.md
@@ -22402,7 +22404,7 @@ msgid ""
 "normal functions are not enough. A typical example is `format!`, which takes "
 "a variable number of arguments, which isn't supported by Rust functions."
 msgstr ""
-"宏：\n"
+"宏（macro）：  \n"
 "Rust 宏可通过名称中的 `!` 符号识别。当普通函数无法满足需求时，可以使用宏。一"
 "个典型示例是 `format!`，其接受可变数量的参数，但 Rust 函数不支持这种类型。"
 
@@ -22411,8 +22413,8 @@ msgid ""
 "`main` function:  \n"
 "Rust programs start executing with the `main` function."
 msgstr ""
-"`main` 函数：\n"
-"Rust 程序使用 `main` 函数开始执行操作。"
+"`main` 函数（`main` function）：  \n"
+"Rust 程序从 `main` 函数开始执行。"
 
 #: src/glossary.md
 msgid ""
@@ -22420,7 +22422,7 @@ msgid ""
 "A control flow construct in Rust that allows for pattern matching on the "
 "value of an expression."
 msgstr ""
-"匹配：\n"
+"匹配（match）：  \n"
 "Rust 中的控制流结构，允许对表达式的值进行模式匹配。"
 
 #: src/glossary.md
@@ -22429,15 +22431,15 @@ msgid ""
 "A situation where a program fails to release memory that is no longer "
 "needed, leading to a gradual increase in memory usage."
 msgstr ""
-"内存泄漏：\n"
-"指程序无法释放不再不要的内存的情况，导致内存用量不断增加。"
+"内存泄漏（memory leak）：  \n"
+"程序无法释放不再不要的内存的情况，会导致内存用量不断增加。"
 
 #: src/glossary.md
 msgid ""
 "method:  \n"
 "A function associated with an object or a type in Rust."
 msgstr ""
-"方法：\n"
+"方法（method）：  \n"
 "与 Rust 中的某个对象或类型相关联的函数。"
 
 #: src/glossary.md
@@ -22446,7 +22448,7 @@ msgid ""
 "A namespace that contains definitions, such as functions, types, or traits, "
 "to organize code in Rust."
 msgstr ""
-"模块：\n"
+"模块（module）：  \n"
 "Rust 中用于归纳整理代码的命名空间，其中包含函数、类型或特性等定义。"
 
 #: src/glossary.md
@@ -22454,7 +22456,7 @@ msgid ""
 "move:  \n"
 "The transfer of ownership of a value from one variable to another in Rust."
 msgstr ""
-"移动：\n"
+"移动（move）：  \n"
 "在 Rust 中，将值的所有权从一个变量转移到另一个变量。"
 
 #: src/glossary.md
@@ -22463,7 +22465,7 @@ msgid ""
 "A property in Rust that allows variables to be modified after they have been "
 "declared."
 msgstr ""
-"可变：\n"
+"可变（mutable）：  \n"
 "Rust 中的一个属性，支持在声明变量后对其进行修改。"
 
 #: src/glossary.md
@@ -22472,7 +22474,7 @@ msgid ""
 "The concept in Rust that defines which part of the code is responsible for "
 "managing the memory associated with a value."
 msgstr ""
-"所有权：\n"
+"所有权（ownership）：  \n"
 "Rust 中的概念，用于定义代码中的哪一部分负责管理与值关联的内存。"
 
 #: src/glossary.md
@@ -22481,7 +22483,7 @@ msgid ""
 "An unrecoverable error condition in Rust that results in the termination of "
 "the program."
 msgstr ""
-"panic：\n"
+"panic：  \n"
 "Rust 中导致程序终止且不可恢复的错误情况。"
 
 #: src/glossary.md
@@ -22489,7 +22491,7 @@ msgid ""
 "parameter:  \n"
 "A value that is passed into a function or method when it is called."
 msgstr ""
-"参数：\n"
+"参数（parameter）：  \n"
 "在调用函数或方法时传入函数或方法的值。"
 
 #: src/glossary.md
@@ -22498,7 +22500,7 @@ msgid ""
 "A combination of values, literals, or structures that can be matched against "
 "an expression in Rust."
 msgstr ""
-"模式：\n"
+"模式（pattern）：  \n"
 "Rust 中可与表达式匹配的值、字面量或结构的组合。"
 
 #: src/glossary.md
@@ -22506,7 +22508,7 @@ msgid ""
 "payload:  \n"
 "The data or information carried by a message, event, or data structure."
 msgstr ""
-"载荷：\n"
+"载荷（payload）：  \n"
 "消息、事件或数据结构所携带的数据或信息。"
 
 #: src/glossary.md
@@ -22515,7 +22517,7 @@ msgid ""
 "A set of instructions that a computer can execute to perform a specific task "
 "or solve a particular problem."
 msgstr ""
-"程序：\n"
+"程序（program）：  \n"
 "计算机为执行特定任务或解决特定问题而执行的一组指令。"
 
 #: src/glossary.md
@@ -22523,7 +22525,7 @@ msgid ""
 "programming language:  \n"
 "A formal system used to communicate instructions to a computer, such as Rust."
 msgstr ""
-"编程语言：\n"
+"编程语言（programming language）：  \n"
 "用于向计算机传递指令的正式系统，例如 Rust。"
 
 #: src/glossary.md
@@ -22532,7 +22534,7 @@ msgid ""
 "The first parameter in a Rust method that represents the instance on which "
 "the method is called."
 msgstr ""
-"接收器：\n"
+"接收器（receiver）：  \n"
 "Rust 方法中的首个参数，表示正在调用该方法的实例。"
 
 #: src/glossary.md
@@ -22541,7 +22543,7 @@ msgid ""
 "A memory management technique in which the number of references to an object "
 "is tracked, and the object is deallocated when the count reaches zero."
 msgstr ""
-"引用计数：\n"
+"引用计数（reference counting）：  \n"
 "一种内存管理方法，可以跟踪某个对象的引用数量，并在计数为零时释放该对象。"
 
 #: src/glossary.md
@@ -22549,7 +22551,7 @@ msgid ""
 "return:  \n"
 "A keyword in Rust used to indicate the value to be returned from a function."
 msgstr ""
-"返回：\n"
+"返回（return）：  \n"
 "Rust 中的一个关键字，用于表示从函数返回的值。"
 
 #: src/glossary.md
@@ -22558,31 +22560,32 @@ msgid ""
 "A systems programming language that focuses on safety, performance, and "
 "concurrency."
 msgstr ""
-"Rust：\n"
+"Rust：  \n"
 "一种系统编程语言，专注于安全性、性能和并发性。"
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 4 of this course."
 msgstr ""
-"Rust 基础知识：\n"
-" 本课程第 1 天到第 3 天的授课内容。"
+"Rust 基础（Rust Fundamentals）：  \n"
+" 本课程第 1 天到第 4 天的内容。"
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
-msgstr "欢迎来到Android 中的Rust"
+msgstr ""
+"Android 中的 Rust（Rust in Android）：  \n"
+"请参阅 [Android 中的 Rust](android.md)."
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "Rust in Chromium:  \n"
 "See [Rust in Chromium](chromium.md)."
-msgstr "欢迎来到Android 中的Rust"
+msgstr ""
+"Chromium 中的 Rust（Rust in Chromium）:  \n"
+"请参阅 [Chromium 中的 Rust](chromium.md)."
 
 #: src/glossary.md
 msgid ""
@@ -22590,7 +22593,7 @@ msgid ""
 "Refers to code that adheres to Rust's ownership and borrowing rules, "
 "preventing memory-related errors."
 msgstr ""
-"安全：\n"
+"安全（safe）：  \n"
 "指代码遵循 Rust 的所有权和借用规则，以防止出现与内存相关的错误。"
 
 #: src/glossary.md
@@ -22598,7 +22601,7 @@ msgid ""
 "scope:  \n"
 "The region of a program where a variable is valid and can be used."
 msgstr ""
-"作用域：\n"
+"作用域（scope）：  \n"
 "程序中变量有效且可使用的区域。"
 
 #: src/glossary.md
@@ -22606,7 +22609,7 @@ msgid ""
 "standard library:  \n"
 "A collection of modules providing essential functionality in Rust."
 msgstr ""
-"标准库：\n"
+"标准库（standard library）：  \n"
 "Rust 中提供基本功能的一系列模块。"
 
 #: src/glossary.md
@@ -22615,7 +22618,7 @@ msgid ""
 "A keyword in Rust used to define static variables or items with a `'static` "
 "lifetime."
 msgstr ""
-"静态：\n"
+"静态（static）：  \n"
 "Rust 中的关键字，用于定义具有 `'static` 生命周期的静态变量或项。"
 
 #: src/glossary.md
@@ -22624,7 +22627,7 @@ msgid ""
 "A data type storing textual data. See [`String` vs `str`](basic-syntax/"
 "string-slices.html) for more."
 msgstr ""
-"字符串：\n"
+"字符串（string）：  \n"
 "一种存储文本数据的数据类型。如需了解详情，请参阅 [`String` 与 `str`](basic-"
 "syntax/string-slices.html)。"
 
@@ -22634,7 +22637,7 @@ msgid ""
 "A composite data type in Rust that groups together variables of different "
 "types under a single name."
 msgstr ""
-"结构体：\n"
+"结构体（struct）：  \n"
 "Rust 中的复合数据类型，可将不同类型的变量归到同一名称下。"
 
 #: src/glossary.md
@@ -22643,7 +22646,7 @@ msgid ""
 "A Rust module containing functions that test the correctness of other "
 "functions."
 msgstr ""
-"test：\n"
+"测试（test）：  \n"
 "Rust 中的模块，其中包含用于测试其他函数是否正确的函数。"
 
 #: src/glossary.md
@@ -22651,7 +22654,7 @@ msgid ""
 "thread:  \n"
 "A separate sequence of execution in a program, allowing concurrent execution."
 msgstr ""
-"线程：\n"
+"线程（thread）：  \n"
 "程序中的单独执行顺序，支持并发执行。"
 
 #: src/glossary.md
@@ -22660,7 +22663,7 @@ msgid ""
 "The property of a program that ensures correct behavior in a multithreaded "
 "environment."
 msgstr ""
-"线程安全：\n"
+"线程安全（thread safety）：  \n"
 "一种程序属性，用于确保多线程环境中的行为正确无误。"
 
 #: src/glossary.md
@@ -22669,7 +22672,7 @@ msgid ""
 "A collection of methods defined for an unknown type, providing a way to "
 "achieve polymorphism in Rust."
 msgstr ""
-"trait：\n"
+"特征（trait）：  \n"
 "用于定义未知类型的一系列方法，为在 Rust 中实现多态性提供了方法。"
 
 #: src/glossary.md
@@ -22678,16 +22681,17 @@ msgid ""
 "An abstraction where you can require types to implement some traits of your "
 "interest."
 msgstr ""
+"特征约束（trait bound）:  \n"
+"一种可以要求类型实现一些感兴趣的特性的抽象。"
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "tuple:  \n"
 "A composite data type that contains variables of different types. Tuple "
 "fields have no names, and are accessed by their ordinal numbers."
 msgstr ""
-"结构体：\n"
-"Rust 中的复合数据类型，可将不同类型的变量归到同一名称下。"
+"元组（tuple）：  \n"
+"包含不同类型变量的复合数据类型。元组的字段没有名称，需要通过序号访问。"
 
 #: src/glossary.md
 msgid ""
@@ -22695,7 +22699,7 @@ msgid ""
 "A classification that specifies which operations can be performed on values "
 "of a particular kind in Rust."
 msgstr ""
-"类型：\n"
+"类型（type）：  \n"
 "一种分类方式，用于指定可以对 Rust 中特定类型的值执行哪些操作。"
 
 #: src/glossary.md
@@ -22704,7 +22708,7 @@ msgid ""
 "The ability of the Rust compiler to deduce the type of a variable or "
 "expression."
 msgstr ""
-"类型推理：\n"
+"类型推导（type inference）：  \n"
 "Rust 编译器能够推断变量或表达式的类型。"
 
 #: src/glossary.md
@@ -22713,7 +22717,7 @@ msgid ""
 "Actions or conditions in Rust that have no specified result, often leading "
 "to unpredictable program behavior."
 msgstr ""
-"未定义的行为：\n"
+"未定义行为（undefined behavior）：  \n"
 "Rust 中未指定结果的操作或条件，通常会导致不可预测的程序行为。"
 
 #: src/glossary.md
@@ -22721,7 +22725,7 @@ msgid ""
 "union:  \n"
 "A data type that can hold values of different types but only one at a time."
 msgstr ""
-"并集：\n"
+"联合体（union）：  \n"
 "一种数据类型，可以存储不同类型的值，但一次只能保存一个值。"
 
 #: src/glossary.md
@@ -22730,7 +22734,7 @@ msgid ""
 "Rust comes with built-in support for running small unit tests and larger "
 "integration tests. See [Unit Tests](testing/unit-tests.html)."
 msgstr ""
-"单元测试：\n"
+"单元测试（unit test）：  \n"
 "Rust 内置了运行小型单元测试和大型集成测试的支持功能。请参阅 [单元测试]"
 "(testing/unit-tests.html)。"
 
@@ -22739,6 +22743,8 @@ msgid ""
 "unit type:  \n"
 "Type that holds no data, written as a tuple with no members."
 msgstr ""
+"单元类型（unit type）:  \n"
+"不保存数据的类型，写为没有成员的元组。"
 
 #: src/glossary.md
 msgid ""
@@ -22746,17 +22752,16 @@ msgid ""
 "The subset of Rust which allows you to trigger _undefined behavior_. See "
 "[Unsafe Rust](unsafe.html)."
 msgstr ""
-"不安全：\n"
-"Rust 的子集，允许您触发 _未定义_ 的行为。请参阅 [不安全 Rust](unsafe.html)。"
+"不安全（unsafe）：  \n"
+"Rust 的子集，允许触发 **未定义行为**。请参阅 [不安全 Rust](unsafe.html)。"
 
 #: src/glossary.md
-#, fuzzy
 msgid ""
 "variable:  \n"
 "A memory location storing data. Variables are valid in a _scope_."
 msgstr ""
-"变量：\n"
-"用于存储数据的内存位置。变量在 _作用域_ 内有效。"
+"变量（variable）：  \n"
+"用于存储数据的内存位置。变量在 **作用域** 内有效。"
 
 #: src/other-resources.md
 msgid "Other Rust Resources"


### PR DESCRIPTION
The po file has been refreshed. Translation range: L22164-L22764.

https://github.com/google/comprehensive-rust/issues/324

Translations of terms refer to the Chinese version of the TRPL and https://github.com/rust-lang-cn/english-chinese-glossary-of-rust/blob/master/rust-glossary.md

Note: Since italics are not used in Chinese to indicate quotation or emphasisin Chinese, English italics have been translated into Chinese bold, and the original English text of terms is marked in full-width parentheses.