### PR TITLE
Slightly simplify binary tree exercise

### DIFF
--- a/src/smart-pointers/exercise.md
+++ b/src/smart-pointers/exercise.md
@@ -14,10 +14,10 @@ Implement the following types, so that the given tests pass.
 Extra Credit: implement an iterator over a binary tree that returns the values
 in order.
 
-```rust,editable
+```rust,editable,ignore
 {{#include exercise.rs:types}}
 
-// Implement `new`, `insert`, `len`, and `has`.
+// Implement `new`, `insert`, `len`, and `has` for `Subtree`.
 
 {{#include exercise.rs:tests}}
 ```

--- a/src/smart-pointers/exercise.rs
+++ b/src/smart-pointers/exercise.rs
@@ -35,7 +35,6 @@ struct Subtree<T: Ord>(Option<Box<Node<T>>>);
 pub struct BinaryTree<T: Ord> {
     root: Subtree<T>,
 }
-// ANCHOR_END: types
 
 impl<T: Ord> BinaryTree<T> {
     fn new() -> Self {
@@ -54,6 +53,7 @@ impl<T: Ord> BinaryTree<T> {
         self.root.len()
     }
 }
+// ANCHOR_END: types
 
 impl<T: Ord> Subtree<T> {
     fn new() -> Self {


### PR DESCRIPTION
Give students a little more context for the binary tree exercise by giving them the wrapper methods on `BinaryTree` at the start and explicitly asking them to implement the methods on `Subtree`. I think this simplifies the exercise a bit and makes it a bit more focused for students.