### PR TITLE
Remove horizontal scrolling in the rust code blocks

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,6 +3,7 @@ imports_granularity = "module"
 wrap_comments = true
 
 # The code blocks get a scrollbar if they are wider than this.
-max_width = 85
+max_width = 81
+
 # Allow all constructs to take up max_width columns.
 use_small_heuristics = "Max"

--- a/src/android/aidl/birthday_service/src/client.rs
+++ b/src/android/aidl/birthday_service/src/client.rs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 //! Birthday service.
-use com_example_birthdayservice::aidl::com::example::birthdayservice::BirthdayInfo::BirthdayInfo;
-use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayInfoProvider::{
-    BnBirthdayInfoProvider, IBirthdayInfoProvider,
+use com_example_birthdayservice::aidl::com::example::birthdayservice::{
+    BirthdayInfo::BirthdayInfo,
+    IBirthdayInfoProvider::{
+        BnBirthdayInfoProvider, IBirthdayInfoProvider,
+    },
+    IBirthdayService::IBirthdayService
 };
-use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;
 use com_example_birthdayservice::binder::{self, BinderFeatures, ParcelFileDescriptor};
 use std::error::Error;
 use std::fs::File;

--- a/src/android/aidl/birthday_service/src/lib.rs
+++ b/src/android/aidl/birthday_service/src/lib.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 //! Implementation of the `IBirthdayService` AIDL interface.
-use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayInfoProvider::IBirthdayInfoProvider;
-use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;
-use com_example_birthdayservice::aidl::com::example::birthdayservice::BirthdayInfo::BirthdayInfo;
+use com_example_birthdayservice::aidl::com::example::birthdayservice::{
+    IBirthdayInfoProvider::IBirthdayInfoProvider,
+    IBirthdayService::IBirthdayService,
+    BirthdayInfo::BirthdayInfo
+};
 use com_example_birthdayservice::binder::{self, ParcelFileDescriptor, SpIBinder, Strong};
 use std::fs::File;
 use std::io::Read;

--- a/src/android/aidl/birthday_service/src/server.rs
+++ b/src/android/aidl/birthday_service/src/server.rs
@@ -15,7 +15,9 @@
 // ANCHOR: main
 //! Birthday service.
 use birthdayservice::BirthdayService;
-use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;
+use com_example_birthdayservice::aidl::com::example::birthdayservice::{
+    IBirthdayService::BnBirthdayService
+};
 use com_example_birthdayservice::binder;
 
 const SERVICE_IDENTIFIER: &str = "birthdayservice";

--- a/src/android/aidl/example-service/client.md
+++ b/src/android/aidl/example-service/client.md
@@ -5,7 +5,9 @@ Finally, we can create a Rust client for our new service.
 _birthday_service/src/client.rs_:
 
 ```rust,ignore
-use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;
+use com_example_birthdayservice::aidl::com::example::birthdayservice::{
+    IBirthdayService::IBirthdayService
+};
 use com_example_birthdayservice::binder;
 
 {{#include ../birthday_service/src/client.rs:main}}

--- a/src/android/aidl/example-service/service.md
+++ b/src/android/aidl/example-service/service.md
@@ -5,7 +5,9 @@ We can now implement the AIDL service:
 _birthday_service/src/lib.rs_:
 
 ```rust,ignore
-use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;
+use com_example_birthdayservice::aidl::com::example::birthdayservice::{
+    IBirthdayService::IBirthdayService
+};
 use com_example_birthdayservice::binder;
 
 {{#include ../birthday_service/src/lib.rs:IBirthdayService}}

--- a/src/bare-metal/microcontrollers/examples/src/bin/typestate.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/typestate.rs
@@ -40,13 +40,17 @@ fn main() -> ! {
         // ...
     }
     let mut pin_output: P0_01<Output<OpenDrain>> = pin_input
-        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, Level::Low);
+        .into_open_drain_output(
+            OpenDrainConfig::Disconnect0Standard1,
+            Level::Low,
+        );
     pin_output.set_high().unwrap();
     // pin_input.is_high(); // Error, moved.
 
-    let _pin2: P0_02<Output<OpenDrain>> = gpio0
-        .p0_02
-        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, Level::Low);
+    let _pin2: P0_02<Output<OpenDrain>> = gpio0.p0_02.into_open_drain_output(
+        OpenDrainConfig::Disconnect0Standard1,
+        Level::Low,
+    );
     let _pin3: P0_03<Output<PushPull>> =
         gpio0.p0_03.into_push_pull_output(Level::Low);
 

--- a/src/borrowing/exercise.md
+++ b/src/borrowing/exercise.md
@@ -16,7 +16,10 @@ method:
 {{#include ../../third_party/rust-on-exercism/health-statistics.rs:setup}}
 
 {{#include ../../third_party/rust-on-exercism/health-statistics.rs:User_visit_doctor}}
-        todo!("Update a user's statistics based on measurements from a visit to the doctor")
+        todo!(
+            "Update a user's statistics based on measurements from a visit to \
+                the doctor"
+        )
     }
 }
 

--- a/src/error-handling/exercise.rs
+++ b/src/error-handling/exercise.rs
@@ -73,7 +73,8 @@ impl<'a> Iterator for Tokenizer<'a> {
             }
             'a'..='z' => {
                 let mut ident = String::from(c);
-                while let Some(c @ ('a'..='z' | '_' | '0'..='9')) = self.0.peek() {
+                while let Some(c @ ('a'..='z' | '_' | '0'..='9')) = self.0.peek()
+                {
                     ident.push(*c);
                     self.0.next();
                 }
@@ -160,7 +161,8 @@ impl<'a> Iterator for Tokenizer<'a> {
             }
             'a'..='z' => {
                 let mut ident = String::from(c);
-                while let Some(c @ ('a'..='z' | '_' | '0'..='9')) = self.0.peek() {
+                while let Some(c @ ('a'..='z' | '_' | '0'..='9')) = self.0.peek()
+                {
                     ident.push(*c);
                     self.0.next();
                 }

--- a/src/iterators/intoiterator.md
+++ b/src/iterators/intoiterator.md
@@ -48,7 +48,8 @@ impl Iterator for GridIter {
 }
 
 fn main() {
-    let grid = Grid { x_coords: vec![3, 5, 7, 9], y_coords: vec![10, 20, 30, 40] };
+    let grid = 
+        Grid { x_coords: vec![3, 5, 7, 9], y_coords: vec![10, 20, 30, 40] };
     for (x, y) in grid {
         println!("point = {x}, {y}");
     }

--- a/src/lifetimes/exercise.md
+++ b/src/lifetimes/exercise.md
@@ -49,7 +49,10 @@ What remains for you is to implement the `parse_field` function and the
 
 
 {{#include exercise.rs:parse_field }}
-        _ => todo!("Based on the wire type, build a Field, consuming as many bytes as necessary.")
+        _ => todo!(
+            "Based on the wire type, build a Field, consuming as many bytes as \
+             necessary."
+        )
     };
     todo!("Return the field, and any un-consumed bytes.")
 }

--- a/src/lifetimes/exercise.rs
+++ b/src/lifetimes/exercise.rs
@@ -170,7 +170,9 @@ fn parse_field(data: &[u8]) -> Result<(Field, &[u8]), Error> {
 /// the message.
 ///
 /// The entire input is consumed.
-fn parse_message<'a, T: ProtoMessage<'a>>(mut data: &'a [u8]) -> Result<T, Error> {
+fn parse_message<'a, T: ProtoMessage<'a>>(
+    mut data: &'a [u8],
+) -> Result<T, Error> {
     let mut result = T::default();
     while !data.is_empty() {
         let parsed = parse_field(data)?;

--- a/src/memory-management/exercise.rs
+++ b/src/memory-management/exercise.rs
@@ -114,8 +114,10 @@ impl PackageBuilder {
 fn main() {
     let base64 = PackageBuilder::new("base64").version("0.13").build();
     println!("base64: {base64:?}");
-    let log =
-        PackageBuilder::new("log").version("0.4").language(Language::Rust).build();
+    let log = PackageBuilder::new("log")
+        .version("0.4")
+        .language(Language::Rust)
+        .build();
     println!("log: {log:?}");
     let serde = PackageBuilder::new("serde")
         .authors(vec!["djmitche".into()])

--- a/src/memory-management/review.md
+++ b/src/memory-management/review.md
@@ -65,7 +65,8 @@ fn main() {
     // String provides no guarantees about its layout, so this could lead to
     // undefined behavior.
     unsafe {
-        let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);
+        let (capacity, ptr, len): (usize, usize, usize) = 
+            std::mem::transmute(s1);
         println!("capacity = {capacity}, ptr = {ptr:#x}, len = {len}");
     }
 }

--- a/src/testing/exercise.rs
+++ b/src/testing/exercise.rs
@@ -24,8 +24,11 @@ pub fn luhn(cc_number: &str) -> bool {
         if let Some(digit) = c.to_digit(10) {
             if double {
                 let double_digit = digit * 2;
-                sum +=
-                    if double_digit > 9 { double_digit - 9 } else { double_digit };
+                sum += if double_digit > 9 {
+                    double_digit - 9
+                } else {
+                    double_digit
+                };
             } else {
                 sum += digit;
             }
@@ -50,8 +53,11 @@ pub fn luhn(cc_number: &str) -> bool {
             digits += 1;
             if double {
                 let double_digit = digit * 2;
-                sum +=
-                    if double_digit > 9 { double_digit - 9 } else { double_digit };
+                sum += if double_digit > 9 {
+                    double_digit - 9
+                } else {
+                    double_digit
+                };
             } else {
                 sum += digit;
             }

--- a/src/unsafe-rust/exercise.rs
+++ b/src/unsafe-rust/exercise.rs
@@ -23,7 +23,8 @@ mod ffi {
     #[repr(C)]
     pub struct DIR {
         _data: [u8; 0],
-        _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+        _marker:
+            core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
     }
 
     // Layout according to the Linux man page for readdir(3), where ino_t and

--- a/src/unsafe-rust/unsafe-functions.md
+++ b/src/unsafe-rust/unsafe-functions.md
@@ -25,7 +25,9 @@ fn main() {
         println!("emoji: {}", emojis.get_unchecked(7..11));
     }
 
-    println!("char count: {}", count_chars(unsafe { emojis.get_unchecked(0..7) }));
+    println!(
+        "char count: {}", 
+        count_chars(unsafe { emojis.get_unchecked(0..7) }));
 
     // SAFETY: `abs` doesn't deal with pointers and doesn't have any safety
     // requirements.

--- a/src/user-defined-types/enums.md
+++ b/src/user-defined-types/enums.md
@@ -88,7 +88,11 @@ Rust has several optimizations it can employ to make enums take up less space.
 
   macro_rules! dbg_bits {
       ($e:expr, $bit_type:ty) => {
-          println!("- {}: {:#x}", stringify!($e), transmute::<_, $bit_type>($e));
+          println!(
+              "- {}: {:#x}", 
+              stringify!($e), 
+              transmute::<_, $bit_type>($e)
+          );
       };
   }
 

--- a/third_party/rust-on-exercism/health-statistics.rs
+++ b/third_party/rust-on-exercism/health-statistics.rs
@@ -38,9 +38,10 @@ impl User {
             visit_count: self.visit_count as u32,
             height_change: measurements.height - self.height,
             blood_pressure_change: match self.last_blood_pressure {
-                Some(lbp) => {
-                    Some((bp.0 as i32 - lbp.0 as i32, bp.1 as i32 - lbp.1 as i32))
-                }
+                Some(lbp) => Some((
+                    bp.0 as i32 - lbp.0 as i32,
+                    bp.1 as i32 - lbp.1 as i32,
+                )),
                 None => None,
             },
         };
@@ -62,14 +63,14 @@ fn main() {
 fn test_visit() {
     let mut bob = User::new(String::from("Bob"), 32, 155.2);
     assert_eq!(bob.visit_count, 0);
-    let report =
-        bob.visit_doctor(Measurements { height: 156.1, blood_pressure: (120, 80) });
+    let report = bob
+        .visit_doctor(Measurements { height: 156.1, blood_pressure: (120, 80) });
     assert_eq!(report.patient_name, "Bob");
     assert_eq!(report.visit_count, 1);
     assert_eq!(report.blood_pressure_change, None);
 
-    let report =
-        bob.visit_doctor(Measurements { height: 156.1, blood_pressure: (115, 76) });
+    let report = bob
+        .visit_doctor(Measurements { height: 156.1, blood_pressure: (115, 76) });
 
     assert_eq!(report.visit_count, 2);
     assert_eq!(report.blood_pressure_change, Some((-5, -4)));


### PR DESCRIPTION
* Reduce `max_width` for `rustfmt`: 85 -> 81 - to fit into blocks with line numbers;
* Apply `rustfmt` for code chunks with long lines;
* Reorganize long `use` statement;
* Manually wrap long strings in macros;

#2012 