### PR TITLE
vi: fix renamed file scoped_threads.md

### DIFF
--- a/po/vi.po
+++ b/po/vi.po
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Threads"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr ""
 
@@ -3629,7 +3629,7 @@ msgstr ""
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -6044,7 +6044,7 @@ msgstr ""
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
@@ -17100,23 +17100,23 @@ msgstr ""
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."


### PR DESCRIPTION
After merging https://github.com/google/comprehensive-rust/pull/2007, the file src/concurrency/scoped-threads.md was renamed into src/concurrency/threads/scoped.md, but the changes were not reflected in all translations files.

There are others file affected by https://github.com/google/comprehensive-rust/pull/2007. I will create a dedicated PR for each of these files to make the review process easier.