### PR TITLE
ru: translate navigation titles: days 3-4

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -509,60 +509,65 @@ msgstr "Заимствование"
 
 #: src/SUMMARY.md src/borrowing/shared.md
 msgid "Borrowing a Value"
-msgstr ""
+msgstr "Заимствование значения"
 
+# Related Rust book translation: The Borrow Checker -> Анализатор заимствований
 #: src/SUMMARY.md src/borrowing/borrowck.md
 msgid "Borrow Checking"
-msgstr ""
+msgstr "Анализатор заимствований"
 
+# Rust book translation is used
 #: src/SUMMARY.md src/borrowing/interior-mutability.md
 msgid "Interior Mutability"
-msgstr ""
+msgstr "Внутренняя изменяемость"
 
 #: src/SUMMARY.md src/borrowing/exercise.md
 msgid "Exercise: Health Statistics"
-msgstr ""
+msgstr "Упражнение: Журнал здоровья"
 
+# Alternatives:
+#   Управление временем жизни ссылок
+#   Концепция времени жизни ссылок
 #: src/SUMMARY.md src/lifetimes.md
 msgid "Lifetimes"
-msgstr ""
+msgstr "Время жизни ссылок"
 
 #: src/SUMMARY.md src/lifetimes/lifetime-annotations.md
 msgid "Lifetime Annotations"
-msgstr ""
+msgstr "Аннотации времени жизни"
 
+# Rust book translation is used (ch. 10.3)
 #: src/SUMMARY.md
 msgid "Lifetime Elision"
-msgstr ""
+msgstr "Неявное выведение времени жизни"
 
 #: src/SUMMARY.md
 msgid "Struct Lifetimes"
-msgstr ""
+msgstr "Аннотации в объявлении структур"
 
 #: src/SUMMARY.md src/lifetimes/exercise.md
 msgid "Exercise: Protobuf Parsing"
-msgstr ""
+msgstr "Упражнение: Разбор Protobuf"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Day 4: Morning"
 msgstr "День 4: Утро"
 
 #: src/SUMMARY.md src/iterators.md
 msgid "Iterators"
-msgstr ""
+msgstr "Итераторы"
 
 #: src/SUMMARY.md src/iterators/iterator.md src/bare-metal/no_std.md
 msgid "`Iterator`"
-msgstr ""
+msgstr "`Iterator`"
 
 #: src/SUMMARY.md src/iterators/intoiterator.md
 msgid "`IntoIterator`"
-msgstr ""
+msgstr "`IntoIterator`"
 
 #: src/SUMMARY.md
 msgid "`FromIterator`"
-msgstr ""
+msgstr "`FromIterator`"
 
 #: src/SUMMARY.md src/iterators/exercise.md
 msgid "Exercise: Iterator Method Chaining"
@@ -570,7 +575,7 @@ msgstr ""
 
 #: src/SUMMARY.md src/modules.md src/modules/modules.md
 msgid "Modules"
-msgstr ""
+msgstr "Модули"
 
 #: src/SUMMARY.md src/modules/filesystem.md
 msgid "Filesystem Hierarchy"
@@ -582,7 +587,7 @@ msgstr ""
 
 #: src/SUMMARY.md
 msgid "`use`, `super`, `self`"
-msgstr ""
+msgstr "`use`, `super`, `self`"
 
 #: src/SUMMARY.md src/modules/exercise.md
 msgid "Exercise: Modules for a GUI Library"
@@ -590,7 +595,7 @@ msgstr ""
 
 #: src/SUMMARY.md src/testing.md src/chromium/testing.md
 msgid "Testing"
-msgstr ""
+msgstr "Тестирование"
 
 #: src/SUMMARY.md
 msgid "Test Modules"
@@ -606,10 +611,9 @@ msgstr ""
 
 #: src/SUMMARY.md src/testing/exercise.md
 msgid "Exercise: Luhn Algorithm"
-msgstr ""
+msgstr "Упражнение: Алгоритм Лу́на"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Day 4: Afternoon"
 msgstr "День 4: После обеда"
 
@@ -619,11 +623,13 @@ msgstr ""
 
 #: src/SUMMARY.md src/error-handling/panics.md
 msgid "Panics"
-msgstr ""
+msgstr "Паники"
 
+# Shouldn't it be the error propagation operator?!
+# Rust book translation is used (ch. 9.2)
 #: src/SUMMARY.md src/error-handling/try.md
 msgid "Try Operator"
-msgstr ""
+msgstr "Проброс ошибок"
 
 #: src/SUMMARY.md src/error-handling/try-conversions.md
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -495,6 +495,7 @@ msgstr "`Rc`"
 msgid "Trait Objects"
 msgstr "Полиморфизм"
 
+# Alternative: Упражнение: Бинарное дерево
 #: src/SUMMARY.md src/smart-pointers/exercise.md
 msgid "Exercise: Binary Tree"
 msgstr "Упражнение: Двоичное дерево"
@@ -559,55 +560,66 @@ msgstr "Итераторы"
 
 #: src/SUMMARY.md src/iterators/iterator.md src/bare-metal/no_std.md
 msgid "`Iterator`"
-msgstr "`Iterator`"
+msgstr "Типаж `Iterator`"
 
 #: src/SUMMARY.md src/iterators/intoiterator.md
 msgid "`IntoIterator`"
