### PR TITLE
Clarify `String` definition

### DIFF
--- a/src/references/strings.md
+++ b/src/references/strings.md
@@ -11,7 +11,7 @@ Including `&str` as a way of representing a slice of valid utf-8
 We can now understand the two string types in Rust:
 
 - `&str` is a slice of UTF-8 encoded bytes, similar to `&[u8]`.
-- `String` has ownership over its heap-allocated buffer of UTF-8 encoded bytes.
+- `String` is an owned buffer of UTF-8 encoded bytes, similar to `Vec<T>`.
 
 <!-- Avoid using fixed integers when slicing since this breaks
 translations. Using the length of s1 and s2 is safe. -->

--- a/src/references/strings.md
+++ b/src/references/strings.md
@@ -11,7 +11,7 @@ Including `&str` as a way of representing a slice of valid utf-8
 We can now understand the two string types in Rust:
 
 - `&str` is a slice of UTF-8 encoded bytes, similar to `&[u8]`.
-- `String` is an owned, heap-allocated buffer of UTF-8 bytes.
+- `String` has ownership over its heap-allocated buffer of UTF-8 encoded bytes.
 
 <!-- Avoid using fixed integers when slicing since this breaks
 translations. Using the length of s1 and s2 is safe. -->

--- a/src/std-types/string.md
+++ b/src/std-types/string.md
@@ -4,7 +4,8 @@ minutes: 10
 
 # String
 
-[`String`][1] represents a widely used heap-allocated growable UTF-8 encoded string buffer:
+[`String`][1] represents a widely used heap-allocated growable UTF-8 encoded
+string buffer:
 
 ```rust,editable
 fn main() {

--- a/src/std-types/string.md
+++ b/src/std-types/string.md
@@ -4,7 +4,7 @@ minutes: 10
 
 # String
 
-[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:
+[`String`][1] represents a widely used heap-allocated growable UTF-8 encoded string buffer:
 
 ```rust,editable
 fn main() {

--- a/src/std-types/string.md
+++ b/src/std-types/string.md
@@ -4,8 +4,7 @@ minutes: 10
 
 # String
 
-[`String`][1] represents a widely used heap-allocated growable UTF-8 encoded
-string buffer:
+[`String`][1] is a growable UTF-8 encoded string:
 
 ```rust,editable
 fn main() {


### PR DESCRIPTION
Changed string definitions in string.md and strings.md files according to discussion #2028 