### PR TITLE
Add @HidenoriKobayashi to CODEOWNERS for Japanese translation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@ po/fa.po @DannyRavi @hamidrezakp @moaminsharifi @mehrad77 @javad-jafari
 po/fr.po @sakex @lb034582341
 po/id.po @tjonganthony @nurlitadf
 po/it.po @detro @nicomazz @bznein
-po/ja.po @keiichiw @chikoski @kantasv
+po/ja.po @keiichiw @chikoski @kantasv @HidenoriKobayashi
 po/ko.po @jiyongp @jooyunghan @namhyung
 po/pl.po @jkotur @dyeroshenko
 po/pt-BR.po @rastringer @hugojacob @henrif75 @joaovicmendes @jcvicelli @azevedoalice


### PR DESCRIPTION
@HidenoriKobayashi has been working on Japanese translation very well so it'd be nice to have him as a CODEOWNER