### PR TITLE
fix: rename scoped-threads.md in translations files

### DIFF
--- a/po/bn.po
+++ b/po/bn.po
@@ -1081,7 +1081,7 @@ msgstr "Concurrency: সকাল"
 msgid "Threads"
 msgstr "সম্পাদনার সুতো"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "স্কোপড Threads"
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr "/// Determine the length of the collatz sequence beginning at `n`.\n"
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"Length: {}\""
 
@@ -6218,7 +6218,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -17399,23 +17399,23 @@ msgid ""
 "lang.org/std/any/index.html)."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/da.po
+++ b/po/da.po
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Threads"
 msgstr "Tråde"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Tråde med virkefelt"
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"Længde: {}\""
 
@@ -5931,7 +5931,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr "\"Hello\""
 
@@ -17351,11 +17351,11 @@ msgstr ""
 "panikkens nyttelast. Dette er et godt tidspunkt til at snakke om [`Any`]"
 "(https://doc.rust-lang.org/std/any/index.html)."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Normale tråde kan ikke låne fra deres omgivelser:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -17363,7 +17363,7 @@ msgstr ""
 "Du kan dog bruge en [tråd med virkefelt (eng: _scoped thread_)](https://doc."
 "rust-lang.org/std/thread/fn.scope.html) for at opnå dette:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -17372,7 +17372,7 @@ msgstr ""
 "blevet forenet med hovedtråden når kaldet afsluttet. De vil således "
 "returnere det lånte data."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/de.po
+++ b/po/de.po
@@ -1090,7 +1090,7 @@ msgstr "Nebenläufigkeit: Morgens"
 msgid "Threads"
 msgstr "Ausführungsstrang"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Ausführungsstrang mit Sichtbarkeitsbereich"
 
@@ -3868,7 +3868,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6572,7 +6572,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -18583,12 +18583,12 @@ msgid ""
 "lang.org/std/any/index.html)."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Normale Threads können nicht von ihrer Umgebung ausleihen:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
@@ -18597,7 +18597,7 @@ msgstr ""
 "Sie können dafür jedoch einen [Scoped Thread](https://doc.rust-lang.org/std/"
 "thread/fn.scope.html) verwenden:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
@@ -18607,7 +18607,7 @@ msgstr ""
 "garantiert alle Threads verbunden sind, sodass sie geliehene Daten "
 "zurückgeben können."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "

--- a/po/el.po
+++ b/po/el.po
@@ -1094,7 +1094,7 @@ msgstr "Συγχρονισμός"
 msgid "Threads"
 msgstr "Νήματα"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Νήματα με εμβέλεια"
 
@@ -3809,7 +3809,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6524,7 +6524,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -18551,12 +18551,12 @@ msgid ""
 "lang.org/std/any/index.html)."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Τα κανονικά νήματα δεν μπορούν να δανειστούν από το περιβάλλον τους:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
@@ -18565,14 +18565,14 @@ msgstr ""
 "Ωστόσο, μπορείτε να χρησιμοποιήσετε ένα [νήμα εμβέλειας](https://doc.rust-"
 "lang.org/std/thread/fn.scope.html) για αυτό:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr "\\<λεπτομέρειες>"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "

--- a/po/es.po
+++ b/po/es.po
@@ -1042,7 +1042,7 @@ msgstr "Concurrencia: mañana"
 msgid "Threads"
 msgstr "Hilos"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Hilos con ámbito"
 
@@ -3976,7 +3976,7 @@ msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 "/// Determina la longitud de la secuencia de Collatz que empieza por `n`.\n"
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"Longitud: {}\""
 
@@ -6993,7 +6993,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr "\"Hola\""
 
@@ -21614,11 +21614,11 @@ msgstr ""
 "útil del pánico. Este es un buen momento para hablar sobre [`Any`](https://"
 "doc.rust-lang.org/std/any/index.html)."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Los hilos normales no pueden tomar nada prestado de su entorno:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -21626,7 +21626,7 @@ msgstr ""
 "Sin embargo, puedes usar un [hilo con ámbito](https://doc.rust-lang.org/std/"
 "thread/fn.scope.html) para lo siguiente:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -21634,7 +21634,7 @@ msgstr ""
 "La razón es que, cuando se completa la función `thread::scope`, se asegura "
 "que todos los hilos están unidos, por lo que pueden devolver datos prestados."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/fa.po
+++ b/po/fa.po
@@ -1076,7 +1076,7 @@ msgstr "همزمانی: صبح"
 msgid "Threads"
 msgstr "تردها"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "محدوده تردها"
 
@@ -3837,7 +3837,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6439,7 +6439,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -17816,23 +17816,23 @@ msgid ""
 "lang.org/std/any/index.html)."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/fr.po
