### PR TITLE
Translate the std library summary, option, and result types into Vietnamese

### DIFF
--- a/po/vi.po
+++ b/po/vi.po
@@ -5793,45 +5793,47 @@ msgstr ""
 
 #: src/std-types.md
 msgid "[Standard Library](./std-types/std.md) (3 minutes)"
-msgstr ""
+msgstr "[Thư viện chuẩn](./std-types/std.md) (3 phút)"
 
 #: src/std-types.md
 msgid "[Documentation](./std-types/docs.md) (5 minutes)"
-msgstr ""
+msgstr "[Tài liệu](./std-types/docs.md) (5 phút)"
 
 #: src/std-types.md
 msgid "[Option](./std-types/option.md) (10 minutes)"
-msgstr ""
+msgstr "[Option](./std-types/option.md) (10 phút)"
 
 #: src/std-types.md
 msgid "[Result](./std-types/result.md) (10 minutes)"
-msgstr ""
+msgstr "[Result](./std-types/result.md) (10 phút)"
 
 #: src/std-types.md
 msgid "[String](./std-types/string.md) (10 minutes)"
-msgstr ""
+msgstr "[String](./std-types/string.md) (10 phút)"
 
 #: src/std-types.md
 msgid "[Vec](./std-types/vec.md) (10 minutes)"
-msgstr ""
+msgstr "[Vec](./std-types/vec.md) (10 phút)"
 
 #: src/std-types.md
 msgid "[HashMap](./std-types/hashmap.md) (10 minutes)"
-msgstr ""
+msgstr "[HashMap](./std-types/hashmap.md) (10 phút)"
 
 #: src/std-types.md
 msgid "[Exercise: Counter](./std-types/exercise.md) (20 minutes)"
-msgstr ""
+msgstr "[Thực hành: Đếm số](./std-types/exercise.md) (20 phút)"
 
 #: src/std-types.md
 msgid "This segment should take about 1 hour and 20 minutes"
-msgstr ""
+msgstr "Phần này sẽ mất khoảng 1 giờ và 20 phút"
 
 #: src/std-types.md
 msgid ""
 "For each of the slides in this section, spend some time reviewing the "
 "documentation pages, highlighting some of the more common methods."
 msgstr ""
+"Hãy dành thời gian xem lại tài liệu cho từng trang trong phần này, đặc biệt "
+"là những hàm phổ biến."
 
 #: src/std-types/std.md
 msgid ""
@@ -5839,45 +5841,59 @@ msgid ""
 "types used by Rust libraries and programs. This way, two libraries can work "
 "together smoothly because they both use the same `String` type."
 msgstr ""
+"Đi kèm với Rust là một thư viện chuẩn tổng hợp các kiểu dữ liệu thông dụng."
+"Nhờ đó, hai thư viện có thể hoạt động cùng nhau một cách mượt mà vì cả hai "
+"đều sử dụng cùng một kiểu `String` của thư viện chuẩn."
 
 #: src/std-types/std.md
 msgid ""
 "In fact, Rust contains several layers of the Standard Library: `core`, "
 "`alloc` and `std`."
 msgstr ""
+"Trong thực tế, thư viện chuẩn của Rust chứa nhiều tầng riêng biệt: `core`, "
+"`alloc` và `std`."
 
 #: src/std-types/std.md
 msgid ""
 "`core` includes the most basic types and functions that don't depend on "
 "`libc`, allocator or even the presence of an operating system."
 msgstr ""
+"`core` bao gồm các kiểu dữ liệu và hàm cơ bản nhất không phụ thuộc vào "
+"`libc`, bộ cấp phát bộ nhớ hoặc thậm chí là hệ điều hành."
 
 #: src/std-types/std.md
 msgid ""
 "`alloc` includes types which require a global heap allocator, such as `Vec`, "
 "`Box` and `Arc`."
 msgstr ""
+"`alloc` bao gồm các kiểu dữ liệu yêu cầu phải được cấp phát trên bộ nhớ "
+"heap, như `Vec`, `Box` và `Arc`."
 
 #: src/std-types/std.md
 msgid ""
 "Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
+"Phần mềm nhúng viết bằng Rust thường chỉ sử dụng `core`, và đôi khi `alloc`."
 
 #: src/std-types/docs.md
 msgid "Rust comes with extensive documentation. For example:"
-msgstr ""
+msgstr "Rust đi kèm với một bộ tài liệu rất chi tiết. Ví dụ:"
 
 #: src/std-types/docs.md
 msgid ""
 "All of the details about [loops](https://doc.rust-lang.org/stable/reference/"
 "expressions/loop-expr.html)."
 msgstr ""
+"Tất cả chi tiết về [vòng lặp](https://doc.rust-lang.org/stable/reference/"
+"expressions/loop-expr.html)."
 
 #: src/std-types/docs.md
 msgid ""
 "Primitive types like [`u8`](https://doc.rust-lang.org/stable/std/primitive."
 "u8.html)."
 msgstr ""
