### PR TITLE
Add @alerque as a reviewer for the Turkish translation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ po/ko.po @jiyongp @jooyunghan @namhyung
 po/pl.po @jkotur @dyeroshenko
 po/pt-BR.po @rastringer @hugojacob @henrif75 @joaovicmendes @jcvicelli @azevedoalice
 po/ru.po @istolga @baltuky @zvonden @dyeroshenko
-po/tr.po @enes1313
+po/tr.po @alerque @enes1313
 po/uk.po @dyeroshenko
 po/vi.po @daivinhtran
 po/zh-CN.po @suetfei @wnghl @anlunx @kongy @noahdragon @superwhd @emmali01 @SketchK @candysonya @AgainstEntropy


### PR DESCRIPTION
See invitation here: https://github.com/google/comprehensive-rust/pull/1971#issuecomment-2061199545

Also note that @enes1313 is marked as a code owner, but they are *not* a collaborator on the repository so the code owner features are non-functional and this is considered an error by the GH parser. Obviously there are two possible resolutions to that...