+++ b/po/fr.po
@@ -1199,7 +1199,7 @@ msgstr "Concurrence : Matin"
 msgid "Threads"
 msgstr "Threads"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Threads délimités"
 
@@ -3702,7 +3702,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6266,7 +6266,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -18592,12 +18592,12 @@ msgstr ""
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Les threads normaux ne peuvent pas emprunter à leur environnement :"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
@@ -18606,7 +18606,7 @@ msgstr ""
 "Cependant, vous pouvez utiliser un [fil de discussion de portée](https://doc."
 "rust-lang.org/std/thread/fn.scope.html) pour cela :"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
@@ -18616,7 +18616,7 @@ msgstr ""
 "les threads sont garantis d'être joints, afin qu'ils puissent renvoyer des "
 "données empruntées."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "

--- a/po/id.po
+++ b/po/id.po
@@ -1030,7 +1030,7 @@ msgstr ""
 msgid "Threads"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr ""
 
@@ -3391,7 +3391,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -5767,7 +5767,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -16961,23 +16961,23 @@ msgid ""
 "lang.org/std/any/index.html)."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/it.po
+++ b/po/it.po
@@ -1124,7 +1124,7 @@ msgstr "Concorrenza: Mattino"
 msgid "Threads"
 msgstr "Threads"
 
-#: src/SUMMARY.md:339 src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:339 src/concurrency/threads/scoped.md:1
 msgid "Scoped Threads"
 msgstr "Thread con Scope (Scoped Threads)"
 
@@ -3902,8 +3902,8 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md:20 src/concurrency/scoped-threads.md:11
-#: src/concurrency/scoped-threads.md:30
+#: src/control-flow-basics/solution.md:20 src/concurrency/threads/scoped.md:11
+#: src/concurrency/threads/scoped.md:30
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6663,7 +6663,7 @@ msgstr ""
 #: src/std-types/string.md:8 src/std-traits/read-and-write.md:35
 #: src/memory-management/review.md:23 src/memory-management/review.md:58
 #: src/testing/unit-tests.md:32 src/testing/unit-tests.md:37
-#: src/concurrency/scoped-threads.md:9 src/concurrency/scoped-threads.md:26
+#: src/concurrency/threads/scoped.md:9 src/concurrency/threads/scoped.md:26
 msgid "\"Hello\""
 msgstr ""
 
@@ -19510,12 +19510,12 @@ msgstr ""
 "al panico carico utile. Questo è un buon momento per parlare di [`Any`]"
 "(https://doc.rust-lang.org/std/any/index.html)."
 
-#: src/concurrency/scoped-threads.md:3
+#: src/concurrency/threads/scoped.md:3
 #, fuzzy
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "I thread normali non possono prendere in prestito dal loro ambiente:"
 
-#: src/concurrency/scoped-threads.md:20
+#: src/concurrency/threads/scoped.md:20
 #, fuzzy
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
@@ -19524,7 +19524,7 @@ msgstr ""
 "Tuttavia, puoi utilizzare un [thread con ambito](https://doc.rust-lang.org/"
 "std/thread/fn.scope.html) per questo:"
 
-#: src/concurrency/scoped-threads.md:40
+#: src/concurrency/threads/scoped.md:40
 #, fuzzy
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
@@ -19534,7 +19534,7 @@ msgstr ""
 "è garantito che tutti i thread vengano uniti, in modo che possano restituire "
 "dati presi in prestito."
 
-#: src/concurrency/scoped-threads.md:42
+#: src/concurrency/threads/scoped.md:42
 #, fuzzy
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "

--- a/po/ja.po
+++ b/po/ja.po
@@ -1072,7 +1072,7 @@ msgstr "並行性： AM"
 msgid "Threads"
 msgstr "スレッド"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "スコープ付きスレッド"
 
@@ -3715,7 +3715,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -17779,11 +17779,11 @@ msgstr ""
 "てみてください。 これは[`Any`](https://doc.rust-lang.org/std/any/index.html)"
 "について話すのに良いタイミングです。"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "通常のスレッドはそれらの環境から借用することはできません:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -17791,7 +17791,7 @@ msgstr ""
 "しかし、そのために[スコープ付きスレッド](https://doc.rust-lang.org/std/"
 "thread/fn.scope.html)を使うことができます:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -17799,7 +17799,7 @@ msgstr ""
 "この理由は、関数`thread::scope`が完了するとき、全てのスレッドはjoinされること"
 "が保証されているので、スレッドが借用したデータを返すことができるためです。"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/ko.po
+++ b/po/ko.po
@@ -1205,7 +1205,7 @@ msgstr "동시성 오전"
 msgid "Threads"
 msgstr "스레드"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "범위 스레드(Scoped Threads)"
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr "/// `n`에서 시작하는 콜라츠 수열의 길이를 결정합니다.\n"
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"길이: {}\""
 