+"Các kiểu dữ liệu cơ bản như [`u8`](https://doc.rust-lang.org/stable/std/"
+"primitive.u8.html)."
 
 #: src/std-types/docs.md
 msgid ""
@@ -5885,10 +5901,13 @@ msgid ""
 "option/enum.Option.html) or [`BinaryHeap`](https://doc.rust-lang.org/stable/"
 "std/collections/struct.BinaryHeap.html)."
 msgstr ""
+"Các kiểu dữ liệu thuộc về thư viện chuẩn như [`Option`](https://doc.rust-"
+"lang.org/stable/std/option/enum.Option.html) hoặc [`BinaryHeap`](https://doc."
+"rust-lang.org/stable/std/collections/struct.BinaryHeap.html)."
 
 #: src/std-types/docs.md
 msgid "In fact, you can document your own code:"
-msgstr ""
+msgstr "Ngoài ra, bạn cũng có thể tự viết tài liệu cho code của bản thân:"
 
 #: src/std-types/docs.md
 msgid ""
@@ -5897,6 +5916,9 @@ msgid ""
 "///\n"
 "/// If the second argument is zero, the result is false.\n"
 msgstr ""
+"/// Xác định xem tham số thứ nhất có chia hết cho tham số thứ hai không.\n"
+"///\n"
+"/// Nếu tham số thứ hai bằng không, trả về kết quả là sai.\n"
 
 #: src/std-types/docs.md
 msgid ""
@@ -5905,28 +5927,40 @@ msgid ""
 "(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
+"Nội dung tài liệu sẽ được xử lý bằng Markdown. Tất cả các thư viện Rust đã "
+"được publish đều sẽ tự động được công cụ [rustdoc](https://doc.rust-lang.org/"
+"rustdoc/what-is-rustdoc.html) viết tài liệu, và được lưu trữ tại [`docs.rs`]"
+"(https://docs.rs). Tất cả thành phần công khai trong một API nên được viết "
+"tài liệu theo phương pháp này."
 
 #: src/std-types/docs.md
 msgid ""
 "To document an item from inside the item (such as inside a module), use `//!"
 "` or `/*! .. */`, called \"inner doc comments\":"
 msgstr ""
+"Để viết tài liệu cho một thành phần từ bên trong thành phần đó (như bên "
+"trong một module), hãy sử dụng `//!` hoặc `/*! .. */`. Cú pháp trên thường "
+"được gọi là \"inner doc comments\":"
 
 #: src/std-types/docs.md
 msgid ""
 "//! This module contains functionality relating to divisibility of "
 "integers.\n"
 msgstr ""
+"//! Module này chứa các chức năng liên quan đến việc kiểm tra quan hệ chia "
+"hết của các số nguyên.\n"
 
 #: src/std-types/docs.md
 msgid ""
 "Show students the generated docs for the `rand` crate at <https://docs.rs/"
 "rand>."
 msgstr ""
+"Cho học sinh xem tài liệu được viết cho thư viện `rand` tại <https://docs.rs/"
+"rand>."
 
 #: src/std-types/option.md
 msgid "Option"
-msgstr ""
+msgstr "Option"
 
 #: src/std-types/option.md
 msgid ""
@@ -5934,58 +5968,71 @@ msgid ""
 "type `T` or nothing. For example, [`String::find`](https://doc.rust-lang.org/"
 "stable/std/string/struct.String.html#method.find) returns an `Option<usize>`."
 msgstr ""
+"Chúng ta đã thấy một số cách dùng `Option<T>`. Kiểu dữ liệu này hoặc lưu trữ "
+"một giá trị kiểu `T` hoặc không lưu trữ gì cả. Ví dụ, hàm [`String::find`]"
+"(https://doc.rust-lang.org/stable/std/string/struct.String.html#method.find) "
+"trả về một `Option<usize>`."
 
 #: src/std-types/option.md
 msgid "\"Löwe 老虎 Léopard Gepardi\""
-msgstr ""
+msgstr "Hoàng Hữu Văn A"
 
 #: src/std-types/option.md
 msgid "'é'"
-msgstr ""
+msgstr "ă"
 
 #: src/std-types/option.md
 msgid "\"find returned {position:?}\""
-msgstr ""
+msgstr "\"find trả về {position:?}\""
 
 #: src/std-types/option.md
 msgid "'Z'"
-msgstr ""
+msgstr "'Z'"
 
 #: src/std-types/option.md
 msgid "\"Character not found\""
-msgstr ""
+msgstr "\"Không tìm thấy ký tự\""
 
 #: src/std-types/option.md
 msgid "`Option` is widely used, not just in the standard library."
 msgstr ""
