### PR TITLE
Add links to the Rust advanced testing workshop

### DIFF
--- a/src/android/testing/googletest.md
+++ b/src/android/testing/googletest.md
@@ -39,6 +39,11 @@ Error: See failure output above
   [commonly used macros and types][prelude].
 
 - This just scratches the surface, there are many builtin matchers.
+  Consider going through the first chapter of
+  ["Advanced testing for Rust applications"](https://github.com/mainmatter/rust-advanced-testing-workshop),
+  a self-guided Rust course: it provides a guided introduction to the library,
+  with exercises to help you get comfortable with `googletest` macros,
+  its matchers and its overall philosophy.
 
 - A particularly nice feature is that mismatches in multi-line strings are shown
   as a diff:

--- a/src/android/testing/googletest.md
+++ b/src/android/testing/googletest.md
@@ -38,12 +38,12 @@ Error: See failure output above
 - The `use googletest::prelude::*;` line imports a number of
   [commonly used macros and types][prelude].
 
-- This just scratches the surface, there are many builtin matchers.
-  Consider going through the first chapter of
+- This just scratches the surface, there are many builtin matchers. Consider
+  going through the first chapter of
   ["Advanced testing for Rust applications"](https://github.com/mainmatter/rust-advanced-testing-workshop),
   a self-guided Rust course: it provides a guided introduction to the library,
-  with exercises to help you get comfortable with `googletest` macros,
-  its matchers and its overall philosophy.
+  with exercises to help you get comfortable with `googletest` macros, its
+  matchers and its overall philosophy.
 
 - A particularly nice feature is that mismatches in multi-line strings are shown
   as a diff:

--- a/src/other-resources.md
+++ b/src/other-resources.md
@@ -47,6 +47,9 @@ A small selection of other guides and tutorial for Rust:
   a series of small presentations covering both basic and advanced part of the
   Rust language. Other topics such as WebAssembly, and async/await are also
   covered.
+- [Testing in Rust: going beyond the basics](https://github.com/mainmatter/rust-advanced-testing-workshop):
+  a self-paced workshop that goes beyond Rust's built-in testing framework. It covers `googletest`, snapshot testing,
+  mocking as well as how to write your own custom test harness. 
 - [Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/)
   and
   [Take your first steps with Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/):

--- a/src/other-resources.md
+++ b/src/other-resources.md
@@ -47,7 +47,7 @@ A small selection of other guides and tutorial for Rust:
   a series of small presentations covering both basic and advanced part of the
   Rust language. Other topics such as WebAssembly, and async/await are also
   covered.
-- [Testing in Rust: going beyond the basics](https://github.com/mainmatter/rust-advanced-testing-workshop):
+- [Advanced testing for Rust applications](https://github.com/mainmatter/rust-advanced-testing-workshop):
   a self-paced workshop that goes beyond Rust's built-in testing framework. It covers `googletest`, snapshot testing,
   mocking as well as how to write your own custom test harness. 
 - [Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/)

--- a/src/other-resources.md
+++ b/src/other-resources.md
@@ -48,8 +48,9 @@ A small selection of other guides and tutorial for Rust:
   Rust language. Other topics such as WebAssembly, and async/await are also
   covered.
 - [Advanced testing for Rust applications](https://github.com/mainmatter/rust-advanced-testing-workshop):
-  a self-paced workshop that goes beyond Rust's built-in testing framework. It covers `googletest`, snapshot testing,
-  mocking as well as how to write your own custom test harness. 
+  a self-paced workshop that goes beyond Rust's built-in testing framework. It
+  covers `googletest`, snapshot testing, mocking as well as how to write your
+  own custom test harness.
 - [Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/)
   and
   [Take your first steps with Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/):


### PR DESCRIPTION
Following up on https://github.com/google/googletest-rust/issues/376