@@ -6802,7 +6802,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr "\"안녕하세요\""
 
@@ -20455,11 +20455,11 @@ msgstr ""
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "보통, 스레드는 스레드 밖에서 데이터를 빌릴 수 없습니다:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -20467,7 +20467,7 @@ msgstr ""
 "하지만, [scoped thread](https://doc.rust-lang.org/std/thread/fn.scope.html)에"
 "서는 가능합니다:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -20475,7 +20475,7 @@ msgstr ""
 "`thread::scope` 함수가 완료되면 그 안에서 생성된 모든 스레드들이 종료했음이 "
 "보장되기 때문에, 그 때 빌렸던 데이터들을 다시 반환할 수 있기 때문입니다."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/pl.po
+++ b/po/pl.po
@@ -1101,7 +1101,7 @@ msgstr "Współbieżność"
 msgid "Threads"
 msgstr "Wątki"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Wątki z zakresem"
 
@@ -3813,7 +3813,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6562,7 +6562,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -18761,12 +18761,12 @@ msgstr ""
 "do paniki ładunek. To dobry moment, aby porozmawiać o [`Dowolny`](https://"
 "doc.rust-lang.org/std/any/index.html)."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Normalne wątki nie mogą pożyczać ze swojego środowiska:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
@@ -18775,7 +18775,7 @@ msgstr ""
 "W tym celu możesz jednak użyć \\[wątku z zakresem\\] [1](https://doc.rust-"
 "lang.org/std/thread/fn.scope.html):"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
@@ -18784,7 +18784,7 @@ msgstr ""
 "Powodem tego jest to, że gdy funkcja `thread::scope` zakończy działanie, "
 "wszystkie wątki zostaną połączone, więc będą mogły zwrócić pożyczone dane."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "

--- a/po/pt-BR.po
+++ b/po/pt-BR.po
@@ -1015,7 +1015,7 @@ msgstr "Concorrência: Manhã"
 msgid "Threads"
 msgstr "Threads"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Threads com Escopo"
 
@@ -3900,7 +3900,7 @@ msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 "/// Determine o comprimento da sequência de Collatz começando em `n`.\n"
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"Comprimento: {}\""
 
@@ -6936,7 +6936,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr "\"Olá\""
 
@@ -20709,11 +20709,11 @@ msgstr ""
 "_payload_ do _panic_. Este é um bom momento para falar sobre [`Any`](https://"
 "doc.rust-lang.org/std/any/index.html)."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "_Threads_ normais não podem emprestar de seu ambiente:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -20721,7 +20721,7 @@ msgstr ""
 "No entanto, você pode usar uma [_thread_ com escopo](https://doc.rust-lang."
 "org/std/thread/fn.scope.html) para isso:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -20729,7 +20729,7 @@ msgstr ""
 "A razão para isso é que, quando a função `thread::scope` for concluída, "
 "todas as _threads_ serão unidas, para que possam retornar dados emprestados."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/ro.po
+++ b/po/ro.po
@@ -1114,7 +1114,7 @@ msgstr "Concurență: Dimineața"
 msgid "Threads"
 msgstr "Conversatii"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 #, fuzzy
 msgid "Scoped Threads"
 msgstr "Filete de acoperire"
@@ -3957,7 +3957,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6872,7 +6872,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -20861,12 +20861,12 @@ msgstr ""
 "acces la sarcina utilă de panică. Acesta este un moment bun pentru a vorbi "
 "despre [`Any`](https://doc.rust-lang.org/std/any/index.html)."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Firele normale nu pot împrumuta din mediul lor:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
@@ -20875,7 +20875,7 @@ msgstr ""
 "Cu toate acestea, puteți utiliza un [scoped thread](https://doc.rust-lang."
 "org/std/thread/fn.scope.html) pentru acest lucru:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
@@ -20884,7 +20884,7 @@ msgstr ""
 "Motivul este că, atunci când funcția `thread::scope` se finalizează, toate "
 "firele sunt garantate a fi unite, astfel încât pot returna date împrumutate."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "

--- a/po/ru.po
+++ b/po/ru.po
@@ -1160,7 +1160,7 @@ msgstr "Concurrency: Утро"
 msgid "Threads"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr ""
 
@@ -3773,7 +3773,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6341,7 +6341,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -17556,23 +17556,23 @@ msgstr ""
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/tr.po
+++ b/po/tr.po
@@ -1099,7 +1099,7 @@ msgstr "Eşzamanlılık: Sabah"
 msgid "Threads"
 msgstr "İş Parçacıkları (Threads)"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Kapsamlı İş Parçacıkları (Threads)"
 
@@ -3892,7 +3892,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr "/// `n`'den başlayan collatz sekansının uzunluğunu belirle.\n"
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"Length: {}\""
 
@@ -6305,7 +6305,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr "\"Merhaba\""
 