+"`Option` được sử dụng rộng rãi ở nhiều nơi, không chỉ trong thư viện chuẩn."
 
 #: src/std-types/option.md
 msgid ""
 "`unwrap` will return the value in an `Option`, or panic. `expect` is similar "
 "but takes an error message."
 msgstr ""
+"`unwrap` sẽ trả về giá trị của `Option` hoặc panic. `expect` hoạt động tương "
+"tự nhưng có thể truyền thêm một thông báo lỗi."
 
 #: src/std-types/option.md
 msgid ""
 "You can panic on None, but you can't \"accidentally\" forget to check for "
 "None."
 msgstr ""
+"Chương trình có thể panic khi gặp phải giá trị `None`, nhưng bạn không thể "
+"\"vô tình\" quên kiểm tra `None`."
 
 #: src/std-types/option.md
 msgid ""
 "It's common to `unwrap`/`expect` all over the place when hacking something "
 "together, but production code typically handles `None` in a nicer fashion."
 msgstr ""
+"Thông thường, ta có thể thoải mái sử dụng `unwrap`/`expect` khi thử nghiệm "
+"một ý tưởng mới, nhưng code production thường xử lý `None` một cách an toàn "
+"hơn."
 
 #: src/std-types/option.md
 msgid ""
 "The niche optimization means that `Option<T>` often has the same size in "
 "memory as `T`."
 msgstr ""
+"`Option<T>` được tối ưu để chiếm bằng bộ nhớ như `T`trong đa số trường hợp."
 
 #: src/std-types/result.md
 msgid "Result"
-msgstr ""
+msgstr "Result"
 
 #: src/std-types/result.md
 msgid ""
@@ -5994,22 +6041,28 @@ msgid ""
 "in the expression exercise, but generic: `Result<T, E>` where `T` is used in "
 "the `Ok` variant and `E` appears in the `Err` variant."
 msgstr ""
+"`Result` hoạt động tương tự như `Option`, nhưng được sử dụng để biểu diễn "
+"kết quả thành công hoặc thất bại của một tác vụ. Tương tự như `Res` trong "
+"phần thực hành về biểu thức, `Result` cũng có hai biến thể khác nhau cho mỗi "
+"trường hợp thành công và thất bại, nhưng được tổng quát hóa: `Result<T, E>` "
+"trong đó `T` được sử dụng trong trường hợp `Ok` và `E` xuất hiện trong "
+"trường hợp `Err`."
 
 #: src/std-types/result.md
 msgid "\"diary.txt\""
-msgstr ""
+msgstr "\"nhat_ky.txt\""
 
 #: src/std-types/result.md
 msgid "\"Dear diary: {contents} ({bytes} bytes)\""
-msgstr ""
+msgstr "\"Hôm nay, tôi đã: {contents} ({bytes} bytes)\""
 
 #: src/std-types/result.md
 msgid "\"Could not read file content\""
-msgstr ""
+msgstr "\"Không thể đọc nội dung tập tin\""
 
 #: src/std-types/result.md
 msgid "\"The diary could not be opened: {err}\""
-msgstr ""
+msgstr "\"Không thể mở nhật ký: {err}\""
 
 #: src/std-types/result.md
 msgid ""
@@ -6018,6 +6071,11 @@ msgid ""
 "case where an error should never happen, `unwrap()` or `expect()` can be "
 "called, and this is a signal of the developer intent too."
 msgstr ""
+"Tương tự với `Option`, giá trị trả về trong trường hợp thành công được đặt "
+"bên trong `Result`, buộc người dùng phải trích xuất giá trị một cách rõ "
+"ràng, đảm bảo mọi lỗi đều được kiểm tra. Trong trường hợp mà lỗi chắc chắn "
+"không thể xảy ra, `unwrap()` hoặc `expect()` có thể được gọi, bày tỏ rõ ràng "
+"ý định của người viết là lỗi không thể xảy ra."
 
 #: src/std-types/result.md
 msgid ""
@@ -6025,12 +6083,17 @@ msgid ""
 "is worth mentioning. It contains a lot of convenience methods and functions "
 "that help functional-style programming."
 msgstr ""
+"Khuyến khích học viên đọc tài liệu về `Result`. Không nhất thiết phải đọc "
+"trong khóa học, nhưng đáng đề cập đến. Tài liệu này chứa nhiều hàm khá tiện "
+"lợi, hỗ trợ việc lập trình theo functional-style programming."
 
 #: src/std-types/result.md
 msgid ""
 "`Result` is the standard type to implement error handling as we will see on "
 "Day 4."
 msgstr ""
+"`Result` là kiểu dữ liệu chuẩn để xử lý lỗi như chúng ta sẽ thấy trong ngày "
+"4."
 
 #: src/std-types/string.md
 msgid "String"


### PR DESCRIPTION
I retained the original names of all standard types because I believed it didn't make sense to translate them.