-msgstr "`IntoIterator`"
+msgstr "Типаж `IntoIterator`"
 
 #: src/SUMMARY.md
 msgid "`FromIterator`"
-msgstr "`FromIterator`"
+msgstr "Типаж `FromIterator`"
 
 #: src/SUMMARY.md src/iterators/exercise.md
+#, fuzzy
 msgid "Exercise: Iterator Method Chaining"
-msgstr ""
+msgstr "Упражнение: Цепочка вычислений"
 
 #: src/SUMMARY.md src/modules.md src/modules/modules.md
 msgid "Modules"
 msgstr "Модули"
 
+# Rust book operates with Module Tree.
+# The corresponding translation was used (ch. 7.3).
 #: src/SUMMARY.md src/modules/filesystem.md
 msgid "Filesystem Hierarchy"
-msgstr ""
+msgstr "Дерево модулей"
 
 #: src/SUMMARY.md src/modules/visibility.md
 msgid "Visibility"
-msgstr ""
+msgstr "Область видимости"
 
 #: src/SUMMARY.md
 msgid "`use`, `super`, `self`"
-msgstr "`use`, `super`, `self`"
+msgstr "Использование `use`, `super` и `self`"
 
 #: src/SUMMARY.md src/modules/exercise.md
 msgid "Exercise: Modules for a GUI Library"
-msgstr ""
+msgstr "Упражнение: Реорганизация графической библиотеки"
 
 #: src/SUMMARY.md src/testing.md src/chromium/testing.md
 msgid "Testing"
 msgstr "Тестирование"
 
+# Alternative: Юнит-тесты
 #: src/SUMMARY.md
 msgid "Test Modules"
-msgstr ""
+msgstr "Модульные тесты"
 
+# Alternatives:
+#   Прочие тесты
+#   Прочие типы тестов
 #: src/SUMMARY.md src/testing/other.md
 msgid "Other Types of Tests"
-msgstr ""
+msgstr "Интеграционные и прочие тесты"
 
+# Alternatives:
+#   Ошибки компиляции и статические анализаторы
+#   Ошибки компиляции и статический анализ
+#   Ошибки, литер и Clippy
 #: src/SUMMARY.md src/testing/lints.md
 msgid "Compiler Lints and Clippy"
-msgstr ""
+msgstr "Ошибки компиляции и Clippy"
 
 #: src/SUMMARY.md src/testing/exercise.md
 msgid "Exercise: Luhn Algorithm"
@@ -619,7 +631,7 @@ msgstr "День 4: После обеда"
 
 #: src/SUMMARY.md src/error-handling.md
 msgid "Error Handling"
-msgstr ""
+msgstr "Обработка ошибок"
 
 #: src/SUMMARY.md src/error-handling/panics.md
 msgid "Panics"
@@ -638,48 +650,50 @@ msgstr "Неявные преобразования"
 
 #: src/SUMMARY.md
 msgid "`Error` Trait"
-msgstr ""
+msgstr "Типаж `Error`"
 
 #: src/SUMMARY.md src/error-handling/thiserror-and-anyhow.md
 msgid "`thiserror` and `anyhow`"
-msgstr ""
+msgstr "`thiserror` и `anyhow`"
 
+# Alternative: Переписать через `Result`
 #: src/SUMMARY.md
 msgid "Exercise: Rewriting with `Result`"
-msgstr ""
+msgstr "Упражнение: Замена на `Result`"
 
 #: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unsafe.md
 msgid "Unsafe Rust"
-msgstr ""
+msgstr "Небезопасный код в Rust"
 
+# Небезопасный код is better aligned with Unsafe Rust title, but возможности better describes chapter content.
 #: src/SUMMARY.md
 msgid "Unsafe"
-msgstr ""
+msgstr "Небезопасные возможности"
 
+# Rare alternative for Raw Pointers: Необработанные указатели
 #: src/SUMMARY.md src/unsafe-rust/dereferencing.md
 msgid "Dereferencing Raw Pointers"
-msgstr ""
+msgstr "Разыменование сырых указателей"
 
 #: src/SUMMARY.md src/unsafe-rust/mutable-static.md
 msgid "Mutable Static Variables"
-msgstr ""
+msgstr "Изменяемые статические переменные"
 
 #: src/SUMMARY.md src/unsafe-rust/unions.md
 msgid "Unions"
-msgstr ""
+msgstr "Объединения"
 
 #: src/SUMMARY.md src/unsafe-rust/unsafe-functions.md
-#, fuzzy
 msgid "Unsafe Functions"
-msgstr "Функции"
+msgstr "Небезопасные функции"
 
 #: src/SUMMARY.md
 msgid "Unsafe Traits"
-msgstr ""
+msgstr "Небезопасные типажи"
 
 #: src/SUMMARY.md
 msgid "Exercise: FFI Wrapper"
-msgstr ""
+msgstr "Упражнение: Обёртка интерфейса внешних функций"
 
 #: src/SUMMARY.md src/bare-metal/android.md
 msgid "Android"


### PR DESCRIPTION
* Translate new `msid`s related to navigation of days 3 and 4 sections;
* Rename to provide more context:
    * `Iterator` -> Типаж `Iterator`
    * `IntoIterator` -> Типаж `IntoIterator`
    * `FromIterator` -> Типаж `FromIterator`
* Rename: Функции -> Небезопасные функции (Unsafe Functions)
* Mention alternatives in translator's comments;
* Mark translations brought from the Rust book;

#326 