@@ -17377,23 +17377,23 @@ msgstr ""
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/uk.po
+++ b/po/uk.po
@@ -1013,7 +1013,7 @@ msgstr "Паралелізм: Ранок"
 msgid "Threads"
 msgstr "Потоки"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "Потоки з областю видимості"
 
@@ -3882,7 +3882,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr "/// Визначте довжину послідовності колатів, яка починається з `n`.\n"
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"Довжина: {}\""
 
@@ -6735,7 +6735,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr "\"Привіт\""
 
@@ -20325,11 +20325,11 @@ msgstr ""
 "отримати доступ до корисного навантаження паніки. Це гарний час, щоб "
 "поговорити про [`Any`](https://doc.rust-lang.org/std/any/index.html)."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "Звичайні потоки не можуть запозичувати зі свого середовища:"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -20337,7 +20337,7 @@ msgstr ""
 "Однак для цього можна використовувати [область](https://doc.rust-lang.org/"
 "std/thread/fn.scope.html):"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -20346,7 +20346,7 @@ msgstr ""
 "усі потоки гарантовано об’єднуються, тому вони можуть повертати запозичені "
 "дані."
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/vi.po
+++ b/po/vi.po
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Threads"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr ""
 
@@ -3629,7 +3629,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6044,7 +6044,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -17100,23 +17100,23 @@ msgstr ""
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -1021,7 +1021,7 @@ msgstr "并发：上午"
 msgid "Threads"
 msgstr "线程"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr "范围线程"
 
@@ -3732,7 +3732,7 @@ msgstr "编写一个函数，用于计算给定初始 `n` 的考拉兹序列的�
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr "/// Determine the length of the collatz sequence beginning at `n`.\n"
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr "\"Length: {}\""
 
@@ -6356,7 +6356,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 #, fuzzy
 msgid "\"Hello\""
 msgstr "\"Hello\""
@@ -20348,11 +20348,11 @@ msgstr ""
 "使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报 载荷的访问权限。现在"
 "有必要介绍一下 [`Any`](https://doc.rust-lang.org/std/any/index.html) 了。"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "常规线程不能从它们所处的环境中借用："
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -20360,7 +20360,7 @@ msgstr ""
 "不过，你可以使用[范围线程](https://doc.rust-lang.org/std/thread/fn.scope."
 "html)来实现此目的："
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -20368,7 +20368,7 @@ msgstr ""
 "其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使得"
 "线程能够返回借用的数据。"
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -833,7 +833,7 @@ msgstr "並行：上午"
 msgid "Threads"
 msgstr "執行緒"
 
-#: src/SUMMARY.md:261 src/concurrency/scoped-threads.md:1
+#: src/SUMMARY.md:261 src/concurrency/threads/scoped.md:1
 msgid "Scoped Threads"
 msgstr "限定範圍執行緒"
 
@@ -17054,11 +17054,11 @@ msgstr ""
 "使用 `handle.join()` 的 `Result` 傳回值，取得恐慌酬載的 存取權。這個階段是提"
 "起 [`Any`](https://doc.rust-lang.org/std/any/index.html) 的好時機。"
 
-#: src/concurrency/scoped-threads.md:3
+#: src/concurrency/threads/scoped.md:3
 msgid "Normal threads cannot borrow from their environment:"
 msgstr "一般執行緒無法借用環境的資源："
 
-#: src/concurrency/scoped-threads.md:5
+#: src/concurrency/threads/scoped.md:5
 msgid ""
 "```rust,editable,compile_fail\n"
 "use std::thread;\n"
@@ -17084,7 +17084,7 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/concurrency/scoped-threads.md:17
+#: src/concurrency/threads/scoped.md:17
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
@@ -17092,7 +17092,7 @@ msgstr ""
 "但是，你可以使用[限定範圍執行緒](https://doc.rust-lang.org/std/thread/fn."
 "scope.html)執行這項功能："
 
-#: src/concurrency/scoped-threads.md:19
+#: src/concurrency/threads/scoped.md:19
 msgid ""
 "```rust,editable\n"
 "use std::thread;\n"
@@ -17122,7 +17122,7 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/concurrency/scoped-threads.md:37
+#: src/concurrency/threads/scoped.md:37
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
@@ -17130,7 +17130,7 @@ msgstr ""
 "原因在於 `thread::scope` 函式完成時，能保證所有執行緒都已加入，因此能夠傳回借"
 "用的資料。"
 
-#: src/concurrency/scoped-threads.md:38
+#: src/concurrency/threads/scoped.md:38
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."


### PR DESCRIPTION
After merging #2007, the file `src/concurrency/scoped-threads.md` was renamed into `src/concurrency/threads/scoped.md`, but the changes were not reflected in all translations files.

There are others file affected by #2007. I will create a dedicated PR for each of these files to make the review process easier.