### PR TITLE
vi: Refresh Vietnamese translation 

### DIFF
--- a/po/vi.po
+++ b/po/vi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2024-03-21T17:33:28-04:00\n"
+"POT-Creation-Date: 2024-05-09T07:49:43+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Vinh Tran <vinhdaitran@google.com>\n"
 "Language-Team: \n"
@@ -12,1240 +12,1376 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: src/SUMMARY.md src/index.md
+#: src/SUMMARY.md:3 src/index.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Chào mừng bạn đến với Comprehensive Rust"
 
-#: src/SUMMARY.md src/running-the-course.md
+#: src/SUMMARY.md:5 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Hướng Dẫn Khóa Học"
 
-#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/SUMMARY.md:6 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Cấu Trúc Khóa Học"
 
-#: src/SUMMARY.md src/running-the-course/keyboard-shortcuts.md
+#: src/SUMMARY.md:7 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Phím Tắt"
 
-#: src/SUMMARY.md src/running-the-course/translations.md
+#: src/SUMMARY.md:8 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Bản Dịch"
 
-#: src/SUMMARY.md src/cargo.md
+#: src/SUMMARY.md:9 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Sử Dụng Cargo"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:10
 msgid "Rust Ecosystem"
 msgstr "Hệ Sinh Thái Rust"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:11
 msgid "Code Samples"
 msgstr "Code Mẫu"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:12
 msgid "Running Cargo Locally"
 msgstr "Chạy Cargo Trong Máy Của Bạn"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:16
 msgid "Day 1: Morning"
 msgstr "Ngày 1: Buổi Sáng"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:18 src/SUMMARY.md:47 src/SUMMARY.md:76 src/SUMMARY.md:96
+#: src/SUMMARY.md:130 src/SUMMARY.md:150 src/SUMMARY.md:169 src/SUMMARY.md:192
+#: src/SUMMARY.md:215 src/SUMMARY.md:264 src/SUMMARY.md:306 src/SUMMARY.md:357
+#: src/SUMMARY.md:381 src/running-the-course/course-structure.md:15
+#: src/running-the-course/course-structure.md:34
+#: src/running-the-course/course-structure.md:52
+#: src/running-the-course/course-structure.md:69 src/welcome-day-1.md:18
+#: src/welcome-day-2.md:18 src/welcome-day-3.md:15 src/welcome-day-4.md:17
+#: src/concurrency/welcome-async.md:1
 msgid "Welcome"
 msgstr "Lời Chào Mừng"
 
-#: src/SUMMARY.md src/hello-world.md src/types-and-values/hello-world.md
+#: src/SUMMARY.md:19 src/SUMMARY.md:24
+#: src/running-the-course/course-structure.md:16 src/welcome-day-1.md:19
+#: src/hello-world.md:1 src/types-and-values.md:7
+#: src/types-and-values/hello-world.md:1
 msgid "Hello, World"
 msgstr ""
 
-#: src/SUMMARY.md src/hello-world/what-is-rust.md
+#: src/SUMMARY.md:20 src/hello-world.md:7 src/hello-world/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Rust là gì?"
 
-#: src/SUMMARY.md src/hello-world/benefits.md
+#: src/SUMMARY.md:21 src/hello-world.md:8 src/hello-world/benefits.md:1
 msgid "Benefits of Rust"
 msgstr ""
 
-#: src/SUMMARY.md src/hello-world/playground.md
+#: src/SUMMARY.md:22 src/hello-world.md:9 src/hello-world/playground.md:1
 msgid "Playground"
 msgstr "Sân chơi (*Playground*)"
 
-#: src/SUMMARY.md src/types-and-values.md
+#: src/SUMMARY.md:23 src/running-the-course/course-structure.md:17
+#: src/welcome-day-1.md:20 src/types-and-values.md:1
 msgid "Types and Values"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/variables.md
+#: src/SUMMARY.md:25 src/types-and-values.md:8
+#: src/types-and-values/variables.md:1
 msgid "Variables"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/values.md
+#: src/SUMMARY.md:26 src/types-and-values.md:9 src/types-and-values/values.md:1
 msgid "Values"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/arithmetic.md
+#: src/SUMMARY.md:27 src/types-and-values.md:10
+#: src/types-and-values/arithmetic.md:1
 msgid "Arithmetic"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/inference.md
+#: src/SUMMARY.md:28 src/types-and-values.md:11
+#: src/types-and-values/inference.md:1
 msgid "Type Inference"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/exercise.md
+#: src/SUMMARY.md:29 src/types-and-values.md:12
+#: src/types-and-values/exercise.md:1
 msgid "Exercise: Fibonacci"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/solution.md
-#: src/control-flow-basics/solution.md src/tuples-and-arrays/solution.md
-#: src/references/solution.md src/user-defined-types/solution.md
-#: src/pattern-matching/solution.md src/methods-and-traits/solution.md
-#: src/generics/solution.md src/std-types/solution.md
-#: src/std-traits/solution.md src/memory-management/solution.md
-#: src/smart-pointers/solution.md src/borrowing/solution.md
-#: src/lifetimes/solution.md src/iterators/solution.md src/modules/solution.md
-#: src/testing/solution.md src/error-handling/solution.md
-#: src/unsafe-rust/solution.md
+#: src/SUMMARY.md:30 src/SUMMARY.md:43 src/SUMMARY.md:54 src/SUMMARY.md:61
+#: src/SUMMARY.md:70 src/SUMMARY.md:83 src/SUMMARY.md:92 src/SUMMARY.md:104
+#: src/SUMMARY.md:114 src/SUMMARY.md:124 src/SUMMARY.md:140 src/SUMMARY.md:146
+#: src/SUMMARY.md:157 src/SUMMARY.md:163 src/SUMMARY.md:175 src/SUMMARY.md:182
+#: src/SUMMARY.md:188 src/SUMMARY.md:200 src/SUMMARY.md:209
+#: src/types-and-values/solution.md:1 src/control-flow-basics/solution.md:1
+#: src/tuples-and-arrays/solution.md:1 src/references/solution.md:1
+#: src/user-defined-types/solution.md:1 src/pattern-matching/solution.md:1
+#: src/methods-and-traits/solution.md:1 src/generics/solution.md:1
+#: src/std-types/solution.md:1 src/std-traits/solution.md:1
+#: src/memory-management/solution.md:1 src/smart-pointers/solution.md:1
+#: src/borrowing/solution.md:1 src/lifetimes/solution.md:1
+#: src/iterators/solution.md:1 src/modules/solution.md:1
+#: src/testing/solution.md:1 src/error-handling/solution.md:1
+#: src/unsafe-rust/solution.md:1
 msgid "Solution"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics.md
+#: src/SUMMARY.md:31 src/running-the-course/course-structure.md:18
+#: src/welcome-day-1.md:21 src/control-flow-basics.md:1
 msgid "Control Flow Basics"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:32
 msgid "`if` Expressions"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/loops.md
+#: src/SUMMARY.md:33 src/control-flow-basics.md:8
+#: src/control-flow-basics/loops.md:1
 msgid "Loops"
 msgstr "Vòng lặp"
 
-#: src/SUMMARY.md src/control-flow-basics/loops/for.md
+#: src/SUMMARY.md:34 src/control-flow-basics/loops/for.md:1
 msgid "`for`"
 msgstr "`for`"
 
-#: src/SUMMARY.md src/control-flow-basics/loops/loop.md
+#: src/SUMMARY.md:35 src/control-flow-basics/loops/loop.md:1
 msgid "`loop`"
 msgstr "`loop`"
 
-#: src/SUMMARY.md src/control-flow-basics/break-continue.md
+#: src/SUMMARY.md:36 src/control-flow-basics/break-continue.md:1
 msgid "`break` and `continue`"
 msgstr "`break` và `continue`"
 
-#: src/SUMMARY.md src/control-flow-basics/break-continue/labels.md
+#: src/SUMMARY.md:37 src/control-flow-basics/break-continue/labels.md:1
 msgid "Labels"
 msgstr "Labels (nhãn)"
 
-#: src/SUMMARY.md src/control-flow-basics/blocks-and-scopes.md
+#: src/SUMMARY.md:38 src/control-flow-basics.md:10
+#: src/control-flow-basics/blocks-and-scopes.md:1
 msgid "Blocks and Scopes"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/SUMMARY.md:39 src/control-flow-basics/blocks-and-scopes/scopes.md:1
 msgid "Scopes and Shadowing"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/functions.md
+#: src/SUMMARY.md:40 src/control-flow-basics.md:11
+#: src/control-flow-basics/functions.md:1
 msgid "Functions"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/macros.md
+#: src/SUMMARY.md:41 src/control-flow-basics.md:12
+#: src/control-flow-basics/macros.md:1
 msgid "Macros"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/exercise.md
+#: src/SUMMARY.md:42 src/control-flow-basics.md:13
+#: src/control-flow-basics/exercise.md:1
 msgid "Exercise: Collatz Sequence"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:45
 msgid "Day 1: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md src/tuples-and-arrays.md
+#: src/SUMMARY.md:48 src/running-the-course/course-structure.md:25
+#: src/welcome-day-1-afternoon.md:7 src/tuples-and-arrays.md:1
 msgid "Tuples and Arrays"
 msgstr ""
 
-#: src/SUMMARY.md src/tuples-and-arrays/arrays.md
+#: src/SUMMARY.md:49 src/tuples-and-arrays.md:7
+#: src/tuples-and-arrays/arrays.md:1
 msgid "Arrays"
 msgstr ""
 
-#: src/SUMMARY.md src/tuples-and-arrays/tuples.md
+#: src/SUMMARY.md:50 src/tuples-and-arrays.md:8
+#: src/tuples-and-arrays/tuples.md:1
 msgid "Tuples"
 msgstr ""
 
-#: src/SUMMARY.md src/tuples-and-arrays/iteration.md
+#: src/SUMMARY.md:51 src/tuples-and-arrays.md:9
+#: src/tuples-and-arrays/iteration.md:1
 msgid "Array Iteration"
 msgstr ""
 
-#: src/SUMMARY.md src/tuples-and-arrays/destructuring.md
+#: src/SUMMARY.md:52 src/tuples-and-arrays.md:10
+#: src/tuples-and-arrays/destructuring.md:1
 msgid "Patterns and Destructuring"
 msgstr ""
 
-#: src/SUMMARY.md src/tuples-and-arrays/exercise.md
+#: src/SUMMARY.md:53 src/tuples-and-arrays.md:11
+#: src/tuples-and-arrays/exercise.md:1
 msgid "Exercise: Nested Arrays"
 msgstr ""
 
-#: src/SUMMARY.md src/references.md
+#: src/SUMMARY.md:55 src/running-the-course/course-structure.md:26
+#: src/welcome-day-1-afternoon.md:8 src/references.md:1
 msgid "References"
 msgstr ""
 
-#: src/SUMMARY.md src/references/shared.md
+#: src/SUMMARY.md:56 src/references.md:7 src/references/shared.md:1
 msgid "Shared References"
 msgstr ""
 
-#: src/SUMMARY.md src/references/exclusive.md
+#: src/SUMMARY.md:57 src/references.md:8 src/references/exclusive.md:1
 msgid "Exclusive References"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:58
 msgid "Slices: `&[T]`"
 msgstr ""
 
-#: src/SUMMARY.md src/references/strings.md
+#: src/SUMMARY.md:59 src/references.md:10 src/references/strings.md:5
 msgid "Strings"
 msgstr ""
 
-#: src/SUMMARY.md src/references/exercise.md
+#: src/SUMMARY.md:60 src/references.md:11 src/references/exercise.md:1
 msgid "Exercise: Geometry"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types.md
+#: src/SUMMARY.md:62 src/running-the-course/course-structure.md:27
+#: src/welcome-day-1-afternoon.md:9 src/user-defined-types.md:1
 msgid "User-Defined Types"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/named-structs.md
+#: src/SUMMARY.md:63 src/user-defined-types.md:7
+#: src/user-defined-types/named-structs.md:1
 msgid "Named Structs"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/tuple-structs.md
+#: src/SUMMARY.md:64 src/user-defined-types.md:8
+#: src/user-defined-types/tuple-structs.md:5
 msgid "Tuple Structs"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/enums.md
-#: src/pattern-matching/destructuring.md
+#: src/SUMMARY.md:65 src/user-defined-types.md:9
+#: src/user-defined-types/enums.md:1
+#: src/pattern-matching/destructuring-enums.md:1
 msgid "Enums"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:66 src/user-defined-types.md:10
 msgid "Static"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:67
 msgid "Const"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/aliases.md
+#: src/SUMMARY.md:68 src/user-defined-types.md:11
+#: src/user-defined-types/aliases.md:1
 msgid "Type Aliases"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/exercise.md
+#: src/SUMMARY.md:69 src/user-defined-types.md:12
+#: src/user-defined-types/exercise.md:1
 msgid "Exercise: Elevator Events"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:74
 msgid "Day 2: Morning"
 msgstr ""
 
-#: src/SUMMARY.md src/pattern-matching.md
+#: src/SUMMARY.md:77 src/running-the-course/course-structure.md:35
+#: src/welcome-day-2.md:19 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr ""
 
-#: src/SUMMARY.md src/pattern-matching/match.md
+#: src/SUMMARY.md:78 src/pattern-matching.md:7 src/pattern-matching/match.md:1
 msgid "Matching Values"
 msgstr ""
 
-#: src/SUMMARY.md src/pattern-matching/destructuring.md
-msgid "Destructuring"
+#: src/SUMMARY.md:79 src/pattern-matching.md:8
+msgid "Destructuring Structs"
 msgstr ""
 
-#: src/SUMMARY.md src/pattern-matching/let-control-flow.md
+#: src/SUMMARY.md:80 src/pattern-matching.md:9
+msgid "Destructuring Enums"
+msgstr ""
+
+#: src/SUMMARY.md:81 src/pattern-matching.md:10
+#: src/pattern-matching/let-control-flow.md:1
 msgid "Let Control Flow"
 msgstr ""
 
-#: src/SUMMARY.md src/pattern-matching/exercise.md
+#: src/SUMMARY.md:82 src/pattern-matching.md:11
+#: src/pattern-matching/exercise.md:1
 msgid "Exercise: Expression Evaluation"
 msgstr ""
 
-#: src/SUMMARY.md src/methods-and-traits.md
+#: src/SUMMARY.md:84 src/running-the-course/course-structure.md:36
+#: src/welcome-day-2.md:20 src/methods-and-traits.md:1
 msgid "Methods and Traits"
 msgstr ""
 
-#: src/SUMMARY.md src/methods-and-traits/methods.md
+#: src/SUMMARY.md:85 src/methods-and-traits.md:7
+#: src/methods-and-traits/methods.md:1
 msgid "Methods"
 msgstr ""
 
-#: src/SUMMARY.md src/methods-and-traits/traits.md
+#: src/SUMMARY.md:86 src/methods-and-traits.md:8
+#: src/methods-and-traits/traits.md:1
 msgid "Traits"
 msgstr ""
 
-#: src/SUMMARY.md
-msgid "Implmementing Traits"
+#: src/SUMMARY.md:87 src/methods-and-traits/traits/implementing.md:1
+msgid "Implementing Traits"
 msgstr ""
 
-#: src/SUMMARY.md src/methods-and-traits/traits/supertraits.md
+#: src/SUMMARY.md:88 src/methods-and-traits/traits/supertraits.md:1
 msgid "Supertraits"
 msgstr ""
 
-#: src/SUMMARY.md src/methods-and-traits/traits/associated-types.md
+#: src/SUMMARY.md:89 src/methods-and-traits/traits/associated-types.md:1
 msgid "Associated Types"
 msgstr ""
 
-#: src/SUMMARY.md src/methods-and-traits/deriving.md
+#: src/SUMMARY.md:90 src/methods-and-traits.md:9
+#: src/methods-and-traits/deriving.md:1
 msgid "Deriving"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:91 src/methods-and-traits.md:10
 msgid "Exercise: Generic Logger"
 msgstr ""
 
-#: src/SUMMARY.md src/generics.md
-msgid "Generics"
-msgstr ""
-
-#: src/SUMMARY.md src/generics/generic-functions.md
-msgid "Generic Functions"
-msgstr ""
-
-#: src/SUMMARY.md src/generics/generic-data.md
-msgid "Generic Data Types"
-msgstr ""
-
-#: src/SUMMARY.md src/generics/generic-traits.md
-msgid "Generic Traits"
-msgstr ""
-
-#: src/SUMMARY.md src/generics/trait-bounds.md
-msgid "Trait Bounds"
-msgstr ""
-
-#: src/SUMMARY.md src/generics/impl-trait.md
-msgid "`impl Trait`"
-msgstr ""
-
-#: src/SUMMARY.md src/generics/exercise.md
-msgid "Exercise: Generic `min`"
-msgstr ""
-
-#: src/SUMMARY.md
+#: src/SUMMARY.md:94
 msgid "Day 2: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types.md
+#: src/SUMMARY.md:97 src/running-the-course/course-structure.md:43
+#: src/welcome-day-2-afternoon.md:7 src/generics.md:1
+msgid "Generics"
+msgstr ""
+
+#: src/SUMMARY.md:98 src/generics.md:7 src/generics/generic-functions.md:1
+msgid "Generic Functions"
+msgstr ""
+
+#: src/SUMMARY.md:99 src/generics.md:8 src/generics/generic-data.md:1
+msgid "Generic Data Types"
+msgstr ""
+
+#: src/SUMMARY.md:100 src/generics/generic-traits.md:1
+msgid "Generic Traits"
+msgstr ""
+
+#: src/SUMMARY.md:101 src/generics.md:9 src/generics/trait-bounds.md:1
+msgid "Trait Bounds"
+msgstr ""
+
+#: src/SUMMARY.md:102 src/generics/impl-trait.md:1
+msgid "`impl Trait`"
+msgstr ""
+
+#: src/SUMMARY.md:103 src/generics/exercise.md:1
+msgid "Exercise: Generic `min`"
+msgstr ""
+
+#: src/SUMMARY.md:105 src/running-the-course/course-structure.md:44
+#: src/welcome-day-2-afternoon.md:8 src/std-types.md:1
 msgid "Standard Library Types"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types/std.md
+#: src/SUMMARY.md:106 src/std-types.md:7 src/std-types/std.md:1
 msgid "Standard Library"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types/docs.md
+#: src/SUMMARY.md:107 src/std-types.md:8 src/std-types/docs.md:1
 msgid "Documentation"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:108
 msgid "`Option`"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:109
 msgid "`Result`"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/types/primitives.md
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/SUMMARY.md:110 src/android/aidl/types/primitives.md:14
+#: src/android/interoperability/cpp/type-mapping.md:5
 msgid "`String`"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types/vec.md
+#: src/SUMMARY.md:111 src/std-types/vec.md:1
 msgid "`Vec`"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types/hashmap.md src/bare-metal/no_std.md
+#: src/SUMMARY.md:112 src/std-types/hashmap.md:1 src/bare-metal/no_std.md:46
 msgid "`HashMap`"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types/exercise.md
+#: src/SUMMARY.md:113 src/std-types.md:14 src/std-types/exercise.md:1
 msgid "Exercise: Counter"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits.md
+#: src/SUMMARY.md:115 src/running-the-course/course-structure.md:45
+#: src/welcome-day-2-afternoon.md:9 src/std-traits.md:1
 msgid "Standard Library Traits"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/comparisons.md src/async.md
+#: src/SUMMARY.md:116 src/std-traits.md:7 src/std-traits/comparisons.md:1
+#: src/concurrency/welcome-async.md:17
 msgid "Comparisons"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/operators.md
+#: src/SUMMARY.md:117 src/std-traits.md:8 src/std-traits/operators.md:1
 msgid "Operators"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/from-and-into.md
+#: src/SUMMARY.md:118 src/std-traits/from-and-into.md:1
 msgid "`From` and `Into`"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/casting.md
+#: src/SUMMARY.md:119 src/std-traits.md:10 src/std-traits/casting.md:1
 msgid "Casting"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/read-and-write.md
+#: src/SUMMARY.md:120 src/std-traits/read-and-write.md:1
 msgid "`Read` and `Write`"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:121
 msgid "`Default`, struct update syntax"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/closures.md
+#: src/SUMMARY.md:122 src/std-traits.md:13 src/std-traits/closures.md:1
 msgid "Closures"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/exercise.md
+#: src/SUMMARY.md:123 src/std-traits.md:14 src/std-traits/exercise.md:1
 msgid "Exercise: ROT13"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:128
 msgid "Day 3: Morning"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management.md
+#: src/SUMMARY.md:131 src/running-the-course/course-structure.md:53
+#: src/welcome-day-3.md:16 src/memory-management.md:1
 msgid "Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/review.md
+#: src/SUMMARY.md:132 src/memory-management.md:7
+#: src/memory-management/review.md:1
 msgid "Review of Program Memory"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/approaches.md
+#: src/SUMMARY.md:133 src/memory-management.md:8
+#: src/memory-management/approaches.md:1
 msgid "Approaches to Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/ownership.md
+#: src/SUMMARY.md:134 src/memory-management.md:9
+#: src/memory-management/ownership.md:1
 msgid "Ownership"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/move.md
+#: src/SUMMARY.md:135 src/memory-management.md:10
+#: src/memory-management/move.md:1
 msgid "Move Semantics"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:136
 msgid "`Clone`"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/copy-types.md
+#: src/SUMMARY.md:137 src/memory-management.md:12
+#: src/memory-management/copy-types.md:1
 msgid "Copy Types"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:138
 msgid "`Drop`"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/exercise.md
+#: src/SUMMARY.md:139 src/memory-management.md:14
+#: src/memory-management/exercise.md:1
 msgid "Exercise: Builder Type"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers.md
+#: src/SUMMARY.md:141 src/running-the-course/course-structure.md:54
+#: src/welcome-day-3.md:17 src/smart-pointers.md:1
 msgid "Smart Pointers"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers/box.md
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/SUMMARY.md:142 src/smart-pointers/box.md:1
+#: src/android/interoperability/cpp/type-mapping.md:9
 msgid "`Box<T>`"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers/rc.md
+#: src/SUMMARY.md:143 src/smart-pointers/rc.md:1
 msgid "`Rc`"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers/trait-objects.md
+#: src/SUMMARY.md:144 src/smart-pointers.md:9
+#: src/smart-pointers/trait-objects.md:1
 msgid "Trait Objects"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers/exercise.md
+#: src/SUMMARY.md:145 src/smart-pointers.md:10 src/smart-pointers/exercise.md:1
 msgid "Exercise: Binary Tree"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:148
 msgid "Day 3: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md src/borrowing.md
+#: src/SUMMARY.md:151 src/running-the-course/course-structure.md:61
+#: src/welcome-day-3-afternoon.md:7 src/borrowing.md:1
 msgid "Borrowing"
 msgstr ""
 
-#: src/SUMMARY.md src/borrowing/shared.md
+#: src/SUMMARY.md:152 src/borrowing.md:7 src/borrowing/shared.md:1
 msgid "Borrowing a Value"
 msgstr ""
 
-#: src/SUMMARY.md src/borrowing/borrowck.md
+#: src/SUMMARY.md:153 src/borrowing.md:8 src/borrowing/borrowck.md:1
 msgid "Borrow Checking"
 msgstr ""
 
-#: src/SUMMARY.md src/borrowing/interior-mutability.md
+#: src/SUMMARY.md:154 src/borrowing.md:9 src/borrowing/examples.md:1
+msgid "Borrow Errors"
+msgstr ""
+
+#: src/SUMMARY.md:155 src/borrowing.md:10
+#: src/borrowing/interior-mutability.md:1
 msgid "Interior Mutability"
 msgstr ""
 
-#: src/SUMMARY.md src/borrowing/exercise.md
+#: src/SUMMARY.md:156 src/borrowing.md:11 src/borrowing/exercise.md:1
 msgid "Exercise: Health Statistics"
 msgstr ""
 
-#: src/SUMMARY.md src/lifetimes.md
+#: src/SUMMARY.md:158 src/running-the-course/course-structure.md:62
+#: src/welcome-day-3-afternoon.md:8 src/lifetimes.md:1
 msgid "Lifetimes"
 msgstr ""
 
-#: src/SUMMARY.md src/lifetimes/lifetime-annotations.md
+#: src/SUMMARY.md:159 src/lifetimes.md:7
+#: src/lifetimes/lifetime-annotations.md:1
 msgid "Lifetime Annotations"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:160 src/lifetimes.md:8
 msgid "Lifetime Elision"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:161 src/lifetimes.md:9
 msgid "Struct Lifetimes"
 msgstr ""
 
-#: src/SUMMARY.md src/lifetimes/exercise.md
+#: src/SUMMARY.md:162 src/lifetimes.md:10 src/lifetimes/exercise.md:1
 msgid "Exercise: Protobuf Parsing"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:167
 msgid "Day 4: Morning"
 msgstr ""
 
-#: src/SUMMARY.md src/iterators.md
+#: src/SUMMARY.md:170 src/running-the-course/course-structure.md:70
+#: src/welcome-day-4.md:18 src/iterators.md:1
 msgid "Iterators"
 msgstr ""
 
-#: src/SUMMARY.md src/iterators/iterator.md src/bare-metal/no_std.md
+#: src/SUMMARY.md:171 src/iterators/iterator.md:1 src/bare-metal/no_std.md:28
 msgid "`Iterator`"
 msgstr ""
 
-#: src/SUMMARY.md src/iterators/intoiterator.md
+#: src/SUMMARY.md:172 src/iterators/intoiterator.md:1
 msgid "`IntoIterator`"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:173
 msgid "`FromIterator`"
 msgstr ""
 
-#: src/SUMMARY.md src/iterators/exercise.md
+#: src/SUMMARY.md:174 src/iterators.md:10 src/iterators/exercise.md:1
 msgid "Exercise: Iterator Method Chaining"
 msgstr ""
 
-#: src/SUMMARY.md src/modules.md src/modules/modules.md
+#: src/SUMMARY.md:176 src/SUMMARY.md:177
+#: src/running-the-course/course-structure.md:71 src/welcome-day-4.md:19
+#: src/modules.md:1 src/modules.md:7 src/modules/modules.md:1
 msgid "Modules"
 msgstr ""
 
-#: src/SUMMARY.md src/modules/filesystem.md
+#: src/SUMMARY.md:178 src/modules.md:8 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr ""
 
-#: src/SUMMARY.md src/modules/visibility.md
+#: src/SUMMARY.md:179 src/modules.md:9 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:180
 msgid "`use`, `super`, `self`"
 msgstr ""
 
-#: src/SUMMARY.md src/modules/exercise.md
+#: src/SUMMARY.md:181 src/modules.md:11 src/modules/exercise.md:1
 msgid "Exercise: Modules for a GUI Library"
 msgstr ""
 
-#: src/SUMMARY.md src/testing.md src/chromium/testing.md
+#: src/SUMMARY.md:183 src/SUMMARY.md:236 src/SUMMARY.md:273
+#: src/running-the-course/course-structure.md:72 src/welcome-day-4.md:20
+#: src/testing.md:1 src/chromium/testing.md:1
 msgid "Testing"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:184 src/testing.md:7
 msgid "Test Modules"
 msgstr ""
 
-#: src/SUMMARY.md src/testing/other.md
+#: src/SUMMARY.md:185 src/testing.md:8 src/testing/other.md:1
 msgid "Other Types of Tests"
 msgstr ""
 
-#: src/SUMMARY.md src/testing/lints.md
+#: src/SUMMARY.md:186 src/testing.md:9 src/testing/lints.md:1
 msgid "Compiler Lints and Clippy"
 msgstr ""
 
-#: src/SUMMARY.md src/testing/exercise.md
+#: src/SUMMARY.md:187 src/testing.md:10 src/testing/exercise.md:1
 msgid "Exercise: Luhn Algorithm"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:190
 msgid "Day 4: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md src/error-handling.md
+#: src/SUMMARY.md:193 src/running-the-course/course-structure.md:79
+#: src/welcome-day-4-afternoon.md:7 src/error-handling.md:1
 msgid "Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md src/error-handling/panics.md
+#: src/SUMMARY.md:194 src/error-handling.md:7 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr ""
 
-#: src/SUMMARY.md src/error-handling/try.md
+#: src/SUMMARY.md:195 src/error-handling.md:8 src/error-handling/try.md:1
 msgid "Try Operator"
 msgstr ""
 
-#: src/SUMMARY.md src/error-handling/try-conversions.md
+#: src/SUMMARY.md:196 src/error-handling.md:9
+#: src/error-handling/try-conversions.md:1
 msgid "Try Conversions"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:197
 msgid "`Error` Trait"
 msgstr ""
 
-#: src/SUMMARY.md src/error-handling/thiserror-and-anyhow.md
+#: src/SUMMARY.md:198 src/error-handling/thiserror-and-anyhow.md:1
 msgid "`thiserror` and `anyhow`"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:199
 msgid "Exercise: Rewriting with `Result`"
 msgstr ""
 
-#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unsafe.md
+#: src/SUMMARY.md:201 src/running-the-course/course-structure.md:80
+#: src/welcome-day-4-afternoon.md:8 src/unsafe-rust.md:1
+#: src/unsafe-rust/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:202 src/unsafe-rust.md:7
 msgid "Unsafe"
 msgstr ""
 
-#: src/SUMMARY.md src/unsafe-rust/dereferencing.md
+#: src/SUMMARY.md:203 src/unsafe-rust.md:8 src/unsafe-rust/dereferencing.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr ""
 
-#: src/SUMMARY.md src/unsafe-rust/mutable-static.md
+#: src/SUMMARY.md:204 src/unsafe-rust.md:9 src/unsafe-rust/mutable-static.md:1
 msgid "Mutable Static Variables"
 msgstr ""
 
-#: src/SUMMARY.md src/unsafe-rust/unions.md
+#: src/SUMMARY.md:205 src/unsafe-rust.md:10 src/unsafe-rust/unions.md:1
 msgid "Unions"
 msgstr ""
 
-#: src/SUMMARY.md src/unsafe-rust/unsafe-functions.md
+#: src/SUMMARY.md:206 src/unsafe-rust.md:11
+#: src/unsafe-rust/unsafe-functions.md:1
 msgid "Unsafe Functions"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:207 src/unsafe-rust.md:12
 msgid "Unsafe Traits"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:208 src/unsafe-rust.md:13
 msgid "Exercise: FFI Wrapper"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/android.md
+#: src/SUMMARY.md:211 src/SUMMARY.md:347 src/bare-metal/android.md:1
 msgid "Android"
 msgstr ""
 
-#: src/SUMMARY.md src/android/setup.md src/chromium/setup.md
+#: src/SUMMARY.md:216 src/SUMMARY.md:265 src/android/setup.md:1
+#: src/chromium/setup.md:1
 msgid "Setup"
 msgstr ""
 
-#: src/SUMMARY.md src/android/build-rules.md
+#: src/SUMMARY.md:217 src/SUMMARY.md:268 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:218
 msgid "Binary"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:219
 msgid "Library"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl.md
+#: src/SUMMARY.md:220 src/android/aidl.md:1
 msgid "AIDL"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/birthday-service.md
+#: src/SUMMARY.md:221 src/android/aidl/birthday-service.md:1
 msgid "Birthday Service Tutorial"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:222
 msgid "Interface"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:223
 msgid "Service API"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:224
 msgid "Service"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:225
 msgid "Server"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/example-service/deploy.md
+#: src/SUMMARY.md:226 src/android/aidl/example-service/deploy.md:1
 msgid "Deploy"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:227
 msgid "Client"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/example-service/changing-definition.md
+#: src/SUMMARY.md:228 src/android/aidl/example-service/changing-definition.md:1
 msgid "Changing API"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:229
 msgid "Updating Implementations"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:230
 msgid "AIDL Types"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/types/primitives.md
+#: src/SUMMARY.md:231 src/android/aidl/types/primitives.md:1
 msgid "Primitive Types"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/types/arrays.md
+#: src/SUMMARY.md:232 src/android/aidl/types/arrays.md:1
 msgid "Array Types"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/types/objects.md
+#: src/SUMMARY.md:233 src/android/aidl/types/objects.md:1
 msgid "Sending Objects"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/types/parcelables.md
+#: src/SUMMARY.md:234 src/android/aidl/types/parcelables.md:1
 msgid "Parcelables"
 msgstr ""
 
-#: src/SUMMARY.md src/android/aidl/types/file-descriptor.md
+#: src/SUMMARY.md:235 src/android/aidl/types/file-descriptor.md:1
 msgid "Sending Files"
 msgstr ""
 
-#: src/SUMMARY.md src/android/testing/googletest.md
+#: src/SUMMARY.md:237 src/android/testing/googletest.md:1
 msgid "GoogleTest"
 msgstr ""
 
-#: src/SUMMARY.md src/android/testing/mocking.md
+#: src/SUMMARY.md:238 src/android/testing/mocking.md:1
 msgid "Mocking"
 msgstr ""
 
-#: src/SUMMARY.md src/android/logging.md src/bare-metal/aps/logging.md
+#: src/SUMMARY.md:239 src/SUMMARY.md:337 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability.md
+#: src/SUMMARY.md:240 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:241
 msgid "With C"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:242
 msgid "Calling C with Bindgen"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:243
 msgid "Calling Rust from C"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp.md
+#: src/SUMMARY.md:244 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/bridge.md
+#: src/SUMMARY.md:245 src/android/interoperability/cpp/bridge.md:1
 msgid "The Bridge Module"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:246
 msgid "Rust Bridge"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/generated-cpp.md
+#: src/SUMMARY.md:247 src/android/interoperability/cpp/generated-cpp.md:1
 msgid "Generated C++"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:248
 msgid "C++ Bridge"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/shared-types.md
+#: src/SUMMARY.md:249 src/android/interoperability/cpp/shared-types.md:1
 msgid "Shared Types"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/shared-enums.md
+#: src/SUMMARY.md:250 src/android/interoperability/cpp/shared-enums.md:1
 msgid "Shared Enums"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/rust-result.md
+#: src/SUMMARY.md:251 src/android/interoperability/cpp/rust-result.md:1
 msgid "Rust Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/cpp-exception.md
+#: src/SUMMARY.md:252 src/android/interoperability/cpp/cpp-exception.md:1
 msgid "C++ Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
+#: src/SUMMARY.md:253 src/android/interoperability/cpp/type-mapping.md:1
 msgid "Additional Types"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:254
 msgid "Building for Android: C++"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:255
 msgid "Building for Android: Genrules"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:256
 msgid "Building for Android: Rust"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:257
 msgid "With Java"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/android/morning.md
-#: src/exercises/bare-metal/morning.md src/exercises/bare-metal/afternoon.md
-#: src/exercises/concurrency/morning.md src/exercises/concurrency/afternoon.md
+#: src/SUMMARY.md:258 src/SUMMARY.md:320 src/SUMMARY.md:349 src/SUMMARY.md:374
+#: src/SUMMARY.md:397 src/running-the-course/course-structure.md:155
+#: src/running-the-course/course-structure.md:165
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1 src/concurrency/welcome.md:20
+#: src/concurrency/sync-exercises.md:1 src/concurrency/welcome-async.md:36
+#: src/concurrency/async-exercises.md:1
 msgid "Exercises"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:260
 msgid "Chromium"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/cargo.md
+#: src/SUMMARY.md:266 src/chromium/cargo.md:1
 msgid "Comparing Chromium and Cargo Ecosystems"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:267
 msgid "Policy"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:269
 msgid "Unsafe Code"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/build-rules/depending.md
+#: src/SUMMARY.md:270 src/chromium/build-rules/depending.md:1
 msgid "Depending on Rust Code from Chromium C++"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/build-rules/vscode.md
+#: src/SUMMARY.md:271 src/chromium/build-rules/vscode.md:1
 msgid "Visual Studio Code"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/chromium/third-party.md
+#: src/SUMMARY.md:272 src/SUMMARY.md:277 src/SUMMARY.md:285 src/SUMMARY.md:298
+#: src/exercises/chromium/third-party.md:1
 msgid "Exercise"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/testing/rust-gtest-interop.md
+#: src/SUMMARY.md:274 src/chromium/testing/rust-gtest-interop.md:1
 msgid "`rust_gtest_interop` Library"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/testing/build-gn.md
+#: src/SUMMARY.md:275 src/chromium/testing/build-gn.md:1
 msgid "GN Rules for Rust Tests"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/testing/chromium-import-macro.md
+#: src/SUMMARY.md:276 src/chromium/testing/chromium-import-macro.md:1
 msgid "`chromium::import!` Macro"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/interoperability-with-cpp.md
+#: src/SUMMARY.md:278 src/chromium/interoperability-with-cpp.md:1
 msgid "Interoperability with C++"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/SUMMARY.md:279
+#: src/chromium/interoperability-with-cpp/example-bindings.md:1
 msgid "Example Bindings"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/SUMMARY.md:280
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:1
 msgid "Limitations of CXX"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/interoperability-with-cpp/error-handling.md
+#: src/SUMMARY.md:281
+#: src/chromium/interoperability-with-cpp/error-handling.md:1
 msgid "CXX Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:282
 msgid "Error Handling: QR Example"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:283
 msgid "Error Handling: PNG Example"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:284
 msgid "Using CXX in Chromium"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/adding-third-party-crates.md
+#: src/SUMMARY.md:286 src/chromium/adding-third-party-crates.md:1
 msgid "Adding Third Party Crates"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:287
 msgid "Configuring Cargo.toml"
 msgstr ""
 
-#: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/SUMMARY.md:288
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:1
 msgid "Configuring `gnrt_config.toml`"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/SUMMARY.md:289
+#: src/chromium/adding-third-party-crates/downloading-crates.md:1
 msgid "Downloading Crates"
 msgstr ""
 
-#: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/SUMMARY.md:290
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:1
 msgid "Generating `gn` Build Rules"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/SUMMARY.md:291
+#: src/chromium/adding-third-party-crates/resolving-problems.md:1
 msgid "Resolving Problems"
 msgstr ""
 
-#: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/SUMMARY.md:292
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:1
 msgid "Build Scripts Which Generate Code"
 msgstr ""
 
-#: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/SUMMARY.md:293
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:1
 msgid "Build Scripts Which Build C++ or Take Arbitrary Actions"
 msgstr ""
 
-#: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/SUMMARY.md:294
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:1
 msgid "Depending on a Crate"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:295
 msgid "Reviews and Audits"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:296
 msgid "Checking into Chromium Source Code"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/adding-third-party-crates/keeping-up-to-date.md
+#: src/SUMMARY.md:297
+#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:1
 msgid "Keeping Crates Up to Date"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:299
 msgid "Bringing It Together - Exercise"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/chromium/solutions.md
+#: src/SUMMARY.md:300 src/exercises/chromium/solutions.md:1
 msgid "Exercise Solutions"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:302
 msgid "Bare Metal: Morning"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/no_std.md
+#: src/SUMMARY.md:307 src/bare-metal/no_std.md:1
 msgid "`no_std`"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:308
 msgid "A Minimal Example"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/no_std.md src/bare-metal/alloc.md
+#: src/SUMMARY.md:309 src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers.md
+#: src/SUMMARY.md:310 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/mmio.md
+#: src/SUMMARY.md:311 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:312
 msgid "PACs"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:313
 msgid "HAL Crates"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:314
 msgid "Board Support Crates"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:315
 msgid "The Type State Pattern"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/embedded-hal.md
+#: src/SUMMARY.md:316 src/bare-metal/microcontrollers/embedded-hal.md:1
 msgid "`embedded-hal`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/probe-rs.md
+#: src/SUMMARY.md:317 src/bare-metal/microcontrollers/probe-rs.md:1
 msgid "`probe-rs` and `cargo-embed`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/debugging.md
+#: src/SUMMARY.md:318 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:319 src/SUMMARY.md:340
 msgid "Other Projects"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/bare-metal/compass.md
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/SUMMARY.md:321 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:322 src/SUMMARY.md:351 src/SUMMARY.md:377 src/SUMMARY.md:400
+#: src/concurrency/sync-exercises.md:9
+#: src/concurrency/sync-exercises/solutions.md:1
+#: src/concurrency/async-exercises.md:9
+#: src/concurrency/async-exercises/solutions.md:1
 msgid "Solutions"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:324
 msgid "Bare Metal: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:326
 msgid "Application Processors"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/aps/entry-point.md
+#: src/SUMMARY.md:327 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:328
 msgid "Inline Assembly"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:329
 msgid "MMIO"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:330
 msgid "Let's Write a UART Driver"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:331
 msgid "More Traits"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:332
 msgid "A Better UART Driver"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/aps/better-uart/bitflags.md
+#: src/SUMMARY.md:333 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:334
 msgid "Multiple Registers"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/aps/better-uart/driver.md
+#: src/SUMMARY.md:335 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:336 src/SUMMARY.md:338
 msgid "Using It"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/aps/exceptions.md
+#: src/SUMMARY.md:339 src/bare-metal/aps/exceptions.md:1
 msgid "Exceptions"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:341
 msgid "Useful Crates"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/zerocopy.md
+#: src/SUMMARY.md:342 src/bare-metal/useful-crates/zerocopy.md:1
 msgid "`zerocopy`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/aarch64-paging.md
+#: src/SUMMARY.md:343 src/bare-metal/useful-crates/aarch64-paging.md:1
 msgid "`aarch64-paging`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/SUMMARY.md:344 src/bare-metal/useful-crates/buddy_system_allocator.md:1
 msgid "`buddy_system_allocator`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/tinyvec.md
+#: src/SUMMARY.md:345 src/bare-metal/useful-crates/tinyvec.md:1
 msgid "`tinyvec`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/spin.md
+#: src/SUMMARY.md:346 src/bare-metal/useful-crates/spin.md:1
 msgid "`spin`"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:348
 msgid "`vmbase`"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:350
 msgid "RTC Driver"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:353
 msgid "Concurrency: Morning"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/threads.md
+#: src/SUMMARY.md:358 src/running-the-course/course-structure.md:151
+#: src/concurrency/welcome.md:16 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md:359 src/concurrency/threads.md:7
+#: src/concurrency/threads/plain.md:1
+msgid "Plain Threads"
+msgstr ""
+
+#: src/SUMMARY.md:360 src/concurrency/threads.md:8
+#: src/concurrency/threads/scoped.md:1
 msgid "Scoped Threads"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/channels.md
+#: src/SUMMARY.md:361 src/running-the-course/course-structure.md:152
+#: src/concurrency/welcome.md:17 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/channels/unbounded.md
+#: src/SUMMARY.md:362 src/concurrency/channels.md:7
+#: src/concurrency/channels/senders-receivers.md:1
+msgid "Senders and Receivers"
+msgstr ""
+
+#: src/SUMMARY.md:363 src/concurrency/channels.md:8
+#: src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/channels/bounded.md
+#: src/SUMMARY.md:364 src/concurrency/channels.md:9
+#: src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/send-sync.md
+#: src/SUMMARY.md:365 src/concurrency/send-sync.md:1
 msgid "`Send` and `Sync`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/send-sync/send.md
+#: src/SUMMARY.md:366 src/concurrency/send-sync.md:7
+#: src/concurrency/send-sync/marker-traits.md:1
+msgid "Marker Traits"
+msgstr ""
+
+#: src/SUMMARY.md:367 src/concurrency/send-sync/send.md:1
 msgid "`Send`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/send-sync/sync.md
+#: src/SUMMARY.md:368 src/concurrency/send-sync/sync.md:1
 msgid "`Sync`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/send-sync/examples.md
+#: src/SUMMARY.md:369 src/concurrency/send-sync.md:10
+#: src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/shared_state.md
+#: src/SUMMARY.md:370 src/running-the-course/course-structure.md:154
+#: src/concurrency/welcome.md:19 src/concurrency/shared-state.md:1
 msgid "Shared State"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/shared_state/arc.md
+#: src/SUMMARY.md:371 src/concurrency/shared-state/arc.md:1
 msgid "`Arc`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/shared_state/mutex.md
+#: src/SUMMARY.md:372 src/concurrency/shared-state/mutex.md:1
 msgid "`Mutex`"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/review.md
-#: src/error-handling/try-conversions.md
-#: src/concurrency/shared_state/example.md
+#: src/SUMMARY.md:373 src/memory-management/review.md:16
+#: src/error-handling/try-conversions.md:23 src/concurrency/shared-state.md:9
+#: src/concurrency/shared-state/example.md:1
 msgid "Example"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/SUMMARY.md:375 src/SUMMARY.md:398 src/concurrency/sync-exercises.md:7
+#: src/concurrency/sync-exercises/dining-philosophers.md:1
+#: src/concurrency/sync-exercises/solutions.md:3
+#: src/concurrency/async-exercises.md:7
 msgid "Dining Philosophers"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/concurrency/link-checker.md
+#: src/SUMMARY.md:376 src/concurrency/sync-exercises.md:8
+#: src/concurrency/sync-exercises/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:379
 msgid "Concurrency: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:382 src/running-the-course/course-structure.md:162
+#: src/concurrency/welcome-async.md:33 src/concurrency/async.md:1
 msgid "Async Basics"
 msgstr ""
 
-#: src/SUMMARY.md src/async/async-await.md
+#: src/SUMMARY.md:383 src/concurrency/async/async-await.md:1
 msgid "`async`/`await`"
 msgstr ""
 
-#: src/SUMMARY.md src/async/futures.md
+#: src/SUMMARY.md:384 src/concurrency/async.md:8
+#: src/concurrency/async/futures.md:1
 msgid "Futures"
 msgstr ""
 
-#: src/SUMMARY.md src/async/runtimes.md
+#: src/SUMMARY.md:385 src/concurrency/async.md:9
+#: src/concurrency/async/runtimes.md:1
 msgid "Runtimes"
 msgstr ""
 
-#: src/SUMMARY.md src/async/runtimes/tokio.md
+#: src/SUMMARY.md:386 src/concurrency/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/concurrency/link-checker.md src/async/tasks.md
-#: src/exercises/concurrency/chat-app.md
+#: src/SUMMARY.md:387 src/concurrency/sync-exercises/link-checker.md:119
+#: src/concurrency/async.md:10 src/concurrency/async/tasks.md:1
+#: src/concurrency/async-exercises/chat-app.md:143
 msgid "Tasks"
 msgstr ""
 
-#: src/SUMMARY.md src/async/channels.md
+#: src/SUMMARY.md:388 src/running-the-course/course-structure.md:163
+#: src/concurrency/welcome-async.md:34 src/concurrency/async-control-flow.md:1
+msgid "Channels and Control Flow"
+msgstr ""
+
+#: src/SUMMARY.md:389 src/concurrency/async-control-flow.md:7
+#: src/concurrency/async-control-flow/channels.md:1
 msgid "Async Channels"
 msgstr ""
 
-#: src/SUMMARY.md
-msgid "Control Flow"
-msgstr ""
-
-#: src/SUMMARY.md src/async/control-flow/join.md
+#: src/SUMMARY.md:390 src/concurrency/async-control-flow.md:8
+#: src/concurrency/async-control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md src/async/control-flow/select.md
+#: src/SUMMARY.md:391 src/concurrency/async-control-flow.md:9
+#: src/concurrency/async-control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:392 src/running-the-course/course-structure.md:164
+#: src/concurrency/welcome-async.md:35 src/concurrency/async-pitfalls.md:1
 msgid "Pitfalls"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:393 src/concurrency/async-pitfalls.md:11
 msgid "Blocking the Executor"
 msgstr ""
 
-#: src/SUMMARY.md src/async/pitfalls/pin.md
+#: src/SUMMARY.md:394 src/concurrency/async-pitfalls/pin.md:1
 msgid "`Pin`"
 msgstr ""
 
-#: src/SUMMARY.md src/async/pitfalls/async-traits.md
+#: src/SUMMARY.md:395 src/concurrency/async-pitfalls.md:13
+#: src/concurrency/async-pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr ""
 
-#: src/SUMMARY.md src/async/pitfalls/cancellation.md
+#: src/SUMMARY.md:396 src/concurrency/async-pitfalls.md:14
+#: src/concurrency/async-pitfalls/cancellation.md:1
 msgid "Cancellation"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/SUMMARY.md:399 src/concurrency/async-exercises.md:8
+#: src/concurrency/async-exercises/chat-app.md:1
+#: src/concurrency/async-exercises/solutions.md:102
 msgid "Broadcast Chat Application"
 msgstr ""
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:402
 msgid "Final Words"
 msgstr ""
 
-#: src/SUMMARY.md src/thanks.md
+#: src/SUMMARY.md:406 src/thanks.md:1
 msgid "Thanks!"
 msgstr ""
 
-#: src/SUMMARY.md src/glossary.md
+#: src/SUMMARY.md:407 src/glossary.md:3
 msgid "Glossary"
 msgstr "Chú giải thuật ngữ"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md:408
 msgid "Other Resources"
 msgstr ""
 
-#: src/SUMMARY.md src/credits.md
+#: src/SUMMARY.md:409 src/credits.md:1
 msgid "Credits"
 msgstr ""
 
-#: src/index.md
+#: src/index.md:3
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
@@ -1257,72 +1393,72 @@ msgid ""
 "com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
-#: src/index.md
+#: src/index.md:7
 msgid ""
 "This is a free Rust course developed by the Android team at Google. The "
 "course covers the full spectrum of Rust, from basic syntax to advanced "
 "topics like generics and error handling."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:11
 msgid ""
 "The latest version of the course can be found at <https://google.github.io/"
 "comprehensive-rust/>. If you are reading somewhere else, please check there "
 "for updates."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:15
 msgid "The course is also available [as a PDF](comprehensive-rust.pdf)."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:17
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
 "anything about Rust and hope to:"
 msgstr ""
 
-#: src/index.md
+#: src/index.md:20
 msgid "Give you a comprehensive understanding of the Rust syntax and language."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:21
 msgid "Enable you to modify existing programs and write new programs in Rust."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:22
 msgid "Show you common Rust idioms."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:24
 msgid "We call the first four course days Rust Fundamentals."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:26
 msgid ""
 "Building on this, you're invited to dive into one or more specialized topics:"
 msgstr ""
 
-#: src/index.md
+#: src/index.md:28
 msgid ""
 "[Android](android.md): a half-day course on using Rust for Android platform "
 "development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:30
 msgid ""
 "[Chromium](chromium.md): a half-day course on using Rust within Chromium "
 "based browsers. This includes interoperability with C++ and how to include "
 "third-party crates in Chromium."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:33
 msgid ""
 "[Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-metal "
 "(embedded) development. Both microcontrollers and application processors are "
 "covered."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:36
 msgid ""
 "[Concurrency](concurrency.md): a whole-day class on concurrency in Rust. We "
 "cover both classical concurrency (preemptively scheduling using threads and "
@@ -1330,52 +1466,52 @@ msgid ""
 "futures)."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:40
 msgid "Non-Goals"
 msgstr ""
 
-#: src/index.md
+#: src/index.md:42
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
 "days. Some non-goals of this course are:"
 msgstr ""
 
-#: src/index.md
+#: src/index.md:45
 msgid ""
 "Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
 "(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
 "(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:50
 msgid "Assumptions"
 msgstr ""
 
-#: src/index.md
+#: src/index.md:52
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
 "statically-typed language and we will sometimes make comparisons with C and "
 "C++ to better explain or contrast the Rust approach."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:56
 msgid ""
 "If you know how to program in a dynamically-typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 
-#: src/index.md
+#: src/index.md:61
 msgid ""
 "This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
 "should cover as well as answers to typical questions which come up in class."
 msgstr ""
 
-#: src/running-the-course.md src/running-the-course/course-structure.md
+#: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
 msgid "This page is for the course instructor."
 msgstr "Trang này là dành cho người hướng dẫn khóa học."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
 "course internally at Google."
@@ -1383,7 +1519,7 @@ msgstr ""
 "Đây là một số thông tin cơ bản về cách chúng tôi triển khai khóa học trong "
 "nội bộ Google."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:8
 msgid ""
 "We typically run classes from 9:00 am to 4:00 pm, with a 1 hour lunch break "
 "in the middle. This leaves 3 hours for the morning class and 3 hours for the "
@@ -1395,11 +1531,11 @@ msgstr ""
 "3 tiếng. Một buổi học sẽ được chia thành nhiều quãng nghỉ để học sinh có "
 "thời gian thực hành."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:13
 msgid "Before you run the course, you will want to:"
 msgstr "Trước khi bắt đầu giảng dạy khóa học này, bạn sẽ cần:"
 
-#: src/running-the-course.md
+#: src/running-the-course.md:15
 msgid ""
 "Make yourself familiar with the course material. We've included speaker "
 "notes to help highlight the key points (please help us by contributing more "
@@ -1415,7 +1551,7 @@ msgstr ""
 "\"Speaker Notes\"). Làm vậy sẽ giúp bạn có thể  thuyết trình với slide rõ "
 "ràng nhất."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:21
 msgid ""
 "Decide on the dates. Since the course takes four days, we recommend that you "
 "schedule the days over two weeks. Course participants have said that they "
@@ -1427,7 +1563,7 @@ msgstr ""
 "việc có những \"khoảng trống\" trong khóa rất có ích để họ có thể tiêu hóa "
 "hết lượng thông tin được cung cấp."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:26
 msgid ""
 "Find a room large enough for your in-person participants. We recommend a "
 "class size of 15-25 people. That's small enough that people are comfortable "
@@ -1445,7 +1581,7 @@ msgstr ""
 "hành mẫu rất nhiều bài live-coding, nên một cái ghế sẽ có ích hơn là một cái "
 "bục giảng đó."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:34
 msgid ""
 "On the day of your course, show up to the room a little early to set things "
 "up. We recommend presenting directly using `mdbook serve` running on your "
@@ -1461,7 +1597,7 @@ msgstr ""
 "ra mượt mà nhất, ngoài ra còn cho phép bạn sửa lỗi chính tả trực tiếp khi "
 "bạn hoặc ai đó phát hiện ra."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:40
 msgid ""
 "Let people solve the exercises by themselves or in small groups. We "
 "typically spend 30-45 minutes on exercises in the morning and in the "
@@ -1479,7 +1615,7 @@ msgstr ""
 "gợi ý mọi người cách để tìm kiếm thông tin liên quan trong thư viện tiêu "
 "chuẩn."
 
-#: src/running-the-course.md
+#: src/running-the-course.md:48
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
 "for you as it has been for us!"
@@ -1488,7 +1624,7 @@ msgstr ""
 "hy vọng bạn có thể tìm thấy niềm vui như cách chúng tôi tìm thấy khi dạy "
 "khóa học này!"
 
-#: src/running-the-course.md
+#: src/running-the-course.md:51
 msgid ""
 "Please [provide feedback](https://github.com/google/comprehensive-rust/"
 "discussions/86) afterwards so that we can keep improving the course. We "
@@ -1503,11 +1639,11 @@ msgstr ""
 "bạn cũng có thể tích cực gửi feedback cho chúng tôi tại [đây](https://github."
 "com/google/comprehensive-rust/discussions/100)!"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:5
 msgid "Rust Fundamentals"
 msgstr "Rust Căn Bản"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:7
 msgid ""
 "The first four days make up [Rust Fundamentals](../welcome-day-1.md). The "
 "days are fast paced and we cover a lot of ground!"
@@ -1515,147 +1651,195 @@ msgstr ""
 "Ở bốn ngày học đầu tiên, ta sẽ nhanh chóng khái quát rất nhiều khía cạnh "
 "[căn bản](../welcome-day-1.md) của Rust!"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:10
+#: src/running-the-course/course-structure.md:146
 msgid "Course schedule:"
 msgstr "Thời khóa biểu:"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:11
 msgid "Day 1 Morning (2 hours and 5 minutes, including breaks)"
 msgstr "Ngày 1 Buổi Sáng (2 tiếng và 5 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-1.md) (5 minutes)"
-msgstr "[Lời Chào Mừng](../welcome-day-1.md) (5 phút)"
+#: src/running-the-course/course-structure.md:13
+#: src/running-the-course/course-structure.md:23
+#: src/running-the-course/course-structure.md:32
+#: src/running-the-course/course-structure.md:41
+#: src/running-the-course/course-structure.md:50
+#: src/running-the-course/course-structure.md:59
+#: src/running-the-course/course-structure.md:67
+#: src/running-the-course/course-structure.md:77
+#: src/running-the-course/course-structure.md:149
+#: src/running-the-course/course-structure.md:160 src/welcome-day-1.md:16
+#: src/welcome-day-1-afternoon.md:5 src/welcome-day-2.md:16
+#: src/welcome-day-2-afternoon.md:5 src/welcome-day-3.md:13
+#: src/welcome-day-3-afternoon.md:5 src/welcome-day-4.md:15
+#: src/welcome-day-4-afternoon.md:5 src/concurrency/welcome.md:14
+#: src/concurrency/welcome-async.md:31
+msgid "Segment"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Hello, World](../hello-world.md) (15 minutes)"
-msgstr "[Hello, World](../hello-world.md) (15 phút)"
+#: src/running-the-course/course-structure.md:13
+#: src/running-the-course/course-structure.md:23
+#: src/running-the-course/course-structure.md:32
+#: src/running-the-course/course-structure.md:41
+#: src/running-the-course/course-structure.md:50
+#: src/running-the-course/course-structure.md:59
+#: src/running-the-course/course-structure.md:67
+#: src/running-the-course/course-structure.md:77
+#: src/running-the-course/course-structure.md:149
+#: src/running-the-course/course-structure.md:160 src/welcome-day-1.md:16
+#: src/hello-world.md:5 src/types-and-values.md:5 src/control-flow-basics.md:5
+#: src/welcome-day-1-afternoon.md:5 src/tuples-and-arrays.md:5
+#: src/references.md:5 src/user-defined-types.md:5 src/welcome-day-2.md:16
+#: src/pattern-matching.md:5 src/methods-and-traits.md:5
+#: src/welcome-day-2-afternoon.md:5 src/generics.md:5 src/std-types.md:5
+#: src/std-traits.md:5 src/welcome-day-3.md:13 src/memory-management.md:5
+#: src/smart-pointers.md:5 src/welcome-day-3-afternoon.md:5 src/borrowing.md:5
+#: src/lifetimes.md:5 src/welcome-day-4.md:15 src/iterators.md:5
+#: src/modules.md:5 src/testing.md:5 src/welcome-day-4-afternoon.md:5
+#: src/error-handling.md:5 src/unsafe-rust.md:5 src/concurrency/welcome.md:14
+#: src/concurrency/threads.md:5 src/concurrency/channels.md:5
+#: src/concurrency/send-sync.md:5 src/concurrency/shared-state.md:5
+#: src/concurrency/sync-exercises.md:5 src/concurrency/welcome-async.md:31
+#: src/concurrency/async.md:5 src/concurrency/async-control-flow.md:5
+#: src/concurrency/async-pitfalls.md:9 src/concurrency/async-exercises.md:5
+msgid "Duration"
+msgstr "Thời lượng"
 
-#: src/running-the-course/course-structure.md
-msgid "[Types and Values](../types-and-values.md) (40 minutes)"
-msgstr "[Kiểu Dữ Liệu và Giá Trị](../types-and-values.md) (40 phút)"
+#: src/running-the-course/course-structure.md:15 src/welcome-day-1.md:18
+#: src/types-and-values.md:7 src/types-and-values.md:8
+#: src/types-and-values.md:9 src/control-flow-basics.md:8
+#: src/control-flow-basics.md:10 src/tuples-and-arrays.md:7
+#: src/tuples-and-arrays.md:8 src/tuples-and-arrays.md:10
+#: src/user-defined-types.md:9 src/user-defined-types.md:10 src/generics.md:7
+#: src/generics.md:10 src/std-types.md:8 src/std-traits.md:10
+#: src/std-traits.md:12 src/memory-management.md:7 src/memory-management.md:9
+#: src/memory-management.md:10 src/memory-management.md:12
+#: src/smart-pointers.md:8 src/lifetimes.md:8 src/lifetimes.md:9
+#: src/iterators.md:7 src/iterators.md:8 src/iterators.md:9 src/modules.md:8
+#: src/modules.md:9 src/testing.md:7 src/testing.md:8 src/error-handling.md:8
+#: src/error-handling.md:9 src/error-handling.md:10 src/error-handling.md:11
+#: src/unsafe-rust.md:7 src/unsafe-rust.md:9 src/unsafe-rust.md:10
+#: src/unsafe-rust.md:11 src/unsafe-rust.md:12
+#: src/concurrency/shared-state.md:7 src/concurrency/async-control-flow.md:9
+#: src/concurrency/async-pitfalls.md:13
+msgid "5 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Control Flow Basics](../control-flow-basics.md) (40 minutes)"
-msgstr "[Điều Khiển Luồng Căn Bản](../control-flow-basics.md) (40 phút)"
+#: src/running-the-course/course-structure.md:16
+#: src/running-the-course/course-structure.md:153 src/welcome-day-1.md:19
+#: src/types-and-values.md:12 src/control-flow-basics.md:13
+#: src/tuples-and-arrays.md:11 src/references.md:11
+#: src/user-defined-types.md:12 src/methods-and-traits.md:8 src/modules.md:11
+#: src/concurrency/welcome.md:18 src/concurrency/threads.md:7
+#: src/concurrency/threads.md:8 src/concurrency/shared-state.md:8
+msgid "15 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:17
+#: src/running-the-course/course-structure.md:18
+#: src/running-the-course/course-structure.md:43
+#: src/running-the-course/course-structure.md:71 src/welcome-day-1.md:20
+#: src/welcome-day-1.md:21 src/welcome-day-2-afternoon.md:7
+#: src/welcome-day-4.md:19
+msgid "40 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:21
 msgid "Day 1 Afternoon (2 hours and 35 minutes, including breaks)"
 msgstr "Ngày 1 Buổi Chiều (2 tiếng và 35 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Tuples and Arrays](../tuples-and-arrays.md) (35 minutes)"
-msgstr "[Tuples và Mảng](../tuples-and-arrays.md) (35 phút)"
+#: src/running-the-course/course-structure.md:25
+#: src/welcome-day-1-afternoon.md:7
+msgid "35 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[References](../references.md) (55 minutes)"
-msgstr "[Tham Chiếu](../references.md) (55 phút)"
+#: src/running-the-course/course-structure.md:26
+#: src/running-the-course/course-structure.md:54
+#: src/running-the-course/course-structure.md:61
+#: src/running-the-course/course-structure.md:79
+#: src/running-the-course/course-structure.md:164
+#: src/welcome-day-1-afternoon.md:8 src/welcome-day-3.md:17
+#: src/welcome-day-3-afternoon.md:7 src/welcome-day-4-afternoon.md:7
+#: src/concurrency/welcome-async.md:35
+msgid "55 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[User-Defined Types](../user-defined-types.md) (50 minutes)"
-msgstr "[Kiểu Dữ Liệu Tự Định Nghĩa](../user-defined-types.md) (50 phút)"
+#: src/running-the-course/course-structure.md:27
+#: src/running-the-course/course-structure.md:36
+#: src/running-the-course/course-structure.md:62
+#: src/welcome-day-1-afternoon.md:9 src/welcome-day-2.md:20
+#: src/welcome-day-3-afternoon.md:8
+msgid "50 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "Day 2 Morning (2 hours and 55 minutes, including breaks)"
+#: src/running-the-course/course-structure.md:30
+msgid "Day 2 Morning (2 hours and 10 minutes, including breaks)"
 msgstr "Ngày 2 Buổi Sáng (2 tiếng và 55 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-2.md) (3 minutes)"
-msgstr "[Lời Chào Mừng](../welcome-day-2.md) (3 phút)"
+#: src/running-the-course/course-structure.md:34
+#: src/running-the-course/course-structure.md:52
+#: src/running-the-course/course-structure.md:69 src/hello-world.md:8
+#: src/types-and-values.md:10 src/types-and-values.md:11
+#: src/control-flow-basics.md:11 src/tuples-and-arrays.md:9
+#: src/welcome-day-2.md:18 src/methods-and-traits.md:9 src/std-types.md:7
+#: src/welcome-day-3.md:15 src/borrowing.md:9 src/welcome-day-4.md:17
+#: src/modules.md:7 src/testing.md:9 src/error-handling.md:7
+msgid "3 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Pattern Matching](../pattern-matching.md) (1 hour)"
-msgstr "[So Khớp Mẫu (Pattern Matching)](../pattern-matching.md) (1 tiếng)"
+#: src/running-the-course/course-structure.md:35
+#: src/running-the-course/course-structure.md:53 src/welcome-day-2.md:19
+#: src/welcome-day-3.md:16
+msgid "1 hour"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Methods and Traits](../methods-and-traits.md) (50 minutes)"
-msgstr "[Phương Thức và Traits](../methods-and-traits.md) (50 phút)"
-
-#: src/running-the-course/course-structure.md
-msgid "[Generics](../generics.md) (40 minutes)"
-msgstr "[Tham Số Hóa Kiểu Dữ Liệu (Generics)](../generics.md) (40 phút)"
-
-#: src/running-the-course/course-structure.md
-msgid "Day 2 Afternoon (3 hours and 10 minutes, including breaks)"
+#: src/running-the-course/course-structure.md:39
+msgid "Day 2 Afternoon (4 hours, including breaks)"
 msgstr "Ngày 2 Buổi Chiều (3 tiếng và 10 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Standard Library Types](../std-types.md) (1 hour and 20 minutes)"
+#: src/running-the-course/course-structure.md:44
+#: src/welcome-day-2-afternoon.md:8
+msgid "1 hour and 20 minutes"
 msgstr ""
-"[Thư Viện Kiểu Dữ Liệu Tiêu Chuẩn (Standard Library Types)](../std-types.md) "
-"(1 tiếng và 20 phút)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Standard Library Traits](../std-traits.md) (1 hour and 40 minutes)"
+#: src/running-the-course/course-structure.md:45
+#: src/welcome-day-2-afternoon.md:9
+msgid "1 hour and 40 minutes"
 msgstr ""
-"[Thư Viện Traits Tiêu Chuẩn (Standard Library Traits)](../std-traits.md) (1 "
-"tiếng và 40 phút)"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:48
 msgid "Day 3 Morning (2 hours and 20 minutes, including breaks)"
 msgstr "Ngày 3 Buổi Sáng (2 tiếng và 20 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-3.md) (3 minutes)"
-msgstr "[Lời Chào Mừng](../welcome-day-3.md) (3 phút)"
-
-#: src/running-the-course/course-structure.md
-msgid "[Memory Management](../memory-management.md) (1 hour)"
-msgstr "[Quản Lý Bộ Nhớ](../memory-management.md) (1 tiếng)"
-
-#: src/running-the-course/course-structure.md
-msgid "[Smart Pointers](../smart-pointers.md) (55 minutes)"
-msgstr "[Con Trỏ Thông Minh](../smart-pointers.md) (55 phút)"
-
-#: src/running-the-course/course-structure.md
-msgid "Day 3 Afternoon (1 hour and 50 minutes, including breaks)"
+#: src/running-the-course/course-structure.md:57
+msgid "Day 3 Afternoon (1 hour and 55 minutes, including breaks)"
 msgstr "Ngày 3 Buổi Chiều (1 tiếng và 50 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Borrowing](../borrowing.md) (50 minutes)"
-msgstr "[Vay Mượn](../borrowing.md) (50 phút)"
-
-#: src/running-the-course/course-structure.md
-msgid "[Lifetimes](../lifetimes.md) (50 minutes)"
-msgstr "[Vòng đời](../lifetimes.md) (50 phút)"
-
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:65
 msgid "Day 4 Morning (2 hours and 40 minutes, including breaks)"
 msgstr "Ngày 4 Buổi Sáng (2 tiếng và 40 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-4.md) (3 minutes)"
-msgstr "[Lời Chào Mừng](../welcome-day-4.md) (3 phút)"
+#: src/running-the-course/course-structure.md:70
+#: src/running-the-course/course-structure.md:72 src/welcome-day-4.md:18
+#: src/welcome-day-4.md:20
+msgid "45 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Iterators](../iterators.md) (45 minutes)"
-msgstr "[Iterators](../iterators.md) (45 phút)"
-
-#: src/running-the-course/course-structure.md
-msgid "[Modules](../modules.md) (40 minutes)"
-msgstr "[Mô Đun](../modules.md) (40 phút)"
-
-#: src/running-the-course/course-structure.md
-msgid "[Testing](../testing.md) (45 minutes)"
-msgstr "[Kiểm Thử](../testing.md) (45 phút)"
-
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:75
 msgid "Day 4 Afternoon (2 hours and 10 minutes, including breaks)"
 msgstr "Ngày 4 Buổi Chiều (2 tiếng và 10 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md
-msgid "[Error Handling](../error-handling.md) (55 minutes)"
-msgstr "[Xử Lý Lỗi](../error-handling.md) (55 phút)"
+#: src/running-the-course/course-structure.md:80
+#: src/welcome-day-4-afternoon.md:8
+msgid "1 hour and 5 minutes"
+msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Unsafe Rust](../unsafe-rust.md) (1 hour and 5 minutes)"
-msgstr "[Rust \"Không An Toàn\"](../unsafe-rust.md) (1 giờ và 5 phút)"
-
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:85
 msgid "Deep Dives"
 msgstr "Chuyên Sâu"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:87
 msgid ""
 "In addition to the 4-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
@@ -1663,11 +1847,11 @@ msgstr ""
 "Ngoài lớp học \"4 ngày\" về Rust căn bản ra, chúng tôi còn cung cấp thêm một "
 "số chủ đề chuyên sâu sau:"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:90
 msgid "Rust in Android"
 msgstr "Rust trong Android"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:92
 msgid ""
 "The [Rust in Android](../android.md) deep dive is a half-day course on using "
 "Rust for Android platform development. This includes interoperability with "
@@ -1677,7 +1861,7 @@ msgstr ""
 "hướng dẫn sử dụng Rust cho phát triển trên nền tảng Android, bao gồm tính "
 "tương tác với C, C++ và Java."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:96
 msgid ""
 "You will need an [AOSP checkout](https://source.android.com/docs/setup/"
 "download/downloading). Make a checkout of the [course repository](https://"
@@ -1692,7 +1876,7 @@ msgstr ""
 "thống build của Android tìm được file `Android.bp` trong thư mục `src/"
 "android/`."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:101
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
 "all Android examples using `src/android/build_all.sh`. Read the script to "
@@ -1703,11 +1887,11 @@ msgstr ""
 "build_all.sh`. Bạn có thể đọc script để xem các lệnh mà nó chạy và xác nhận "
 "rằng mọi thứ đều hoạt động khi bạn kích hoạt bằng tay."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:108
 msgid "Rust in Chromium"
 msgstr "Rust trong Chromium"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:110
 msgid ""
 "The [Rust in Chromium](../chromium.md) deep dive is a half-day course on "
 "using Rust as part of the Chromium browser. It includes using Rust in "
@@ -1719,7 +1903,7 @@ msgstr ""
 "gồm hệ thống build `gn`, đưa vào thư viện bên thứ ba (\"crates\") và tính "
 "tương tác với C++."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:115
 msgid ""
 "You will need to be able to build Chromium --- a debug, component build is "
 "[recommended](../chromium/setup.md) for speed but any build will work. "
@@ -1731,11 +1915,11 @@ msgstr ""
 "chỉ cần bạn đảm bảo rằng mình sẽ chạy được trình duyệt Chromium vừa build "
 "xong."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:119
 msgid "Bare-Metal Rust"
 msgstr "Bare-Metal Rust"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:121
 msgid ""
 "The [Bare-Metal Rust](../bare-metal.md) deep dive is a full day class on "
 "using Rust for bare-metal (embedded) development. Both microcontrollers and "
@@ -1745,7 +1929,7 @@ msgstr ""
 "hướng dẫn sử dụng Rust cho phát triển nhúng (bare-metal). Nội dung về vi "
 "điều khiển và bộ xử lý ứng dụng sẽ được bao quát trong phần này."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:125
 msgid ""
 "For the microcontroller part, you will need to buy the [BBC micro:bit]"
 "(https://microbit.org/) v2 development board ahead of time. Everybody will "
@@ -1756,11 +1940,11 @@ msgstr ""
 "microbit.org/) v2. Mỗi người sẽ cần cài đặt một số packages dựa theo miêu tả "
 "ở [trang chào mừng](../bare-metal.md)."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:130
 msgid "Concurrency in Rust"
 msgstr "Tính đồng thời trong Rust"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:132
 msgid ""
 "The [Concurrency in Rust](../concurrency.md) deep dive is a full day class "
 "on classical as well as `async`/`await` concurrency."
@@ -1768,7 +1952,7 @@ msgstr ""
 "Chủ đề chuyên sâu [Tính đồng thời trong Rust](../concurrency.md) là khóa học "
 "một ngày hướng dẫn về khái niệm đồng thời `async`/`await` điển hình."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:135
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
 "to go. You can then copy/paste the examples into `src/main.rs` to experiment "
@@ -1778,11 +1962,51 @@ msgstr ""
 "để sẵn sàng chạy. Rồi bạn có thể copy/paste các ví dụ vào `src/main.rs` để "
 "thử nghiệm:"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:147
+msgid "Morning (3 hours and 20 minutes, including breaks)"
+msgstr "Ngày 3 Buổi Sáng (2 tiếng và 20 phút, bao gồm thời gian nghỉ)"
+
+#: src/running-the-course/course-structure.md:151
+#: src/running-the-course/course-structure.md:154
+#: src/running-the-course/course-structure.md:162 src/pattern-matching.md:11
+#: src/std-traits.md:14 src/smart-pointers.md:10 src/lifetimes.md:10
+#: src/iterators.md:10 src/testing.md:10 src/error-handling.md:12
+#: src/unsafe-rust.md:13 src/concurrency/welcome.md:16
+#: src/concurrency/welcome.md:19 src/concurrency/sync-exercises.md:9
+#: src/concurrency/welcome-async.md:33 src/concurrency/async-exercises.md:8
+msgid "30 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:152
+#: src/running-the-course/course-structure.md:163 src/methods-and-traits.md:10
+#: src/std-types.md:14 src/std-traits.md:13 src/memory-management.md:14
+#: src/borrowing.md:11 src/concurrency/welcome.md:17
+#: src/concurrency/sync-exercises.md:7 src/concurrency/sync-exercises.md:8
+#: src/concurrency/welcome-async.md:34 src/concurrency/async-pitfalls.md:12
+#: src/concurrency/async-pitfalls.md:14 src/concurrency/async-exercises.md:7
+#: src/concurrency/async-exercises.md:9
+msgid "20 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:153 src/concurrency/welcome.md:18
+msgid "Send and Sync"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:155
+#: src/running-the-course/course-structure.md:165 src/concurrency/welcome.md:20
+#: src/concurrency/welcome-async.md:36
+msgid "1 hour and 10 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:158
+msgid "Afternoon (3 hours and 20 minutes, including breaks)"
+msgstr "Buổi Chiều (3 tiếng và 20 phút, bao gồm thời gian nghỉ)"
+
+#: src/running-the-course/course-structure.md:170
 msgid "Format"
 msgstr "Quy Chuẩn"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:172
 msgid ""
 "The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
@@ -1790,43 +2014,43 @@ msgstr ""
 "Khóa học này hướng tới tính tương tác cao nên chúng tôi khuyến khích để các "
 "câu hỏi dẫn bạn đi khám phá nhiều thứ thú vị của Rust!"
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Dưới đây là một vài phím tắt có ích cho việc sử dụng mdBook:"
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:5
 msgid "Arrow-Left"
 msgstr "Mũi tên trái"
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:5
 msgid ": Navigate to the previous page."
 msgstr ": Điều hướng tới trang trước."
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:6
 msgid "Arrow-Right"
 msgstr "Mũi tên phải"
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:6
 msgid ": Navigate to the next page."
 msgstr ": Điều hướng tới trang tiếp theo."
 
-#: src/running-the-course/keyboard-shortcuts.md src/cargo/code-samples.md
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
 msgid "Ctrl + Enter"
 msgstr "Ctrl + Enter"
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:7
 msgid ": Execute the code sample that has focus."
 msgstr ": Chạy đoạn code mẫu chỉ định."
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:8
 msgid "s"
 msgstr "s"
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:8
 msgid ": Activate the search bar."
 msgstr ": Kích hoạt thanh tìm kiếm."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:3
 msgid ""
 "The course has been translated into other languages by a set of wonderful "
 "volunteers:"
@@ -1834,7 +2058,7 @@ msgstr ""
 "Khóa học này đã được dịch ra các ngôn ngữ sau nhờ các tình nguyện viên tuyệt "
 "vời:"
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:6
 msgid ""
 "[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
 "by [@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
@@ -1846,7 +2070,7 @@ msgstr ""
 "github.com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), "
 "và [@henrif75](https://github.com/henrif75)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:8
 msgid ""
 "[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
 "by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
@@ -1862,7 +2086,7 @@ msgstr ""
 "github.com/superwhd), [@SketchK](https://github.com/SketchK), và [@nodmp]"
 "(https://github.com/nodmp)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:10
 msgid ""
 "[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
 "by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
@@ -1876,7 +2100,7 @@ msgstr ""
 "github.com/kuanhungchen), và [@johnathan79717](https://github.com/"
 "johnathan79717)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:12
 msgid ""
 "[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
 "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), "
@@ -1888,7 +2112,7 @@ msgstr ""
 "[@jooyunghan](https://github.com/jooyunghan), và [@namhyung](https://github."
 "com/namhyung)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:13
 msgid ""
 "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
 "(https://github.com/deavid)."
@@ -1896,18 +2120,18 @@ msgstr ""
 "[Tiếng Tây Ban Nha](https://google.github.io/comprehensive-rust/es/) và "
 "[@deavid](https://github.com/deavid)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:15
 msgid ""
 "Use the language picker in the top-right corner to switch between languages."
 msgstr ""
 "Sử dụng nút lựa chọn ngôn ngữ ở góc phía trên bên phải để đổi sang ngôn ngữ "
 "khác."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:17
 msgid "Incomplete Translations"
 msgstr "Bản Dịch Chưa Hoàn Chỉnh"
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:19
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
@@ -1915,7 +2139,7 @@ msgstr ""
 "Hiện tại, vẫn còn một lượng lớn các bản dịch đang được tiến hành. Chúng tôi "
 "liên kết đến các bản dịch được cập nhật gần đây nhất:"
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:22
 msgid ""
 "[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
 "(https://github.com/raselmandol)."
@@ -1923,15 +2147,17 @@ msgstr ""
 "[Tiếng Bengal](https://google.github.io/comprehensive-rust/bn/) bởi "
 "[@raselmandol](https://github.com/raselmandol)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:23
 msgid ""
 "[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
-"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+"(https://github.com/KookaS), [@vcaen](https://github.com/vcaen) and "
+"[@AdrienBaudemont](https://github.com/AdrienBaudemont)."
 msgstr ""
 "[Tiếng Pháp](https://google.github.io/comprehensive-rust/fr/) bởi [@KookaS]"
-"(https://github.com/KookaS) và [@vcaen](https://github.com/vcaen)."
+"(https://github.com/KookaS), [@vcaen](https://github.com/vcaen) và "
+"[@AdrienBaudemont](https://github.com/AdrienBaudemont)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:24
 msgid ""
 "[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
 "(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
@@ -1939,7 +2165,7 @@ msgstr ""
 "[Tiếng Đức](https://google.github.io/comprehensive-rust/de/) bởi [@Throvn]"
 "(https://github.com/Throvn) và [@ronaldfw](https://github.com/ronaldfw)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:25
 msgid ""
 "[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
 "(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
@@ -1949,7 +2175,7 @@ msgstr ""
 "JPN](https://github.com/CoinEZ) và [@momotaro1105](https://github.com/"
 "momotaro1105)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:26
 msgid ""
 "[Italian](https://google.github.io/comprehensive-rust/it/) by "
 "[@henrythebuilder](https://github.com/henrythebuilder) and [@detro](https://"
@@ -1959,7 +2185,7 @@ msgstr ""
 "[@henrythebuilder](https://github.com/henrythebuilder) và [@detro](https://"
 "github.com/detro)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:28
 msgid ""
 "If you want to help with this effort, please see [our instructions](https://"
 "github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
@@ -1972,7 +2198,7 @@ msgstr ""
 "một bản [issue tracker](https://github.com/google/comprehensive-rust/"
 "issues/1957)."
 
-#: src/cargo.md
+#: src/cargo.md:3
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
 "rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
@@ -1986,15 +2212,15 @@ msgstr ""
 "tóm tắt ngắn gọn Cargo là gì, nó phù hợp với hệ sinh thái rộng lớn hơn ra "
 "sao, và nó phù hợp với khóa đào tạo như thế nào."
 
-#: src/cargo.md
+#: src/cargo.md:9
 msgid "Installation"
 msgstr "Cài đặt"
 
-#: src/cargo.md
+#: src/cargo.md:11
 msgid "**Please follow the instructions on <https://rustup.rs/>.**"
 msgstr "**Vui lòng tuân theo hướng dẫn cài đặt tại <https://rustup.rs/>.**"
 
-#: src/cargo.md
+#: src/cargo.md:13
 msgid ""
 "This will give you the Cargo build tool (`cargo`) and the Rust compiler "
 "(`rustc`). You will also get `rustup`, a command line utility that you can "
@@ -2004,7 +2230,7 @@ msgstr ""
 "(`rustc`). Bạn cũng sẽ có `rustup`, một tiện ích dòng lệnh mà bạn có thể sử "
 "dụng để cài đặt các phiên bản khác nhau cho trình biên dịch."
 
-#: src/cargo.md
+#: src/cargo.md:17
 msgid ""
 "After installing Rust, you should configure your editor or IDE to work with "
 "Rust. Most editors do this by talking to [rust-analyzer](https://rust-"
@@ -2023,7 +2249,7 @@ msgstr ""
 "Bên cạnh đó, vẫn còn một IDE khác khá phổ biến được phát triển bởi JetBrains "
 "là [RustRover](https://www.jetbrains.com/rust/)."
 
-#: src/cargo.md
+#: src/cargo.md:25
 msgid ""
 "On Debian/Ubuntu, you can also install Cargo, the Rust source and the [Rust "
 "formatter](https://github.com/rust-lang/rustfmt) via `apt`. However, this "
@@ -2035,18 +2261,18 @@ msgstr ""
 "Tuy nhiên, bạn sẽ chỉ cài được phiên bản đã bị quá hạn và có thể dẫn tới "
 "những lỗi không mong muốn. Câu lệnh để cài sẽ là như sau:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:1
 msgid "The Rust Ecosystem"
 msgstr "Hệ Sinh Thái Rust"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:3
 msgid ""
 "The Rust ecosystem consists of a number of tools, of which the main ones are:"
 msgstr ""
 "Hệ sinh thái của Rust bao gồm một số lượng đáng kể các công cụ, trong đó nổi "
 "bật nhất như là:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:5
 msgid ""
 "`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
 "intermediate formats."
@@ -2054,7 +2280,7 @@ msgstr ""
 "`rustc`: trình biên dịch Rust, thứ mà sẽ \"dịch\" các file `.rs` sang dạng "
 "nhị phân hoặc các formats bậc trung khác."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:8
 msgid ""
 "`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
 "download dependencies, usually hosted on <https://crates.io>, and it will "
@@ -2066,7 +2292,7 @@ msgstr ""
 "đưa chúng cho `rustc` khi bạn xây dựng dự án. Cargo còn có các trình chạy "
 "kiểm thử được cài sẵn phục vụ cho việc thực thi các đơn vị kiểm thử."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:13
 msgid ""
 "`rustup`: the Rust toolchain installer and updater. This tool is used to "
 "install and update `rustc` and `cargo` when new versions of Rust are "
@@ -2080,14 +2306,14 @@ msgstr ""
 "viện tiêu chuẩn. Bạn có thể cài đặt nhiều phiên bản Rust cùng lúc và "
 "`rustup` sẽ cho bạn chuyển đổi các phiên bản với nhau khi cần."
 
-#: src/cargo/rust-ecosystem.md src/types-and-values/hello-world.md
-#: src/references/exclusive.md src/pattern-matching/destructuring.md
-#: src/memory-management/move.md src/error-handling/try.md src/android/setup.md
-#: src/async/async-await.md
+#: src/cargo/rust-ecosystem.md:21 src/types-and-values/hello-world.md:26
+#: src/references/exclusive.md:20 src/memory-management/move.md:153
+#: src/error-handling/try.md:53 src/android/setup.md:18
+#: src/concurrency/async/async-await.md:26
 msgid "Key points:"
 msgstr "Các điểm chính:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:23
 msgid ""
 "Rust has a rapid release schedule with a new release coming out every six "
 "weeks. New releases maintain backwards compatibility with old releases --- "
@@ -2097,12 +2323,12 @@ msgstr ""
 "sáu tuần. Các phiên bản mới bảo toàn tính tương thích với các phiên bản cũ "
 "--- cùng với đó chúng kích hoạt thêm các chức năng mới."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:27
 msgid ""
 "There are three release channels: \"stable\", \"beta\", and \"nightly\"."
 msgstr "Có tổng cộng ba kênh phát hành: \"stable\", \"beta\", và \"nightly\"."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:29
 msgid ""
 "New features are being tested on \"nightly\", \"beta\" is what becomes "
 "\"stable\" every six weeks."
@@ -2110,7 +2336,7 @@ msgstr ""
 "Các tính năng mới dang được thử nghiệm trên \"nightly\", còn \"beta\" sẽ trở "
 "thành \"stable\" sau mỗi sáu tuần."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:32
 msgid ""
 "Dependencies can also be resolved from alternative [registries](https://doc."
 "rust-lang.org/cargo/reference/registries.html), git, folders, and more."
@@ -2119,7 +2345,7 @@ msgstr ""
 "(https://doc.rust-lang.org/cargo/reference/registries.html) thay thế, git, "
 "các thư mục, v.v..."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:35
 msgid ""
 "Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
 "current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
@@ -2127,7 +2353,7 @@ msgstr ""
 "Rust còn có nhiều [phiên bản lớn](https://doc.rust-lang.org/edition-guide/): "
 "Rust 2021 là bản hiện tại, Rust 2018, và Rust 2015."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:38
 msgid ""
 "The editions are allowed to make backwards incompatible changes to the "
 "language."
@@ -2135,7 +2361,7 @@ msgstr ""
 "Các phiên bản lớn được cho phép thực hiện các thay đổi không tương thích đối "
 "với ngôn ngữ."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:41
 msgid ""
 "To prevent breaking code, editions are opt-in: you select the edition for "
 "your crate via the `Cargo.toml` file."
@@ -2143,7 +2369,7 @@ msgstr ""
 "Để phòng trừ phá vỡ cấu trúc mã, các phiên bản lớn sẽ được chọn cho crate "
 "của bạn thông qua file `Cargo.toml`."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:44
 msgid ""
 "To avoid splitting the ecosystem, Rust compilers can mix code written for "
 "different editions."
@@ -2151,7 +2377,7 @@ msgstr ""
 "Nhằm tránh hệ sinh thái bị chia nhỏ ra, trình biên dịch Rust có thể trộn lẫn "
 "các đoạn mã được viết dưới các phiên bản lớn khác nhau."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:47
 msgid ""
 "Mention that it is quite rare to ever use the compiler directly not through "
 "`cargo` (most users never do)."
@@ -2160,7 +2386,7 @@ msgstr ""
 "không thông qua `cargo` là việc rất hiếm (hầu hết người dùng không bao giờ "
 "làm như vậy)."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:50
 msgid ""
 "It might be worth alluding that Cargo itself is an extremely powerful and "
 "comprehensive tool. It is capable of many advanced features including but "
@@ -2169,21 +2395,21 @@ msgstr ""
 "Nói không ngoa bản thân Cargo là một công cụ cự kỳ mạnh mẽ và toàn diện. Nó "
 "có khả năng bao gồm nhưng không giới hạn tới nhiều tính năng mở rộng sau:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:53
 msgid "Project/package structure"
 msgstr "Cấu trúc dự án/bộ phần mềm."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:54
 msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
 msgstr ""
 "[Workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:55
 msgid "Dev Dependencies and Runtime Dependency management/caching"
 msgstr ""
 "Các Dev Dependencies và trình quản lý/bộ nhớ đệm cho Runtime Dependency."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:56
 msgid ""
 "[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
 "html)"
@@ -2191,7 +2417,7 @@ msgstr ""
 "[Build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
 "html)."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:57
 msgid ""
 "[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
 "html)"
@@ -2199,7 +2425,7 @@ msgstr ""
 "[Cài đặt trên toàn môi trường](https://doc.rust-lang.org/cargo/commands/"
 "cargo-install.html)."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:58
 msgid ""
 "It is also extensible with sub command plugins as well (such as [cargo "
 "clippy](https://github.com/rust-lang/rust-clippy))."
@@ -2207,16 +2433,16 @@ msgstr ""
 "Nó còn có khả năng mở rộng được với các lệnh con dưới dạng plugins (như là "
 "[cargo clippy](https://github.com/rust-lang/rust-clippy))."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:60
 msgid ""
 "Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
 msgstr "Tham khảo thêm tại [The Cargo Book](https://doc.rust-lang.org/cargo/)."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:1
 msgid "Code Samples in This Training"
 msgstr "Code Mẫu Trong Khóa Đào Tạo"
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:3
 msgid ""
 "For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
@@ -2227,7 +2453,7 @@ msgstr ""
 "việc chuẩn bị được thực hiện dễ dàng hơn và đảm bảo trải nghiệm đồng nhất "
 "với mọi người."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
 "the exercises. On the last day, we will do a larger exercise which shows you "
@@ -2237,23 +2463,23 @@ msgstr ""
 "hơn. Trong ngày học cuối cùng, chúng tôi sẽ làm một bài tập lớn để cho bạn "
 "thấy cách làm việc với các gói phụ thuộc và bạn sẽ cần Cargo để làm nó."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
 msgstr "Các khối code trong khóa học này hoàn toàn tương tác được:"
 
-#: src/cargo/code-samples.md src/cargo/running-locally.md
+#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:46
 msgid "\"Edit me!\""
 msgstr "\"Chỉnh sửa tôi đê!\""
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:19
 msgid "You can use "
 msgstr "Bạn có thể sử dụng "
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:19
 msgid " to execute the code when focus is in the text box."
 msgstr " để thực thi khối code đang chứa con trỏ soạn thảo của bạn."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:24
 msgid ""
 "Most code samples are editable like shown above. A few code samples are not "
 "editable for various reasons:"
@@ -2261,7 +2487,7 @@ msgstr ""
 "Hầu hết các đoạn code mẫu đều có thể chỉnh sửa được như trên. Nhưng có một "
 "ít các đoạn mẫu lại không chỉnh sửa được vì vài lý do sau:"
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:27
 msgid ""
 "The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
 "open it in the real Playground to demonstrate unit tests."
@@ -2270,7 +2496,7 @@ msgstr ""
 "copy-paste đoạn code và mở nó trong một Playground thực sự để minh họa các "
 "thử nghiệm."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:30
 msgid ""
 "The embedded playgrounds lose their state the moment you navigate away from "
 "the page! This is the reason that the students should solve the exercises "
@@ -2280,11 +2506,11 @@ msgstr ""
 "sang trang khác! Vì lý do này, các học sinh nên giải các bài thực hành sử "
 "dụng Rust đã được cài đặt trong máy tính riêng hoặc qua Playground thực sự."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:1
 msgid "Running Code Locally with Cargo"
 msgstr "Chạy Cargo Trong Máy Tính Của Bạn"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
 "need to first install Rust. Do this by following the [instructions in the "
@@ -2298,7 +2524,7 @@ msgstr ""
 "cách sử dụng `rustc` và `cargo` ở đây. Tại thời điểm bài này được viết, "
 "phiên bản ổn định mới nhất của Rust có các số phiên bản sau:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:16
 msgid ""
 "You can use any later version too since Rust maintains backwards "
 "compatibility."
@@ -2306,7 +2532,7 @@ msgstr ""
 "Bạn cũng có thể sử dụng bất kỳ phiên bản nào ra sau đó vì Rust luôn bảo trì "
 "khả năng tương thích ngược của nó."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:18
 msgid ""
 "With this in place, follow these steps to build a Rust binary from one of "
 "the examples in this training:"
@@ -2314,25 +2540,25 @@ msgstr ""
 "Sau khi cài xong, tuân theo các bước sau đây để xây dựng tệp nhị phân Rust "
 "từ một trong các ví dụ trong khóa đào tạo:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:21
 msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr "Nhấn vào nút \"Copy to clipboard\" trong ví dụ mà bạn muốn copy."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:23
 msgid ""
 "Use `cargo new exercise` to create a new `exercise/` directory for your code:"
 msgstr ""
 "Sử dụng `cargo new exercise` để tạo một thư mục `exercise/` mới cho code của "
 "bạn:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:30
 msgid ""
 "Navigate into `exercise/` and use `cargo run` to build and run your binary:"
 msgstr ""
 "Điều hướng tới `exercise/` và sử dụng `cargo run` để build và chạy tệp nhị "
 "phân của bạn:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:41
 msgid ""
 "Replace the boiler-plate code in `src/main.rs` with your own code. For "
 "example, using the example on the previous page, make `src/main.rs` look like"
@@ -2340,11 +2566,11 @@ msgstr ""
 "Thay thế khung code trong `src/main.rs` với code riêng của bạn. Chẳng hạn, "
 "sử dụng ví dụ ở trang trước, viết `src/main.rs` sao cho thành như sau"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:50
 msgid "Use `cargo run` to build and run your updated binary:"
 msgstr "Sử dụng `cargo run` để build và chạy tệp nhị phân vừa được cập nhật:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:60
 msgid ""
 "Use `cargo check` to quickly check your project for errors, use `cargo "
 "build` to compile it without running it. You will find the output in `target/"
@@ -2356,7 +2582,7 @@ msgstr ""
 "`target/debug/` cho debug build thông thường. Sử dụng `cargo build --"
 "release` để xuất ra bản build tối ưu cho việc xuất bản ở `target/release/`."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:65
 msgid ""
 "You can add dependencies for your project by editing `Cargo.toml`. When you "
 "run `cargo` commands, it will automatically download and compile missing "
@@ -2366,7 +2592,7 @@ msgstr ""
 "`Cargo.toml`. Khi bạn chạy các lệnh `cargo`, nó sẽ tự động tải về và biên "
 "dịch các gói phụ thuộc bị thiếu cho bạn."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:73
 msgid ""
 "Try to encourage the class participants to install Cargo and use a local "
 "editor. It will make their life easier since they will have a normal "
@@ -2376,11 +2602,11 @@ msgstr ""
 "Editor ở máy riêng. Điều này sẽ giúp cuộc sống của họ dễ thở hơn một tý vì "
 "họ sẽ được làm việc trong một môi trường phát triển bình thường."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:1
 msgid "Welcome to Day 1"
 msgstr "Chào mừng tới Ngày 1"
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:3
 msgid ""
 "This is the first day of Rust Fundamentals. We will cover a lot of ground "
 "today:"
@@ -2388,7 +2614,7 @@ msgstr ""
 "Đây là ngày học đầu tiên của Rust Căn Bản. Sẽ có rất nhiều nội dung mà chúng "
 "ta bao quát trong hôm nay:"
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:5
 msgid ""
 "Basic Rust syntax: variables, scalar and compound types, enums, structs, "
 "references, functions, and methods."
@@ -2396,74 +2622,52 @@ msgstr ""
 "Câu lệnh Rust cơ bản: các biến, kiểu dữ liệu đơn giản và phức hợp, enum, "
 "struct, tham chiếu, hàm và phương thức."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:7
 msgid "Types and type inference."
 msgstr "Các kiểu dữ liệu và suy luận kiểu."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:8
 msgid "Control flow constructs: loops, conditionals, and so on."
 msgstr "Các cấu trúc điều kiển luồng: vòng lặp, điều kiện, vân vân..."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:9
 msgid "User-defined types: structs and enums."
 msgstr "Các kiểu dữ liệu tự định nghĩa: struct và enum."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:10
 msgid "Pattern matching: destructuring enums, structs, and arrays."
 msgstr "So khớp mẫu: hủy enum, struct, và mảng."
 
-#: src/welcome-day-1.md src/welcome-day-2.md src/welcome-day-3.md
-#: src/welcome-day-4.md
+#: src/welcome-day-1.md:12 src/welcome-day-2.md:12 src/welcome-day-3.md:9
+#: src/welcome-day-4.md:11 src/concurrency/welcome.md:10
+#: src/concurrency/welcome-async.md:27
 msgid "Schedule"
 msgstr "Mục lục"
 
-#: src/welcome-day-1.md src/welcome-day-1-afternoon.md src/welcome-day-2.md
-#: src/welcome-day-2-afternoon.md src/welcome-day-3.md
-#: src/welcome-day-3-afternoon.md src/welcome-day-4.md
-#: src/welcome-day-4-afternoon.md
-msgid "In this session:"
-msgstr "Trong buổi này:"
-
-#: src/welcome-day-1.md
-msgid "[Welcome](./welcome-day-1.md) (5 minutes)"
-msgstr "[Lời Chào Mừng](./welcome-day-1.md) (5 phút)"
-
-#: src/welcome-day-1.md
-msgid "[Hello, World](./hello-world.md) (15 minutes)"
-msgstr "[Hello, World](./hello-world.md) (15 phút)"
-
-#: src/welcome-day-1.md
-msgid "[Types and Values](./types-and-values.md) (40 minutes)"
-msgstr "[Kiểu Dữ Liệu Và Giá Trị](./types-and-values.md) (40 phút)"
-
-#: src/welcome-day-1.md
-msgid "[Control Flow Basics](./control-flow-basics.md) (40 minutes)"
-msgstr "[Điều Khiển Luồng Cơ Bản](./control-flow-basics.md) (40 phút)"
-
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:14
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 5 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Buổi học nên kéo dài khoảng 2 tiếng và 5 phút, bao gồm thời gian 10 phút "
-"nghỉ trưa"
+"nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:27
 msgid "Please remind the students that:"
 msgstr "Hãy lưu ý các học viên rằng:"
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:29
 msgid ""
 "They should ask questions when they get them, don't save them to the end."
 msgstr "Học viên nên đặt câu hỏi bất kì khi nào thay vì đợi đến cuối buổi học."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:30
 msgid ""
 "The class is meant to be interactive and discussions are very much "
 "encouraged!"
 msgstr "Lớp học rất khuyến khích có nhiều sự tương tác và thảo luận!"
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:31
 msgid ""
 "As an instructor, you should try to keep the discussions relevant, i.e., "
 "keep the discussions related to how Rust does things vs some other language. "
@@ -2476,12 +2680,12 @@ msgstr ""
 "khăn, nhưng ta thà chấp nhận nó để học viên thấy hứng thú hơn là việc giao "
 "tiếp một chiều."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:35
 msgid ""
 "The questions will likely mean that we talk about things ahead of the slides."
 msgstr "Một phần có thể bị hỏi trước khi ta học tới slide của phần đó."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:36
 msgid ""
 "This is perfectly okay! Repetition is an important part of learning. "
 "Remember that the slides are just a support and you are free to skip them as "
@@ -2491,7 +2695,7 @@ msgstr ""
 "trọng của việc học. Hãy nhớ rằng các slides chỉ là công cụ hỗ trợ cho bạn và "
 "bạn có thể bỏ qua chúng nếu muốn."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:40
 msgid ""
 "The idea for the first day is to show the \"basic\" things in Rust that "
 "should have immediate parallels in other languages. The more advanced parts "
@@ -2501,7 +2705,7 @@ msgstr ""
 "tương tự với các ngôn ngữ khác. Các phần nâng cao hơn sẽ được đề cập tới ở "
 "những ngày kế tiếp."
 
-#: src/welcome-day-1.md
+#: src/welcome-day-1.md:44
 msgid ""
 "If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. Note that there is an exercise at the end of each segment, "
@@ -2515,32 +2719,50 @@ msgstr ""
 "gian ở sau mỗi đề mục là nhằm giúp bạn giữ đúng tiến độ khóa học, nhưng bạn "
 "cũng có thể thoải mái điều chỉnh linh hoạt nếu cần thiết!"
 
-#: src/hello-world.md src/types-and-values.md src/control-flow-basics.md
-#: src/tuples-and-arrays.md src/references.md src/user-defined-types.md
-#: src/pattern-matching.md src/methods-and-traits.md src/generics.md
-#: src/std-types.md src/std-traits.md src/memory-management.md
-#: src/smart-pointers.md src/borrowing.md src/lifetimes.md src/iterators.md
-#: src/modules.md src/testing.md src/error-handling.md src/unsafe-rust.md
-msgid "In this segment:"
+#: src/hello-world.md:3 src/concurrency/send-sync.md:3
+msgid "This segment should take about 15 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 15 phút, bao gồm:"
+
+#: src/hello-world.md:5 src/types-and-values.md:5 src/control-flow-basics.md:5
+#: src/tuples-and-arrays.md:5 src/references.md:5 src/user-defined-types.md:5
+#: src/pattern-matching.md:5 src/methods-and-traits.md:5 src/generics.md:5
+#: src/std-types.md:5 src/std-traits.md:5 src/memory-management.md:5
+#: src/smart-pointers.md:5 src/borrowing.md:5 src/lifetimes.md:5
+#: src/iterators.md:5 src/modules.md:5 src/testing.md:5 src/error-handling.md:5
+#: src/unsafe-rust.md:5 src/concurrency/threads.md:5
+#: src/concurrency/channels.md:5 src/concurrency/send-sync.md:5
+#: src/concurrency/shared-state.md:5 src/concurrency/sync-exercises.md:5
+#: src/concurrency/async.md:5 src/concurrency/async-control-flow.md:5
+#: src/concurrency/async-pitfalls.md:9 src/concurrency/async-exercises.md:5
+msgid "Slide"
 msgstr ""
 
-#: src/hello-world.md
-msgid "[What is Rust?](./hello-world/what-is-rust.md) (10 minutes)"
+#: src/hello-world.md:7 src/references.md:7 src/references.md:8
+#: src/references.md:9 src/references.md:10 src/user-defined-types.md:7
+#: src/user-defined-types.md:8 src/pattern-matching.md:7
+#: src/pattern-matching.md:10 src/methods-and-traits.md:7 src/generics.md:8
+#: src/generics.md:9 src/generics.md:11 src/std-types.md:9 src/std-types.md:10
+#: src/std-types.md:11 src/std-types.md:12 src/std-types.md:13
+#: src/std-traits.md:7 src/std-traits.md:8 src/std-traits.md:9
+#: src/std-traits.md:11 src/memory-management.md:8 src/memory-management.md:13
+#: src/smart-pointers.md:7 src/smart-pointers.md:9 src/borrowing.md:7
+#: src/borrowing.md:8 src/borrowing.md:10 src/lifetimes.md:7 src/modules.md:10
+#: src/unsafe-rust.md:8 src/concurrency/channels.md:7
+#: src/concurrency/channels.md:9 src/concurrency/send-sync.md:10
+#: src/concurrency/shared-state.md:9 src/concurrency/async.md:7
+#: src/concurrency/async.md:9 src/concurrency/async.md:10
+#: src/concurrency/async-control-flow.md:7 src/concurrency/async-pitfalls.md:11
+msgid "10 minutes"
 msgstr ""
 
-#: src/hello-world.md
-msgid "[Benefits of Rust](./hello-world/benefits.md) (3 minutes)"
+#: src/hello-world.md:9 src/control-flow-basics.md:12
+#: src/user-defined-types.md:11 src/memory-management.md:11
+#: src/concurrency/channels.md:8 src/concurrency/send-sync.md:7
+#: src/concurrency/send-sync.md:8 src/concurrency/send-sync.md:9
+msgid "2 minutes"
 msgstr ""
 
-#: src/hello-world.md
-msgid "[Playground](./hello-world/playground.md) (2 minutes)"
-msgstr ""
-
-#: src/hello-world.md
-msgid "This segment should take about 15 minutes"
-msgstr ""
-
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:3
 msgid ""
 "Rust is a new programming language which had its [1.0 release in 2015]"
 "(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
@@ -2548,15 +2770,15 @@ msgstr ""
 "Rust là một ngôn ngữ lập trình mới được phát hành [phiên bản 1.0 vào năm "
 "2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:5
 msgid "Rust is a statically compiled language in a similar role as C++"
 msgstr "Rust là một ngôn ngữ được biên dịch tĩnh với vai trò tương tự như C++"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:6
 msgid "`rustc` uses LLVM as its backend."
 msgstr "`rustc` sử dụng LLVM làm bộ dịch backend."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:7
 msgid ""
 "Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
 "nightly/rustc/platform-support.html):"
@@ -2564,170 +2786,170 @@ msgstr ""
 "Rust hỗ trợ rất nhiều [nền tảng và kiểu kiến trúc](https://doc.rust-lang.org/"
 "nightly/rustc/platform-support.html):"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:9
 msgid "x86, ARM, WebAssembly, ..."
 msgstr ""
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:10
 msgid "Linux, Mac, Windows, ..."
 msgstr ""
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:11
 msgid "Rust is used for a wide range of devices:"
 msgstr "Rust được sử dụng cho nhiều loại thiết bị:"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:12
 msgid "firmware and boot loaders,"
 msgstr "firmware và các chương trình khởi động (*boot loaders*),"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:13
 msgid "smart displays,"
 msgstr "màn hình thông minh,"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:14
 msgid "mobile phones,"
 msgstr "điện thoại di động,"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:15
 msgid "desktops,"
 msgstr "máy tính,"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:16
 msgid "servers."
 msgstr "máy chủ."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust phù hợp trong cùng lĩnh vực như C++:"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:23
 msgid "High flexibility."
 msgstr "Độ linh hoạt cao."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:24
 msgid "High level of control."
 msgstr "Có quyền điều khiển cao."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:25
 msgid ""
 "Can be scaled down to very constrained devices such as microcontrollers."
 msgstr ""
 "Có thể ứng dụng với các thiết bị có tài nguyên hạn chế như vi điều khiển."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:26
 msgid "Has no runtime or garbage collection."
 msgstr ""
 "Không có thời gian chạy (*runtime*) hay trình thu dọn rác (*garbage "
 "collection*)."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:27
 msgid "Focuses on reliability and safety without sacrificing performance."
 msgstr ""
 "Tập trung vào tính đáng tin cậy và độ an toàn mà không làm giảm hiệu suất."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:3
 msgid "Some unique selling points of Rust:"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:5
 msgid ""
 "_Compile time memory safety_ - whole classes of memory bugs are prevented at "
 "compile time"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:7
 msgid "No uninitialized variables."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:8
 msgid "No double-frees."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:9
 msgid "No use-after-free."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:10
 msgid "No `NULL` pointers."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:11
 msgid "No forgotten locked mutexes."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:12
 msgid "No data races between threads."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:13
 msgid "No iterator invalidation."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:15
 msgid ""
 "_No undefined runtime behavior_ - what a Rust statement does is never left "
 "unspecified"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:17
 msgid "Array access is bounds checked."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:18
 msgid "Integer overflow is defined (panic or wrap-around)."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:20
 msgid ""
 "_Modern language features_ - as expressive and ergonomic as higher-level "
 "languages"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:22
 msgid "Enums and pattern matching."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:23
 msgid "Generics."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:24
 msgid "No overhead FFI."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:25
 msgid "Zero-cost abstractions."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:26
 msgid "Great compiler errors."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:27
 msgid "Built-in dependency manager."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:28
 msgid "Built-in support for testing."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:29
 msgid "Excellent Language Server Protocol support."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:34
 msgid ""
 "Do not spend much time here. All of these points will be covered in more "
 "depth later."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:37
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
 "Depending on the answer you can highlight different features of Rust:"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:40
 msgid ""
 "Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
 "via the borrow checker. You get performance like in C and C++, but you don't "
@@ -2735,7 +2957,7 @@ msgid ""
 "constructs like pattern matching and built-in dependency management."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:45
 msgid ""
 "Experience with Java, Go, Python, JavaScript...: You get the same memory "
 "safety as in those languages, plus a similar high-level language feeling. In "
@@ -2743,7 +2965,7 @@ msgid ""
 "collector) as well as access to low-level hardware (should you need it)"
 msgstr ""
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:3
 msgid ""
 "The [Rust Playground](https://play.rust-lang.org/) provides an easy way to "
 "run short Rust programs, and is the basis for the examples and exercises in "
@@ -2756,7 +2978,7 @@ msgstr ""
 "chương trình “hello-world”. Rust Playground đi kèm với một vài tính năng hữu "
 "ích:"
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:8
 msgid ""
 "Under \"Tools\", use the `rustfmt` option to format your code in the "
 "\"standard\" way."
@@ -2764,7 +2986,7 @@ msgstr ""
 "Ở phần “Công cụ (*Tools*)”, sử dụng tuỳ chọn`rustfmt` để định dạng đoạn code "
 "của bạn theo cách “tiêu chuẩn”."
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:11
 msgid ""
 "Rust has two main \"profiles\" for generating code: Debug (extra runtime "
 "checks, less optimization) and Release (fewer runtime checks, lots of "
@@ -2775,7 +2997,7 @@ msgstr ""
 "(*Release*) (ít thông tin hỗ trợ trong quá trình chạy (*runtime*), tối ưu "
 "hoá nhiều hơn). Các tuỳ chọn này có trong mục “Gỡ lỗi (*Debug*)” ở phía trên."
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:15
 msgid ""
 "If you're interested, use \"ASM\" under \"...\" to see the generated "
 "assembly code."
@@ -2783,7 +3005,7 @@ msgstr ""
 "Nếu bạn quan tâm, bạn có thể sử dụng chế độ “ASM” ở trong phần “...” để xem "
 "đoạn code Assembly được tạo."
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:21
 msgid ""
 "As students head into the break, encourage them to open up the playground "
 "and experiment a little. Encourage them to keep the tab open and try things "
@@ -2797,93 +3019,69 @@ msgstr ""
 "những học viên nâng cao muốn biết thêm về tối ưu hoá của Rust và những đoạn "
 "code Assembly được tạo ra."
 
-#: src/types-and-values.md
-msgid "[Hello, World](./types-and-values/hello-world.md) (5 minutes)"
-msgstr ""
+#: src/types-and-values.md:3 src/control-flow-basics.md:3 src/generics.md:3
+#: src/modules.md:3
+msgid "This segment should take about 40 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 40 phút, bao gồm:"
 
-#: src/types-and-values.md
-msgid "[Variables](./types-and-values/variables.md) (5 minutes)"
-msgstr ""
-
-#: src/types-and-values.md
-msgid "[Values](./types-and-values/values.md) (5 minutes)"
-msgstr ""
-
-#: src/types-and-values.md
-msgid "[Arithmetic](./types-and-values/arithmetic.md) (3 minutes)"
-msgstr ""
-
-#: src/types-and-values.md
-msgid "[Type Inference](./types-and-values/inference.md) (3 minutes)"
-msgstr ""
-
-#: src/types-and-values.md
-msgid "[Exercise: Fibonacci](./types-and-values/exercise.md) (15 minutes)"
-msgstr ""
-
-#: src/types-and-values.md src/control-flow-basics.md src/generics.md
-#: src/modules.md
-msgid "This segment should take about 40 minutes"
-msgstr ""
-
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:3
 msgid ""
 "Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:8
 msgid "\"Hello 🌍!\""
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:12
 msgid "What you see:"
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:14
 msgid "Functions are introduced with `fn`."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:15
 msgid "Blocks are delimited by curly braces like in C and C++."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:16
 msgid "The `main` function is the entry point of the program."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:17
 msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:18
 msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:23
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
 "see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:28
 msgid ""
 "Rust is very much like other languages in the C/C++/Java tradition. It is "
 "imperative and it doesn't try to reinvent things unless absolutely necessary."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:31
 msgid "Rust is modern with full support for things like Unicode."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:33
 msgid ""
 "Rust uses macros for situations where you want to have a variable number of "
 "arguments (no function [overloading](../control-flow-basics/functions.md))."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:36
 msgid ""
 "Macros being 'hygienic' means they don't accidentally capture identifiers "
 "from the scope they are used in. Rust macros are actually only [partially "
@@ -2891,7 +3089,7 @@ msgid ""
 "html)."
 msgstr ""
 
-#: src/types-and-values/hello-world.md
+#: src/types-and-values/hello-world.md:40
 msgid ""
 "Rust is multi-paradigm. For example, it has powerful [object-oriented "
 "programming features](https://doc.rust-lang.org/book/ch17-00-oop.html), and, "
@@ -2899,164 +3097,164 @@ msgid ""
 "concepts](https://doc.rust-lang.org/book/ch13-00-functional-features.html)."
 msgstr ""
 
-#: src/types-and-values/variables.md
+#: src/types-and-values/variables.md:3
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are made with "
 "`let`:"
 msgstr ""
 
-#: src/types-and-values/variables.md src/control-flow-basics/loops/for.md
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/types-and-values/variables.md:9 src/control-flow-basics/loops/for.md:9
+#: src/control-flow-basics/blocks-and-scopes.md:17
 msgid "\"x: {x}\""
 msgstr ""
 
-#: src/types-and-values/variables.md
+#: src/types-and-values/variables.md:10
 msgid ""
 "// x = 20;\n"
 "    // println!(\"x: {x}\");\n"
 msgstr ""
 
-#: src/types-and-values/variables.md
+#: src/types-and-values/variables.md:18
 msgid ""
 "Uncomment the `x = 20` to demonstrate that variables are immutable by "
 "default. Add the `mut` keyword to allow changes."
 msgstr ""
 
-#: src/types-and-values/variables.md
+#: src/types-and-values/variables.md:21
 msgid ""
 "The `i32` here is the type of the variable. This must be known at compile "
 "time, but type inference (covered later) allows the programmer to omit it in "
 "many cases."
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:3
 msgid ""
 "Here are some basic built-in types, and the syntax for literal values of "
 "each type."
 msgstr ""
 
-#: src/types-and-values/values.md src/unsafe-rust/exercise.md
+#: src/types-and-values/values.md:6 src/unsafe-rust/exercise.md:16
 msgid "Types"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:6
 msgid "Literals"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:8
 msgid "Signed integers"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:8
 msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:8
 msgid "`-10`, `0`, `1_000`, `123_i64`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:9
 msgid "Unsigned integers"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:9
 msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:9
 msgid "`0`, `123`, `10_u16`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:10
 msgid "Floating point numbers"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:10
 msgid "`f32`, `f64`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:10
 msgid "`3.14`, `-10.0e20`, `2_f32`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:11
 msgid "Unicode scalar values"
 msgstr ""
 
-#: src/types-and-values/values.md src/android/aidl/types/primitives.md
+#: src/types-and-values/values.md:11 src/android/aidl/types/primitives.md:9
 msgid "`char`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:11
 msgid "`'a'`, `'α'`, `'∞'`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:12
 msgid "Booleans"
 msgstr ""
 
-#: src/types-and-values/values.md src/android/aidl/types/primitives.md
+#: src/types-and-values/values.md:12 src/android/aidl/types/primitives.md:7
 msgid "`bool`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:12
 msgid "`true`, `false`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:14
 msgid "The types have widths as follows:"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:16
 msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:17
 msgid "`isize` and `usize` are the width of a pointer,"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:18
 msgid "`char` is 32 bits wide,"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:19
 msgid "`bool` is 8 bits wide."
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:24
 msgid "There are a few syntaxes which are not shown above:"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:26
 msgid ""
 "All underscores in numbers can be left out, they are for legibility only. So "
 "`1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written "
 "as `123i64`."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:9
 msgid "\"result: {}\""
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:16
 msgid ""
 "This is the first time we've seen a function other than `main`, but the "
 "meaning should be clear: it takes three integers, and returns an integer. "
 "Functions will be covered in more detail later."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:20
 msgid "Arithmetic is very similar to other languages, with similar precedence."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:22
 msgid ""
 "What about integer overflow? In C and C++ overflow of _signed_ integers is "
 "actually undefined, and might do different things on different platforms or "
 "compilers. In Rust, it's defined."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:26
 msgid ""
 "Change the `i32`'s to `i16` to see an integer overflow, which panics "
 "(checked) in a debug build and wraps in a release build. There are other "
@@ -3065,23 +3263,23 @@ msgid ""
 "a)`."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:31
 msgid ""
 "In fact, the compiler will detect overflow of constant expressions, which is "
 "why the example requires a separate function."
 msgstr ""
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
 msgstr ""
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:29
 msgid ""
 "This slide demonstrates how the Rust compiler infers types based on "
 "constraints given by variable declarations and usages."
 msgstr ""
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:32
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
 "of some sort of dynamic \"any type\" that can hold any data. The machine "
@@ -3090,84 +3288,67 @@ msgid ""
 "code."
 msgstr ""
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:37
 msgid ""
 "When nothing constrains the type of an integer literal, Rust defaults to "
 "`i32`. This sometimes appears as `{integer}` in error messages. Similarly, "
 "floating-point literals default to `f64`."
 msgstr ""
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:46
 msgid "// ERROR: no implementation for `{float} == {integer}`\n"
 msgstr ""
 
-#: src/types-and-values/exercise.md
+#: src/types-and-values/exercise.md:3
 msgid ""
-"The first and second Fibonacci numbers are both `1`. For n>2, the n'th "
-"Fibonacci number is calculated recursively as the sum of the n-1'th and "
-"n-2'th Fibonacci numbers."
+"The Fibonacci sequence begins with `[0,1]`. For n>1, the n'th Fibonacci "
+"number is calculated recursively as the sum of the n-1'th and n-2'th "
+"Fibonacci numbers."
 msgstr ""
 
-#: src/types-and-values/exercise.md
+#: src/types-and-values/exercise.md:6
 msgid ""
 "Write a function `fib(n)` that calculates the n'th Fibonacci number. When "
 "will this function panic?"
 msgstr ""
 
-#: src/types-and-values/exercise.md
+#: src/types-and-values/exercise.md:12
 msgid "// The base case.\n"
 msgstr ""
 
-#: src/types-and-values/exercise.md src/control-flow-basics/exercise.md
+#: src/types-and-values/exercise.md:13 src/types-and-values/exercise.md:16
+#: src/control-flow-basics/exercise.md:27
+#: src/control-flow-basics/exercise.md:31
 msgid "\"Implement this\""
 msgstr ""
 
-#: src/types-and-values/exercise.md
+#: src/types-and-values/exercise.md:15
 msgid "// The recursive case.\n"
 msgstr ""
 
-#: src/types-and-values/exercise.md src/types-and-values/solution.md
+#: src/types-and-values/exercise.md:22 src/types-and-values/solution.md:14
 msgid "\"fib({n}) = {}\""
 msgstr ""
 
-#: src/control-flow-basics.md
-msgid "[if Expressions](./control-flow-basics/if.md) (4 minutes)"
-msgstr "[Lệnh if](./control-flow-basics/if.md) (4 phút)"
+#: src/control-flow-basics.md:7
+msgid "if Expressions"
+msgstr "Lệnh `if`"
 
-#: src/control-flow-basics.md
-msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
-msgstr "[Vòng lặp](./control-flow-basics/loops.md) (5 phút)"
-
-#: src/control-flow-basics.md
-msgid ""
-"[break and continue](./control-flow-basics/break-continue.md) (4 minutes)"
+#: src/control-flow-basics.md:7 src/control-flow-basics.md:9
+#: src/pattern-matching.md:8 src/pattern-matching.md:9
+#: src/concurrency/async.md:8 src/concurrency/async-control-flow.md:8
+msgid "4 minutes"
 msgstr ""
-"[Lệnh break và lệnh continue](./control-flow-basics/break-continue.md) (4 "
-"phút)"
 
-#: src/control-flow-basics.md
-msgid ""
-"[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (5 minutes)"
-msgstr "[Khối và phạm vi](./control-flow-basics/blocks-and-scopes.md) (5 phút)"
+#: src/control-flow-basics.md:9
+msgid "break and continue"
+msgstr "`break` và `continue`"
 
-#: src/control-flow-basics.md
-msgid "[Functions](./control-flow-basics/functions.md) (3 minutes)"
-msgstr "[Hàm](./control-flow-basics/functions.md) (3 phút)"
-
-#: src/control-flow-basics.md
-msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
-msgstr "[Macros](./control-flow-basics/macros.md) (2 phút)"
-
-#: src/control-flow-basics.md
-msgid ""
-"[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (15 minutes)"
-msgstr "[Bài tập: Chuỗi Collatz](./control-flow-basics/exercise.md) (15 phút)"
-
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:1
 msgid "`if` expressions"
 msgstr "Lệnh `if`"
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:3
 msgid ""
 "You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
 "if-expr.html#if-expressions) exactly like `if` statements in other languages:"
@@ -3176,19 +3357,19 @@ msgstr ""
 "if-expr.html#if-expressions) giống hệt như lệnh `if` ở những ngôn ngữ lập "
 "trình khác"
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:11
 msgid "\"zero!\""
 msgstr "\"số không\""
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:13
 msgid "\"biggish\""
 msgstr "\"số lớn\""
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:15
 msgid "\"huge\""
 msgstr "\"số rất hơn\""
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:20
 msgid ""
 "In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
@@ -3196,19 +3377,19 @@ msgstr ""
 "Ngoài ra, học viên có thể sử dụng `if` như một biểu thức. Biểu thức cuối "
 "cùng của mỗi khối lệnh sẽ trở thành giá trị của biểu thức `if` đó"
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:26
 msgid "\"small\""
 msgstr "\"nhỏ\""
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:26
 msgid "\"large\""
 msgstr "\"lớn\""
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:27
 msgid "\"number size: {}\""
 msgstr "\"kích thước số: {}\""
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:34
 msgid ""
 "Because `if` is an expression and must have a particular type, both of its "
 "branch blocks must have the same type. Show what happens if you add `;` "
@@ -3218,7 +3399,7 @@ msgstr ""
 "nhánh khối lệnh phải có cùng một kiểu dữ liểu. Hãy trình bày nếu học viên "
 "thêm dấu `;` vào sau `\"nhỏ\"` ở ví dụ thứ hai"
 
-#: src/control-flow-basics/if.md
+#: src/control-flow-basics/if.md:38
 msgid ""
 "When `if` is used in an expression, the expression must have a `;` to "
 "separate it from the next statement. Remove the `;` before `println!` to see "
@@ -3228,15 +3409,15 @@ msgstr ""
 "tách biệt nó khỏi lệnh tiếp theo. Loại bỏ dấu `;` sau `println!` để thấy "
 "được lỗi biên dịch"
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:3
 msgid "There are three looping keywords in Rust: `while`, `loop`, and `for`:"
 msgstr "Có ba từ khóa cho vòng lặp trong Rust: while`, `loop` và `for`"
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:5
 msgid "`while`"
 msgstr "`while`"
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:7
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
 "expr.html#predicate-loops) works much like in other languages, executing the "
@@ -3246,22 +3427,22 @@ msgstr ""
 "html#predicate-loops) hoạt đông tương tự như những ngôn ngữ lập trình khác, "
 "thực hiện vòng lặp lại một khối lệnh trong khi điều kiện còn đúng"
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:18
 msgid "\"Final x: {x}\""
 msgstr "\"Số x cuối cùng: {x}\""
 
-#: src/control-flow-basics/loops/for.md
+#: src/control-flow-basics/loops/for.md:3
 msgid ""
 "The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) iterates "
 "over ranges of values or the items in a collection:"
 msgstr ""
 "[Từ khóa `for`] lặp lại qua chuỗi dữ liệu hoặc các phần tử trong một tập hợp:"
 
-#: src/control-flow-basics/loops/for.md
+#: src/control-flow-basics/loops/for.md:13
 msgid "\"elem: {elem}\""
 msgstr "\"elem: {elem}\""
 
-#: src/control-flow-basics/loops/for.md
+#: src/control-flow-basics/loops/for.md:20
 msgid ""
 "Under the hood `for` loops use a concept called \"iterators\" to handle "
 "iterating over different kinds of ranges/collections. Iterators will be "
@@ -3271,7 +3452,7 @@ msgstr ""
 "\"iterators\" để xử việc lặp lại qua nhiều dạng dãy/tập hợp khác nhau. "
 "Iterators sẽ được nhắc tới chi tiết sau."
 
-#: src/control-flow-basics/loops/for.md
+#: src/control-flow-basics/loops/for.md:23
 msgid ""
 "Note that the `for` loop only iterates to `4`. Show the `1..=5` syntax for "
 "an inclusive range."
@@ -3279,7 +3460,7 @@ msgstr ""
 "Lưu ý rằng vòng lặp `for` chỉ lặp tới `4`. Trình bày cú pháp `1..=5` để có "
 "một dãy bao gồm"
 
-#: src/control-flow-basics/loops/loop.md
+#: src/control-flow-basics/loops/loop.md:3
 msgid ""
 "The [`loop` statement](https://doc.rust-lang.org/std/keyword.loop.html) just "
 "loops forever, until a `break`."
@@ -3287,11 +3468,11 @@ msgstr ""
 "[Từ khóa `loop`](https://doc.rust-lang.org/std/keyword.loop.html) là một "
 "vòng lặp bất tận, cho tới khi `break`."
 
-#: src/control-flow-basics/loops/loop.md
+#: src/control-flow-basics/loops/loop.md:11
 msgid "\"{i}\""
 msgstr "\"{i}\""
 
-#: src/control-flow-basics/break-continue.md
+#: src/control-flow-basics/break-continue.md:3
 msgid ""
 "If you want to immediately start the next iteration use [`continue`](https://"
 "doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
@@ -3300,7 +3481,7 @@ msgstr ""
 "(https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-"
 "expressions)."
 
-#: src/control-flow-basics/break-continue.md
+#: src/control-flow-basics/break-continue.md:6
 msgid ""
 "If you want to exit any kind of loop early, use [`break`](https://doc.rust-"
 "lang.org/reference/expressions/loop-expr.html#break-expressions). For "
@@ -3312,16 +3493,17 @@ msgstr ""
 "với `loop`, từ khóa này có thể dùng một biểu thức tùy chọn trở thành giá trị "
 "của biểu thức `loop` "
 
-#: src/control-flow-basics/break-continue.md src/std-traits/exercise.md
-#: src/std-traits/solution.md src/smart-pointers/trait-objects.md
-#: src/modules/exercise.md src/modules/solution.md
-#: src/android/build-rules/library.md
-#: src/android/interoperability/cpp/rust-bridge.md
-#: src/async/pitfalls/cancellation.md
+#: src/control-flow-basics/break-continue.md:22 src/std-traits/exercise.md:23
+#: src/std-traits/solution.md:29 src/smart-pointers/trait-objects.md:93
+#: src/smart-pointers/trait-objects.md:94
+#: src/borrowing/interior-mutability.md:47 src/modules/exercise.md:136
+#: src/modules/solution.md:78 src/android/build-rules/library.md:44
+#: src/android/interoperability/cpp/rust-bridge.md:17
+#: src/concurrency/async-pitfalls/cancellation.md:59
 msgid "\"{}\""
 msgstr "\"{}\""
 
-#: src/control-flow-basics/break-continue/labels.md
+#: src/control-flow-basics/break-continue/labels.md:3
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
 "used to break out of nested loops:"
@@ -3329,11 +3511,11 @@ msgstr ""
 "Cả `continue` và `break` có thể sử dụng một nhãn tùy chọn để được sử dụng để "
 "thoát ra khỏi những vòng lặp lồng nhau"
 
-#: src/control-flow-basics/break-continue/labels.md
+#: src/control-flow-basics/break-continue/labels.md:19
 msgid "\"elements searched: {elements_searched}\""
 msgstr "\"elements searched: {elements_searched}\""
 
-#: src/control-flow-basics/break-continue/labels.md
+#: src/control-flow-basics/break-continue/labels.md:25
 msgid ""
 "Note that `loop` is the only looping construct which returns a non-trivial "
 "value. This is because it's guaranteed to be entered at least once (unlike "
@@ -3343,89 +3525,90 @@ msgstr ""
 "là vởi vì vòng lặp sẽ chắc chắn được nhập vào ít nhất một lần (không giống "
 "như vòng lặp `while` và `for`) "
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:3
 msgid "Blocks"
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:5
 msgid ""
 "A block in Rust contains a sequence of expressions, enclosed by braces `{}`. "
 "Each block has a value and a type, which are those of the last expression of "
 "the block:"
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:14
 msgid "\"y: {y}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:21
 msgid ""
 "If the last expression ends with `;`, then the resulting value and type is "
 "`()`."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:26
 msgid ""
 "You can show how the value of the block changes by changing the last line in "
 "the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:3
 msgid "A variable's scope is limited to the enclosing block."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:5
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
 "the same scope:"
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:11
 msgid "\"before: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md src/generics/exercise.md
-#: src/generics/solution.md src/std-traits/from-and-into.md
-#: src/lifetimes/solution.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:13
+#: src/generics/exercise.md:18 src/generics/solution.md:20
+#: src/std-traits/from-and-into.md:7 src/std-traits/from-and-into.md:19
+#: src/lifetimes/solution.md:225
 msgid "\"hello\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:14
 msgid "\"inner scope: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:17
 msgid "\"shadowed in inner scope: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:20
 msgid "\"after: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:26
 msgid ""
 "Show that a variable's scope is limited by adding a `b` in the inner block "
 "in the last example, and then trying to access it outside that block."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:28
 msgid ""
 "Shadowing is different from mutation, because after shadowing both "
 "variable's memory locations exist at the same time. Both are available under "
 "the same name, depending where you use it in the code."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:31
 msgid "A shadowing variable can have a different type."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:32
 msgid ""
 "Shadowing looks obscure at first, but is convenient for holding on to values "
 "after `.unwrap()`."
 msgstr ""
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:22
 msgid ""
 "Declaration parameters are followed by a type (the reverse of some "
 "programming languages), then a return type."
@@ -3433,7 +3616,7 @@ msgstr ""
 "Những tham số phải được chú thích sau bằng một kiểu dữ liệu (ngược lại với "
 "một số ngôn ngữ lập trình khác), rồi một giá trị trả về."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:24
 msgid ""
 "The last expression in a function body (or any block) becomes the return "
 "value. Simply omit the `;` at the end of the expression. The `return` "
@@ -3445,7 +3628,7 @@ msgstr ""
 "dụng để trả về sớm, nhưng \"giá trị trần (bare value)\" là triết lí ngôn ngữ "
 "(idiomatic) khi đặt ở cuối hàm (tái cấu trúc `gcd` dể sử dụng `return`)."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:28
 msgid ""
 "Some functions have no return value, and return the 'unit type', `()`. The "
 "compiler will infer this if the `-> ()` return type is omitted."
@@ -3454,14 +3637,14 @@ msgstr ""
 "biên dịch sẽ kết luận rằng kiểu dữ liệu sẽ là `-> ()` nếu kiểu dữ liệu trả "
 "về được bỏ qua."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:30
 msgid ""
 "Overloading is not supported -- each function has a single implementation."
 msgstr ""
 "Overloading (nạp chồng) không được hỗ trợ -- mỗi hàm chỉ có duy nhất một "
 "triển khai."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:31
 msgid ""
 "Always takes a fixed number of parameters. Default arguments are not "
 "supported. Macros can be used to support variadic functions."
@@ -3469,7 +3652,7 @@ msgstr ""
 "Luôn luôn lấy một số những tham số nhất định. Đối số mặc định không đưọc hỗ "
 "trợ. Macros có thể sử dụng cho hỗ trợ hàm đa tham số."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:33
 msgid ""
 "Always takes a single set of parameter types. These types can be generic, "
 "which will be covered later."
@@ -3477,276 +3660,249 @@ msgstr ""
 "Luôn luôn chỉ lấy một nhóm kiểu tham số dữ liệu. Những kiểu dữ liệu này có "
 "thể là generic (tổng quát), và sẽ được đề cập tới ở phần sau."
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:3
 msgid ""
 "Macros are expanded into Rust code during compilation, and can take a "
 "variable number of arguments. They are distinguished by a `!` at the end. "
 "The Rust standard library includes an assortment of useful macros."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:7
 msgid ""
 "`println!(format, ..)` prints a line to standard output, applying formatting "
 "described in [`std::fmt`](https://doc.rust-lang.org/std/fmt/index.html)."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:9
 msgid ""
 "`format!(format, ..)` works just like `println!` but returns the result as a "
 "string."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:11
 msgid "`dbg!(expression)` logs the value of the expression and returns it."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:12
 msgid ""
 "`todo!()` marks a bit of code as not-yet-implemented. If executed, it will "
 "panic."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:14
 msgid ""
 "`unreachable!()` marks a bit of code as unreachable. If executed, it will "
 "panic."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:32
 msgid "\"{n}! = {}\""
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:39
 msgid ""
 "The takeaway from this section is that these common conveniences exist, and "
 "how to use them. Why they are defined as macros, and what they expand to, is "
 "not especially critical."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:43
 msgid ""
 "The course does not cover defining macros, but a later section will describe "
 "use of derive macros."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:3
 msgid ""
 "The [Collatz Sequence](https://en.wikipedia.org/wiki/Collatz_conjecture) is "
 "defined as follows, for an arbitrary n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:4 src/control-flow-basics/exercise.md:10
 msgid "1"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:4
 msgid " greater than zero:"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:6 src/control-flow-basics/exercise.md:7
+#: src/control-flow-basics/exercise.md:8
 msgid "If _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:6 src/control-flow-basics/exercise.md:7
+#: src/control-flow-basics/exercise.md:8
 msgid "i"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:6
 msgid "_ is 1, then the sequence terminates at _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:6
 msgid "_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:7
 msgid "_ is even, then _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:7 src/control-flow-basics/exercise.md:8
 msgid "i+1"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:7
 msgid " = n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:7
 msgid " / 2_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:8
 msgid "_ is odd, then _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:8
 msgid " = 3 * n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:8
 msgid " + 1_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:10
 msgid "For example, beginning with _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:10
 msgid "_ = 3:"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:12
 msgid "3 is odd, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:12
 msgid "2"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:12
 msgid "_ = 3 * 3 + 1 = 10;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:13
 msgid "10 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
+#: src/control-flow-basics/exercise.md:13 src/bare-metal/aps/better-uart.md:22
 msgid "3"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:13
 msgid "_ = 10 / 2 = 5;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:14
 msgid "5 is odd, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
+#: src/control-flow-basics/exercise.md:14 src/bare-metal/aps/better-uart.md:10
 msgid "4"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:14
 msgid "_ = 3 * 5 + 1 = 16;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:15
 msgid "16 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:15
 msgid "5"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:15
 msgid "_ = 16 / 2 = 8;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:16
 msgid "8 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
+#: src/control-flow-basics/exercise.md:16 src/bare-metal/aps/better-uart.md:14
+#: src/bare-metal/aps/better-uart.md:17
 msgid "6"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:16
 msgid "_ = 8 / 2 = 4;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:17
 msgid "4 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:17
 msgid "7"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:17
 msgid "_ = 4 / 2 = 2;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:18
 msgid "2 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
+#: src/control-flow-basics/exercise.md:18 src/bare-metal/aps/better-uart.md:12
+#: src/bare-metal/aps/better-uart.md:15
 msgid "8"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:18
 msgid "_ = 1; and"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:19
 msgid "the sequence terminates."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:21
 msgid ""
 "Write a function to calculate the length of the collatz sequence for a given "
 "initial `n`."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md src/control-flow-basics/solution.md
+#: src/control-flow-basics/exercise.md:25 src/control-flow-basics/solution.md:4
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md:20 src/concurrency/threads/scoped.md:11
+#: src/concurrency/threads/scoped.md:30
 msgid "\"Length: {}\""
 msgstr ""
 
-#: src/welcome-day-1-afternoon.md src/welcome-day-2-afternoon.md
-#: src/welcome-day-3-afternoon.md src/welcome-day-4-afternoon.md
+#: src/welcome-day-1-afternoon.md:1 src/welcome-day-2-afternoon.md:1
+#: src/welcome-day-3-afternoon.md:1 src/welcome-day-4-afternoon.md:1
 msgid "Welcome Back"
 msgstr ""
 
-#: src/welcome-day-1-afternoon.md
-msgid "[Tuples and Arrays](./tuples-and-arrays.md) (35 minutes)"
-msgstr ""
-
-#: src/welcome-day-1-afternoon.md
-msgid "[References](./references.md) (55 minutes)"
-msgstr ""
-
-#: src/welcome-day-1-afternoon.md
-msgid "[User-Defined Types](./user-defined-types.md) (50 minutes)"
-msgstr ""
-
-#: src/welcome-day-1-afternoon.md
+#: src/welcome-day-1-afternoon.md:3
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 35 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
+"Buổi học nên kéo dài khoảng 2 tiếng và 35 phút, bao gồm thời gian 10 phút "
+"nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/tuples-and-arrays.md
-msgid "[Arrays](./tuples-and-arrays/arrays.md) (5 minutes)"
-msgstr ""
+#: src/tuples-and-arrays.md:3
+msgid "This segment should take about 35 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 35 phút, bao gồm:"
 
-#: src/tuples-and-arrays.md
-msgid "[Tuples](./tuples-and-arrays/tuples.md) (5 minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays.md
-msgid "[Array Iteration](./tuples-and-arrays/iteration.md) (3 minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays.md
-msgid ""
-"[Patterns and Destructuring](./tuples-and-arrays/destructuring.md) (5 "
-"minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays.md
-msgid "[Exercise: Nested Arrays](./tuples-and-arrays/exercise.md) (15 minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays.md
-msgid "This segment should take about 35 minutes"
-msgstr ""
-
-#: src/tuples-and-arrays/arrays.md
+#: src/tuples-and-arrays/arrays.md:16
 msgid ""
 "A value of the array type `[T; N]` holds `N` (a compile-time constant) "
 "elements of the same type `T`. Note that the length of the array is _part of "
@@ -3755,18 +3911,18 @@ msgid ""
 "covered later."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md
+#: src/tuples-and-arrays/arrays.md:22
 msgid ""
 "Try accessing an out-of-bounds array element. Array accesses are checked at "
 "runtime. Rust can usually optimize these checks away, and they can be "
 "avoided using unsafe Rust."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md
+#: src/tuples-and-arrays/arrays.md:26
 msgid "We can use literals to assign values to arrays."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md
+#: src/tuples-and-arrays/arrays.md:28
 msgid ""
 "The `println!` macro asks for the debug implementation with the `?` format "
 "parameter: `{}` gives the default output, `{:?}` gives the debug output. "
@@ -3775,180 +3931,163 @@ msgid ""
 "here."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md
+#: src/tuples-and-arrays/arrays.md:33
 msgid ""
 "Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
 "easier to read."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md
+#: src/tuples-and-arrays/tuples.md:16
 msgid "Like arrays, tuples have a fixed length."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md
+#: src/tuples-and-arrays/tuples.md:18
 msgid "Tuples group together values of different types into a compound type."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md
+#: src/tuples-and-arrays/tuples.md:20
 msgid ""
 "Fields of a tuple can be accessed by the period and the index of the value, "
 "e.g. `t.0`, `t.1`."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md
+#: src/tuples-and-arrays/tuples.md:23
 msgid ""
 "The empty tuple `()` is referred to as the \"unit type\" and signifies "
 "absence of a return value, akin to `void` in other languages."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md
+#: src/tuples-and-arrays/iteration.md:3
 msgid "The `for` statement supports iterating over arrays (but not tuples)."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md
+#: src/tuples-and-arrays/iteration.md:19
 msgid ""
 "This functionality uses the `IntoIterator` trait, but we haven't covered "
 "that yet."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md
+#: src/tuples-and-arrays/iteration.md:22
 msgid ""
 "The `assert_ne!` macro is new here. There are also `assert_eq!` and `assert!"
 "` macros. These are always checked while, debug-only variants like "
 "`debug_assert!` compile to nothing in release builds."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
+#: src/tuples-and-arrays/destructuring.md:3
 msgid ""
 "When working with tuples and other structured values it's common to want to "
 "extract the inner values into local variables. This can be done manually by "
 "directly accessing the inner values:"
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
+#: src/tuples-and-arrays/destructuring.md:11
+#: src/tuples-and-arrays/destructuring.md:21
 msgid "\"left: {left}, right: {right}\""
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
+#: src/tuples-and-arrays/destructuring.md:15
 msgid ""
 "However, Rust also supports using pattern matching to destructure a larger "
 "value into its constituent parts:"
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
+#: src/tuples-and-arrays/destructuring.md:28
 msgid ""
 "The patterns used here are \"irrefutable\", meaning that the compiler can "
 "statically verify that the value on the right of `=` has the same structure "
 "as the pattern."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
+#: src/tuples-and-arrays/destructuring.md:31
 msgid ""
 "A variable name is an irrefutable pattern that always matches any value, "
 "hence why we can also use `let` to declare a single variable."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
+#: src/tuples-and-arrays/destructuring.md:33
 msgid ""
 "Rust also supports using patterns in conditionals, allowing for equality "
 "comparison and destructuring to happen at the same time. This form of "
 "pattern matching will be discussed in more detail later."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
+#: src/tuples-and-arrays/destructuring.md:36
 msgid ""
 "Edit the examples above to show the compiler error when the pattern doesn't "
 "match the value being matched on."
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:3
 msgid "Arrays can contain other arrays:"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:9
 msgid "What is the type of this variable?"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:11
 msgid ""
 "Use an array such as the above to write a function `transpose` which will "
 "transpose a matrix (turn rows into columns):"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md
-msgid "Hard-code both functions to operate on 3 × 3 matrices."
-msgstr ""
-
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:22
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and implement the "
-"functions:"
+"function. This function only operates on 3x3 matrices."
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/borrowing/exercise.md
-#: src/unsafe-rust/exercise.md
+#: src/tuples-and-arrays/exercise.md:26 src/borrowing/exercise.md:14
+#: src/unsafe-rust/exercise.md:51
 msgid "// TODO: remove this when you're done with your implementation.\n"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
+#: src/tuples-and-arrays/exercise.md:36 src/tuples-and-arrays/exercise.md:44
+#: src/tuples-and-arrays/solution.md:17 src/tuples-and-arrays/solution.md:25
 msgid "//\n"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
+#: src/tuples-and-arrays/exercise.md:53 src/tuples-and-arrays/solution.md:34
 msgid "// <-- the comment makes rustfmt add a newline\n"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
+#: src/tuples-and-arrays/exercise.md:58 src/tuples-and-arrays/solution.md:39
 msgid "\"matrix: {:#?}\""
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
+#: src/tuples-and-arrays/exercise.md:60 src/tuples-and-arrays/solution.md:41
 msgid "\"transposed: {:#?}\""
 msgstr ""
 
-#: src/references.md
-msgid "[Shared References](./references/shared.md) (10 minutes)"
+#: src/references.md:3 src/smart-pointers.md:3 src/borrowing.md:3
+#: src/error-handling.md:3 src/concurrency/async-pitfalls.md:7
+msgid "This segment should take about 55 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 55 phút, bao gồm:"
+
+#: src/references.md:9
+msgid "Slices: &\\[T\\]"
 msgstr ""
 
-#: src/references.md
-msgid "[Exclusive References](./references/exclusive.md) (10 minutes)"
-msgstr ""
-
-#: src/references.md
-msgid "[Slices: &\\[T\\]](./references/slices.md) (10 minutes)"
-msgstr ""
-
-#: src/references.md
-msgid "[Strings](./references/strings.md) (10 minutes)"
-msgstr ""
-
-#: src/references.md
-msgid "[Exercise: Geometry](./references/exercise.md) (15 minutes)"
-msgstr ""
-
-#: src/references.md src/smart-pointers.md src/error-handling.md
-msgid "This segment should take about 55 minutes"
-msgstr ""
-
-#: src/references/shared.md
+#: src/references/shared.md:3
 msgid ""
 "A reference provides a way to access another value without taking "
 "responsibility for the value, and is also called \"borrowing\". Shared "
 "references are read-only, and the referenced data cannot change."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:20
 msgid ""
 "A shared reference to a type `T` has type `&T`. A reference value is made "
 "with the `&` operator. The `*` operator \"dereferences\" a reference, "
 "yielding its value."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:24
 msgid "Rust will statically forbid dangling references:"
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:38
 msgid ""
 "A reference is said to \"borrow\" the value it refers to, and this is a good "
 "model for students not familiar with pointers: code can use the reference to "
@@ -3956,7 +4095,7 @@ msgid ""
 "course will get into more detail on ownership in day 3."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:43
 msgid ""
 "References are implemented as pointers, and a key advantage is that they can "
 "be much smaller than the thing they point to. Students familiar with C or C+"
@@ -3965,20 +4104,20 @@ msgid ""
 "pointers."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:48
 msgid ""
 "Rust does not automatically create references for you - the `&` is always "
 "required."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:51
 msgid ""
 "Rust will auto-dereference in some cases, in particular when invoking "
 "methods (try `r.is_ascii()`). There is no need for an `->` operator like in "
 "C++."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:54
 msgid ""
 "In this example, `r` is mutable so that it can be reassigned (`r = &b`). "
 "Note that this re-binds `r`, so that it refers to something else. This is "
@@ -3986,13 +4125,13 @@ msgid ""
 "value."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:58
 msgid ""
 "A shared reference does not allow modifying the value it refers to, even if "
 "that value was mutable. Try `*r = 'X'`."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:61
 msgid ""
 "Rust is tracking the lifetimes of all references to ensure they live long "
 "enough. Dangling references cannot occur in safe Rust. `x_axis` would return "
@@ -4000,17 +4139,17 @@ msgid ""
 "returns, so this will not compile."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:66
 msgid "We will talk more about borrowing when we get to ownership."
 msgstr ""
 
-#: src/references/exclusive.md
+#: src/references/exclusive.md:3
 msgid ""
 "Exclusive references, also known as mutable references, allow changing the "
 "value they refer to. They have type `&mut T`."
 msgstr ""
 
-#: src/references/exclusive.md
+#: src/references/exclusive.md:22
 msgid ""
 "\"Exclusive\" means that only this reference can be used to access the "
 "value. No other references (shared or exclusive) can exist at the same time, "
@@ -4019,7 +4158,7 @@ msgid ""
 "alive."
 msgstr ""
 
-#: src/references/exclusive.md
+#: src/references/exclusive.md:27
 msgid ""
 "Be sure to note the difference between `let mut x_coord: &i32` and `let "
 "x_coord: &mut i32`. The first one represents a shared reference which can be "
@@ -4027,60 +4166,60 @@ msgid ""
 "reference to a mutable value."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:1
 msgid "Slices"
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:18
 msgid "Slices borrow data from the sliced type."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:19
 msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:24
 msgid ""
 "We create a slice by borrowing `a` and specifying the starting and ending "
 "indexes in brackets."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:27
 msgid ""
 "If the slice starts at index 0, Rust’s range syntax allows us to drop the "
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
 "identical."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:31
 msgid ""
 "The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
 "identical."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:34
 msgid ""
 "To easily create a slice of the full array, we can therefore use `&a[..]`."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:36
 msgid ""
 "`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
 "computation on slices of different sizes."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:40
 msgid ""
 "Slices always borrow from another object. In this example, `a` has to remain "
 "'alive' (in scope) for at least as long as our slice."
 msgstr ""
 
-#: src/references/slices.md
+#: src/references/slices.md:43
 msgid ""
 "The question about modifying `a[3]` can spark an interesting discussion, but "
 "the answer is that for memory safety reasons you cannot do it through `a` at "
@@ -4089,65 +4228,67 @@ msgid ""
 "`println`, when the slice is no longer used."
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:7
 msgid "We can now understand the two string types in Rust:"
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:9
 msgid "`&str` is a slice of UTF-8 encoded bytes, similar to `&[u8]`."
 msgstr ""
 
-#: src/references/strings.md
-msgid "`String` is an owned, heap-allocated buffer of UTF-8 bytes."
+#: src/references/strings.md:10
+msgid ""
+"`String` is an owned buffer of UTF-8 encoded bytes, similar to `Vec<T>`."
 msgstr ""
 
-#: src/references/strings.md src/std-traits/read-and-write.md
+#: src/references/strings.md:17 src/std-traits/read-and-write.md:36
 msgid "\"World\""
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:18
 msgid "\"s1: {s1}\""
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:20
 msgid "\"Hello \""
 msgstr ""
 
-#: src/references/strings.md src/memory-management/move.md
+#: src/references/strings.md:21 src/references/strings.md:23
+#: src/memory-management/move.md:9
 msgid "\"s2: {s2}\""
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:26
 msgid "\"s3: {s3}\""
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:33
 msgid ""
 "`&str` introduces a string slice, which is an immutable reference to UTF-8 "
 "encoded string data stored in a block of memory. String literals "
 "(`\"Hello\"`), are stored in the program’s binary."
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:37
 msgid ""
 "Rust's `String` type is a wrapper around a vector of bytes. As with a "
 "`Vec<T>`, it is owned."
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:40
 msgid ""
 "As with many other types `String::from()` creates a string from a string "
 "literal; `String::new()` creates a new empty string, to which string data "
 "can be added using the `push()` and `push_str()` methods."
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:44
 msgid ""
 "The `format!()` macro is a convenient way to generate an owned string from "
 "dynamic values. It accepts the same format specification as `println!()`."
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:47
 msgid ""
 "You can borrow `&str` slices from `String` via `&` and optionally range "
 "selection. If you select a byte range that is not aligned to character "
@@ -4155,7 +4296,7 @@ msgid ""
 "characters and is preferred over trying to get character boundaries right."
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:52
 msgid ""
 "For C++ programmers: think of `&str` as `std::string_view` from C++, but the "
 "one that always points to a valid string in memory. Rust `String` is a rough "
@@ -4163,25 +4304,25 @@ msgid ""
 "UTF-8 encoded bytes and will never use a small-string optimization)."
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:57
 msgid "Byte strings literals allow you to create a `&[u8]` value directly:"
 msgstr ""
 
-#: src/references/strings.md
+#: src/references/strings.md:67
 msgid ""
 "Raw strings allow you to create a `&str` value with escapes disabled: "
 "`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
 "amount of `#` on either side of the quotes:"
 msgstr ""
 
-#: src/references/exercise.md
+#: src/references/exercise.md:3
 msgid ""
 "We will create a few utility functions for 3-dimensional geometry, "
 "representing a point as `[f64;3]`. It is up to you to determine the function "
 "signatures."
 msgstr ""
 
-#: src/references/exercise.md
+#: src/references/exercise.md:7
 msgid ""
 "// Calculate the magnitude of a vector by summing the squares of its "
 "coordinates\n"
@@ -4190,264 +4331,240 @@ msgid ""
 "// root, like `v.sqrt()`.\n"
 msgstr ""
 
-#: src/references/exercise.md
+#: src/references/exercise.md:15
 msgid ""
 "// Normalize a vector by calculating its magnitude and dividing all of its\n"
 "// coordinates by that magnitude.\n"
 msgstr ""
 
-#: src/references/exercise.md
+#: src/references/exercise.md:23
 msgid "// Use the following `main` to test your work.\n"
 msgstr ""
 
-#: src/references/exercise.md src/references/solution.md
+#: src/references/exercise.md:27 src/references/solution.md:22
 msgid "\"Magnitude of a unit vector: {}\""
 msgstr ""
 
-#: src/references/exercise.md src/references/solution.md
+#: src/references/exercise.md:30 src/references/solution.md:25
 msgid "\"Magnitude of {v:?}: {}\""
 msgstr ""
 
-#: src/references/exercise.md src/references/solution.md
+#: src/references/exercise.md:32 src/references/solution.md:27
 msgid "\"Magnitude of {v:?} after normalization: {}\""
 msgstr ""
 
-#: src/references/solution.md
+#: src/references/solution.md:4
 msgid "/// Calculate the magnitude of the given vector.\n"
 msgstr ""
 
-#: src/references/solution.md
+#: src/references/solution.md:12
 msgid ""
 "/// Change the magnitude of the vector to 1.0 without changing its "
 "direction.\n"
 msgstr ""
 
-#: src/user-defined-types.md
-msgid "[Named Structs](./user-defined-types/named-structs.md) (10 minutes)"
-msgstr ""
+#: src/user-defined-types.md:3 src/methods-and-traits.md:3 src/lifetimes.md:3
+msgid "This segment should take about 50 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 50 phút, bao gồm:"
 
-#: src/user-defined-types.md
-msgid "[Tuple Structs](./user-defined-types/tuple-structs.md) (10 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid "[Enums](./user-defined-types/enums.md) (5 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid "[Static](./user-defined-types/static.md) (5 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid "[Type Aliases](./user-defined-types/aliases.md) (2 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid ""
-"[Exercise: Elevator Events](./user-defined-types/exercise.md) (15 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md src/methods-and-traits.md src/borrowing.md
-#: src/lifetimes.md
-msgid "This segment should take about 50 minutes"
-msgstr ""
-
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:3
 msgid "Like C and C++, Rust has support for custom structs:"
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:12
 msgid "\"{} is {} years old\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
-#: src/android/interoperability/with-c/bindgen.md
+#: src/user-defined-types/named-structs.md:16
+#: src/android/interoperability/with-c/bindgen.md:87
 msgid "\"Peter\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:22
 msgid "\"Avery\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:27
 msgid "\"Jackie\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md src/user-defined-types/enums.md
-#: src/pattern-matching/match.md src/methods-and-traits/methods.md
+#: src/user-defined-types/named-structs.md:35
+#: src/user-defined-types/enums.md:29 src/pattern-matching/match.md:38
+#: src/methods-and-traits/methods.md:69
 msgid "Key Points:"
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:37
 msgid "Structs work like in C or C++."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:38
 msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:39
 msgid "Unlike in C++, there is no inheritance between structs."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:40
 msgid ""
 "This may be a good time to let people know there are different types of "
 "structs."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:42
 msgid ""
 "Zero-sized structs (e.g. `struct Foo;`) might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
 "value itself."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:45
 msgid ""
 "The next slide will introduce Tuple structs, used when the field names are "
 "not important."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:47
 msgid ""
 "If you already have variables with the right names, then you can create the "
 "struct using a shorthand."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:49
 msgid ""
 "The syntax `..avery` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:7
 msgid "If the field names are unimportant, you can use a tuple struct:"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:14
 msgid "\"({}, {})\""
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:18
 msgid "This is often used for single-field wrappers (called newtypes):"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:25
 msgid "\"Ask a rocket scientist at NASA\""
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
-#: src/android/interoperability/cpp/cpp-bridge.md
-#: src/bare-metal/microcontrollers/type-state.md
-#: src/async/pitfalls/cancellation.md
+#: src/user-defined-types/tuple-structs.md:29
+#: src/android/interoperability/cpp/cpp-bridge.md:50
+#: src/bare-metal/microcontrollers/type-state.md:14
+#: src/concurrency/async-pitfalls/cancellation.md:99
+#: src/concurrency/async-pitfalls/cancellation.md:102
 msgid "// ...\n"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:41
 msgid ""
 "Newtypes are a great way to encode additional information about the value in "
 "a primitive type, for example:"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:43
 msgid "The number is measured in some units: `Newtons` in the example above."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:44
 msgid ""
 "The value passed some validation when it was created, so you no longer have "
 "to validate it again at every use: `PhoneNumber(String)` or `OddNumber(u32)`."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:47
 msgid ""
 "Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
 "single field in the newtype."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:49
 msgid ""
 "Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
 "for instance using booleans as integers."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:51
 msgid "Operator overloading is discussed on Day 3 (generics)."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:52
 msgid ""
 "The example is a subtle reference to the [Mars Climate Orbiter](https://en."
 "wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:3
 msgid ""
 "The `enum` keyword allows the creation of a type which has a few different "
 "variants:"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:15
 msgid "// Simple variant\n"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:16
 msgid "// Tuple variant\n"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:17
 msgid "// Struct variant\n"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:22
 msgid "\"On this turn: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:31
 msgid "Enumerations allow you to collect a set of values under one type."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:32
 msgid ""
 "`Direction` is a type with variants. There are two values of `Direction`: "
 "`Direction::Left` and `Direction::Right`."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:34
 msgid ""
 "`PlayerMove` is a type with three variants. In addition to the payloads, "
 "Rust will store a discriminant so that it knows at runtime which variant is "
 "in a `PlayerMove` value."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:37
 msgid "This might be a good time to compare structs and enums:"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:38
 msgid ""
 "In both, you can have a simple version without fields (unit struct) or one "
 "with different types of fields (variant payloads)."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:40
 msgid ""
 "You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:43
 msgid "Rust uses minimal space to store the discriminant."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:44
 msgid "If necessary, it stores an integer of the smallest required size"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:45
 msgid ""
 "If the allowed variant values do not cover all bit patterns, it will use "
 "invalid bit patterns to encode the discriminant (the \"niche "
@@ -4455,62 +4572,62 @@ msgid ""
 "integer or `NULL` for the `None` variant."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:49
 msgid ""
 "You can control the discriminant if needed (e.g., for compatibility with C):"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:67
 msgid ""
 "Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
 "bytes."
 msgstr ""
 
-#: src/user-defined-types/enums.md src/user-defined-types/static.md
-#: src/memory-management/review.md src/memory-management/move.md
-#: src/smart-pointers/box.md src/borrowing/shared.md
+#: src/user-defined-types/enums.md:70 src/user-defined-types/static.md:27
+#: src/memory-management/review.md:51 src/memory-management/move.md:100
+#: src/smart-pointers/box.md:85 src/borrowing/shared.md:33
 msgid "More to Explore"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:72
 msgid ""
 "Rust has several optimizations it can employ to make enums take up less "
 "space."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:74
 msgid ""
 "Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
 "option/#representation), Rust guarantees that `size_of::<T>()` equals "
 "`size_of::<Option<T>>()`."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:78
 msgid ""
 "Example code if you want to show how the bitwise representation _may_ look "
 "like in practice. It's important to note that the compiler provides no "
 "guarantees regarding this representation, therefore this is totally unsafe."
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:1
 msgid "`static`"
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:3
 msgid ""
 "Static variables will live during the whole execution of the program, and "
 "therefore will not move:"
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:7
 msgid "\"Welcome to RustOS 3.14\""
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:10
 msgid "\"{BANNER}\""
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:14
 msgid ""
 "As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
 "vs-static.html), these are not inlined upon use and have an actual "
@@ -4520,74 +4637,74 @@ msgid ""
 "`const` is generally preferred."
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:23
 msgid "`static` is similar to mutable global variables in C++."
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:24
 msgid ""
 "`static` provides object identity: an address in memory and state as "
 "required by types with interior mutability such as `Mutex<T>`."
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:29
 msgid ""
 "Because `static` variables are accessible from any thread, they must be "
 "`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
 "lang.org/std/sync/struct.Mutex.html), atomic or similar."
 msgstr ""
 
-#: src/user-defined-types/static.md
+#: src/user-defined-types/static.md:34
 msgid "Thread-local data can be created with the macro `std::thread_local`."
 msgstr ""
 
-#: src/user-defined-types/const.md
+#: src/user-defined-types/const.md:1
 msgid "`const`"
 msgstr ""
 
-#: src/user-defined-types/const.md
+#: src/user-defined-types/const.md:3
 msgid ""
 "Constants are evaluated at compile time and their values are inlined "
 "wherever they are used:"
 msgstr ""
 
-#: src/user-defined-types/const.md
+#: src/user-defined-types/const.md:26
 msgid ""
 "According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
 "vs-static.html) these are inlined upon use."
 msgstr ""
 
-#: src/user-defined-types/const.md
+#: src/user-defined-types/const.md:28
 msgid ""
 "Only functions marked `const` can be called at compile time to generate "
 "`const` values. `const` functions can however be called at runtime."
 msgstr ""
 
-#: src/user-defined-types/const.md
+#: src/user-defined-types/const.md:33
 msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`"
 msgstr ""
 
-#: src/user-defined-types/const.md
+#: src/user-defined-types/const.md:34
 msgid ""
 "It isn't super common that one would need a runtime evaluated constant, but "
 "it is helpful and safer than using a static."
 msgstr ""
 
-#: src/user-defined-types/aliases.md
+#: src/user-defined-types/aliases.md:3
 msgid ""
 "A type alias creates a name for another type. The two types can be used "
 "interchangeably."
 msgstr ""
 
-#: src/user-defined-types/aliases.md
+#: src/user-defined-types/aliases.md:13
 msgid "// Aliases are more useful with long, complex types:\n"
 msgstr ""
 
-#: src/user-defined-types/aliases.md
+#: src/user-defined-types/aliases.md:23
 msgid "C programmers will recognize this as similar to a `typedef`."
 msgstr ""
 
-#: src/user-defined-types/exercise.md
+#: src/user-defined-types/exercise.md:3
 msgid ""
 "We will create a data structure to represent an event in an elevator control "
 "system. It is up to you to define the types and functions to construct "
@@ -4595,299 +4712,272 @@ msgid ""
 "with `{:?}`."
 msgstr ""
 
-#: src/user-defined-types/exercise.md
+#: src/user-defined-types/exercise.md:7
 msgid ""
 "This exercise only requires creating and populating data structures so that "
 "`main` runs without errors. The next part of the course will cover getting "
 "data out of these structures."
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:12 src/user-defined-types/solution.md:4
 msgid ""
 "/// An event in the elevator system that the controller must react to.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md
+#: src/user-defined-types/exercise.md:15
 msgid "// TODO: add required variants\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:17 src/user-defined-types/solution.md:22
 msgid "/// A direction of travel.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:24 src/user-defined-types/solution.md:39
 msgid "/// The car has arrived on the given floor.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:29 src/user-defined-types/solution.md:44
 msgid "/// The car doors have opened.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:34 src/user-defined-types/solution.md:49
 msgid "/// The car doors have closed.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:39 src/user-defined-types/solution.md:54
 msgid ""
 "/// A directional button was pressed in an elevator lobby on the given "
 "floor.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:44 src/user-defined-types/solution.md:59
 msgid "/// A floor button was pressed in the elevator car.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:52 src/user-defined-types/solution.md:67
 msgid "\"A ground floor passenger has pressed the up button: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:55 src/user-defined-types/solution.md:70
 msgid "\"The car has arrived on the ground floor: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:56 src/user-defined-types/solution.md:71
 msgid "\"The car door opened: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:58 src/user-defined-types/solution.md:73
 msgid "\"A passenger has pressed the 3rd floor button: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:61 src/user-defined-types/solution.md:76
 msgid "\"The car door closed: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:62 src/user-defined-types/solution.md:77
 msgid "\"The car has arrived on the 3rd floor: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:7
 msgid "/// A button was pressed.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:10
 msgid "/// The car has arrived at the given floor.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:13
 msgid "/// The car's doors have opened.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:16
 msgid "/// The car's doors have closed.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:19
 msgid "/// A floor is represented as an integer.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:29
 msgid "/// A user-accessible button.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:33
 msgid "/// A button in the elevator lobby on the given floor.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md
+#: src/user-defined-types/solution.md:36
 msgid "/// A floor button within the car.\n"
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:1
 msgid "Welcome to Day 2"
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:3
 msgid ""
 "Now that we have seen a fair amount of Rust, today will focus on Rust's type "
 "system:"
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:6
 msgid "Pattern matching: extracting data from structures."
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:7
 msgid "Methods: associating functions with types."
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:8
 msgid "Traits: behaviors shared by multiple types."
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:9
 msgid "Generics: parameterizing types on other types."
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:10
 msgid ""
 "Standard library types and traits: a tour of Rust's rich standard library."
 msgstr ""
 
-#: src/welcome-day-2.md
-msgid "[Welcome](./welcome-day-2.md) (3 minutes)"
-msgstr ""
-
-#: src/welcome-day-2.md
-msgid "[Pattern Matching](./pattern-matching.md) (1 hour)"
-msgstr ""
-
-#: src/welcome-day-2.md
-msgid "[Methods and Traits](./methods-and-traits.md) (50 minutes)"
-msgstr ""
-
-#: src/welcome-day-2.md
-msgid "[Generics](./generics.md) (40 minutes)"
-msgstr ""
-
-#: src/welcome-day-2.md
+#: src/welcome-day-2.md:14 src/welcome-day-4-afternoon.md:3
 msgid ""
-"Including 10 minute breaks, this session should take about 2 hours and 55 "
-"minutes"
+"Including 10 minute breaks, this session should take about 2 hours and 10 "
+"minutes. It contains:"
 msgstr ""
+"Buổi học nên kéo dài khoảng 2 tiếng và 10 phút, bao gồm thời gian 10 phút "
+"nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/pattern-matching.md
-msgid "[Matching Values](./pattern-matching/match.md) (10 minutes)"
-msgstr ""
+#: src/pattern-matching.md:3 src/memory-management.md:3
+msgid "This segment should take about 1 hour. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 1 giờ, bao gồm:"
 
-#: src/pattern-matching.md
-msgid "[Destructuring](./pattern-matching/destructuring.md) (10 minutes)"
-msgstr ""
-
-#: src/pattern-matching.md
-msgid "[Let Control Flow](./pattern-matching/let-control-flow.md) (10 minutes)"
-msgstr ""
-
-#: src/pattern-matching.md
-msgid ""
-"[Exercise: Expression Evaluation](./pattern-matching/exercise.md) (30 "
-"minutes)"
-msgstr ""
-
-#: src/pattern-matching.md src/memory-management.md
-msgid "This segment should take about 1 hour"
-msgstr ""
-
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:3
 msgid ""
 "The `match` keyword lets you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:6
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:11
 msgid "'x'"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:13
 msgid "'q'"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:13
 msgid "\"Quitting\""
 msgstr ""
 
-#: src/pattern-matching/match.md src/generics/exercise.md
-#: src/generics/solution.md src/std-traits/solution.md
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/pattern-matching/match.md:14 src/generics/exercise.md:15
+#: src/generics/solution.md:17 src/std-traits/solution.md:16
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:75
+#: src/error-handling/solution.md:60 src/error-handling/solution.md:75
 msgid "'a'"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:14
 msgid "'s'"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:14
 msgid "'w'"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:14
 msgid "'d'"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:14
 msgid "\"Moving around\""
 msgstr ""
 
-#: src/pattern-matching/match.md src/error-handling/exercise.md
-#: src/error-handling/solution.md
+#: src/pattern-matching/match.md:15 src/error-handling/exercise.md:51
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:74
+#: src/error-handling/solution.md:51 src/error-handling/solution.md:60
+#: src/error-handling/solution.md:74
 msgid "'0'"
 msgstr ""
 
-#: src/pattern-matching/match.md src/error-handling/exercise.md
-#: src/error-handling/solution.md
+#: src/pattern-matching/match.md:15 src/error-handling/exercise.md:51
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:74
+#: src/error-handling/solution.md:51 src/error-handling/solution.md:60
+#: src/error-handling/solution.md:74
 msgid "'9'"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:15
 msgid "\"Number input\""
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:16
 msgid "\"Lowercase: {key}\""
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:17
 msgid "\"Something else\""
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:22
 msgid ""
 "The `_` pattern is a wildcard pattern which matches any value. The "
 "expressions _must_ be exhaustive, meaning that it covers every possibility, "
 "so `_` is often used as the final catch-all case."
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:26
 msgid ""
 "Match can be used as an expression. Just like `if`, each match arm must have "
 "the same type. The type is the last expression of the block, if any. In the "
 "example above, the type is `()`."
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:30
 msgid ""
 "A variable in the pattern (`key` in this example) will create a binding that "
 "can be used within the match arm."
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:33
 msgid "A match guard causes the arm to match only if the condition is true."
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:40
 msgid ""
 "You might point out how some specific characters are being used when in a "
 "pattern"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:42
 msgid "`|` as an `or`"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:43
 msgid "`..` can expand as much as it needs to be"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:44
 msgid "`1..=5` represents an inclusive range"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:45
 msgid "`_` is a wild card"
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:47
 msgid ""
 "Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
 "allow."
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:49
 msgid ""
 "They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
@@ -4895,99 +4985,103 @@ msgid ""
 "result in other arms of the original `match` expression being considered."
 msgstr ""
 
-#: src/pattern-matching/match.md
+#: src/pattern-matching/match.md:53
 msgid ""
 "The condition defined in the guard applies to every expression in a pattern "
 "with an `|`."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
-msgid "Like tuples, structs and enums can also be destructured by matching:"
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:1
 msgid "Structs"
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:3
+msgid "Like tuples, Struct can also be destructured by matching:"
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:15
 msgid "\"x.0 = 1, b = {b}, y = {y}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:16
 msgid "\"y = 2, x = {i:?}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:17
 msgid "\"y = {y}, other fields were ignored\""
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
-msgid ""
-"Patterns can also be used to bind variables to parts of your values. This is "
-"how you inspect the structure of your types. Let us start with a simple "
-"`enum` type:"
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
-msgid "\"cannot divide {n} into two equal parts\""
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
-msgid "\"{n} divided in two is {half}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
-msgid "\"sorry, an error happened: {msg}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
-msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the first "
-"arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm, `msg` is bound to the error message."
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:25
 msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:26
 msgid "Add a new field to `Foo` and make changes to the pattern as needed."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:27
 msgid ""
 "The distinction between a capture and a constant expression can be hard to "
 "spot. Try changing the `2` in the second arm to a variable, and see that it "
 "subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:3
+msgid "Like tuples, enums can also be destructured by matching:"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:5
+msgid ""
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:18
+msgid "\"cannot divide {n} into two equal parts\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:25
+msgid "\"{n} divided in two is {half}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:26
+msgid "\"sorry, an error happened: {msg}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:31
+msgid ""
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm, `msg` is bound to the error message."
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:38
 msgid ""
 "The `if`/`else` expression is returning an enum that is later unpacked with "
 "a `match`."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:40
 msgid ""
 "You can try adding a third variant to the enum definition and displaying the "
 "errors when running the code. Point out the places where your code is now "
 "inexhaustive and how the compiler tries to give you hints."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:43
 msgid ""
 "The values in the enum variants can only be accessed after being pattern "
 "matched."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:45
 msgid ""
 "Demonstrate what happens when the search is inexhaustive. Note the advantage "
 "the Rust compiler provides by confirming when all cases are handled."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:47
 msgid ""
 "Save the result of `divide_in_two` in the `result` variable and `match` it "
 "in a loop. That won't compile because `msg` is consumed when matched. To fix "
@@ -4997,40 +5091,41 @@ msgid ""
 "support older Rust, replace `msg` with `ref msg` in the pattern."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:3
 msgid ""
 "Rust has a few control flow constructs which differ from other languages. "
 "They are used for pattern matching:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:6
+#: src/pattern-matching/let-control-flow.md:10
 msgid "`if let` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:7
 msgid "`while let` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:8
 msgid "`match` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:12
 msgid ""
 "The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
 "expr.html#if-let-expressions) lets you execute different code depending on "
 "whether a value matches a pattern:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:22
 msgid "\"slept for {:?}\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:32
 msgid "`let else` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:34
 msgid ""
 "For the common case of matching a pattern and returning from the function, "
 "use [`let else`](https://doc.rust-lang.org/rust-by-example/flow_control/"
@@ -5038,36 +5133,41 @@ msgid ""
 "- anything but falling off the end of the block)."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:44
+#: src/pattern-matching/let-control-flow.md:107
 msgid "\"got None\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:50
+#: src/pattern-matching/let-control-flow.md:111
 msgid "\"got empty string\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:56
+#: src/pattern-matching/let-control-flow.md:115
 msgid "\"not a hex digit\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md src/pattern-matching/solution.md
+#: src/pattern-matching/let-control-flow.md:61
+#: src/pattern-matching/solution.md:113
 msgid "\"result: {:?}\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md src/generics/trait-bounds.md
-#: src/smart-pointers/solution.md src/testing/solution.md
-#: src/android/testing.md src/android/testing/googletest.md
+#: src/pattern-matching/let-control-flow.md:61 src/generics/trait-bounds.md:16
+#: src/smart-pointers/solution.md:87 src/smart-pointers/solution.md:90
+#: src/testing/solution.md:83 src/android/testing.md:40
+#: src/android/testing/googletest.md:11 src/android/testing/googletest.md:12
 msgid "\"foo\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:65
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
 "reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
 "repeatedly tests a value against a pattern:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:81
 msgid ""
 "Here [`String::pop`](https://doc.rust-lang.org/stable/std/string/struct."
 "String.html#method.pop) returns `Some(c)` until the string is empty, after "
@@ -5075,62 +5175,62 @@ msgid ""
 "all items."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:89
 msgid "if-let"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:91
 msgid ""
 "Unlike `match`, `if let` does not have to cover all branches. This can make "
 "it more concise than `match`."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:93
 msgid "A common usage is handling `Some` values when working with `Option`."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:94
 msgid ""
 "Unlike `match`, `if let` does not support guard clauses for pattern matching."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:96
 msgid "let-else"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:98
 msgid ""
 "`if-let`s can pile up, as shown. The `let-else` construct supports "
 "flattening this nested code. Rewrite the awkward version for students, so "
 "they can see the transformation."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:102
 msgid "The rewritten version is:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:122
 msgid "while-let"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:124
 msgid ""
 "Point out that the `while let` loop will keep going as long as the value "
 "matches the pattern."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:126
 msgid ""
 "You could rewrite the `while let` loop as an infinite loop with an if "
 "statement that breaks when there is no value to unwrap for `name.pop()`. The "
 "`while let` provides syntactic sugar for the above scenario."
 msgstr ""
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:3
 msgid "Let's write a simple recursive evaluator for arithmetic expressions."
 msgstr ""
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:5
 msgid ""
 "The `Box` type here is a smart pointer, and will be covered in detail later "
 "in the course. An expression can be \"boxed\" with `Box::new` as seen in the "
@@ -5138,7 +5238,7 @@ msgid ""
 "\"unbox\" it: `eval(*boxed_expr)`."
 msgstr ""
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:10
 msgid ""
 "Some expressions cannot be evaluated and will return an error. The standard "
 "[`Result<Value, String>`](https://doc.rust-lang.org/std/result/enum.Result."
@@ -5147,7 +5247,7 @@ msgid ""
 "later."
 msgstr ""
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:15
 msgid ""
 "Copy and paste the code into the Rust playground, and begin implementing "
 "`eval`. The final product should pass the tests. It may be helpful to use "
@@ -5155,114 +5255,98 @@ msgid ""
 "temporarily with `#[ignore]`:"
 msgstr ""
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:26
 msgid ""
 "If you finish early, try writing a test that results in division by zero or "
 "integer overflow. How could you handle this with `Result` instead of a panic?"
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
+#: src/pattern-matching/exercise.md:30 src/pattern-matching/solution.md:4
 msgid "/// An operation to perform on two subexpressions.\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
+#: src/pattern-matching/exercise.md:38 src/pattern-matching/solution.md:12
 msgid "/// An expression, in tree form.\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
+#: src/pattern-matching/exercise.md:42 src/pattern-matching/solution.md:16
 msgid "/// An operation on two subexpressions.\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
+#: src/pattern-matching/exercise.md:45 src/pattern-matching/solution.md:19
 msgid "/// A literal value\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
+#: src/pattern-matching/exercise.md:104 src/pattern-matching/solution.md:40
+#: src/pattern-matching/solution.md:102
 msgid "\"division by zero\""
 msgstr ""
 
-#: src/pattern-matching/solution.md
+#: src/pattern-matching/solution.md:112
 msgid "\"expr: {:?}\""
 msgstr ""
 
-#: src/methods-and-traits.md
-msgid "[Methods](./methods-and-traits/methods.md) (10 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid "[Traits](./methods-and-traits/traits.md) (15 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid "[Deriving](./methods-and-traits/deriving.md) (3 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid ""
-"[Exercise: Generic Logger](./methods-and-traits/exercise.md) (20 minutes)"
-msgstr ""
-
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:3
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
 "an `impl` block:"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:14
 msgid "// No receiver, a static method\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:19
 msgid "// Exclusive borrowed read-write access to self\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:24
 msgid "// Shared and read-only borrowed access to self\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:26
 msgid "\"Recorded {} laps for {}:\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:28
 msgid "\"Lap {idx}: {lap} sec\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:32
 msgid "// Exclusive ownership of self\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:35
 msgid "\"Race {} is finished, total lap time: {}\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:40
 msgid "\"Monaco Grand Prix\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:47
 msgid "// race.add_lap(42);\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:51
 msgid ""
 "The `self` arguments specify the \"receiver\" - the object the method acts "
 "on. There are several common receivers for a method:"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:54
 msgid ""
 "`&self`: borrows the object from the caller using a shared and immutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:56
 msgid ""
 "`&mut self`: borrows the object from the caller using a unique and mutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:58
 msgid ""
 "`self`: takes ownership of the object and moves it away from the caller. The "
 "method becomes the owner of the object. The object will be dropped "
@@ -5270,215 +5354,211 @@ msgid ""
 "transmitted. Complete ownership does not automatically mean mutability."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:62
 msgid "`mut self`: same as above, but the method can mutate the object."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:63
 msgid ""
 "No receiver: this becomes a static method on the struct. Typically used to "
 "create constructors which are called `new` by convention."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:71
 msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:72
 msgid ""
 "Methods are called on an instance of a type (such as a struct or enum), the "
 "first parameter represents the instance as `self`."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:74
 msgid ""
 "Developers may choose to use methods to take advantage of method receiver "
 "syntax and to help keep them more organized. By using methods we can keep "
 "all the implementation code in one predictable place."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:77
 msgid "Point out the use of the keyword `self`, a method receiver."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:78
 msgid ""
 "Show that it is an abbreviated term for `self: Self` and perhaps show how "
 "the struct name could also be used."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:80
 msgid ""
 "Explain that `Self` is a type alias for the type the `impl` block is in and "
 "can be used elsewhere in the block."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:82
 msgid ""
 "Note how `self` is used like other structs and dot notation can be used to "
 "refer to individual fields."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:84
 msgid ""
 "This might be a good time to demonstrate how the `&self` differs from `self` "
 "by trying to run `finish` twice."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:86
 msgid ""
 "Beyond variants on `self`, there are also [special wrapper types](https://"
 "doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
 "receiver types, such as `Box<Self>`."
 msgstr ""
 
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:3
 msgid ""
 "Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:7
 msgid "/// Return a sentence from this pet.\n"
 msgstr ""
 
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:10
 msgid "/// Print a string to the terminal greeting this pet.\n"
 msgstr ""
 
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:18
 msgid ""
 "A trait defines a number of methods that types must have in order to "
 "implement the trait."
 msgstr ""
 
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:21
 msgid ""
 "In the \"Generics\" segment, next, we will see how to build functionality "
 "that is generic over all types implementing a trait."
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md
-msgid "Implementing Traits"
-msgstr ""
-
-#: src/methods-and-traits/traits/implementing.md
+#: src/methods-and-traits/traits/implementing.md:8
 msgid "\"Oh you're a cutie! What's your name? {}\""
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md
-#: src/smart-pointers/trait-objects.md
+#: src/methods-and-traits/traits/implementing.md:19
+#: src/smart-pointers/trait-objects.md:20
 msgid "\"Woof, my name is {}!\""
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md
-#: src/smart-pointers/trait-objects.md
+#: src/methods-and-traits/traits/implementing.md:24
+#: src/smart-pointers/trait-objects.md:33
 msgid "\"Fido\""
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md
+#: src/methods-and-traits/traits/implementing.md:31
 msgid ""
 "To implement `Trait` for `Type`, you use an `impl Trait for Type { .. }` "
 "block."
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md
+#: src/methods-and-traits/traits/implementing.md:34
 msgid ""
 "Unlike Go interfaces, just having matching methods is not enough: a `Cat` "
 "type with a `talk()` method would not automatically satisfy `Pet` unless it "
 "is in an `impl Pet` block."
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md
+#: src/methods-and-traits/traits/implementing.md:38
 msgid ""
 "Traits may provide default implementations of some methods. Default "
 "implementations can rely on all the methods of the trait. In this case, "
 "`greet` is provided, and relies on `talk`."
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md
+#: src/methods-and-traits/traits/supertraits.md:3
 msgid ""
 "A trait can require that types implementing it also implement other traits, "
 "called _supertraits_. Here, any type implementing `Pet` must implement "
 "`Animal`."
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md
-#: src/async/control-flow/select.md
+#: src/methods-and-traits/traits/supertraits.md:30
+#: src/concurrency/async-control-flow/select.md:44
 msgid "\"Rex\""
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md
+#: src/methods-and-traits/traits/supertraits.md:31
 msgid "\"{} has {} legs\""
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md
+#: src/methods-and-traits/traits/supertraits.md:37
 msgid ""
 "This is sometimes called \"trait inheritance\" but students should not "
 "expect this to behave like OO inheritance. It just specifies an additional "
 "requirement on implementations of a trait."
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md
+#: src/methods-and-traits/traits/associated-types.md:3
 msgid ""
 "Associated types are placeholder types which are supplied by the trait "
 "implementation."
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md
-#: src/async/control-flow/join.md
+#: src/methods-and-traits/traits/associated-types.md:25
+#: src/concurrency/async-control-flow/join.md:30
 msgid "\"{:?}\""
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md
+#: src/methods-and-traits/traits/associated-types.md:31
 msgid ""
 "Associated types are sometimes also called \"output types\". The key "
 "observation is that the implementer, not the caller, chooses this type."
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md
+#: src/methods-and-traits/traits/associated-types.md:34
 msgid ""
 "Many standard library traits have associated types, including arithmetic "
 "operators and `Iterator`."
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:3
 msgid ""
 "Supported traits can be automatically implemented for your custom types, as "
 "follows:"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:15
 msgid "// Default trait adds `default` constructor.\n"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:16
 msgid "// Clone trait adds `clone` method.\n"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:17
 msgid "\"EldurScrollz\""
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:18
 msgid "// Debug trait adds support for printing with `{:?}`.\n"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:19
 msgid "\"{:?} vs. {:?}\""
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:26
 msgid ""
 "Derivation is implemented with macros, and many crates provide useful derive "
 "macros to add useful functionality. For example, `serde` can derive "
 "serialization support for a struct using `#[derive(Serialize)]`."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:1
 msgid "Exercise: Logger Trait"
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:3
 msgid ""
 "Let's design a simple logging utility, using a trait `Logger` with a `log` "
 "method. Code which might log its progress can then take an `&impl Logger`. "
@@ -5486,97 +5566,93 @@ msgid ""
 "production build it would send messages to a log server."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:8
 msgid ""
 "However, the `StderrLogger` given below logs all messages, regardless of "
 "verbosity. Your task is to write a `VerbosityFilter` type that will ignore "
 "messages above a maximum verbosity."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:12
 msgid ""
 "This is a common pattern: a struct wrapping a trait implementation and "
 "implementing that same trait, adding behavior in the process. What other "
 "kinds of wrappers might be useful in a logging utility?"
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
+#: src/methods-and-traits/exercise.md:20 src/methods-and-traits/solution.md:7
 msgid "/// Log a message at the given verbosity level.\n"
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
+#: src/methods-and-traits/exercise.md:28 src/methods-and-traits/solution.md:15
 msgid "\"verbosity={verbosity}: {message}\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
+#: src/methods-and-traits/exercise.md:33 src/methods-and-traits/solution.md:20
 msgid "\"FYI\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
+#: src/methods-and-traits/exercise.md:34 src/methods-and-traits/solution.md:21
 msgid "\"Uhoh\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:36
 msgid "// TODO: Define and implement `VerbosityFilter`.\n"
 msgstr ""
 
-#: src/methods-and-traits/solution.md
+#: src/methods-and-traits/solution.md:23
 msgid "/// Only log messages up to the given verbosity level.\n"
 msgstr ""
 
-#: src/generics.md
-msgid "[Generic Functions](./generics/generic-functions.md) (5 minutes)"
+#: src/welcome-day-2-afternoon.md:3
+msgid ""
+"Including 10 minute breaks, this session should take about 4 hours. It "
+"contains:"
+msgstr ""
+"Buổi học nên kéo dài khoảng 4 tiếng, bao gồm thời gian 10 phút nghỉ trưa. "
+"Nội dung buổi học bao gồm:"
+
+#: src/generics.md:10
+msgid "impl Trait"
 msgstr ""
 
-#: src/generics.md
-msgid "[Generic Data Types](./generics/generic-data.md) (10 minutes)"
+#: src/generics.md:11
+msgid "Exercise: Generic min"
 msgstr ""
 
-#: src/generics.md
-msgid "[Trait Bounds](./generics/trait-bounds.md) (10 minutes)"
-msgstr ""
-
-#: src/generics.md
-msgid "[impl Trait](./generics/impl-trait.md) (5 minutes)"
-msgstr ""
-
-#: src/generics.md
-msgid "[Exercise: Generic min](./generics/exercise.md) (10 minutes)"
-msgstr ""
-
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:3
 msgid ""
 "Rust supports generics, which lets you abstract algorithms or data "
 "structures (such as sorting or a binary tree) over the types used or stored."
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:7
 msgid "/// Pick `even` or `odd` depending on the value of `n`.\n"
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:17
 msgid "\"picked a number: {:?}\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:18
 msgid "\"picked a tuple: {:?}\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:18
 msgid "\"dog\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:18
 msgid "\"cat\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:25
 msgid ""
 "Rust infers a type for T based on the types of the arguments and return "
 "value."
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:27
 msgid ""
 "This is similar to C++ templates, but Rust partially compiles the generic "
 "function immediately, so that function must be valid for all types matching "
@@ -5585,102 +5661,98 @@ msgid ""
 "still considers it invalid. C++ would let you do this."
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:33
 msgid ""
 "Generic code is turned into non-generic code based on the call sites. This "
 "is a zero-cost abstraction: you get exactly the same result as if you had "
 "hand-coded the data structures without the abstraction."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:3
 msgid "You can use generics to abstract over the concrete field type:"
 msgstr ""
 
-#: src/generics/generic-data.md
-msgid "// fn set_x(&mut self, x: T)\n"
-msgstr ""
-
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:25
 msgid "\"{integer:?} and {float:?}\""
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:26
 msgid "\"coords: {:?}\""
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:33
 msgid ""
 "_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
 "redundant?"
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:35
 msgid ""
 "This is because it is a generic implementation section for generic type. "
 "They are independently generic."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:37
 msgid "It means these methods are defined for any `T`."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:38
 msgid "It is possible to write `impl Point<u32> { .. }`."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:39
 msgid ""
 "`Point` is still generic and you can use `Point<f64>`, but methods in this "
 "block will only be available for `Point<u32>`."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:42
 msgid ""
 "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`. Update the "
 "code to allow points that have elements of different types, by using two "
 "type variables, e.g., `T` and `U`."
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:3
 msgid ""
 "Traits can also be generic, just like types and functions. A trait's "
 "parameters get concrete types when it is used."
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:12
 msgid "\"Converted from integer: {from}\""
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:18
 msgid "\"Converted from bool: {from}\""
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:25
 msgid "\"{from_int:?}, {from_bool:?}\""
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:31
 msgid ""
 "The `From` trait will be covered later in the course, but its [definition in "
 "the `std` docs](https://doc.rust-lang.org/std/convert/trait.From.html) is "
 "simple."
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:35
 msgid ""
 "Implementations of the trait do not need to cover all possible type "
 "parameters. Here, `Foo::From(\"hello\")` would not compile because there is "
 "no `From<&str>` implementation for `Foo`."
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:39
 msgid ""
 "Generic traits take types as \"input\", while associated types are a kind of "
-"\"output type. A trait can have multiple implementations for different input "
-"types."
+"\"output\" type. A trait can have multiple implementations for different "
+"input types."
 msgstr ""
 
-#: src/generics/generic-traits.md
+#: src/generics/generic-traits.md:43
 msgid ""
 "In fact, Rust requires that at most one implementation of a trait match for "
 "any type T. Unlike some other languages, Rust has no heuristic for choosing "
@@ -5689,100 +5761,100 @@ msgid ""
 "html)."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:3
 msgid ""
 "When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:12
 msgid "// struct NotClonable;\n"
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:18
 msgid "\"{pair:?}\""
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:25
 msgid "Try making a `NonClonable` and passing it to `duplicate`."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:27
 msgid "When multiple traits are necessary, use `+` to join them."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:29
 msgid "Show a `where` clause, students will encounter it when reading code."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:40
 msgid "It declutters the function signature if you have many parameters."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:41
 msgid "It has additional features making it more powerful."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:42
 msgid ""
 "If someone asks, the extra feature is that the type on the left of \":\" can "
 "be arbitrary, like `Option<T>`."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:45
 msgid ""
 "Note that Rust does not (yet) support specialization. For example, given the "
 "original `duplicate`, it is invalid to add a specialized `duplicate(a: u32)`."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:3
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:7
 msgid ""
 "// Syntactic sugar for:\n"
 "//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:19
 msgid "\"{many}\""
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:21
 msgid "\"{many_more}\""
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:23
 msgid "\"debuggable: {debuggable:?}\""
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:30
 msgid ""
 "`impl Trait` allows you to work with types which you cannot name. The "
 "meaning of `impl Trait` is a bit different in the different positions."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:33
 msgid ""
 "For a parameter, `impl Trait` is like an anonymous generic parameter with a "
 "trait bound."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:36
 msgid ""
 "For a return type, it means that the return type is some concrete type that "
 "implements the trait, without naming the type. This can be useful when you "
 "don't want to expose the concrete type in a public API."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:40
 msgid ""
 "Inference is hard in return position. A function returning `impl Foo` picks "
 "the concrete type it returns, without writing it out in the source. A "
@@ -5792,106 +5864,81 @@ msgid ""
 "<Vec<_>>()`."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:47
 msgid ""
 "What is the type of `debuggable`? Try `let debuggable: () = ..` to see what "
 "the error message shows."
 msgstr ""
 
-#: src/generics/exercise.md
+#: src/generics/exercise.md:3
 msgid ""
 "In this short exercise, you will implement a generic `min` function that "
 "determines the minimum of two values, using the [`Ord`](https://doc.rust-"
 "lang.org/stable/std/cmp/trait.Ord.html) trait."
 msgstr ""
 
-#: src/generics/exercise.md
+#: src/generics/exercise.md:8
 msgid "// TODO: implement the `min` function used in `main`.\n"
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/generics/exercise.md:15 src/generics/solution.md:17
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:75
+#: src/error-handling/solution.md:60 src/error-handling/solution.md:75
 msgid "'z'"
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
+#: src/generics/exercise.md:16 src/generics/solution.md:18
 msgid "'7'"
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
+#: src/generics/exercise.md:16 src/generics/solution.md:18
 msgid "'1'"
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
+#: src/generics/exercise.md:18 src/generics/solution.md:20
 msgid "\"goodbye\""
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
+#: src/generics/exercise.md:19 src/generics/solution.md:21
 msgid "\"bat\""
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
+#: src/generics/exercise.md:19 src/generics/solution.md:21
 msgid "\"armadillo\""
 msgstr ""
 
-#: src/generics/exercise.md
+#: src/generics/exercise.md:26
 msgid ""
 "Show students the [`Ord`](https://doc.rust-lang.org/stable/std/cmp/trait.Ord."
 "html) trait and [`Ordering`](https://doc.rust-lang.org/stable/std/cmp/enum."
 "Ordering.html) enum."
 msgstr ""
 
-#: src/welcome-day-2-afternoon.md
-msgid "[Standard Library Types](./std-types.md) (1 hour and 20 minutes)"
+#: src/std-types.md:3
+msgid "This segment should take about 1 hour and 20 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 20 phút, bao gồm:"
+
+#: src/std-types.md:9 src/std-types/option.md:1
+msgid "Option"
+msgstr "Option"
+
+#: src/std-types.md:10 src/std-types/result.md:1
+msgid "Result"
+msgstr "Result"
+
+#: src/std-types.md:11 src/std-types/string.md:1
+msgid "String"
 msgstr ""
 
-#: src/welcome-day-2-afternoon.md
-msgid "[Standard Library Traits](./std-traits.md) (1 hour and 40 minutes)"
+#: src/std-types.md:12
+msgid "Vec"
 msgstr ""
 
-#: src/welcome-day-2-afternoon.md
-msgid ""
-"Including 10 minute breaks, this session should take about 3 hours and 10 "
-"minutes"
+#: src/std-types.md:13
+msgid "HashMap"
 msgstr ""
 
-#: src/std-types.md
-msgid "[Standard Library](./std-types/std.md) (3 minutes)"
-msgstr "[Thư viện chuẩn](./std-types/std.md) (3 phút)"
-
-#: src/std-types.md
-msgid "[Documentation](./std-types/docs.md) (5 minutes)"
-msgstr "[Tài liệu](./std-types/docs.md) (5 phút)"
-
-#: src/std-types.md
-msgid "[Option](./std-types/option.md) (10 minutes)"
-msgstr "[Option](./std-types/option.md) (10 phút)"
-
-#: src/std-types.md
-msgid "[Result](./std-types/result.md) (10 minutes)"
-msgstr "[Result](./std-types/result.md) (10 phút)"
-
-#: src/std-types.md
-msgid "[String](./std-types/string.md) (10 minutes)"
-msgstr "[String](./std-types/string.md) (10 phút)"
-
-#: src/std-types.md
-msgid "[Vec](./std-types/vec.md) (10 minutes)"
-msgstr "[Vec](./std-types/vec.md) (10 phút)"
-
-#: src/std-types.md
-msgid "[HashMap](./std-types/hashmap.md) (10 minutes)"
-msgstr "[HashMap](./std-types/hashmap.md) (10 phút)"
-
-#: src/std-types.md
-msgid "[Exercise: Counter](./std-types/exercise.md) (20 minutes)"
-msgstr "[Thực hành: Đếm số](./std-types/exercise.md) (20 phút)"
-
-#: src/std-types.md
-msgid "This segment should take about 1 hour and 20 minutes"
-msgstr "Phần này sẽ mất khoảng 1 giờ và 20 phút"
-
-#: src/std-types.md
+#: src/std-types.md:19
 msgid ""
 "For each of the slides in this section, spend some time reviewing the "
 "documentation pages, highlighting some of the more common methods."
@@ -5899,7 +5946,7 @@ msgstr ""
 "Hãy dành thời gian xem lại tài liệu cho từng trang trong phần này, đặc biệt "
 "là những hàm phổ biến."
 
-#: src/std-types/std.md
+#: src/std-types/std.md:3
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
 "types used by Rust libraries and programs. This way, two libraries can work "
@@ -5909,7 +5956,7 @@ msgstr ""
 "Nhờ đó, hai thư viện có thể hoạt động cùng nhau một cách mượt mà vì cả hai "
 "đều sử dụng cùng một kiểu `String` của thư viện chuẩn."
 
-#: src/std-types/std.md
+#: src/std-types/std.md:7
 msgid ""
 "In fact, Rust contains several layers of the Standard Library: `core`, "
 "`alloc` and `std`."
@@ -5917,7 +5964,7 @@ msgstr ""
 "Trong thực tế, thư viện chuẩn của Rust chứa nhiều tầng riêng biệt: `core`, "
 "`alloc` và `std`."
 
-#: src/std-types/std.md
+#: src/std-types/std.md:10
 msgid ""
 "`core` includes the most basic types and functions that don't depend on "
 "`libc`, allocator or even the presence of an operating system."
@@ -5925,7 +5972,7 @@ msgstr ""
 "`core` bao gồm các kiểu dữ liệu và hàm cơ bản nhất không phụ thuộc vào "
 "`libc`, bộ cấp phát bộ nhớ hoặc thậm chí là hệ điều hành."
 
-#: src/std-types/std.md
+#: src/std-types/std.md:12
 msgid ""
 "`alloc` includes types which require a global heap allocator, such as `Vec`, "
 "`Box` and `Arc`."
@@ -5933,17 +5980,17 @@ msgstr ""
 "`alloc` bao gồm các kiểu dữ liệu yêu cầu phải được cấp phát trên bộ nhớ "
 "heap, như `Vec`, `Box` và `Arc`."
 
-#: src/std-types/std.md
+#: src/std-types/std.md:14
 msgid ""
 "Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
 "Phần mềm nhúng viết bằng Rust thường chỉ sử dụng `core`, và đôi khi `alloc`."
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:3
 msgid "Rust comes with extensive documentation. For example:"
 msgstr "Rust đi kèm với một bộ tài liệu rất chi tiết. Ví dụ:"
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:5
 msgid ""
 "All of the details about [loops](https://doc.rust-lang.org/stable/reference/"
 "expressions/loop-expr.html)."
@@ -5951,7 +5998,7 @@ msgstr ""
 "Tất cả chi tiết về [vòng lặp](https://doc.rust-lang.org/stable/reference/"
 "expressions/loop-expr.html)."
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:7
 msgid ""
 "Primitive types like [`u8`](https://doc.rust-lang.org/stable/std/primitive."
 "u8.html)."
@@ -5959,7 +6006,7 @@ msgstr ""
 "Các kiểu dữ liệu cơ bản như [`u8`](https://doc.rust-lang.org/stable/std/"
 "primitive.u8.html)."
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:9
 msgid ""
 "Standard library types like [`Option`](https://doc.rust-lang.org/stable/std/"
 "option/enum.Option.html) or [`BinaryHeap`](https://doc.rust-lang.org/stable/"
@@ -5969,11 +6016,11 @@ msgstr ""
 "lang.org/stable/std/option/enum.Option.html) hoặc [`BinaryHeap`](https://doc."
 "rust-lang.org/stable/std/collections/struct.BinaryHeap.html)."
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:13
 msgid "In fact, you can document your own code:"
 msgstr "Ngoài ra, bạn cũng có thể tự viết tài liệu cho code của bản thân:"
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:16
 msgid ""
 "/// Determine whether the first argument is divisible by the second "
 "argument.\n"
@@ -5984,7 +6031,7 @@ msgstr ""
 "///\n"
 "/// Nếu tham số thứ hai bằng không, trả về kết quả là sai.\n"
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:27
 msgid ""
 "The contents are treated as Markdown. All published Rust library crates are "
 "automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
@@ -5997,7 +6044,7 @@ msgstr ""
 "(https://docs.rs). Tất cả thành phần công khai trong một API nên được viết "
 "tài liệu theo phương pháp này."
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:32
 msgid ""
 "To document an item from inside the item (such as inside a module), use `//!"
 "` or `/*! .. */`, called \"inner doc comments\":"
@@ -6006,7 +6053,7 @@ msgstr ""
 "trong một module), hãy sử dụng `//!` hoặc `/*! .. */`. Cú pháp trên thường "
 "được gọi là \"inner doc comments\":"
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:36
 msgid ""
 "//! This module contains functionality relating to divisibility of "
 "integers.\n"
@@ -6014,7 +6061,7 @@ msgstr ""
 "//! Module này chứa các chức năng liên quan đến việc kiểm tra quan hệ chia "
 "hết của các số nguyên.\n"
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:42
 msgid ""
 "Show students the generated docs for the `rand` crate at <https://docs.rs/"
 "rand>."
@@ -6022,11 +6069,7 @@ msgstr ""
 "Cho học sinh xem tài liệu được viết cho thư viện `rand` tại <https://docs.rs/"
 "rand>."
 
-#: src/std-types/option.md
-msgid "Option"
-msgstr "Option"
-
-#: src/std-types/option.md
+#: src/std-types/option.md:3
 msgid ""
 "We have already seen some use of `Option<T>`. It stores either a value of "
 "type `T` or nothing. For example, [`String::find`](https://doc.rust-lang.org/"
@@ -6037,32 +6080,32 @@ msgstr ""
 "(https://doc.rust-lang.org/stable/std/string/struct.String.html#method.find) "
 "trả về một `Option<usize>`."
 
-#: src/std-types/option.md
+#: src/std-types/option.md:10
 msgid "\"Löwe 老虎 Léopard Gepardi\""
 msgstr "Hoàng Hữu Văn A"
 
-#: src/std-types/option.md
+#: src/std-types/option.md:11
 msgid "'é'"
 msgstr "ă"
 
-#: src/std-types/option.md
+#: src/std-types/option.md:12 src/std-types/option.md:15
 msgid "\"find returned {position:?}\""
 msgstr "\"find trả về {position:?}\""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:14
 msgid "'Z'"
 msgstr "'Z'"
 
-#: src/std-types/option.md
+#: src/std-types/option.md:16
 msgid "\"Character not found\""
 msgstr "\"Không tìm thấy ký tự\""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:23
 msgid "`Option` is widely used, not just in the standard library."
 msgstr ""
 "`Option` được sử dụng rộng rãi ở nhiều nơi, không chỉ trong thư viện chuẩn."
 
-#: src/std-types/option.md
+#: src/std-types/option.md:24
 msgid ""
 "`unwrap` will return the value in an `Option`, or panic. `expect` is similar "
 "but takes an error message."
@@ -6070,7 +6113,7 @@ msgstr ""
 "`unwrap` sẽ trả về giá trị của `Option` hoặc panic. `expect` hoạt động tương "
 "tự nhưng có thể truyền thêm một thông báo lỗi."
 
-#: src/std-types/option.md
+#: src/std-types/option.md:26
 msgid ""
 "You can panic on None, but you can't \"accidentally\" forget to check for "
 "None."
@@ -6078,7 +6121,7 @@ msgstr ""
 "Chương trình có thể panic khi gặp phải giá trị `None`, nhưng bạn không thể "
 "\"vô tình\" quên kiểm tra `None`."
 
-#: src/std-types/option.md
+#: src/std-types/option.md:28
 msgid ""
 "It's common to `unwrap`/`expect` all over the place when hacking something "
 "together, but production code typically handles `None` in a nicer fashion."
@@ -6087,18 +6130,14 @@ msgstr ""
 "một ý tưởng mới, nhưng code production thường xử lý `None` một cách an toàn "
 "hơn."
 
-#: src/std-types/option.md
+#: src/std-types/option.md:30
 msgid ""
 "The niche optimization means that `Option<T>` often has the same size in "
 "memory as `T`."
 msgstr ""
 "`Option<T>` được tối ưu để chiếm bằng bộ nhớ như `T`trong đa số trường hợp."
 
-#: src/std-types/result.md
-msgid "Result"
-msgstr "Result"
-
-#: src/std-types/result.md
+#: src/std-types/result.md:3
 msgid ""
 "`Result` is similar to `Option`, but indicates the success or failure of an "
 "operation, each with a different type. This is similar to the `Res` defined "
@@ -6112,23 +6151,23 @@ msgstr ""
 "trong đó `T` được sử dụng trong trường hợp `Ok` và `E` xuất hiện trong "
 "trường hợp `Err`."
 
-#: src/std-types/result.md
+#: src/std-types/result.md:13
 msgid "\"diary.txt\""
 msgstr "\"nhat_ky.txt\""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:18
 msgid "\"Dear diary: {contents} ({bytes} bytes)\""
 msgstr "\"Hôm nay, tôi đã: {contents} ({bytes} bytes)\""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:20
 msgid "\"Could not read file content\""
 msgstr "\"Không thể đọc nội dung tập tin\""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:24
 msgid "\"The diary could not be opened: {err}\""
 msgstr "\"Không thể mở nhật ký: {err}\""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:33
 msgid ""
 "As with `Option`, the successful value sits inside of `Result`, forcing the "
 "developer to explicitly extract it. This encourages error checking. In the "
@@ -6141,7 +6180,7 @@ msgstr ""
 "không thể xảy ra, `unwrap()` hoặc `expect()` có thể được gọi, bày tỏ rõ ràng "
 "ý định của người viết là lỗi không thể xảy ra."
 
-#: src/std-types/result.md
+#: src/std-types/result.md:37
 msgid ""
 "`Result` documentation is a recommended read. Not during the course, but it "
 "is worth mentioning. It contains a lot of convenience methods and functions "
@@ -6151,7 +6190,7 @@ msgstr ""
 "trong khóa học, nhưng đáng đề cập đến. Tài liệu này chứa nhiều hàm khá tiện "
 "lợi, hỗ trợ việc lập trình theo functional-style programming."
 
-#: src/std-types/result.md
+#: src/std-types/result.md:40
 msgid ""
 "`Result` is the standard type to implement error handling as we will see on "
 "Day 4."
@@ -6159,62 +6198,59 @@ msgstr ""
 "`Result` là kiểu dữ liệu chuẩn để xử lý lỗi như chúng ta sẽ thấy trong ngày "
 "4."
 
-#: src/std-types/string.md
-msgid "String"
-msgstr ""
-
-#: src/std-types/string.md
+#: src/std-types/string.md:3
 msgid ""
-"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
-"standard heap-allocated growable UTF-8 string buffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is a "
+"growable UTF-8 encoded string:"
 msgstr ""
 
-#: src/std-types/string.md src/std-traits/read-and-write.md
-#: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/std-types/string.md:8 src/std-traits/read-and-write.md:35
+#: src/memory-management/review.md:23 src/memory-management/review.md:58
+#: src/testing/unit-tests.md:32 src/testing/unit-tests.md:37
+#: src/concurrency/threads/scoped.md:9 src/concurrency/threads/scoped.md:26
 msgid "\"Hello\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:9
 msgid "\"s1: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:13
 msgid "'!'"
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:14
 msgid "\"s2: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:16
 msgid "\"🇨🇭\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:17
 msgid "\"s3: len = {}, number of chars = {}\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:21
 msgid ""
 "`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
 "string/struct.String.html#deref-methods-str), which means that you can call "
 "all `str` methods on a `String`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:30
 msgid ""
 "`String::new` returns a new empty string, use `String::with_capacity` when "
 "you know how much data you want to push to the string."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:32
 msgid ""
 "`String::len` returns the size of the `String` in bytes (which can be "
 "different from its length in characters)."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:34
 msgid ""
 "`String::chars` returns an iterator over the actual characters. Note that a "
 "`char` can be different from what a human will consider a \"character\" due "
@@ -6222,58 +6258,58 @@ msgid ""
 "unicode_segmentation/struct.Graphemes.html)."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:37
 msgid ""
 "When people refer to strings they could either be talking about `&str` or "
 "`String`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:39
 msgid ""
 "When a type implements `Deref<Target = T>`, the compiler will let you "
 "transparently call methods from `T`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:41
 msgid ""
 "We haven't discussed the `Deref` trait yet, so at this point this mostly "
 "explains the structure of the sidebar in the documentation."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:43
 msgid ""
 "`String` implements `Deref<Target = str>` which transparently gives it "
 "access to `str`'s methods."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:45
 msgid "Write and compare `let s3 = s1.deref();` and `let s3 = &*s1;`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:46
 msgid ""
 "`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
 "with some extra guarantees."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:49
 msgid "Compare the different ways to index a `String`:"
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:50
 msgid ""
 "To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
 "out-of-bounds."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:52
 msgid ""
 "To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:54
 msgid ""
 "Many types can be converted to a string with the [`to_string`](https://doc."
 "rust-lang.org/std/string/trait.ToString.html#tymethod.to_string) method. "
@@ -6282,145 +6318,146 @@ msgid ""
 "string."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:3
 msgid ""
 "[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
 "resizable heap-allocated buffer:"
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:9
 msgid "\"v1: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:14
 msgid "\"v2: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:16
 msgid "// Canonical macro to initialize a vector with elements.\n"
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:19
 msgid "// Retain only the even elements.\n"
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:21 src/std-types/vec.md:25
 msgid "\"{v3:?}\""
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:23
 msgid "// Remove consecutive duplicates.\n"
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:29
 msgid ""
 "`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
 "struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:38
 msgid ""
 "`Vec` is a type of collection, along with `String` and `HashMap`. The data "
 "it contains is stored on the heap. This means the amount of data doesn't "
 "need to be known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:41
 msgid ""
 "Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
 "explicitly. As always with Rust type inference, the `T` was established "
 "during the first `push` call."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:44
 msgid ""
 "`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
 "supports adding initial elements to the vector."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:46
 msgid ""
 "To index the vector you use `[` `]`, but they will panic if out of bounds. "
 "Alternatively, using `get` will return an `Option`. The `pop` function will "
 "remove the last element."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:49
 msgid ""
 "Slices are covered on day 3. For now, students only need to know that a "
 "value of type `Vec` gives access to all of the documented slice methods, too."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:3
 msgid "Standard hash map with protection against HashDoS attacks:"
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:10
 msgid "\"Adventures of Huckleberry Finn\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:11
 msgid "\"Grimms' Fairy Tales\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:12 src/std-types/hashmap.md:21
+#: src/std-types/hashmap.md:29
 msgid "\"Pride and Prejudice\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:14
 msgid "\"Les Misérables\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:16
 msgid "\"We know about {} books, but not Les Misérables.\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:21 src/std-types/hashmap.md:29
 msgid "\"Alice's Adventure in Wonderland\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:23
 msgid "\"{book}: {count} pages\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:24
 msgid "\"{book} is unknown.\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:28
 msgid "// Use the .entry() method to insert a value if nothing is found.\n"
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:34
 msgid "\"{page_counts:#?}\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:41
 msgid ""
 "`HashMap` is not defined in the prelude and needs to be brought into scope."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:42
 msgid ""
 "Try the following lines of code. The first line will see if a book is in the "
 "hashmap and if not return an alternative value. The second line will insert "
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:48 src/std-types/hashmap.md:60
 msgid "\"Harry Potter and the Sorcerer's Stone\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:51 src/std-types/hashmap.md:61
 msgid "\"The Hunger Games\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:54
 msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:55
 msgid ""
 "Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
 "doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
@@ -6428,26 +6465,26 @@ msgid ""
 "us to easily initialize a hash map from a literal array:"
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:65
 msgid ""
 "Alternatively HashMap can be built from any `Iterator` which yields key-"
 "value tuples."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:67
 msgid ""
 "We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
 "examples easier. Using references in collections can, of course, be done, "
 "but it can lead into complications with the borrow checker."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:70
 msgid ""
 "Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:73
 msgid ""
 "This type has several \"method-specific\" return types, such as `std::"
 "collections::hash_map::Keys`. These types often appear in searches of the "
@@ -6455,7 +6492,7 @@ msgid ""
 "to the `keys` method."
 msgstr ""
 
-#: src/std-types/exercise.md
+#: src/std-types/exercise.md:3
 msgid ""
 "In this exercise you will take a very simple data structure and make it "
 "generic. It uses a [`std::collections::HashMap`](https://doc.rust-lang.org/"
@@ -6463,218 +6500,200 @@ msgid ""
 "have been seen and how many times each one has appeared."
 msgstr ""
 
-#: src/std-types/exercise.md
+#: src/std-types/exercise.md:9
 msgid ""
 "The initial version of `Counter` is hard coded to only work for `u32` "
 "values. Make the struct and its methods generic over the type of value being "
 "tracked, that way `Counter` can track any type of value."
 msgstr ""
 
-#: src/std-types/exercise.md
+#: src/std-types/exercise.md:13
 msgid ""
 "If you finish early, try using the [`entry`](https://doc.rust-lang.org/"
 "stable/std/collections/struct.HashMap.html#method.entry) method to halve the "
 "number of hash lookups required to implement the `count` method."
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:20 src/std-types/solution.md:6
 msgid ""
 "/// Counter counts the number of times each value of type T has been seen.\n"
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:27 src/std-types/solution.md:13
 msgid "/// Create a new Counter.\n"
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:34 src/std-types/solution.md:18
 msgid "/// Count an occurrence of the given value.\n"
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:43 src/std-types/solution.md:23
 msgid "/// Return the number of times the given value has been seen.\n"
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:59 src/std-types/solution.md:39
 msgid "\"saw {} values equal to {}\""
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:63 src/std-types/exercise.md:65
+#: src/std-types/exercise.md:66 src/std-types/solution.md:43
+#: src/std-types/solution.md:45 src/std-types/solution.md:46
 msgid "\"apple\""
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:64 src/std-types/solution.md:44
 msgid "\"orange\""
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:66 src/std-types/solution.md:46
 msgid "\"got {} apples\""
 msgstr ""
 
-#: src/std-traits.md
-msgid "[Comparisons](./std-traits/comparisons.md) (10 minutes)"
+#: src/std-traits.md:3
+msgid "This segment should take about 1 hour and 40 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 40 phút, bao gồm:"
+
+#: src/std-traits.md:9
+msgid "From and Into"
 msgstr ""
 
-#: src/std-traits.md
-msgid "[Operators](./std-traits/operators.md) (10 minutes)"
+#: src/std-traits.md:11
+msgid "Read and Write"
 msgstr ""
 
-#: src/std-traits.md
-msgid "[From and Into](./std-traits/from-and-into.md) (10 minutes)"
+#: src/std-traits.md:12
+msgid "Default, struct update syntax"
 msgstr ""
 
-#: src/std-traits.md
-msgid "[Casting](./std-traits/casting.md) (5 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Read and Write](./std-traits/read-and-write.md) (10 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Default, struct update syntax](./std-traits/default.md) (5 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Closures](./std-traits/closures.md) (20 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Exercise: ROT13](./std-traits/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "This segment should take about 1 hour and 40 minutes"
-msgstr ""
-
-#: src/std-traits.md
+#: src/std-traits.md:19
 msgid ""
 "As with the standard-library types, spend time reviewing the documentation "
 "for each trait."
 msgstr ""
 
-#: src/std-traits.md
+#: src/std-traits.md:22
 msgid "This section is long. Take a break midway through."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:3
 msgid ""
 "These traits support comparisons between values. All traits can be derived "
 "for types containing fields that implement these traits."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:6
 msgid "`PartialEq` and `Eq`"
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:8
 msgid ""
 "`PartialEq` is a partial equivalence relation, with required method `eq` and "
 "provided method `ne`. The `==` and `!=` operators will call these methods."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:23
 msgid ""
 "`Eq` is a full equivalence relation (reflexive, symmetric, and transitive) "
 "and implies `PartialEq`. Functions that require full equivalence will use "
 "`Eq` as a trait bound."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:27
 msgid "`PartialOrd` and `Ord`"
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:29
 msgid ""
 "`PartialOrd` defines a partial ordering, with a `partial_cmp` method. It is "
 "used to implement the `<`, `<=`, `>=`, and `>` operators."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:49
 msgid "`Ord` is a total ordering, with `cmp` returning `Ordering`."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:54
 msgid ""
 "`PartialEq` can be implemented between different types, but `Eq` cannot, "
 "because it is reflexive:"
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:69
 msgid ""
 "In practice, it's common to derive these traits, but uncommon to implement "
 "them."
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:3
 msgid ""
 "Operator overloading is implemented via traits in [`std::ops`](https://doc."
 "rust-lang.org/std/ops/index.html):"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:23
 msgid "\"{:?} + {:?} = {:?}\""
 msgstr ""
 
-#: src/std-traits/operators.md src/memory-management/drop.md
+#: src/std-traits/operators.md:30 src/memory-management/drop.md:48
 msgid "Discussion points:"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:32
 msgid ""
 "You could implement `Add` for `&Point`. In which situations is that useful?"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:33
 msgid ""
 "Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
 "the operator is not `Copy`, you should consider overloading the operator for "
 "`&T` as well. This avoids unnecessary cloning on the call site."
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:36
 msgid ""
 "Why is `Output` an associated type? Could it be made a type parameter of the "
 "method?"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:38
 msgid ""
 "Short answer: Function type parameters are controlled by the caller, but "
 "associated types (like `Output`) are controlled by the implementer of a "
 "trait."
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:41
 msgid ""
 "You could implement `Add` for two different types, e.g. `impl Add<(i32, "
 "i32)> for Point` would add a tuple to a `Point`."
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:3
 msgid ""
 "Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
 "html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
 "facilitate type conversions:"
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:11 src/std-traits/from-and-into.md:23
 msgid "\"{s}, {addr}, {one}, {bigger}\""
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:15
 msgid ""
 "[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
 "automatically implemented when [`From`](https://doc.rust-lang.org/std/"
 "convert/trait.From.html) is implemented:"
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:30
 msgid ""
 "That's why it is common to only implement `From`, as your type will get "
 "`Into` implementation too."
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:32
 msgid ""
 "When declaring a function argument input type like \"anything that can be "
 "converted into a `String`\", the rule is opposite, you should use `Into`. "
@@ -6682,32 +6701,32 @@ msgid ""
 "implement `Into`."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:3
 msgid ""
 "Rust has no _implicit_ type conversions, but does support explicit casts "
 "with `as`. These generally follow C semantics where those are defined."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:9
 msgid "\"as u16: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:10
 msgid "\"as i16: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:11
 msgid "\"as u8: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:15
 msgid ""
 "The results of `as` are _always_ defined in Rust and consistent across "
 "platforms. This might not match your intuition for changing sign or casting "
 "to a smaller type -- check the docs, and comment for clarity."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:19
 msgid ""
 "Casting with `as` is a relatively sharp tool that is easy to use "
 "incorrectly, and can be a source of subtle bugs as future maintenance work "
@@ -6717,7 +6736,7 @@ msgid ""
 "was in the high bits)."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:25
 msgid ""
 "For infallible casts (e.g. `u32` to `u64`), prefer using `From` or `Into` "
 "over `as` to confirm that the cast is in fact infallible. For fallible "
@@ -6725,124 +6744,124 @@ msgid ""
 "that fit differently from those that don't."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:33
 msgid "Consider taking a break after this slide."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:35
 msgid ""
 "`as` is similar to a C++ static cast. Use of `as` in cases where data might "
 "be lost is generally discouraged, or at least deserves an explanatory "
 "comment."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:38
 msgid "This is common in casting integers to `usize` for use as an index."
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:3
 msgid ""
 "Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
 "[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
 "abstract over `u8` sources:"
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:14
 msgid "b\"foo\\nbar\\nbaz\\n\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:15
 msgid "\"lines in slice: {}\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:18
 msgid "\"lines in file: {}\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:23
 msgid ""
 "Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
 "you abstract over `u8` sinks:"
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:30
 msgid "\"\\n\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:37
 msgid "\"Logged: {:?}\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:1
 msgid "The `Default` Trait"
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:3
 msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
 "produces a default value for a type."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:18
 msgid "\"John Smith\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:24
 msgid "\"{default_struct:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:27
 msgid "\"Y is set!\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:28
 msgid "\"{almost_default_struct:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md src/lifetimes/exercise.md
-#: src/lifetimes/solution.md
+#: src/std-traits/default.md:31 src/lifetimes/exercise.md:211
+#: src/lifetimes/solution.md:214
 msgid "\"{:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:38
 msgid ""
 "It can be implemented directly or it can be derived via `#[derive(Default)]`."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:39
 msgid ""
 "A derived implementation will produce a value where all fields are set to "
 "their default values."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:41
 msgid "This means all types in the struct must implement `Default` too."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:42
 msgid ""
 "Standard Rust types often implement `Default` with reasonable values (e.g. "
 "`0`, `\"\"`, etc)."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:44
 msgid "The partial struct initialization works nicely with default."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:45
 msgid ""
 "The Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:47
 msgid ""
 "The `..` syntax is called [struct update syntax](https://doc.rust-lang.org/"
 "book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
 "with-struct-update-syntax)."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:3
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
 "they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
@@ -6850,86 +6869,87 @@ msgid ""
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:10
 msgid "\"Calling function on {input}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:16 src/std-traits/closures.md:17
 msgid "\"add_3: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:24 src/std-traits/closures.md:25
 msgid "\"accumulate: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:28
 msgid "\"multiply_sum: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:35
 msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
 "perhaps captures nothing at all. It can be called multiple times "
 "concurrently."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:38
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
 "multiple times, but not concurrently."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:41
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
 "might consume captured values."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:44
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
 "I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
 "use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:48
 msgid ""
 "When you define a function that takes a closure, you should take `FnOnce` if "
 "you can (i.e. you call it once), or `FnMut` else, and last `Fn`. This allows "
 "the most flexibility for the caller."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:52
 msgid ""
 "In contrast, when you have a closure, the most flexible you can have is `Fn` "
 "(it can be passed everywhere), then `FnMut`, and lastly `FnOnce`."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:55
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
 "`multiply_sum`), depending on what the closure captures."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:58
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
 "keyword makes them capture by value."
 msgstr ""
 
-#: src/std-traits/closures.md src/smart-pointers/trait-objects.md
+#: src/std-traits/closures.md:63 src/smart-pointers/trait-objects.md:91
+#: src/smart-pointers/trait-objects.md:92
 msgid "\"{} {}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:67
 msgid "\"Hi\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:68
 msgid "\"Greg\""
 msgstr ""
 
-#: src/std-traits/exercise.md
+#: src/std-traits/exercise.md:3
 msgid ""
 "In this example, you will implement the classic [\"ROT13\" cipher](https://"
 "en.wikipedia.org/wiki/ROT13). Copy this code to the playground, and "
@@ -6937,151 +6957,116 @@ msgid ""
 "ensure the result is still valid UTF-8."
 msgstr ""
 
-#: src/std-traits/exercise.md
+#: src/std-traits/exercise.md:15
 msgid "// Implement the `Read` trait for `RotDecoder`.\n"
 msgstr ""
 
-#: src/std-traits/exercise.md src/std-traits/solution.md
+#: src/std-traits/exercise.md:20 src/std-traits/exercise.md:33
+#: src/std-traits/solution.md:26 src/std-traits/solution.md:39
 msgid "\"Gb trg gb gur bgure fvqr!\""
 msgstr ""
 
-#: src/std-traits/exercise.md src/std-traits/solution.md
+#: src/std-traits/exercise.md:36 src/std-traits/solution.md:42
 msgid "\"To get to the other side!\""
 msgstr ""
 
-#: src/std-traits/exercise.md
+#: src/std-traits/exercise.md:55
 msgid ""
 "What happens if you chain two `RotDecoder` instances together, each rotating "
 "by 13 characters?"
 msgstr ""
 
-#: src/std-traits/solution.md
+#: src/std-traits/solution.md:16
 msgid "'A'"
 msgstr ""
 
-#: src/welcome-day-3.md
+#: src/welcome-day-3.md:1
 msgid "Welcome to Day 3"
 msgstr ""
 
-#: src/welcome-day-3.md
+#: src/welcome-day-3.md:3
 msgid "Today, we will cover:"
 msgstr ""
 
-#: src/welcome-day-3.md
+#: src/welcome-day-3.md:5
 msgid ""
 "Memory management, lifetimes, and the borrow checker: how Rust ensures "
 "memory safety."
 msgstr ""
 
-#: src/welcome-day-3.md
+#: src/welcome-day-3.md:7
 msgid "Smart pointers: standard library pointer types."
 msgstr ""
 
-#: src/welcome-day-3.md
-msgid "[Welcome](./welcome-day-3.md) (3 minutes)"
-msgstr ""
-
-#: src/welcome-day-3.md
-msgid "[Memory Management](./memory-management.md) (1 hour)"
-msgstr ""
-
-#: src/welcome-day-3.md
-msgid "[Smart Pointers](./smart-pointers.md) (55 minutes)"
-msgstr ""
-
-#: src/welcome-day-3.md
+#: src/welcome-day-3.md:11
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 20 "
-"minutes"
+"minutes. It contains:"
+msgstr ""
+"Buổi học nên kéo dài khoảng 2 tiếng và 20 phút, bao gồm thời gian 10 phút "
+"nghỉ trưa. Nội dung buổi học bao gồm:"
+
+#: src/memory-management.md:11 src/memory-management/clone.md:1
+msgid "Clone"
 msgstr ""
 
-#: src/memory-management.md
-msgid "[Review of Program Memory](./memory-management/review.md) (5 minutes)"
+#: src/memory-management.md:13
+msgid "Drop"
 msgstr ""
 
-#: src/memory-management.md
-msgid ""
-"[Approaches to Memory Management](./memory-management/approaches.md) (10 "
-"minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Ownership](./memory-management/ownership.md) (5 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Move Semantics](./memory-management/move.md) (5 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Clone](./memory-management/clone.md) (2 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Copy Types](./memory-management/copy-types.md) (5 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Drop](./memory-management/drop.md) (10 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Exercise: Builder Type](./memory-management/exercise.md) (20 minutes)"
-msgstr ""
-
-#: src/memory-management/review.md
+#: src/memory-management/review.md:3
 msgid "Programs allocate memory in two ways:"
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:5
 msgid "Stack: Continuous area of memory for local variables."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:6
 msgid "Values have fixed sizes known at compile time."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:7
 msgid "Extremely fast: just move a stack pointer."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:8
 msgid "Easy to manage: follows function calls."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:9
 msgid "Great memory locality."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:11
 msgid "Heap: Storage of values outside of function calls."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:12
 msgid "Values have dynamic sizes determined at runtime."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:13
 msgid "Slightly slower than the stack: some book-keeping needed."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:14
 msgid "No guarantee of memory locality."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:18
 msgid ""
 "Creating a `String` puts fixed-sized metadata on the stack and dynamically "
 "sized data, the actual string, on the heap:"
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:44
 msgid ""
 "Mention that a `String` is backed by a `Vec`, so it has a capacity and "
 "length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:47
 msgid ""
 "If students ask about it, you can mention that the underlying memory is heap "
 "allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
@@ -7089,21 +7074,21 @@ msgid ""
 "[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:53
 msgid ""
 "We can inspect the memory layout with `unsafe` Rust. However, you should "
 "point out that this is rightfully unsafe!"
 msgstr ""
 
-#: src/memory-management/review.md src/testing/unit-tests.md
+#: src/memory-management/review.md:59 src/testing/unit-tests.md:15
 msgid "' '"
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:60
 msgid "\"world\""
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:61
 msgid ""
 "// DON'T DO THIS AT HOME! For educational purposes only.\n"
 "    // String provides no guarantees about its layout, so this could lead "
@@ -7111,76 +7096,76 @@ msgid ""
 "    // undefined behavior.\n"
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:66
 msgid "\"capacity = {capacity}, ptr = {ptr:#x}, len = {len}\""
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:5
 msgid "Full control via manual memory management: C, C++, Pascal, ..."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:6
 msgid "Programmer decides when to allocate or free heap memory."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:7
 msgid ""
 "Programmer must determine whether a pointer still points to valid memory."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:8
 msgid "Studies show, programmers make mistakes."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:9
 msgid ""
 "Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:11
 msgid ""
 "A runtime system ensures that memory is not freed until it can no longer be "
 "referenced."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:13
 msgid ""
 "Typically implemented with reference counting, garbage collection, or RAII."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:15
 msgid "Rust offers a new mix:"
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:17
 msgid ""
 "Full control _and_ safety via compile time enforcement of correct memory "
 "management."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:20
 msgid "It does this with an explicit ownership concept."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:25
 msgid ""
 "This slide is intended to help students coming from other languages to put "
 "Rust in context."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:28
 msgid ""
 "C must manage heap manually with `malloc` and `free`. Common errors include "
 "forgetting to call `free`, calling it multiple times for the same pointer, "
 "or dereferencing a pointer after the memory it points to has been freed."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:32
 msgid ""
 "C++ has tools like smart pointers (`unique_ptr`, `shared_ptr`) that take "
 "advantage of language guarantees about calling destructors to ensure memory "
@@ -7188,7 +7173,7 @@ msgid ""
 "tools and create similar bugs to C."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:37
 msgid ""
 "Java, Go, and Python rely on the garbage collector to identify memory that "
 "is no longer reachable and discard it. This guarantees that any pointer can "
@@ -7196,7 +7181,7 @@ msgid ""
 "GC has a runtime cost and is difficult to tune properly."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:42
 msgid ""
 "Rust's ownership and borrowing model can, in many cases, get the performance "
 "of C, with alloc and free operations precisely where they are required -- "
@@ -7206,64 +7191,64 @@ msgid ""
 "(not covered in this class)."
 msgstr ""
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:3
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
 "to use a variable outside its scope:"
 msgstr ""
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:20
 msgid ""
 "We say that the variable _owns_ the value. Every Rust value has precisely "
 "one owner at all times."
 msgstr ""
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:23
 msgid ""
 "At the end of the scope, the variable is _dropped_ and the data is freed. A "
 "destructor can run here to free up resources."
 msgstr ""
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:29
 msgid ""
 "Students familiar with garbage-collection implementations will know that a "
 "garbage collector starts with a set of \"roots\" to find all reachable "
 "memory. Rust's \"single owner\" principle is a similar idea."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:3
 msgid "An assignment will transfer _ownership_ between variables:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:7
 msgid "\"Hello!\""
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:10
 msgid "// println!(\"s1: {s1}\");\n"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:14
 msgid "The assignment of `s1` to `s2` transfers ownership."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:15
 msgid "When `s1` goes out of scope, nothing happens: it does not own anything."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:16
 msgid "When `s2` goes out of scope, the string data is freed."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:18
 msgid "Before move to `s2`:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:35
 msgid "After move to `s2`:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:37
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -7272,136 +7257,137 @@ msgid ""
 ":    s1 \"(inaccessible)\"    :     :                                     :\n"
 ":   +-----------+-------+   :     :   +----+----+----+----+----+----+   :\n"
 ":   | ptr       |   o---+---+--+--+-->| H  | e  | l  | l  | o  | !  |   :\n"
-":   | len       |     4 |   :  |  :   +----+----+----+----+----+----+   :\n"
-":   | capacity  |     4 |   :  |  :                                     :\n"
+":   | len       |     6 |   :  |  :   +----+----+----+----+----+----+   :\n"
+":   | capacity  |     6 |   :  |  :                                     :\n"
 ":   +-----------+-------+   :  |  :                                     :\n"
 ":                           :  |  `- - - - - - - - - - - - - - - - - - -'\n"
 ":    s2                     :  |\n"
 ":   +-----------+-------+   :  |\n"
 ":   | ptr       |   o---+---+--'\n"
-":   | len       |     4 |   :\n"
-":   | capacity  |     4 |   :\n"
+":   | len       |     6 |   :\n"
+":   | capacity  |     6 |   :\n"
 ":   +-----------+-------+   :\n"
 ":                           :\n"
 "`- - - - - - - - - - - - - -'\n"
 "```"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:58
 msgid ""
 "When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:63 src/memory-management/clone.md:8
 msgid "\"Hello {name}\""
 msgstr ""
 
-#: src/memory-management/move.md src/android/interoperability/java.md
+#: src/memory-management/move.md:67 src/memory-management/clone.md:12
+#: src/android/interoperability/java.md:57
 msgid "\"Alice\""
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:69
 msgid "// say_hello(name);\n"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:76
 msgid ""
 "Mention that this is the opposite of the defaults in C++, which copies by "
 "value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:79
 msgid ""
 "It is only the ownership that moves. Whether any machine code is generated "
 "to manipulate the data itself is a matter of optimization, and such copies "
 "are aggressively optimized away."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:83
 msgid ""
 "Simple values (such as integers) can be marked `Copy` (see later slides)."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:85
 msgid "In Rust, clones are explicit (by using `clone`)."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:87
 msgid "In the `say_hello` example:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:89
 msgid ""
 "With the first call to `say_hello`, `main` gives up ownership of `name`. "
 "Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:91
 msgid ""
 "The heap memory allocated for `name` will be freed at the end of the "
 "`say_hello` function."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:93
 msgid ""
 "`main` can retain ownership if it passes `name` as a reference (`&name`) and "
 "if `say_hello` accepts a reference as a parameter."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:95
 msgid ""
 "Alternatively, `main` can pass a clone of `name` in the first call (`name."
 "clone()`)."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:97
 msgid ""
 "Rust makes it harder than C++ to inadvertently create copies by making move "
 "semantics the default, and by forcing programmers to make clones explicit."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:102
 msgid "Defensive Copies in Modern C++"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:104
 msgid "Modern C++ solves this differently:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:107
 msgid "\"Cpp\""
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:108
 msgid "// Duplicate the data in s1.\n"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:111
 msgid ""
 "The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:112
 msgid "When `s1` and `s2` go out of scope, they each free their own memory."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:114
 msgid "Before copy-assignment:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:130
 msgid "After copy-assignment:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:155
 msgid ""
 "C++ has made a slightly different choice than Rust. Because `=` copies data, "
 "the string data has to be cloned. Otherwise we would get a double-free when "
 "either string goes out of scope."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:159
 msgid ""
 "C++ also has [`std::move`](https://en.cppreference.com/w/cpp/utility/move), "
 "which is used to indicate when a value may be moved from. If the example had "
@@ -7410,164 +7396,172 @@ msgid ""
 "programmer is allowed to keep using `s1`."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:164
 msgid ""
 "Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
 "which is being copied or moved."
 msgstr ""
 
-#: src/memory-management/clone.md
-msgid "Clone"
-msgstr ""
-
-#: src/memory-management/clone.md
+#: src/memory-management/clone.md:3
 msgid ""
 "Sometimes you _want_ to make a copy of a value. The `Clone` trait "
 "accomplishes this."
 msgstr ""
 
-#: src/memory-management/clone.md
+#: src/memory-management/clone.md:21
 msgid ""
 "The idea of `Clone` is to make it easy to spot where heap allocations are "
-"occurring. Look for `.clone()` and a few others like `Vec::new` or `Box::"
-"new`."
+"occurring. Look for `.clone()` and a few others like `vec!` or `Box::new`."
 msgstr ""
 
-#: src/memory-management/clone.md
+#: src/memory-management/clone.md:24
 msgid ""
 "It's common to \"clone your way out\" of problems with the borrow checker, "
 "and return later to try to optimize those clones away."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/clone.md:27
+msgid ""
+"`clone` generally performs a deep copy of the value, meaning that if you e."
+"g. clone an array, all of the elements of the array are cloned as well."
+msgstr ""
+
+#: src/memory-management/clone.md:30
+msgid ""
+"The behavior for `clone` is user-defined, so it can perform custom cloning "
+"logic if needed."
+msgstr ""
+
+#: src/memory-management/copy-types.md:3
 msgid ""
 "While move semantics are the default, certain types are copied by default:"
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:16
 msgid "These types implement the `Copy` trait."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:18
 msgid "You can opt-in your own types to use copy semantics:"
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:34
 msgid "After the assignment, both `p1` and `p2` own their own data."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:35
 msgid "We can also use `p1.clone()` to explicitly copy the data."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:40
 msgid "Copying and cloning are not the same thing:"
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:42
 msgid ""
 "Copying refers to bitwise copies of memory regions and does not work on "
 "arbitrary objects."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:44
 msgid ""
 "Copying does not allow for custom logic (unlike copy constructors in C++)."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:45
 msgid ""
 "Cloning is a more general operation and also allows for custom behavior by "
 "implementing the `Clone` trait."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:47
 msgid "Copying does not work on types that implement the `Drop` trait."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:49
 msgid "In the above example, try the following:"
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:51
 msgid ""
 "Add a `String` field to `struct Point`. It will not compile because `String` "
 "is not a `Copy` type."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:53
 msgid ""
 "Remove `Copy` from the `derive` attribute. The compiler error is now in the "
 "`println!` for `p1`."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:55
 msgid "Show that it works if you clone `p1` instead."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:1
 msgid "The `Drop` Trait"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:3
 msgid ""
 "Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
 "html) can specify code to run when they go out of scope:"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:13
 msgid "\"Dropping {}\""
 msgstr ""
 
-#: src/memory-management/drop.md src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/memory-management/drop.md:18
+#: src/concurrency/sync-exercises/link-checker.md:85
+#: src/concurrency/sync-exercises/solutions.md:121
 msgid "\"a\""
 msgstr ""
 
-#: src/memory-management/drop.md src/android/testing/googletest.md
+#: src/memory-management/drop.md:20 src/android/testing/googletest.md:12
 msgid "\"b\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:22
 msgid "\"c\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:23
 msgid "\"d\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:24
 msgid "\"Exiting block B\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:26
 msgid "\"Exiting block A\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:29
 msgid "\"Exiting main\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:36
 msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:37
 msgid "Values are automatically dropped when they go out of scope."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:38
 msgid ""
 "When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
 "drop` implementation will be called."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:40
 msgid ""
 "All its fields will then be dropped too, whether or not it implements `Drop`."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:41
 msgid ""
 "`std::mem::drop` is just an empty function that takes any value. The "
 "significance is that it takes ownership of the value, so at the end of its "
@@ -7575,187 +7569,175 @@ msgid ""
 "values earlier than they would otherwise go out of scope."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:45
 msgid ""
 "This can be useful for objects that do some work on `drop`: releasing locks, "
 "closing files, etc."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:50
 msgid "Why doesn't `Drop::drop` take `self`?"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:51
 msgid ""
 "Short-answer: If it did, `std::mem::drop` would be called at the end of the "
 "block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:53
 msgid "Try replacing `drop(a)` with `a.drop()`."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:3
 msgid ""
 "In this example, we will implement a complex data type that owns all of its "
 "data. We will use the \"builder pattern\" to support building a new value "
 "piece-by-piece, using convenience functions."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:7
 msgid "Fill in the missing pieces."
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:22 src/memory-management/solution.md:16
 msgid "/// A representation of a software package.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:34 src/memory-management/solution.md:28
 msgid ""
 "/// Return a representation of this package as a dependency, for use in\n"
 "    /// building other packages.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:37
 msgid "\"1\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:40 src/memory-management/solution.md:37
 msgid ""
 "/// A builder for a Package. Use `build()` to create the `Package` itself.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:46
 msgid "\"2\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:49 src/memory-management/solution.md:52
 msgid "/// Set the package version.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:55 src/memory-management/solution.md:58
 msgid "/// Set the package authors.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:57
 msgid "\"3\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:60 src/memory-management/solution.md:64
 msgid "/// Add an additional dependency.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:62
 msgid "\"4\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:65 src/memory-management/solution.md:70
 msgid "/// Set the language. If not set, language defaults to None.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:67
 msgid "\"5\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
 msgid "\"base64\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
 msgid "\"0.13\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:77 src/memory-management/solution.md:83
 msgid "\"base64: {base64:?}\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
 msgid "\"log\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
 msgid "\"0.4\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:80 src/memory-management/solution.md:86
 msgid "\"log: {log:?}\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:81 src/memory-management/solution.md:87
 msgid "\"serde\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:82 src/memory-management/solution.md:88
 msgid "\"djmitche\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:83 src/memory-management/solution.md:89
 msgid "\"4.0\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:87 src/memory-management/solution.md:93
 msgid "\"serde: {serde:?}\""
 msgstr ""
 
-#: src/memory-management/solution.md
+#: src/memory-management/solution.md:45
 msgid "\"0.1\""
 msgstr ""
 
-#: src/smart-pointers.md
-msgid "[Box"
+#: src/smart-pointers.md:7
+msgid "Box"
 msgstr ""
 
-#: src/smart-pointers.md
-msgid "](./smart-pointers/box.md) (10 minutes)"
+#: src/smart-pointers.md:8
+msgid "Rc"
 msgstr ""
 
-#: src/smart-pointers.md
-msgid "[Rc](./smart-pointers/rc.md) (5 minutes)"
-msgstr ""
-
-#: src/smart-pointers.md
-msgid "[Trait Objects](./smart-pointers/trait-objects.md) (10 minutes)"
-msgstr ""
-
-#: src/smart-pointers.md
-msgid "[Exercise: Binary Tree](./smart-pointers/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:3
 msgid ""
 "[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
 "pointer to data on the heap:"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:9
 msgid "\"five: {}\""
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:26
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
 "methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
 "trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:30
 msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:35
 msgid "/// A non-empty list: first element and the rest of the list.\n"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:37
 msgid "/// An empty list.\n"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:44
 msgid "\"{list:?}\""
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:48
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
@@ -7777,43 +7759,43 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:64
 msgid ""
 "`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
 "not null."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:66
 msgid "A `Box` can be useful when you:"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:67
 msgid ""
 "have a type whose size that can't be known at compile time, but the Rust "
 "compiler wants to know an exact size."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:69
 msgid ""
 "want to transfer ownership of a large amount of data. To avoid copying large "
 "amounts of data on the stack, instead store the data on the heap in a `Box` "
 "so only the pointer is moved."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:73
 msgid ""
 "If `Box` was not used and we attempted to embed a `List` directly into the "
 "`List`, the compiler would not be able to compute a fixed size for the "
 "struct in memory (the `List` would be of infinite size)."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:77
 msgid ""
 "`Box` solves this problem as it has the same size as a regular pointer and "
 "just points at the next element of the `List` in the heap."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:80
 msgid ""
 "Remove the `Box` in the List definition and show the compiler error. We get "
 "the message \"recursive without indirection\", because for data recursion, "
@@ -7821,112 +7803,125 @@ msgid ""
 "storing the value directly."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:87
 msgid "Niche Optimization"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:89
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
-"allows the compiler to optimize the memory layout:"
+"Though `Box` looks like `std::unique_ptr` in C++, it cannot be empty/null. "
+"This makes `Box` one of the types that allow the compiler to optimize "
+"storage of some enums."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:93
 msgid ""
-"```bob\n"
-" Stack                           Heap\n"
-".- - - - - - - - - - - - - - .     .- - - - - - - - - - - - - -.\n"
-":                            :     :                           :\n"
-":    list                    :     :                           :\n"
-":   +---------+----+----+    :     :    +---------+----+----+  :\n"
-":   | Element | 1  | o--+----+-----+--->| Element | 2  | // |  :\n"
-":   +---------+----+----+    :     :    +---------+----+----+  :\n"
-":                            :     :                           :\n"
-":                            :     :                           :\n"
-"'- - - - - - - - - - - - - - '     '- - - - - - - - - - - - - -'\n"
-"```"
+"For example, `Option<Box<T>>` has the same size, as just `Box<T>`, because "
+"compiler uses NULL-value to discriminate variants instead of using explicit "
+"tag ([\"Null Pointer Optimization\"](https://doc.rust-lang.org/std/option/"
+"#representation)):"
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/box.md:103
+msgid "\"Just box\""
+msgstr ""
+
+#: src/smart-pointers/box.md:105
+msgid "\"Optional box\""
+msgstr "\"Optional box\""
+
+#: src/smart-pointers/box.md:111
+msgid "\"Size of just_box: {}\""
+msgstr ""
+
+#: src/smart-pointers/box.md:112
+msgid "\"Size of optional_box: {}\""
+msgstr ""
+
+#: src/smart-pointers/box.md:113
+msgid "\"Size of none: {}\""
+msgstr ""
+
+#: src/smart-pointers/rc.md:3
 msgid ""
 "[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
 "counted shared pointer. Use this when you need to refer to the same data "
 "from multiple places:"
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:13
 msgid "\"a: {a}\""
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:14
 msgid "\"b: {b}\""
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:18
 msgid ""
 "See [`Arc`](../concurrency/shared_state/arc.md) and [`Mutex`](https://doc."
 "rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
 "context."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:19
 msgid ""
 "You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
 "org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:30
 msgid ""
 "`Rc`'s count ensures that its contained value is valid for as long as there "
 "are references."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:32
 msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:33
 msgid ""
 "`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
 "be ignored when looking for performance issues in code."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:36
 msgid ""
 "`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
 "and returns a mutable reference."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:38
 msgid "Use `Rc::strong_count` to check the reference count."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:39
 msgid ""
 "`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
 "cycles that will be dropped properly (likely in combination with `RefCell`)."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:3
 msgid ""
 "Trait objects allow for values of different types, for instance in a "
 "collection:"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:26
 msgid "\"Miau!\""
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:36
 msgid "\"Hello, who are you? {}\""
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:41
 msgid "Memory layout after allocating `pets`:"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:43
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -7986,25 +7981,25 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:78
 msgid ""
 "Types that implement a given trait may be of different sizes. This makes it "
 "impossible to have things like `Vec<dyn Pet>` in the example above."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:80
 msgid ""
 "`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
 "implements `Pet`."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:82
 msgid ""
 "In the example, `pets` is allocated on the stack and the vector data is on "
 "the heap. The two vector elements are _fat pointers_:"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:84
 msgid ""
 "A fat pointer is a double-width pointer. It has two components: a pointer to "
 "the actual object and a pointer to the [virtual method table](https://en."
@@ -8012,17 +8007,17 @@ msgid ""
 "implementation of that particular object."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:87
 msgid ""
 "The data for the `Dog` named Fido is the `name` and `age` fields. The `Cat` "
 "has a `lives` field."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md
+#: src/smart-pointers/trait-objects.md:89
 msgid "Compare these outputs in the above example:"
 msgstr ""
 
-#: src/smart-pointers/exercise.md
+#: src/smart-pointers/exercise.md:3
 msgid ""
 "A binary tree is a tree-type data structure where every node has two "
 "children (left and right). We will create a tree where each node stores a "
@@ -8030,98 +8025,76 @@ msgid ""
 "values, and all nodes in N's right subtree will contain larger values."
 msgstr ""
 
-#: src/smart-pointers/exercise.md
+#: src/smart-pointers/exercise.md:8
 msgid "Implement the following types, so that the given tests pass."
 msgstr ""
 
-#: src/smart-pointers/exercise.md
+#: src/smart-pointers/exercise.md:10
 msgid ""
 "Extra Credit: implement an iterator over a binary tree that returns the "
 "values in order."
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
+#: src/smart-pointers/exercise.md:14 src/smart-pointers/solution.md:5
 msgid "/// A node in the binary tree.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
+#: src/smart-pointers/exercise.md:21 src/smart-pointers/solution.md:13
 msgid "/// A possibly-empty subtree.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
+#: src/smart-pointers/exercise.md:25 src/smart-pointers/solution.md:17
 msgid ""
 "/// A container storing a set of values, using a binary tree.\n"
 "///\n"
 "/// If the same value is added multiple times, it is only stored once.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md
-msgid "// Implement `new`, `insert`, `len`, and `has`.\n"
+#: src/smart-pointers/exercise.md:51
+msgid "// Implement `new`, `insert`, `len`, and `has` for `Subtree`.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
+#: src/smart-pointers/exercise.md:66 src/smart-pointers/solution.md:105
 msgid "// not a unique item\n"
 msgstr ""
 
-#: src/smart-pointers/solution.md src/android/testing/googletest.md
+#: src/smart-pointers/solution.md:89 src/android/testing/googletest.md:11
 msgid "\"bar\""
 msgstr ""
 
-#: src/welcome-day-3-afternoon.md
-msgid "[Borrowing](./borrowing.md) (50 minutes)"
-msgstr ""
-
-#: src/welcome-day-3-afternoon.md
-msgid "[Lifetimes](./lifetimes.md) (50 minutes)"
-msgstr ""
-
-#: src/welcome-day-3-afternoon.md
+#: src/welcome-day-3-afternoon.md:3
 msgid ""
-"Including 10 minute breaks, this session should take about 1 hour and 50 "
-"minutes"
+"Including 10 minute breaks, this session should take about 1 hour and 55 "
+"minutes. It contains:"
 msgstr ""
+"Buổi học nên kéo dài khoảng 1 tiếng và 55 phút, bao gồm thời gian 10 phút "
+"nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/borrowing.md
-msgid "[Borrowing a Value](./borrowing/shared.md) (10 minutes)"
-msgstr ""
-
-#: src/borrowing.md
-msgid "[Borrow Checking](./borrowing/borrowck.md) (10 minutes)"
-msgstr ""
-
-#: src/borrowing.md
-msgid "[Interior Mutability](./borrowing/interior-mutability.md) (10 minutes)"
-msgstr ""
-
-#: src/borrowing.md
-msgid "[Exercise: Health Statistics](./borrowing/exercise.md) (20 minutes)"
-msgstr ""
-
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:3
 msgid ""
 "As we saw before, instead of transferring ownership when calling a function, "
 "you can let a function _borrow_ the value:"
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:24
 msgid "The `add` function _borrows_ two points and returns a new point."
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:25
 msgid "The caller retains ownership of the inputs."
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:30
 msgid ""
 "This slide is a review of the material on references from day 1, expanding "
 "slightly to include function arguments and return values."
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:35
 msgid "Notes on stack returns:"
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:37
 msgid ""
 "Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
@@ -8132,11 +8105,11 @@ msgid ""
 "the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:63
 msgid "The Rust compiler can do return value optimization (RVO)."
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:64
 msgid ""
 "In C++, copy elision has to be defined in the language specification because "
 "constructors can have side effects. In Rust, this is not an issue at all. If "
@@ -8144,46 +8117,46 @@ msgid ""
 "copy."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:3
 msgid ""
 "Rust's _borrow checker_ puts constraints on the ways you can borrow values. "
 "For a given value, at any time:"
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:6
 msgid "You can have one or more shared references to the value, _or_"
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:7
 msgid "You can have exactly one exclusive reference to the value."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:29
 msgid ""
 "Note that the requirement is that conflicting references not _exist_ at the "
 "same point. It does not matter where the reference is dereferenced."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:31
 msgid ""
 "The above code does not compile because `a` is borrowed as mutable (through "
 "`c`) and as immutable (through `b`) at the same time."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:33
 msgid ""
 "Move the `println!` statement for `b` before the scope that introduces `c` "
 "to make the code compile."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:35
 msgid ""
 "After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:38
 msgid ""
 "The exclusive reference constraint is quite strong. Rust uses it to ensure "
 "that data races do not occur. Rust also _relies_ on this constraint to "
@@ -8191,7 +8164,7 @@ msgid ""
 "cached in a register for the lifetime of that reference."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:42
 msgid ""
 "The borrow checker is designed to accommodate many common patterns, such as "
 "taking exclusive references to different fields in a struct at the same "
@@ -8199,51 +8172,81 @@ msgid ""
 "this often results in \"fighting with the borrow checker.\""
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/examples.md:3
+msgid ""
+"As a concrete example of how these borrowing rules prevent memory errors, "
+"consider the case of modifying a collection while there are references to "
+"its elements:"
+msgstr ""
+
+#: src/borrowing/examples.md:12
+msgid "\"{elem}\""
+msgstr "\"{elem}\""
+
+#: src/borrowing/examples.md:16
+msgid "Similarly, consider the case of iterator invalidation:"
+msgstr ""
+
+#: src/borrowing/examples.md:30
+msgid ""
+"In both of these cases, modifying the collection by pushing new elements "
+"into it can potentially invalidate existing references to the collection's "
+"elements if the collection has to reallocate."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:3
 msgid ""
 "In some situations, it's necessary to modify data behind a shared (read-"
 "only) reference. For example, a shared data structure might have an internal "
 "cache, and wish to update that cache from read-only methods."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:7
 msgid ""
 "The \"interior mutability\" pattern allows exclusive (mutable) access behind "
 "a shared reference. The standard library provides several ways to do this, "
 "all while still ensuring safety, typically by performing a runtime check."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:11
 msgid "`RefCell`"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
-msgid "\"graph: {root:#?}\""
+#: src/borrowing/interior-mutability.md:17
+#: src/borrowing/interior-mutability.md:43
+msgid "// Note that `cell` is NOT declared as mutable.\n"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
-msgid "\"graph sum: {}\""
+#: src/borrowing/interior-mutability.md:24
+msgid ""
+"// This triggers an error at runtime.\n"
+"        // let other = cell.borrow();\n"
+"        // println!(\"{}\", *other);\n"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:29
+msgid "\"{cell:?}\""
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:33
 msgid "`Cell`"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:35
 msgid ""
 "`Cell` wraps a value and allows getting or setting the value, even with a "
 "shared reference to the `Cell`. However, it does not allow any references to "
 "the value. Since there are no references, borrowing rules cannot be broken."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:54
 msgid ""
 "The main thing to take away from this slide is that Rust provides _safe_ "
 "ways to modify data behind a shared reference. There are a variety of ways "
 "to ensure that safety, and `RefCell` and `Cell` are two of them."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:58
 msgid ""
 "`RefCell` enforces Rust's usual borrowing rules (either multiple shared "
 "references or a single exclusive reference) with a runtime check. In this "
@@ -8251,93 +8254,64 @@ msgid ""
 "succeed."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:63
 msgid ""
-"`Rc` only allows shared (read-only) access to its contents, since its "
-"purpose is to allow (and count) many references. But we want to modify the "
-"value, so we need interior mutability."
+"The extra block in the `RefCell` example is to end the borrow created by the "
+"call to `borrow_mut` before we print the cell. Trying to print a borrowed "
+"`RefCell` just shows the message `\"{borrowed}\"`."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:67
 msgid ""
 "`Cell` is a simpler means to ensure safety: it has a `set` method that takes "
 "`&self`. This needs no runtime check, but requires moving values, which can "
 "have its own cost."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
-msgid ""
-"Demonstrate that reference loops can be created by adding `root` to `subtree."
-"children`."
-msgstr ""
-
-#: src/borrowing/interior-mutability.md
-msgid ""
-"To demonstrate a runtime panic, add a `fn inc(&mut self)` that increments "
-"`self.value` and calls the same method on its children. This will panic in "
-"the presence of the reference loop, with `thread 'main' panicked at 'already "
-"borrowed: BorrowMutError'`."
-msgstr ""
-
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:3
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
 "you need to keep track of users' health statistics."
 msgstr ""
 
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:6
 msgid ""
 "You'll start with a stubbed function in an `impl` block as well as a `User` "
 "struct definition. Your goal is to implement the stubbed out method on the "
 "`User` `struct` defined in the `impl` block."
 msgstr ""
 
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:10
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "method:"
 msgstr ""
 
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:45
 msgid ""
 "\"Update a user's statistics based on measurements from a visit to the "
 "doctor\""
 msgstr ""
 
-#: src/borrowing/exercise.md src/borrowing/solution.md
-#: src/android/build-rules/library.md
-#: src/android/aidl/example-service/client.md
+#: src/borrowing/exercise.md:50 src/borrowing/exercise.md:56
+#: src/borrowing/exercise.md:60 src/borrowing/solution.md:52
+#: src/borrowing/solution.md:58 src/borrowing/solution.md:62
+#: src/android/build-rules/library.md:44
+#: src/android/aidl/example-service/client.md:15
 msgid "\"Bob\""
 msgstr ""
 
-#: src/borrowing/exercise.md src/borrowing/solution.md
+#: src/borrowing/exercise.md:51 src/borrowing/solution.md:53
 msgid "\"I'm {} and my age is {}\""
 msgstr ""
 
-#: src/lifetimes.md
-msgid ""
-"[Lifetime Annotations](./lifetimes/lifetime-annotations.md) (10 minutes)"
-msgstr ""
-
-#: src/lifetimes.md
-msgid "[Lifetime Elision](./lifetimes/lifetime-elision.md) (5 minutes)"
-msgstr ""
-
-#: src/lifetimes.md
-msgid "[Struct Lifetimes](./lifetimes/struct-lifetimes.md) (5 minutes)"
-msgstr ""
-
-#: src/lifetimes.md
-msgid "[Exercise: Protobuf Parsing](./lifetimes/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:3
 msgid ""
 "A reference has a _lifetime_, which must not \"outlive\" the value it refers "
 "to. This is verified by the borrow checker."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:6
 msgid ""
 "The lifetime can be implicit - this is what we have seen so far. Lifetimes "
 "can also be explicit: `&'a Point`, `&'document str`. Lifetimes start with "
@@ -8345,28 +8319,28 @@ msgid ""
 "`Point` which is valid for at least the lifetime `a`\"."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:11
 msgid ""
 "Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
 "yourself. Explicit lifetime annotations create constraints where there is "
 "ambiguity; the compiler verifies that there is a valid solution."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:15
 msgid ""
 "Lifetimes become more complicated when considering passing values to and "
 "returning values from functions."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:36
 msgid "// What is the lifetime of p3?\n"
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:37
 msgid "\"p3: {p3:?}\""
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:44
 msgid ""
 "In this example, the compiler does not know what lifetime to infer for `p3`. "
 "Looking inside the function body shows that it can only safely assume that "
@@ -8375,26 +8349,26 @@ msgid ""
 "values."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:50
 msgid "Add `'a` appropriately to `left_most`:"
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:56
 msgid ""
 "This says, \"given p1 and p2 which both outlive `'a`, the return value lives "
 "for at least `'a`."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:59
 msgid ""
 "In common cases, lifetimes can be elided, as described on the next slide."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:1
 msgid "Lifetimes in Function Calls"
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:3
 msgid ""
 "Lifetimes for function arguments and return values must be fully specified, "
 "but Rust allows lifetimes to be elided in most cases with [a few simple "
@@ -8402,44 +8376,44 @@ msgid ""
 "inference -- it is just a syntactic shorthand."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:8
 msgid "Each argument which does not have a lifetime annotation is given one."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:9
 msgid ""
 "If there is only one argument lifetime, it is given to all un-annotated "
 "return values."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:11
 msgid ""
 "If there are multiple argument lifetimes, but the first one is for `self`, "
 "that lifetime is given to all un-annotated return values."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:53
 msgid "In this example, `cab_distance` is trivially elided."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:55
 msgid ""
 "The `nearest` function provides another example of a function with multiple "
 "references in its arguments that requires explicit annotation."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:58
 msgid "Try adjusting the signature to \"lie\" about the lifetimes returned:"
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:64
 msgid ""
 "This won't compile, demonstrating that the annotations are checked for "
 "validity by the compiler. Note that this is not the case for raw pointers "
 "(unsafe), and this is a common source of errors with unsafe Rust."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:68
 msgid ""
 "Students may ask when to use lifetimes. Rust borrows _always_ have "
 "lifetimes. Most of the time, elision and type inference mean these don't "
@@ -8448,60 +8422,60 @@ msgid ""
 "just work with owned data by cloning values where necessary."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:1
 msgid "Lifetimes in Data Structures"
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:3
 msgid ""
 "If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:10
 msgid "\"Bye {text}!\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:14
 msgid "\"The quick brown fox jumps over the lazy dog.\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:17
 msgid "// erase(text);\n"
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:18
 msgid "\"{fox:?}\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:19
 msgid "\"{dog:?}\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:26
 msgid ""
 "In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
 "`Highlight` that uses that data."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:29
 msgid ""
 "If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
 "the borrow checker throws an error."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:31
 msgid ""
 "Types with borrowed data force users to hold on to the original data. This "
 "can be useful for creating lightweight views, but it generally makes them "
 "somewhat harder to use."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:34
 msgid "When possible, make data structures own their data directly."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:35
 msgid ""
 "Some structs with multiple references inside can have more than one lifetime "
 "annotation. This can be necessary if there is a need to describe lifetime "
@@ -8509,7 +8483,7 @@ msgid ""
 "of the struct itself. Those are very advanced use cases."
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:3
 msgid ""
 "In this exercise, you will build a parser for the [protobuf binary encoding]"
 "(https://protobuf.dev/programming-guides/encoding/). Don't worry, it's "
@@ -8517,7 +8491,7 @@ msgid ""
 "slices of data. The underlying data itself is never copied."
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:8
 msgid ""
 "Fully parsing a protobuf message requires knowing the types of the fields, "
 "indexed by their field numbers. That is typically provided in a `proto` "
@@ -8525,11 +8499,11 @@ msgid ""
 "statements in functions that get called for each field."
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:13
 msgid "We'll use the following proto:"
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:28
 msgid ""
 "A proto message is encoded as a series of fields, one after the next. Each "
 "is implemented as a \"tag\" followed by the value. The tag contains a field "
@@ -8537,7 +8511,7 @@ msgid ""
 "defining how the payload should be determined from the byte stream."
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:33
 msgid ""
 "Integers, including the tag, are represented with a variable-length encoding "
 "called VARINT. Luckily, `parse_varint` is defined for you below. The given "
@@ -8545,45 +8519,45 @@ msgid ""
 "to parse a message into a series of calls to those callbacks."
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:38
 msgid ""
 "What remains for you is to implement the `parse_field` function and the "
 "`ProtoMessage` trait for `Person` and `PhoneNumber`."
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:49 src/lifetimes/solution.md:11
 msgid "\"Invalid varint\""
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:51 src/lifetimes/solution.md:13
 msgid "\"Invalid wire-type\""
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:53 src/lifetimes/solution.md:15
 msgid "\"Unexpected EOF\""
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:55 src/lifetimes/solution.md:17
 msgid "\"Invalid length\""
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:57 src/lifetimes/solution.md:19
 msgid "\"Unexpected wire-type)\""
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:59 src/lifetimes/solution.md:21
 msgid "\"Invalid string (not UTF-8)\""
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:62 src/lifetimes/solution.md:24
 msgid "/// A wire type as seen on the wire.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:65 src/lifetimes/solution.md:27
 msgid "/// The Varint WireType indicates the value is a single VARINT.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:67 src/lifetimes/solution.md:29
 msgid ""
 "//I64,  -- not needed for this exercise\n"
 "    /// The Len WireType indicates that the value is a length represented as "
@@ -8591,62 +8565,62 @@ msgid ""
 "    /// VARINT followed by exactly that number of bytes.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:71 src/lifetimes/solution.md:33
 msgid ""
 "/// The I32 WireType indicates that the value is precisely 4 bytes in\n"
 "    /// little-endian order containing a 32-bit signed integer.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:76 src/lifetimes/solution.md:38
 msgid "/// A field's value, typed based on the wire type.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:80 src/lifetimes/solution.md:42
 msgid "//I64(i64),  -- not needed for this exercise\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:85 src/lifetimes/solution.md:47
 msgid "/// A field, containing the field number and its value.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:102 src/lifetimes/solution.md:64
 msgid "//1 => WireType::I64,  -- not needed for this exercise\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:132 src/lifetimes/solution.md:94
 msgid ""
 "/// Parse a VARINT, returning the parsed value and the remaining bytes.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:140 src/lifetimes/solution.md:102
 msgid ""
 "// This is the last byte of the VARINT, so convert it to\n"
 "            // a u64 and return it.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:150 src/lifetimes/solution.md:112
 msgid "// More than 7 bytes is invalid.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:153 src/lifetimes/solution.md:115
 msgid "/// Convert a tag into a field number and a WireType.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:161 src/lifetimes/solution.md:122
 msgid "/// Parse a field, returning the remaining bytes\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:167
 msgid ""
 "\"Based on the wire type, build a Field, consuming as many bytes as "
 "necessary.\""
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:169
 msgid "\"Return the field, and any un-consumed bytes.\""
 msgstr ""
 
-#: src/lifetimes/exercise.md src/lifetimes/solution.md
+#: src/lifetimes/exercise.md:171 src/lifetimes/solution.md:153
 msgid ""
 "/// Parse a message in the given data, calling `T::add_field` for each field "
 "in\n"
@@ -8655,96 +8629,78 @@ msgid ""
 "/// The entire input is consumed.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md
+#: src/lifetimes/exercise.md:198
 msgid "// TODO: Implement ProtoMessage for Person and PhoneNumber.\n"
 msgstr ""
 
-#: src/lifetimes/solution.md
+#: src/lifetimes/solution.md:146
 msgid "// Unwrap error because `value` is definitely 4 bytes long.\n"
 msgstr ""
 
-#: src/lifetimes/solution.md
+#: src/lifetimes/solution.md:187 src/lifetimes/solution.md:198
 msgid "// skip everything else\n"
 msgstr ""
 
-#: src/lifetimes/solution.md
+#: src/lifetimes/solution.md:225 src/lifetimes/solution.md:232
+#: src/lifetimes/solution.md:239
 msgid "b\"hello\""
 msgstr ""
 
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:1
 msgid "Welcome to Day 4"
 msgstr ""
 
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:3
 msgid ""
 "Today we will cover topics relating to building large-scale software in Rust:"
 msgstr ""
 
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:5
 msgid "Iterators: a deep dive on the `Iterator` trait."
 msgstr ""
 
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:6
 msgid "Modules and visibility."
 msgstr ""
 
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:7
 msgid "Testing."
 msgstr ""
 
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:8
 msgid "Error handling: panics, `Result`, and the try operator `?`."
 msgstr ""
 
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:9
 msgid ""
 "Unsafe Rust: the escape hatch when you can't express yourself in safe Rust."
 msgstr ""
 
-#: src/welcome-day-4.md
-msgid "[Welcome](./welcome-day-4.md) (3 minutes)"
-msgstr ""
-
-#: src/welcome-day-4.md
-msgid "[Iterators](./iterators.md) (45 minutes)"
-msgstr ""
-
-#: src/welcome-day-4.md
-msgid "[Modules](./modules.md) (40 minutes)"
-msgstr ""
-
-#: src/welcome-day-4.md
-msgid "[Testing](./testing.md) (45 minutes)"
-msgstr ""
-
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md:13
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 40 "
-"minutes"
+"minutes. It contains:"
+msgstr ""
+"Buổi học nên kéo dài khoảng 2 tiếng và 40 phút, bao gồm thời gian 10 phút "
+"nghỉ trưa. Nội dung buổi học bao gồm:"
+
+#: src/iterators.md:3 src/testing.md:3
+msgid "This segment should take about 45 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 45 phút, bao gồm:"
+
+#: src/iterators.md:7
+msgid "Iterator"
 msgstr ""
 
-#: src/iterators.md
-msgid "[Iterator](./iterators/iterator.md) (5 minutes)"
+#: src/iterators.md:8
+msgid "IntoIterator"
 msgstr ""
 
-#: src/iterators.md
-msgid "[IntoIterator](./iterators/intoiterator.md) (5 minutes)"
+#: src/iterators.md:9 src/iterators/fromiterator.md:1
+msgid "FromIterator"
 msgstr ""
 
-#: src/iterators.md
-msgid "[FromIterator](./iterators/fromiterator.md) (5 minutes)"
-msgstr ""
-
-#: src/iterators.md
-msgid ""
-"[Exercise: Iterator Method Chaining](./iterators/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/iterators.md src/testing.md
-msgid "This segment should take about 45 minutes"
-msgstr ""
-
-#: src/iterators/iterator.md
+#: src/iterators/iterator.md:3
 msgid ""
 "The [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
 "trait supports iterating over values in a collection. It requires a `next` "
@@ -8752,11 +8708,11 @@ msgid ""
 "`Iterator`, and you can implement it yourself, too:"
 msgstr ""
 
-#: src/iterators/iterator.md
+#: src/iterators/iterator.md:27
 msgid "\"fib({i}): {n}\""
 msgstr ""
 
-#: src/iterators/iterator.md
+#: src/iterators/iterator.md:35
 msgid ""
 "The `Iterator` trait implements many common functional programming "
 "operations over collections (e.g. `map`, `filter`, `reduce`, etc). This is "
@@ -8765,7 +8721,7 @@ msgid ""
 "implementations."
 msgstr ""
 
-#: src/iterators/iterator.md
+#: src/iterators/iterator.md:40
 msgid ""
 "`IntoIterator` is the trait that makes for loops work. It is implemented by "
 "collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
@@ -8773,7 +8729,7 @@ msgid ""
 "vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:3
 msgid ""
 "The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait [`IntoIterator`](https://doc.rust-lang.org/std/"
@@ -8781,47 +8737,47 @@ msgid ""
 "It is used automatically by the `for` loop."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:49
 msgid "\"point = {x}, {y}\""
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:57
 msgid ""
 "Click through to the docs for `IntoIterator`. Every implementation of "
 "`IntoIterator` must declare two types:"
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:60
 msgid "`Item`: the type to iterate over, such as `i8`,"
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:61
 msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:63
 msgid ""
 "Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:66
 msgid "The example iterates over all combinations of x and y coordinates."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:68
 msgid ""
 "Try iterating over the grid twice in `main`. Why does this fail? Note that "
 "`IntoIterator::into_iter` takes ownership of `self`."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:71
 msgid ""
 "Fix this issue by implementing `IntoIterator` for `&Grid` and storing a "
 "reference to the `Grid` in `GridIter`."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:74
 msgid ""
 "The same problem can occur for standard library types: `for e in "
 "some_vector` will take ownership of `some_vector` and iterate over owned "
@@ -8829,64 +8785,60 @@ msgid ""
 "over references to elements of `some_vector`."
 msgstr ""
 
-#: src/iterators/fromiterator.md
-msgid "FromIterator"
-msgstr ""
-
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:3
 msgid ""
 "[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
 "lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
 "std/iter/trait.Iterator.html)."
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:9
 msgid "\"prime_squares: {prime_squares:?}\""
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:16
 msgid "`Iterator` implements"
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:25
 msgid "There are two ways to specify `B` for this method:"
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:27
 msgid ""
 "With the \"turbofish\": `some_iterator.collect::<COLLECTION_TYPE>()`, as "
 "shown. The `_` shorthand used here lets Rust infer the type of the `Vec` "
 "elements."
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:29
 msgid ""
 "With type inference: `let prime_squares: Vec<_> = some_iterator.collect()`. "
 "Rewrite the example to use this form."
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:32
 msgid ""
 "There are basic implementations of `FromIterator` for `Vec`, `HashMap`, etc. "
 "There are also more specialized implementations which let you do cool things "
 "like convert an `Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 
-#: src/iterators/exercise.md
+#: src/iterators/exercise.md:3
 msgid ""
 "In this exercise, you will need to find and use some of the provided methods "
 "in the [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
 "trait to implement a complex calculation."
 msgstr ""
 
-#: src/iterators/exercise.md
+#: src/iterators/exercise.md:6
 msgid ""
 "Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Use an iterator expression and `collect` the result to construct the "
 "return value."
 msgstr ""
 
-#: src/iterators/exercise.md src/iterators/solution.md
+#: src/iterators/exercise.md:11 src/iterators/solution.md:4
 msgid ""
 "/// Calculate the differences between elements of `values` offset by "
 "`offset`,\n"
@@ -8895,260 +8847,239 @@ msgid ""
 "/// Element `n` of the result is `values[(n+offset)%len] - values[n]`.\n"
 msgstr ""
 
-#: src/modules.md
-msgid "[Modules](./modules/modules.md) (3 minutes)"
+#: src/modules.md:10 src/modules/paths.md:1
+msgid "use, super, self"
 msgstr ""
 
-#: src/modules.md
-msgid "[Filesystem Hierarchy](./modules/filesystem.md) (5 minutes)"
-msgstr ""
-
-#: src/modules.md
-msgid "[Visibility](./modules/visibility.md) (5 minutes)"
-msgstr ""
-
-#: src/modules.md
-msgid "[use, super, self](./modules/paths.md) (10 minutes)"
-msgstr ""
-
-#: src/modules.md
-msgid ""
-"[Exercise: Modules for a GUI Library](./modules/exercise.md) (15 minutes)"
-msgstr ""
-
-#: src/modules/modules.md
+#: src/modules/modules.md:3
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:5
 msgid "Similarly, `mod` lets us namespace types and functions:"
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:10
 msgid "\"In the foo module\""
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:16
 msgid "\"In the bar module\""
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:29
 msgid ""
 "Packages provide functionality and include a `Cargo.toml` file that "
 "describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:31
 msgid ""
 "Crates are a tree of modules, where a binary crate creates an executable and "
 "a library crate compiles to a library."
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:33
 msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:3
 msgid ""
 "Omitting the module content will tell Rust to look for it in another file:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:9
 msgid ""
 "This tells rust that the `garden` module content is found at `src/garden."
 "rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
 "vegetables.rs`."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:13
 msgid "The `crate` root is in:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:15
 msgid "`src/lib.rs` (for a library crate)"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:16
 msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:18
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
 "comments\". These document the item that contains them -- in this case, a "
 "module."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:22
 msgid ""
 "//! This module implements the garden, including a highly performant "
 "germination\n"
 "//! implementation.\n"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:24
 msgid "// Re-export types from this module.\n"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:28
 msgid "/// Sow the given seed packets.\n"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:33
 msgid "/// Harvest the produce in the garden that is ready.\n"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:43
 msgid ""
 "Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
 "`module.rs`, and this is still a working alternative for editions after 2018."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:46
 msgid ""
 "The main reason to introduce `filename.rs` as alternative to `filename/mod."
 "rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:49
 msgid "Deeper nesting can use folders, even if the main module is a file:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:59
 msgid ""
 "The place rust will look for modules can be changed with a compiler "
 "directive:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:62
 msgid "\"some/path.rs\""
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:66
 msgid ""
 "This is useful, for example, if you would like to place tests for a module "
 "in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:3
 msgid "Modules are a privacy boundary:"
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:5
 msgid "Module items are private by default (hides implementation details)."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:6
 msgid "Parent and sibling items are always visible."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:7
 msgid ""
 "In other words, if an item is visible in module `foo`, it's visible in all "
 "the descendants of `foo`."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:13
 msgid "\"outer::private\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:17
 msgid "\"outer::public\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:22
 msgid "\"outer::inner::private\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:26
 msgid "\"outer::inner::public\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:40
 msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:42
 msgid ""
 "Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
 "of public visibility."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:45
 msgid ""
 "See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
 "privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:47
 msgid "Configuring `pub(crate)` visibility is a common pattern."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:48
 msgid "Less commonly, you can give visibility to a specific path."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:49
 msgid ""
 "In any case, visibility must be granted to an ancestor module (and all of "
 "its descendants)."
 msgstr ""
 
-#: src/modules/paths.md
-msgid "use, super, self"
-msgstr ""
-
-#: src/modules/paths.md
+#: src/modules/paths.md:3
 msgid ""
 "A module can bring symbols from another module into scope with `use`. You "
 "will typically see something like this at the top of each module:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:11
 msgid "Paths"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:13
 msgid "Paths are resolved as follows:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:15
 msgid "As a relative path:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:16
 msgid "`foo` or `self::foo` refers to `foo` in the current module,"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:17
 msgid "`super::foo` refers to `foo` in the parent module."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:19
 msgid "As an absolute path:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:20
 msgid "`crate::foo` refers to `foo` in the root of the current crate,"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:21
 msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:26
 msgid ""
 "It is common to \"re-export\" symbols at a shorter path. For example, the "
 "top-level `lib.rs` in a crate might have"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:36
 msgid ""
 "making `DiskStorage` and `NetworkStorage` available to other crates with a "
 "convenient, short path."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:39
 msgid ""
 "For the most part, only items that appear in a module need to be `use`'d. "
 "However, a trait must be in scope to call any methods on that trait, even if "
@@ -9157,278 +9088,268 @@ msgid ""
 "`use std::io::Read`."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:45
 msgid ""
 "The `use` statement can have a wildcard: `use std::io::*`. This is "
 "discouraged because it is not clear which items are imported, and those "
 "might change over time."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:3
 msgid ""
 "In this exercise, you will reorganize a small GUI Library implementation. "
 "This library defines a `Widget` trait and a few implementations of that "
 "trait, as well as a `main` function."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:7
 msgid ""
 "It is typical to put each type or set of closely-related types into its own "
 "module, so each widget type should get its own module."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:10
 msgid "Cargo Setup"
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:12
 msgid ""
 "The Rust playground only supports one file, so you will need to make a Cargo "
 "project on your local filesystem:"
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:21
 msgid ""
 "Edit the resulting `src/main.rs` to add `mod` statements, and add additional "
 "files in the `src` directory."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:24
 msgid "Source"
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:26
 msgid "Here's the single-module implementation of the GUI library:"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:30 src/modules/solution.md:36
 msgid "/// Natural width of `self`.\n"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:33 src/modules/solution.md:39
 msgid "/// Draw the widget into a buffer.\n"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:36 src/modules/solution.md:42
 msgid "/// Draw the widget on standard output.\n"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:40 src/modules/solution.md:46
 msgid "\"{buffer}\""
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:88
 msgid "// Add 4 paddings for borders\n"
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:100
 msgid ""
 "// TODO: Change draw_into to return Result<(), std::fmt::Error>. Then use "
 "the\n"
 "        // ?-operator here instead of .unwrap().\n"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:102 src/modules/exercise.md:108
+#: src/modules/solution.md:165 src/modules/solution.md:171
 msgid "\"+-{:-<inner_width$}-+\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md src/testing/unit-tests.md
-#: src/testing/solution.md
+#: src/modules/exercise.md:102 src/modules/exercise.md:104
+#: src/modules/exercise.md:108 src/modules/exercise.md:122
+#: src/modules/exercise.md:126 src/modules/solution.md:110
+#: src/modules/solution.md:114 src/modules/solution.md:165
+#: src/modules/solution.md:167 src/modules/solution.md:171
+#: src/testing/unit-tests.md:27 src/testing/solution.md:89
 msgid "\"\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:103 src/modules/solution.md:166
 msgid "\"| {:^inner_width$} |\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:104 src/modules/solution.md:167
 msgid "\"+={:=<inner_width$}=+\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:106 src/modules/solution.md:169
 msgid "\"| {:inner_width$} |\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:114 src/modules/solution.md:100
 msgid "// add a bit of padding\n"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:122 src/modules/exercise.md:126
+#: src/modules/solution.md:110 src/modules/solution.md:114
 msgid "\"+{:-<width$}+\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:124 src/modules/solution.md:112
 msgid "\"|{:^width$}|\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:141 src/modules/solution.md:183
 msgid "\"Rust GUI Demo 1.23\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:142 src/modules/solution.md:185
 msgid "\"This is a small text GUI demo.\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:143 src/modules/solution.md:186
 msgid "\"Click me!\""
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:151
 msgid ""
 "Encourage students to divide the code in a way that feels natural for them, "
 "and get accustomed to the required `mod`, `use`, and `pub` declarations. "
 "Afterward, discuss what organizations are most idiomatic."
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:30
 msgid "// ---- src/widgets.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:56
 msgid "// ---- src/widgets/label.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:71
 msgid "// ANCHOR_END: Label-width\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:75
 msgid "// ANCHOR: Label-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:77
 msgid "// ANCHOR_END: Label-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:84
 msgid "// ---- src/widgets/button.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:99
 msgid "// ANCHOR_END: Button-width\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:103
 msgid "// ANCHOR: Button-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:105
 msgid "// ANCHOR_END: Button-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:120
 msgid "// ---- src/widgets/window.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:147
 msgid ""
 "// ANCHOR_END: Window-width\n"
 "        // Add 4 paddings for borders\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:152
 msgid "// ANCHOR: Window-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:154
 msgid "// ANCHOR_END: Window-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:162
 msgid ""
 "// TODO: after learning about error handling, you can change\n"
 "        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
 "        // the ?-operator here instead of .unwrap().\n"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:177
 msgid "// ---- src/main.rs ----\n"
 msgstr ""
 
-#: src/testing.md
-msgid "[Test Modules](./testing/unit-tests.md) (5 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Other Types of Tests](./testing/other.md) (5 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Compiler Lints and Clippy](./testing/lints.md) (3 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Exercise: Luhn Algorithm](./testing/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:5
 msgid "Unit tests are supported throughout your code."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:7
 msgid "Integration tests are supported via the `tests/` directory."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:9
 msgid ""
 "Tests are marked with `#[test]`. Unit tests are often put in a nested "
 "`tests` module, using `#[cfg(test)]` to conditionally compile them only when "
 "building tests."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:37
 msgid "\"Hello World\""
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:42
 msgid "This lets you unit test private helpers."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:43
 msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:48
 msgid "Run the tests in the playground in order to show their results."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:3
 msgid "Integration Tests"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:5
 msgid "If you want to test your library as a client, use an integration test."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:7
 msgid "Create a `.rs` file under `tests/`:"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:10
 msgid "// tests/my_library.rs\n"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:19
 msgid "These tests only have access to the public API of your crate."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:21
 msgid "Documentation Tests"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:23
 msgid "Rust has built-in support for documentation tests:"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:26
 msgid ""
 "/// Shortens a string to the given length.\n"
 "///\n"
@@ -9439,296 +9360,268 @@ msgid ""
 "/// ```\n"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:38
 msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:39
 msgid "The code will be compiled and executed as part of `cargo test`."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:40
 msgid ""
 "Adding `#` in the code will hide it from the docs, but will still compile/"
 "run it."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:42
 msgid ""
 "Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:3
 msgid ""
 "The Rust compiler produces fantastic error messages, as well as helpful "
 "built-in lints. [Clippy](https://doc.rust-lang.org/clippy/) provides even "
 "more lints, organized into groups that can be enabled per-project."
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:14
 msgid "\"X probably fits in a u16, right? {}\""
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:21
 msgid ""
 "Run the code sample and examine the error message. There are also lints "
 "visible here, but those will not be shown once the code compiles. Switch to "
 "the Playground site to show those lints."
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:25
 msgid ""
 "After resolving the lints, run `clippy` on the playground site to show "
 "clippy warnings. Clippy has extensive documentation of its lints, and adds "
 "new lints (including default-deny lints) all the time."
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:29
 msgid ""
 "Note that errors or warnings with `help: ...` can be fixed with `cargo fix` "
 "or via your editor."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:3
 msgid "Luhn Algorithm"
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:5
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
 "to validate credit card numbers. The algorithm takes a string as input and "
 "does the following to validate the credit card number:"
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:9
 msgid "Ignore all spaces. Reject number with fewer than two digits."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:11
 msgid ""
 "Moving from **right to left**, double every second digit: for the number "
 "`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:14
 msgid ""
 "After doubling a digit, sum the digits if the result is greater than 9. So "
 "doubling `7` becomes `14` which becomes `1 + 4 = 5`."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:17
 msgid "Sum all the undoubled and doubled digits."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:19
 msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:21
 msgid ""
 "The provided code provides a buggy implementation of the luhn algorithm, "
 "along with two basic unit tests that confirm that most the algorithm is "
 "implemented correctly."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:25
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and write additional "
 "tests to uncover bugs in the provided implementation, fixing any bugs you "
 "find."
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:57 src/testing/solution.md:69
 msgid "\"4263 9826 4026 9299\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:58 src/testing/solution.md:70
 msgid "\"4539 3195 0343 6467\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:59 src/testing/solution.md:71
 msgid "\"7992 7398 713\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:64 src/testing/solution.md:76
 msgid "\"4223 9826 4026 9299\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:65 src/testing/solution.md:77
 msgid "\"4539 3195 0343 6476\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:66 src/testing/solution.md:78
 msgid "\"8273 1232 7352 0569\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:4
 msgid "// This is the buggy version that appears in the problem.\n"
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:27
 msgid "// This is the solution and passes all of the tests below.\n"
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:56
 msgid "\"1234 5678 1234 5670\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:58
 msgid "\"Is {cc_number} a valid credit card number? {}\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:59
 msgid "\"yes\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:59
 msgid "\"no\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:84
 msgid "\"foo 0 0\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:90
 msgid "\" \""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:91
 msgid "\"  \""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:92
 msgid "\"    \""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:97
 msgid "\"0\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:102
 msgid "\" 0 0 \""
 msgstr ""
 
-#: src/welcome-day-4-afternoon.md
-msgid "[Error Handling](./error-handling.md) (55 minutes)"
+#: src/error-handling.md:10
+msgid "Error Trait"
 msgstr ""
 
-#: src/welcome-day-4-afternoon.md
-msgid "[Unsafe Rust](./unsafe-rust.md) (1 hour and 5 minutes)"
+#: src/error-handling.md:11
+msgid "thiserror and anyhow"
 msgstr ""
 
-#: src/welcome-day-4-afternoon.md
-msgid ""
-"Including 10 minute breaks, this session should take about 2 hours and 10 "
-"minutes"
+#: src/error-handling.md:12 src/error-handling/exercise.md:1
+msgid "Exercise: Rewriting with Result"
 msgstr ""
 
-#: src/error-handling.md
-msgid "[Panics](./error-handling/panics.md) (3 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid "[Try Operator](./error-handling/try.md) (5 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid "[Try Conversions](./error-handling/try-conversions.md) (5 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid "[Error Trait](./error-handling/error.md) (5 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid ""
-"[thiserror and anyhow](./error-handling/thiserror-and-anyhow.md) (5 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid ""
-"[Exercise: Rewriting with Result](./error-handling/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:3
 msgid "Rust handles fatal errors with a \"panic\"."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:5
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:10
 msgid "\"v[100]: {}\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:14
 msgid "Panics are for unrecoverable and unexpected errors."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:15
 msgid "Panics are symptoms of bugs in the program."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:16
 msgid "Runtime failures like failed bounds checks can panic"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:17
 msgid "Assertions (such as `assert!`) panic on failure"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:18
 msgid "Purpose-specific panics can use the `panic!` macro."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:19
 msgid ""
 "A panic will \"unwind\" the stack, dropping values just as if the functions "
 "had returned."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:21
 msgid ""
 "Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:26
 msgid ""
 "By default, a panic will cause the stack to unwind. The unwinding can be "
 "caught:"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:32
 msgid "\"No problem here!\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:33 src/error-handling/panics.md:38
 msgid "\"{result:?}\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:36
 msgid "\"oh no!\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:42
 msgid ""
 "Catching is unusual; do not attempt to implement exceptions with "
 "`catch_unwind`!"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:44
 msgid ""
 "This can be useful in servers which should keep running even if a single "
 "request crashes."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:46
 msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:3
 msgid ""
 "Runtime errors like connection-refused or file-not-found are handled with "
 "the `Result` type, but matching this type on every call can be cumbersome. "
@@ -9736,42 +9629,42 @@ msgid ""
 "turn the common"
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:15
 msgid "into the much simpler"
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:21
 msgid "We can use this to simplify our error handling code:"
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:42
 msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
 msgstr ""
 
-#: src/error-handling/try.md src/error-handling/try-conversions.md
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/try.md:43 src/error-handling/try-conversions.md:65
+#: src/error-handling/thiserror-and-anyhow.md:36
 msgid "\"config.dat\""
 msgstr ""
 
-#: src/error-handling/try.md src/error-handling/try-conversions.md
+#: src/error-handling/try.md:44 src/error-handling/try-conversions.md:66
 msgid "\"username or error: {username:?}\""
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:51
 msgid "Simplify the `read_username` function to use `?`."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:55
 msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:56
 msgid ""
 "Use the `fs::write` call to test out the different scenarios: no file, empty "
 "file, file with username."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:58
 msgid ""
 "Note that `main` can return a `Result<(), E>` as long as it implements `std::"
 "process::Termination`. In practice, this means that `E` implements `Debug`. "
@@ -9779,37 +9672,36 @@ msgid ""
 "on error."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:3
 msgid ""
 "The effective expansion of `?` is a little more complicated than previously "
 "indicated:"
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:10
 msgid "works the same as"
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:19
 msgid ""
 "The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function. This makes it easy to encapsulate errors into "
 "higher-level errors."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:42
 msgid "\"IO error: {e}\""
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:43
 msgid "\"Found no username in {path}\""
 msgstr ""
 
-#: src/error-handling/try-conversions.md
-#: src/error-handling/thiserror-and-anyhow.md
-msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
+#: src/error-handling/try-conversions.md:64
+msgid "//std::fs::write(\"config.dat\", \"\").unwrap();\n"
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:73
 msgid ""
 "The `?` operator must return a value compatible with the return type of the "
 "function. For `Result`, it means that the error types have to be compatible. "
@@ -9818,31 +9710,31 @@ msgid ""
 "same type or if `ErrorOuter` implements `From<ErrorInner>`."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:79
 msgid ""
 "A common alternative to a `From` implementation is `Result::map_err`, "
 "especially when the conversion only happens in one place."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:82
 msgid ""
 "There is no compatibility requirement for `Option`. A function returning "
 "`Option<T>` can use the `?` operator on `Option<U>` for arbitrary `T` and "
 "`U` types."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:86
 msgid ""
 "A function that returns `Result` cannot use `?` on `Option` and vice versa. "
 "However, `Option::ok_or` converts `Option` to `Result` whereas `Result::ok` "
 "turns `Result` into `Option`."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:1
 msgid "Dynamic Error Types"
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:3
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
 "our own enum covering all the different possibilities. The `std::error::"
@@ -9850,29 +9742,29 @@ msgid ""
 "error."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:20 src/error-handling/error.md:21
 msgid "\"count.dat\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:20
 msgid "\"1i3\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:22
 msgid "\"Count: {count}\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:23
 msgid "\"Error: {err}\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:31
 msgid ""
 "The `read_count` function can return `std::io::Error` (from file operations) "
 "or `std::num::ParseIntError` (from `String::parse`)."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:34
 msgid ""
 "Boxing errors saves on code, but gives up the ability to cleanly handle "
 "different error cases differently in the program. As such it's generally not "
@@ -9881,7 +9773,7 @@ msgid ""
 "message somewhere."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:40
 msgid ""
 "Make sure to implement the `std::error::Error` trait when defining a custom "
 "error type so it can be boxed. But if you need to support the `no_std` "
@@ -9890,101 +9782,101 @@ msgid ""
 "issues/103765) only."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:3
 msgid ""
 "The [`thiserror`](https://docs.rs/thiserror/) and [`anyhow`](https://docs.rs/"
 "anyhow/) crates are widely used to simplify error handling."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:7
 msgid ""
 "`thiserror` is often used in libraries to create custom error types that "
 "implement `From<T>`."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:9
 msgid ""
 "`anyhow` is often used by applications to help with error handling in "
 "functions, including adding contextual information to your errors."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:19
 msgid "\"Found no username in {0}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:25
 msgid "\"Failed to open {path}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:27
 msgid "\"Failed to read\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:35
+msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:37
 msgid "\"Username: {username}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:38
 msgid "\"Error: {err:?}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:46
 msgid "`thiserror`"
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:48
 msgid ""
 "The `Error` derive macro is provided by `thiserror`, and has lots of useful "
 "attributes to help define error types in a compact way."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:50
 msgid "The `std::error::Error` trait is derived automatically."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:51
 msgid "The message from `#[error]` is used to derive the `Display` trait."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:53
 msgid "`anyhow`"
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:55
 msgid ""
 "`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
 "it's again generally not a good choice for the public API of a library, but "
 "is widely used in applications."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:58
 msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:59
 msgid ""
 "Actual error type inside of it can be extracted for examination if necessary."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:60
 msgid ""
 "Functionality provided by `anyhow::Result<T>` may be familiar to Go "
 "developers, as it provides similar usage patterns and ergonomics to `(T, "
 "error)` from Go."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:63
 msgid ""
 "`anyhow::Context` is a trait implemented for the standard `Result` and "
 "`Option` types. `use anyhow::Context` is necessary to enable `.context()` "
 "and `.with_context()` on those types."
 msgstr ""
 
-#: src/error-handling/exercise.md
-msgid "Exercise: Rewriting with Result"
-msgstr ""
-
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:3
 msgid ""
 "The following implements a very simple parser for an expression language. "
 "However, it handles errors by panicking. Rewrite it to instead use idiomatic "
@@ -9992,184 +9884,156 @@ msgid ""
 "use `thiserror` and `anyhow`."
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:8
 msgid ""
 "HINT: start by fixing error handling in the `parse` function. Once that is "
 "working correctly, update `Tokenizer` to implement "
 "`Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:15 src/error-handling/solution.md:9
 msgid "/// An arithmetic operator.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:22 src/error-handling/solution.md:16
 msgid "/// A token in the expression language.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:30 src/error-handling/solution.md:24
 msgid "/// An expression in the expression language.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:34 src/error-handling/solution.md:28
 msgid "/// A reference to a variable.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:36 src/error-handling/solution.md:30
 msgid "/// A literal number.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:38 src/error-handling/solution.md:32
 msgid "/// A binary operation.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:60 src/error-handling/solution.md:60
+#: src/error-handling/solution.md:75
 msgid "'_'"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:76 src/error-handling/solution.md:76
 msgid "'+'"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:77 src/error-handling/solution.md:77
 msgid "'-'"
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:78
 msgid "\"Unexpected character {c}\""
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:88 src/error-handling/solution.md:87
 msgid "\"Unexpected end of input\""
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:92
 msgid "\"Invalid 32-bit integer'\""
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:96 src/error-handling/exercise.md:106
 msgid "\"Unexpected token {tok:?}\""
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:98 src/error-handling/solution.md:110
 msgid "// Look ahead to parse a binary operation if present.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:114 src/error-handling/solution.md:127
 msgid "\"10+foo+20-30\""
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:115 src/error-handling/solution.md:128
 msgid "\"{expr:?}\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:42
 msgid "\"Unexpected character '{0}' in input\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:85
 msgid "\"Tokenizer error: {0}\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:89
 msgid "\"Unexpected token {0:?}\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:91
 msgid "\"Invalid number\""
 msgstr ""
 
-#: src/unsafe-rust.md
-msgid "[Unsafe](./unsafe-rust/unsafe.md) (5 minutes)"
-msgstr ""
+#: src/unsafe-rust.md:3
+msgid "This segment should take about 1 hour and 5 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 5 phút, bao gồm:"
 
-#: src/unsafe-rust.md
-msgid ""
-"[Dereferencing Raw Pointers](./unsafe-rust/dereferencing.md) (10 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Mutable Static Variables](./unsafe-rust/mutable-static.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Unions](./unsafe-rust/unions.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Unsafe Functions](./unsafe-rust/unsafe-functions.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Unsafe Traits](./unsafe-rust/unsafe-traits.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Exercise: FFI Wrapper](./unsafe-rust/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "This segment should take about 1 hour and 5 minutes"
-msgstr ""
-
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:3
 msgid "The Rust language has two parts:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:5
 msgid "**Safe Rust:** memory safe, no undefined behavior possible."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:6
 msgid ""
 "**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:8
 msgid ""
 "We saw mostly safe Rust in this course, but it's important to know what "
 "Unsafe Rust is."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
 "carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:14
 msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:16
 msgid "Dereference raw pointers."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:17
 msgid "Access or modify mutable static variables."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:18
 msgid "Access `union` fields."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:19
 msgid "Call `unsafe` functions, including `extern` functions."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:20
 msgid "Implement `unsafe` traits."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:22
 msgid ""
 "We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
 "unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:29
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
 "have turned off some compiler safety features and have to write correct code "
@@ -10177,37 +10041,37 @@ msgid ""
 "rules."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:7
 msgid "\"careful!\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:12
 msgid ""
-"// Safe because r1 and r2 were obtained from references and so are\n"
-"    // guaranteed to be non-null and properly aligned, the objects "
-"underlying\n"
-"    // the references from which they were obtained are live throughout the\n"
-"    // whole unsafe block, and they are not accessed either through the\n"
-"    // references or concurrently through any other pointers.\n"
+"// SAFETY: r1 and r2 were obtained from references and so are guaranteed to\n"
+"    // be non-null and properly aligned, the objects underlying the "
+"references\n"
+"    // from which they were obtained are live throughout the whole unsafe\n"
+"    // block, and they are not accessed either through the references or\n"
+"    // concurrently through any other pointers.\n"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:18
 msgid "\"r1 is: {}\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:19
 msgid "\"uhoh\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:20
 msgid "\"r2 is: {}\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:23
 msgid ""
 "// NOT SAFE. DO NOT DO THIS.\n"
 "    /*\n"
@@ -10217,77 +10081,82 @@ msgid ""
 "    */"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:35
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
 "a comment for each `unsafe` block explaining how the code inside it "
 "satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:39
 msgid ""
 "In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:42
 msgid "The pointer must be non-null."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:43
 msgid ""
 "The pointer must be _dereferenceable_ (within the bounds of a single "
 "allocated object)."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:45
 msgid "The object must not have been deallocated."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:46
 msgid "There must not be concurrent accesses to the same location."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:47
 msgid ""
 "If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:50
 msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:52
 msgid ""
 "The \"NOT SAFE\" section gives an example of a common kind of UB bug: `*r1` "
 "has the `'static` lifetime, so `r3` has type `&'static String`, and thus "
 "outlives `s`. Creating a reference from a pointer requires _great care_."
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:3
 msgid "It is safe to read an immutable static variable:"
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:6
 msgid "\"Hello, world!\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:9
 msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:13
 msgid ""
 "However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:20 src/unsafe-rust/mutable-static.md:29
+msgid ""
+"// SAFETY: There are no other threads which could be accessing `COUNTER`.\n"
+msgstr ""
+
+#: src/unsafe-rust/mutable-static.md:31
 msgid "\"COUNTER: {COUNTER}\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:39
 msgid ""
 "The program here is safe because it is single-threaded. However, the Rust "
 "compiler is conservative and will assume the worst. Try removing the "
@@ -10295,36 +10164,36 @@ msgid ""
 "mutate a static from multiple threads."
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:44
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:14
 msgid "\"int: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:15
 msgid "\"bool: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:15
 msgid "// Undefined behavior!\n"
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:22
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:25
 msgid ""
 "If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
@@ -10332,53 +10201,62 @@ msgid ""
 "crates/zerocopy) crate."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:3 src/unsafe-rust/unsafe-functions.md:76
 msgid "Calling Unsafe Functions"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:5
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md src/unsafe-rust/exercise.md
-#: src/unsafe-rust/solution.md src/android/interoperability/with-c.md
-#: src/android/interoperability/with-c/rust.md
-#: src/android/interoperability/cpp/cpp-bridge.md
-#: src/exercises/chromium/build-rules.md src/bare-metal/aps/inline-assembly.md
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/unsafe-rust/unsafe-functions.md:9 src/unsafe-rust/exercise.md:91
+#: src/unsafe-rust/solution.md:41 src/android/interoperability/with-c.md:9
+#: src/android/interoperability/with-c/rust.md:15
+#: src/android/interoperability/with-c/rust.md:30
+#: src/android/interoperability/cpp/cpp-bridge.md:29
+#: src/android/interoperability/cpp/cpp-bridge.md:38
+#: src/exercises/chromium/build-rules.md:8
+#: src/exercises/chromium/build-rules.md:21
+#: src/bare-metal/aps/inline-assembly.md:19
+#: src/bare-metal/aps/better-uart/using.md:24
+#: src/bare-metal/aps/logging/using.md:23
+#: src/exercises/bare-metal/solutions-afternoon.md:43
 msgid "\"C\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:14
 msgid "\"🗻∈🌏\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:16
 msgid ""
-"// Safe because the indices are in the correct order, within the bounds of\n"
-"    // the string slice, and lie on UTF-8 sequence boundaries.\n"
+"// SAFETY: The indices are in the correct order, within the bounds of the\n"
+"    // string slice, and lie on UTF-8 sequence boundaries.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:19
+#: src/unsafe-rust/unsafe-functions.md:20
+#: src/unsafe-rust/unsafe-functions.md:21
 msgid "\"emoji: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:24
 msgid "\"char count: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
-msgid "// Undefined behavior if abs misbehaves.\n"
+#: src/unsafe-rust/unsafe-functions.md:26
+msgid ""
+"// SAFETY: `abs` doesn't deal with pointers and doesn't have any safety\n"
+"    // requirements.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:29
 msgid "\"Absolute value of -3 according to C: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:32
 msgid ""
 "// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
@@ -10386,17 +10264,18 @@ msgid ""
 "    // emojis.get_unchecked(0..3) }));\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:43
+#: src/unsafe-rust/unsafe-functions.md:88
 msgid "Writing Unsafe Functions"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:45
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
 "conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:49
 msgid ""
 "/// Swaps the values pointed to by the given pointers.\n"
 "///\n"
@@ -10405,15 +10284,15 @@ msgid ""
 "/// The pointers must be valid and properly aligned.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
-msgid "// Safe because ...\n"
+#: src/unsafe-rust/unsafe-functions.md:64
+msgid "// SAFETY: ...\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:69
 msgid "\"a = {}, b = {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:78
 msgid ""
 "`get_unchecked`, like most `_unchecked` functions, is unsafe, because it can "
 "create UB if the range is incorrect. `abs` is incorrect for a different "
@@ -10423,19 +10302,19 @@ msgid ""
 "undefined behaviour under any arbitrary circumstances."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:85
 msgid ""
 "The `\"C\"` in this example is the ABI; [other ABIs are available too]"
 "(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:90
 msgid ""
 "We wouldn't actually use pointers for a `swap` function - it can be done "
 "safely with references."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:93
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
 "`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
@@ -10443,207 +10322,212 @@ msgid ""
 "edition."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
 "must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:6
 msgid ""
 "For example, the `zerocopy` crate has an unsafe trait that looks [something "
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:12
 msgid ""
 "/// ...\n"
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
-msgid "// Safe because u32 has a defined representation and no padding.\n"
+#: src/unsafe-rust/unsafe-traits.md:26
+msgid "// SAFETY: `u32` has a defined representation and no padding.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:34
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:37
 msgid ""
 "The actual safety section for `AsBytes` is rather longer and more "
 "complicated."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:39
 msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:1
 msgid "Safe FFI Wrapper"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:3
 msgid ""
 "Rust has great support for calling functions through a _foreign function "
 "interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the names of files in a directory."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:7
 msgid "You will want to consult the manual pages:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:9
 msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:10
 msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:11
 msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:13
 msgid ""
 "You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
 "ffi/) module. There you find a number of string types which you need for the "
 "exercise:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:16
 msgid "Encoding"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:16
 msgid "Use"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:18
 msgid ""
 "[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
 "(https://doc.rust-lang.org/std/string/struct.String.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:18
 msgid "UTF-8"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:18
 msgid "Text processing in Rust"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:19
 msgid ""
 "[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
 "(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:19
 msgid "NUL-terminated"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:19
 msgid "Communicating with C functions"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:20
 msgid ""
 "[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
 "[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:20
 msgid "OS-specific"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:20
 msgid "Communicating with the OS"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:22
 msgid "You will convert between all these types:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:24
 msgid ""
 "`&str` to `CString`: you need to allocate space for a trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:25
 msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:26
 msgid ""
 "`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:28
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
 "unknown data\","
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:30
 msgid ""
 "`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
 "(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:33
 msgid ""
 "`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
 "return it and call `readdir` again."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:36
 msgid ""
 "The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
 "useful chapter about FFI."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:47
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:56 src/unsafe-rust/exercise.md:69
+#: src/unsafe-rust/exercise.md:80 src/unsafe-rust/exercise.md:94
+#: src/unsafe-rust/exercise.md:102 src/unsafe-rust/solution.md:6
+#: src/unsafe-rust/solution.md:19 src/unsafe-rust/solution.md:30
+#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
 msgid "\"macos\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:59 src/unsafe-rust/solution.md:9
 msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:66 src/unsafe-rust/solution.md:16
 msgid ""
 "// Layout according to the Linux man page for readdir(3), where ino_t and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:79 src/unsafe-rust/solution.md:29
 msgid "// Layout according to the macOS man page for dir(5).\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:94 src/unsafe-rust/exercise.md:102
+#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
 msgid "\"x86_64\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:97 src/unsafe-rust/solution.md:47
 msgid ""
 "// See https://github.com/rust-lang/libc/issues/414 and the section on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
@@ -10654,117 +10538,118 @@ msgid ""
 "PowerPC.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:103 src/unsafe-rust/solution.md:53
 msgid "\"readdir$INODE64\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:121 src/unsafe-rust/solution.md:71
 msgid ""
 "// Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:130
 msgid "// Keep calling readdir until we get a NULL pointer back.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:137 src/unsafe-rust/solution.md:105
 msgid "// Call closedir as needed.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
-#: src/android/interoperability/with-c/rust.md
+#: src/unsafe-rust/exercise.md:143 src/unsafe-rust/solution.md:116
+#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
+#: src/android/interoperability/with-c/rust.md:44
 msgid "\".\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:144 src/unsafe-rust/solution.md:117
 msgid "\"files: {:#?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:74
 msgid "\"Invalid path: {err}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:75
 msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:78
 msgid "\"Could not open {:?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:88
 msgid ""
 "// Keep calling readdir until we get a NULL pointer back.\n"
 "        // SAFETY: self.dir is never NULL.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:92
 msgid "// We have reached the end of the directory.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:95
 msgid ""
 "// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
 "        // terminated.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:107
 msgid "// SAFETY: self.dir is not NULL.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:109
 msgid "\"Could not close {:?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:128
 msgid "\"no-such-directory\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:136 src/unsafe-rust/solution.md:151
 msgid "\"Non UTF-8 character in path\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
 msgid "\"..\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:147 src/unsafe-rust/solution.md:155
 msgid "\"foo.txt\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:147
 msgid "\"The Foo Diaries\\n\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:148 src/unsafe-rust/solution.md:155
 msgid "\"bar.png\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:148
 msgid "\"<PNG>\\n\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:149 src/unsafe-rust/solution.md:155
 msgid "\"crab.rs\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:149
 msgid "\"//! Crab\\n\""
 msgstr ""
 
-#: src/android.md
+#: src/android.md:1
 msgid "Welcome to Rust in Android"
 msgstr ""
 
-#: src/android.md
+#: src/android.md:3
 msgid ""
 "Rust is supported for system software on Android. This means that you can "
 "write new services, libraries, drivers or even firmware in Rust (or improve "
 "existing code as needed)."
 msgstr ""
 
-#: src/android.md
+#: src/android.md:7
 msgid ""
 "We will attempt to call Rust from one of your own projects today. So try to "
 "find a little corner of your code base where we can move some lines of code "
@@ -10772,171 +10657,171 @@ msgid ""
 "that parses some raw bytes would be ideal."
 msgstr ""
 
-#: src/android.md
+#: src/android.md:14
 msgid ""
 "The speaker may mention any of the following given the increased use of Rust "
 "in Android:"
 msgstr ""
 
-#: src/android.md
+#: src/android.md:17
 msgid ""
 "Service example: [DNS over HTTP](https://security.googleblog.com/2022/07/dns-"
 "over-http3-in-android.html)"
 msgstr ""
 
-#: src/android.md
+#: src/android.md:20
 msgid ""
 "Libraries: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
 "appendix/rutabaga_gfx.html)"
 msgstr ""
 
-#: src/android.md
+#: src/android.md:23
 msgid ""
 "Kernel Drivers: [Binder](https://lore.kernel.org/rust-for-linux/20231101-"
 "rust-binder-v1-0-08ba9197f637@google.com/)"
 msgstr ""
 
-#: src/android.md
+#: src/android.md:26
 msgid ""
 "Firmware: [pKVM firmware](https://security.googleblog.com/2023/10/bare-metal-"
 "rust-in-android.html)"
 msgstr ""
 
-#: src/android/setup.md
+#: src/android/setup.md:3
 msgid ""
 "We will be using a Cuttlefish Android Virtual Device to test our code. Make "
 "sure you have access to one or create a new one with:"
 msgstr ""
 
-#: src/android/setup.md
+#: src/android/setup.md:12
 msgid ""
 "Please see the [Android Developer Codelab](https://source.android.com/docs/"
 "setup/start) for details."
 msgstr ""
 
-#: src/android/setup.md
+#: src/android/setup.md:20
 msgid ""
 "Cuttlefish is a reference Android device designed to work on generic Linux "
 "desktops. MacOS support is also planned."
 msgstr ""
 
-#: src/android/setup.md
+#: src/android/setup.md:23
 msgid ""
 "The Cuttlefish system image maintains high fidelity to real devices, and is "
 "the ideal emulator to run many Rust use cases."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:3
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:5
 msgid "Module Type"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:5
 msgid "Description"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:7
 msgid "`rust_binary`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:7
 msgid "Produces a Rust binary."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:8
 msgid "`rust_library`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:8
 msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:9
 msgid "`rust_ffi`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:9
 msgid ""
 "Produces a Rust C library usable by `cc` modules, and provides both static "
 "and shared variants."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:10
 msgid "`rust_proc_macro`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:10
 msgid ""
 "Produces a `proc-macro` Rust library. These are analogous to compiler "
 "plugins."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:11
 msgid "`rust_test`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:11
 msgid "Produces a Rust test binary that uses the standard Rust test harness."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:12
 msgid "`rust_fuzz`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:12
 msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:13
 msgid "`rust_protobuf`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:13
 msgid ""
 "Generates source and produces a Rust library that provides an interface for "
 "a particular protobuf."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:14
 msgid "`rust_bindgen`"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:14
 msgid ""
 "Generates source and produces a Rust library containing Rust bindings to C "
 "libraries."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:16
 msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:20
 msgid "Additional items speaker may mention:"
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:22
 msgid ""
 "Cargo is not optimized for multi-language repos, and also downloads packages "
 "from the internet."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:25
 msgid ""
 "For compliance and performance, Android must have crates in-tree. It must "
 "also interop with C/C++/Java code. Soong fills that gap."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:28
 msgid ""
 "Soong has many similarities to Bazel, which is the open-source variant of "
 "Blaze (used in google3)."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:31
 msgid ""
 "There is a plan to transition [Android](https://source.android.com/docs/"
 "setup/build/bazel/introduction), [ChromeOS](https://chromium.googlesource."
@@ -10944,58 +10829,58 @@ msgid ""
 "build/bazel/introduction) to Bazel."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:37
 msgid "Learning Bazel-like build rules is useful for all Rust OS developers."
 msgstr ""
 
-#: src/android/build-rules.md
+#: src/android/build-rules.md:39
 msgid "Fun fact: Data from Star Trek is a Soong-type Android."
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:1
 msgid "Rust Binaries"
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:3
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
 "create the following files:"
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 msgid "_hello_rust/Android.bp_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:10 src/android/build-rules/binary.md:11
 msgid "\"hello_rust\""
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
-#: src/android/logging.md
+#: src/android/build-rules/binary.md:12 src/android/build-rules/library.md:19
+#: src/android/logging.md:12
 msgid "\"src/main.rs\""
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
 msgid "_hello_rust/src/main.rs_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/build-rules/binary.md:19 src/android/build-rules/library.md:37
 msgid "//! Rust demo.\n"
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/build-rules/binary.md:20 src/android/build-rules/library.md:41
 msgid "/// Prints a greeting to standard output.\n"
 msgstr ""
 
-#: src/android/build-rules/binary.md src/exercises/chromium/build-rules.md
+#: src/android/build-rules/binary.md:23 src/exercises/chromium/build-rules.md:9
 msgid "\"Hello from Rust!\""
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:27
 msgid "You can now build, push, and run the binary:"
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:29
 msgid ""
 "```shell\n"
 "m hello_rust\n"
@@ -11004,76 +10889,76 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:1
 msgid "Rust Libraries"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:3
 msgid "You use `rust_library` to create a new Rust library for Android."
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:5
 msgid "Here we declare a dependency on two libraries:"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:7
 msgid "`libgreeting`, which we define below,"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:8
 msgid ""
 "`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
 "(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
 "crates/)."
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:17 src/android/build-rules/library.md:18
 msgid "\"hello_rust_with_dep\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:21 src/android/build-rules/library.md:28
 msgid "\"libgreetings\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:22
 msgid "\"libtextwrap\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:24
 msgid "// Need this to avoid dynamic link error.\n"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:29
 msgid "\"greetings\""
 msgstr ""
 
-#: src/android/build-rules/library.md
-#: src/android/aidl/example-service/service.md src/android/testing.md
-#: src/android/interoperability/java.md
+#: src/android/build-rules/library.md:30
+#: src/android/aidl/example-service/service.md:28 src/android/testing.md:12
+#: src/android/testing.md:18 src/android/interoperability/java.md:39
 msgid "\"src/lib.rs\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:48
 msgid "_hello_rust/src/lib.rs_:"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:51
 msgid "//! Greeting library.\n"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:52
 msgid "/// Greet `name`.\n"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:55
 msgid "\"Hello {name}, it is very nice to meet you!\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:59
 msgid "You build, push, and run the binary like before:"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:61
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
@@ -11083,216 +10968,217 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md
+#: src/android/aidl.md:3
 msgid ""
 "The [Android Interface Definition Language (AIDL)](https://developer.android."
 "com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
-#: src/android/aidl.md
+#: src/android/aidl.md:8
 msgid "Rust code can call existing AIDL servers,"
 msgstr ""
 
-#: src/android/aidl.md
+#: src/android/aidl.md:9
 msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
-#: src/android/aidl/birthday-service.md
+#: src/android/aidl/birthday-service.md:3
 msgid ""
 "To illustrate how to use Rust with Binder, we're going to walk through the "
 "process of creating a Binder interface. We're then going to both implement "
 "the described service and write client code that talks to that service."
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/interface.md:1
 msgid "AIDL Interfaces"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/interface.md:3
 msgid "You declare the API of your service using an AIDL interface:"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/interface.md:5
+#: src/android/aidl/example-service/service-bindings.md:6
 msgid ""
 "_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
-#: src/android/aidl/example-service/service-bindings.md
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/interface.md:8
+#: src/android/aidl/example-service/service-bindings.md:9
+#: src/android/aidl/example-service/changing-definition.md:8
 msgid "/** Birthday service interface. */"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
-#: src/android/aidl/example-service/service-bindings.md
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/interface.md:10
+#: src/android/aidl/example-service/service-bindings.md:11
+#: src/android/aidl/example-service/changing-definition.md:11
 msgid "/** Generate a Happy Birthday message. */"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/interface.md:15
 msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/interface.md:19
 msgid "\"com.example.birthdayservice\""
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/interface.md:20
 msgid "\"com/example/birthdayservice/*.aidl\""
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/interface.md:23
 msgid "// Rust is not enabled by default\n"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/interface.md:32
 msgid ""
 "Note that the directory structure under the `aidl/` directory needs to match "
 "the package name used in the AIDL file, i.e. the package is `com.example."
 "birthdayservice` and the file is at `aidl/com/example/IBirthdayService.aidl`."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/service-bindings.md:1
 msgid "Generated Service API"
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/service-bindings.md:3
 msgid ""
 "Binder generates a trait corresponding to the interface definition. trait to "
 "talk to the service."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/service-bindings.md:16
 msgid "_Generated trait_:"
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/service-bindings.md:24
 msgid ""
 "Your service will need to implement this trait, and your client will use "
 "this trait to talk to the service."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/service-bindings.md:29
 msgid ""
 "The generated bindings can be found at `out/soong/.intermediates/<path to "
 "module>/`."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/service-bindings.md:31
 msgid ""
 "Point out how the generated function signature, specifically the argument "
 "and return types, correspond the interface definition."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/service-bindings.md:33
 msgid ""
 "`String` for an argument results in a different Rust type than `String` as a "
 "return type."
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/service.md:1
 msgid "Service Implementation"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/service.md:3
 msgid "We can now implement the AIDL service:"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/service.md:5
+#: src/android/aidl/example-service/changing-implementation.md:5
 msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/service.md:10
 msgid "/// The `IBirthdayService` implementation.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
-#: src/android/aidl/example-service/changing-implementation.md
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/example-service/service.md:18
+#: src/android/aidl/example-service/changing-implementation.md:16
+#: src/android/aidl/types/file-descriptor.md:57
 msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
-#: src/android/aidl/example-service/server.md
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/service.md:23
+#: src/android/aidl/example-service/server.md:28
+#: src/android/aidl/example-service/client.md:31
 msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/service.md:27
+#: src/android/aidl/example-service/server.md:38
 msgid "\"libbirthdayservice\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
-#: src/android/aidl/example-service/server.md
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/service.md:29
+#: src/android/aidl/example-service/server.md:13
+#: src/android/aidl/example-service/client.md:11
 msgid "\"birthdayservice\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
-#: src/android/aidl/example-service/server.md
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/service.md:31
+#: src/android/aidl/example-service/server.md:36
+#: src/android/aidl/example-service/client.md:39
 msgid "\"com.example.birthdayservice-rust\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
-#: src/android/aidl/example-service/server.md
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/service.md:32
+#: src/android/aidl/example-service/server.md:37
+#: src/android/aidl/example-service/client.md:40
 msgid "\"libbinder_rs\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/service.md:39
 msgid ""
 "Point out the path to the generated `IBirthdayService` trait, and explain "
 "why each of the segments is necessary."
 msgstr ""
 
-#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/service.md:41
 msgid ""
 "TODO: What does the `binder::Interface` trait do? Are there methods to "
 "override? Where source?"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:1
 msgid "AIDL Server"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:3
 msgid "Finally, we can create a server which exposes the service:"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:5
 msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:8
 msgid "//! Birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:14
 msgid "/// Entry point for birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:23
 msgid "\"Failed to register service\""
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:32
+#: src/android/aidl/example-service/server.md:33
 msgid "\"birthday_server\""
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:34
 msgid "\"src/server.rs\""
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/server.md:40
+#: src/android/aidl/example-service/client.md:42
 msgid "// To avoid dynamic link error.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:46
 msgid ""
 "The process for taking a user-defined service implementation (in this case "
 "the `BirthdayService` type, which implements the `IBirthdayService`) and "
@@ -11301,11 +11187,11 @@ msgid ""
 "another language. Explain to students why each step is necessary."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:52
 msgid "Create an instance of your service type (`BirthdayService`)."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:53
 msgid ""
 "Wrap the service object in corresponding `Bn*` type (`BnBirthdayService` in "
 "this case). This type is generated by Binder and provides the common Binder "
@@ -11314,23 +11200,23 @@ msgid ""
 "`BirthdayService` within the generated `BnBinderService`."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:58
 msgid ""
 "Call `add_service`, giving it a service identifier and your service object "
 "(the `BnBirthdayService` object in the example)."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/server.md:60
 msgid ""
 "Call `join_thread_pool` to add the current thread to Binder's thread pool "
 "and start listening for connections."
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md
+#: src/android/aidl/example-service/deploy.md:3
 msgid "We can now build, push, and start the service:"
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md
+#: src/android/aidl/example-service/deploy.md:5
 msgid ""
 "```shell\n"
 "m birthday_server\n"
@@ -11341,62 +11227,64 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md
+#: src/android/aidl/example-service/deploy.md:12
 msgid "In another terminal, check that the service runs:"
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md
+#: src/android/aidl/example-service/deploy.md:22
 msgid "You can also call the service with `service call`:"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:1
 msgid "AIDL Client"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:3
 msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/client.md:5
+#: src/android/aidl/example-service/changing-implementation.md:29
 msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:12
 msgid "/// Call the birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md src/android/aidl/types/objects.md
-#: src/android/aidl/types/parcelables.md
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/example-service/client.md:23
+#: src/android/aidl/types/objects.md:54
+#: src/android/aidl/types/parcelables.md:32
+#: src/android/aidl/types/file-descriptor.md:20
 msgid "\"Failed to connect to BirthdayService\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:25
 msgid "// Call the service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:27
 msgid "\"{msg}\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:35
+#: src/android/aidl/example-service/client.md:36
 msgid "\"birthday_client\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:37
 msgid "\"src/client.rs\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:46
 msgid "Notice that the client does not depend on `libbirthdayservice`."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:48
 msgid "Build, push, and run the client on your device:"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:50
 msgid ""
 "```shell\n"
 "m birthday_client\n"
@@ -11406,20 +11294,20 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:62
 msgid ""
 "`Strong<dyn IBirthdayService>` is the trait object representing the service "
 "that the client has connected to."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:64
 msgid ""
 "`Strong` is a custom smart pointer type for Binder. It handles both an in-"
 "process ref count for the service trait object, and the global Binder ref "
 "count that tracks how many processes have a reference to the object."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:67
 msgid ""
 "Note that the trait object that the client uses to talk to the service uses "
 "the exact same trait that the server implements. For a given Binder "
@@ -11427,203 +11315,203 @@ msgid ""
 "server use."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/client.md:71
 msgid ""
 "Use the same service identifier used when registering the service. This "
 "should ideally be defined in a common crate that both the client and server "
 "can depend on."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/changing-definition.md:3
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
 "specify a list of lines for the birthday card:"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/changing-definition.md:16
 msgid "This results in an updated trait definition for `IBirthdayService`:"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/changing-definition.md:31
 msgid ""
 "Note how the `String[]` in the AIDL definition is translated as a "
 "`&[String]` in Rust, i.e. that idiomatic Rust types are used in the "
 "generated bindings wherever possible:"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/changing-definition.md:34
 msgid "`in` array arguments are translated to slices."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/changing-definition.md:35
 msgid "`out` and `inout` args are translated to `&mut Vec<T>`."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md
+#: src/android/aidl/example-service/changing-definition.md:36
 msgid "Return values are translated to returning a `Vec<T>`."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/changing-implementation.md:1
 msgid "Updating Client and Service"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/changing-implementation.md:3
 msgid "Update the client and server code to account for the new API."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/changing-implementation.md:20
 msgid "'\\n'"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/changing-implementation.md:36
 msgid "\"Habby birfday to yuuuuu\""
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/changing-implementation.md:37
 msgid "\"And also: many more\""
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/example-service/changing-implementation.md:44
 msgid ""
 "TODO: Move code snippets into project files where they'll actually be built?"
 msgstr ""
 
-#: src/android/aidl/types.md
+#: src/android/aidl/types.md:1
 msgid "Working With AIDL Types"
 msgstr ""
 
-#: src/android/aidl/types.md
+#: src/android/aidl/types.md:3
 msgid "AIDL types translate into the appropriate idiomatic Rust type:"
 msgstr ""
 
-#: src/android/aidl/types.md
+#: src/android/aidl/types.md:5
 msgid "Primitive types map (mostly) to idiomatic Rust types."
 msgstr ""
 
-#: src/android/aidl/types.md
+#: src/android/aidl/types.md:6
 msgid "Collection types like slices, `Vec`s and string types are supported."
 msgstr ""
 
-#: src/android/aidl/types.md
+#: src/android/aidl/types.md:7
 msgid ""
 "References to AIDL objects and file handles can be sent between clients and "
 "services."
 msgstr ""
 
-#: src/android/aidl/types.md
+#: src/android/aidl/types.md:9
 msgid "File handles and parcelables are fully supported."
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:3
 msgid "Primitive types map (mostly) idiomatically:"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:5
 msgid "AIDL Type"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md src/android/aidl/types/arrays.md
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/aidl/types/primitives.md:5 src/android/aidl/types/arrays.md:7
+#: src/android/interoperability/cpp/type-mapping.md:3
 msgid "Rust Type"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:5
 msgid "Note"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:7
 msgid "`boolean`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:8
 msgid "`byte`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:8
 msgid "`i8`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:8
 msgid "Note that bytes are signed."
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:9
 msgid "`u16`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:9
 msgid "Note the usage of `u16`, NOT `u32`."
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:10
 msgid "`int`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:10
 msgid "`i32`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:11
 msgid "`long`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:11
 msgid "`i64`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:12
 msgid "`float`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:12
 msgid "`f32`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:13
 msgid "`double`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md
+#: src/android/aidl/types/primitives.md:13
 msgid "`f64`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:3
 msgid ""
 "The array types (`T[]`, `byte[]`, and `List<T>`) get translated to the "
 "appropriate Rust array type depending on how they are used in the function "
 "signature:"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:7
 msgid "Position"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:9
 msgid "`in` argument"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:9
 msgid "`&[T]`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:10
 msgid "`out`/`inout` argument"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:10
 msgid "`&mut Vec<T>`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:11
 msgid "Return"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/aidl/types/arrays.md:11
+#: src/android/interoperability/cpp/type-mapping.md:11
 msgid "`Vec<T>`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:15
 msgid ""
 "In Android 13 or higher, fixed-size arrays are supported, i.e. `T[N]` "
 "becomes `[T; N]`. Fixed-size arrays can have multiple dimensions (e.g. "
@@ -11631,112 +11519,114 @@ msgid ""
 "as array types."
 msgstr ""
 
-#: src/android/aidl/types/arrays.md
+#: src/android/aidl/types/arrays.md:18
 msgid "Arrays in parcelable fields always get translated to `Vec<T>`."
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:3
 msgid ""
 "AIDL objects can be sent either as a concrete AIDL type or as the type-"
 "erased `IBinder` interface:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:6
 msgid ""
 "**birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider."
 "aidl**:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md src/android/aidl/types/parcelables.md
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/objects.md:17
+#: src/android/aidl/types/parcelables.md:16
+#: src/android/aidl/types/file-descriptor.md:6
 msgid ""
 "**birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl**:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:23
 msgid "/** The same thing, but using a binder object. */"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:26
 msgid "/** The same thing, but using `IBinder`. */"
 msgstr ""
 
-#: src/android/aidl/types/objects.md src/android/aidl/types/parcelables.md
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/objects.md:31
+#: src/android/aidl/types/parcelables.md:27
+#: src/android/aidl/types/file-descriptor.md:15
 msgid "**birthday_service/src/client.rs**:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:34
 msgid "/// Rust struct implementing the `IBirthdayInfoProvider` interface.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:56
 msgid "// Create a binder object for the `IBirthdayInfoProvider` interface.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:62
 msgid "// Send the binder object to the service.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:65
 msgid ""
 "// Perform the same operation but passing the provider as an `SpIBinder`.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md
+#: src/android/aidl/types/objects.md:72
 msgid ""
 "Note the usage of `BnBirthdayInfoProvider`. This serves the same purpose as "
 "`BnBirthdayService` that we saw previously."
 msgstr ""
 
-#: src/android/aidl/types/parcelables.md
+#: src/android/aidl/types/parcelables.md:3
 msgid "Binder for Rust supports sending parcelables directly:"
 msgstr ""
 
-#: src/android/aidl/types/parcelables.md
+#: src/android/aidl/types/parcelables.md:5
 msgid ""
 "**birthday_service/aidl/com/example/birthdayservice/BirthdayInfo.aidl**:"
 msgstr ""
 
-#: src/android/aidl/types/parcelables.md
+#: src/android/aidl/types/parcelables.md:22
 msgid "/** The same thing, but with a parcelable. */"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:3
 msgid ""
 "Files can be sent between Binder clients/servers using the "
 "`ParcelFileDescriptor` type:"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:10
 msgid "/** The same thing, but loads info from a file. */"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:22
 msgid "// Open a file and put the birthday info in it.\n"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:23
 msgid "\"/data/local/tmp/birthday.info\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:24
 msgid "\"{name}\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:25
 msgid "\"{years}\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:27
 msgid "// Create a `ParcelFileDescriptor` from the file and send it.\n"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:33
 msgid "**birthday_service/src/lib.rs**:"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:41
 msgid ""
 "// Convert the file descriptor to a `File`. `ParcelFileDescriptor` wraps\n"
 "        // an `OwnedFd`, which can be cloned and then used to create a "
@@ -11744,90 +11634,90 @@ msgid ""
 "        // object.\n"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:48
 msgid "\"Invalid file handle\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:64
 msgid ""
 "`ParcelFileDescriptor` wraps an `OwnedFd`, and so can be created from a "
 "`File` (or any other type that wraps an `OwnedFd`), and can be used to "
 "create a new `File` handle on the other side."
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md
+#: src/android/aidl/types/file-descriptor.md:67
 msgid ""
 "Other types of file descriptors can be wrapped and sent, e.g. TCP, UDP, and "
 "UNIX sockets."
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:1
 msgid "Testing in Android"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:3
 msgid ""
 "Building on [Testing](../testing.md), we will now look at how unit tests "
 "work in AOSP. Use the `rust_test` module for your unit tests:"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:6
 msgid "_testing/Android.bp_:"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:10
 msgid "\"libleftpad\""
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:11
 msgid "\"leftpad\""
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:16
 msgid "\"libleftpad_test\""
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:17
 msgid "\"leftpad_test\""
 msgstr ""
 
-#: src/android/testing.md src/android/interoperability/with-c/bindgen.md
+#: src/android/testing.md:20 src/android/interoperability/with-c/bindgen.md:116
 msgid "\"general-tests\""
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:24
 msgid "_testing/src/lib.rs_:"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:27
 msgid "//! Left-padding library.\n"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:28
 msgid "/// Left-pad `s` to `width`.\n"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:31
 msgid "\"{s:>width$}\""
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:40
 msgid "\"  foo\""
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:45
 msgid "\"foobar\""
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:50
 msgid "You can now run the test with"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:56
 msgid "The output looks like this:"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:58
 msgid ""
 "```text\n"
 "INFO: Elapsed time: 2.666s, Critical Path: 2.40s\n"
@@ -11841,88 +11731,94 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/testing.md
+#: src/android/testing.md:68
 msgid ""
 "Notice how you only mention the root of the library crate. Tests are found "
 "recursively in nested modules."
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:3
 msgid ""
 "The [GoogleTest](https://docs.rs/googletest/) crate allows for flexible test "
 "assertions using _matchers_:"
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:11
 msgid "\"baz\""
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:12
 msgid "\"xyz\""
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:16
 msgid ""
 "If we change the last element to `\"!\"`, the test fails with a structured "
 "error message pin-pointing the error:"
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:37
 msgid ""
 "GoogleTest is not part of the Rust Playground, so you need to run this "
 "example in a local environment. Use `cargo add googletest` to quickly add it "
 "to an existing Cargo project."
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:41
 msgid ""
 "The `use googletest::prelude::*;` line imports a number of [commonly used "
 "macros and types](https://docs.rs/googletest/latest/googletest/prelude/index."
 "html)."
 msgstr ""
 
-#: src/android/testing/googletest.md
-msgid "This just scratches the surface, there are many builtin matchers."
+#: src/android/testing/googletest.md:44
+msgid ""
+"This just scratches the surface, there are many builtin matchers. Consider "
+"going through the first chapter of [\"Advanced testing for Rust "
+"applications\"](https://github.com/mainmatter/rust-advanced-testing-"
+"workshop), a self-guided Rust course: it provides a guided introduction to "
+"the library, with exercises to help you get comfortable with `googletest` "
+"macros, its matchers and its overall philosophy."
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:51
 msgid ""
 "A particularly nice feature is that mismatches in multi-line strings are "
 "shown as a diff:"
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:57
 msgid ""
 "\"Memory safety found,\\n\\\n"
 "                 Rust's strong typing guides the way,\\n\\\n"
 "                 Secure code you'll write.\""
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:62
 msgid ""
 "\"Memory safety found,\\n\\\n"
 "            Rust's silly humor guides the way,\\n\\\n"
 "            Secure code you'll write.\""
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:69
 msgid "shows a color-coded diff (colors not shown here):"
 msgstr ""
 
-#: src/android/testing/googletest.md
+#: src/android/testing/googletest.md:86
 msgid ""
 "The crate is a Rust port of [GoogleTest for C++](https://google.github.io/"
 "googletest/)."
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:3
 msgid ""
 "For mocking, [Mockall](https://docs.rs/mockall/) is a widely used library. "
 "You need to refactor your code to use traits, which you can then quickly "
 "mock:"
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:27
 msgid ""
 "Mockall is the recommended mocking library in Android (AOSP). There are "
 "other [mocking libraries available on crates.io](https://crates.io/keywords/"
@@ -11931,7 +11827,7 @@ msgid ""
 "easy to get a mock implementation of a given trait."
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:33
 msgid ""
 "Note that mocking is somewhat _controversial_: mocks allow you to completely "
 "isolate a test from its dependencies. The immediate result is faster and "
@@ -11939,7 +11835,7 @@ msgid ""
 "wrongly and return output different from what the real dependencies would do."
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:38
 msgid ""
 "If at all possible, it is recommended that you use the real dependencies. As "
 "an example, many databases allow you to configure an in-memory backend. This "
@@ -11947,90 +11843,90 @@ msgid ""
 "and will automatically clean up after themselves."
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:43
 msgid ""
 "Similarly, many web frameworks allow you to start an in-process server which "
 "binds to a random port on `localhost`. Always prefer this over mocking away "
 "the framework since it helps you test your code in the real environment."
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:47
 msgid ""
 "Mockall is not part of the Rust Playground, so you need to run this example "
 "in a local environment. Use `cargo add mockall` to quickly add Mockall to an "
 "existing Cargo project."
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:51
 msgid ""
 "Mockall has a lot more functionality. In particular, you can set up "
 "expectations which depend on the arguments passed. Here we use this to mock "
 "a cat which becomes hungry 3 hours after the last time it was fed:"
 msgstr ""
 
-#: src/android/testing/mocking.md
+#: src/android/testing/mocking.md:69
 msgid ""
 "You can use `.times(n)` to limit the number of times a mock method can be "
 "called to `n` --- the mock will automatically panic when dropped if this "
 "isn't satisfied."
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:3
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
 "or `stdout` (on-host):"
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:6
 msgid "_hello_rust_logs/Android.bp_:"
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:10 src/android/logging.md:11
 msgid "\"hello_rust_logs\""
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:14
 msgid "\"liblog_rust\""
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:15
 msgid "\"liblogger\""
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:21
 msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:24
 msgid "//! Rust logging demo.\n"
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:27
 msgid "/// Logs a greeting.\n"
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:32
 msgid "\"rust\""
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:35
 msgid "\"Starting program.\""
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:36
 msgid "\"Things are going fine.\""
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:37
 msgid "\"Something went wrong!\""
 msgstr ""
 
-#: src/android/logging.md src/android/interoperability/with-c/bindgen.md
-#: src/android/interoperability/with-c/rust.md
+#: src/android/logging.md:41 src/android/interoperability/with-c/bindgen.md:99
+#: src/android/interoperability/with-c/rust.md:72
 msgid "Build, push, and run the binary on your device:"
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:43
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
@@ -12040,177 +11936,194 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md
+#: src/android/logging.md:49
 msgid "The logs show up in `adb logcat`:"
 msgstr ""
 
-#: src/android/interoperability.md
+#: src/android/interoperability.md:3
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
 "means that you can:"
 msgstr ""
 
-#: src/android/interoperability.md
+#: src/android/interoperability.md:6
 msgid "Call Rust functions from other languages."
 msgstr ""
 
-#: src/android/interoperability.md
+#: src/android/interoperability.md:7
 msgid "Call functions written in other languages from Rust."
 msgstr ""
 
-#: src/android/interoperability.md
+#: src/android/interoperability.md:9
 msgid ""
 "When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:1
 msgid "Interoperability with C"
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:3
 msgid ""
 "Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:6
 msgid "You can do it by hand if you want:"
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:15
+msgid "// SAFETY: `abs` doesn't have any safety requirements.\n"
+msgstr ""
+
+#: src/android/interoperability/with-c.md:17
 msgid "\"{x}, {abs_x}\""
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:21
 msgid ""
 "We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
 "safe-ffi-wrapper.md)."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:24
 msgid ""
 "This assumes full knowledge of the target platform. Not recommended for "
 "production."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:27
 msgid "We will look at better options next."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:1
 msgid "Using Bindgen"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:3
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
 "tool can auto-generate bindings from a C header file."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:6
 msgid "First create a small C library:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:8
 msgid "_interoperability/bindgen/libbirthday.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:19
 msgid "_interoperability/bindgen/libbirthday.c_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:22
 msgid "<stdio.h>"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:23
+#: src/android/interoperability/with-c/bindgen.md:50
 msgid "\"libbirthday.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:26
+#: src/android/interoperability/with-c/bindgen.md:29
 msgid "\"+--------------\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:27
 msgid "\"| Happy Birthday %s!\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:28
 msgid "\"| Congratulations with the %i years!\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:33
 msgid "Add this to your `Android.bp` file:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:35
+#: src/android/interoperability/with-c/bindgen.md:55
+#: src/android/interoperability/with-c/bindgen.md:69
+#: src/android/interoperability/with-c/bindgen.md:109
 msgid "_interoperability/bindgen/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:39
+#: src/android/interoperability/with-c/bindgen.md:63
 msgid "\"libbirthday\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:40
 msgid "\"libbirthday.c\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
 "Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:47
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:53
 msgid "You can now auto-generate the bindings:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:59
+#: src/android/interoperability/with-c/bindgen.md:75
 msgid "\"libbirthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:60
 msgid "\"birthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:61
 msgid "\"libbirthday_wrapper.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:62
 msgid "\"bindings\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:67
 msgid "Finally, we can use the bindings in our Rust program:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:73
 msgid "\"print_birthday_card\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:74
 msgid "\"main.rs\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:79
 msgid "_interoperability/bindgen/main.rs_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:82
 msgid "//! Bindgen demo.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
-msgid "// SAFETY: `print_card` is safe to call with a valid `card` pointer.\n"
+#: src/android/interoperability/with-c/bindgen.md:89
+msgid ""
+"// SAFETY: The pointer we pass is valid because it came from a Rust\n"
+"    // reference, and the `name` it contains refers to `name` above which "
+"also\n"
+"    // remains valid. `print_card` doesn't store either pointer to use "
+"later\n"
+"    // after it returns.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:101
 msgid ""
 "```shell\n"
 "m print_birthday_card\n"
@@ -12220,99 +12133,102 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:107
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:113
+#: src/android/interoperability/with-c/bindgen.md:115
 msgid "\"libbirthday_bindgen_test\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:114
 msgid "\":libbirthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:118
+#: src/android/interoperability/with-c/bindgen.md:119
 msgid "\"none\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:118
 msgid "// Generated file, skip linting\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:1
 msgid "Calling Rust"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:3
 msgid "Exporting Rust functions and types to C is easy:"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:5
 msgid "_interoperability/rust/libanalyze/analyze.rs_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:8
 msgid "//! Rust FFI demo.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:12
 msgid "/// Analyze the numbers.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:17
 msgid "\"x ({x}) is smallest!\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:19
 msgid "\"y ({y}) is probably larger than x ({x})\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:24
 msgid "_interoperability/rust/libanalyze/analyze.h_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:37
 msgid "_interoperability/rust/libanalyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:41
+#: src/android/interoperability/with-c/rust.md:68
 msgid "\"libanalyze_ffi\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:42
 msgid "\"analyze_ffi\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:43
 msgid "\"analyze.rs\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:48
 msgid "We can now call this from a C binary:"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:50
 msgid "_interoperability/rust/analyze/main.c_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:53
 msgid "\"analyze.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:62
 msgid "_interoperability/rust/analyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:66
 msgid "\"analyze_numbers\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:67
 msgid "\"main.c\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:74
 msgid ""
 "```shell\n"
 "m analyze_numbers\n"
@@ -12322,82 +12238,82 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:82
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
 "will just be the name of the function. You can also use `#[export_name = "
 "\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
-#: src/android/interoperability/cpp.md
+#: src/android/interoperability/cpp.md:3
 msgid ""
 "The [CXX crate](https://cxx.rs/) makes it possible to do safe "
 "interoperability between Rust and C++."
 msgstr ""
 
-#: src/android/interoperability/cpp.md
+#: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:3
 msgid ""
 "CXX relies on a description of the function signatures that will be exposed "
 "from each language to the other. You provide this description using extern "
 "blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:9
 msgid "\"org::blobstore\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:11
 msgid "// Shared structs with fields visible to both languages.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/generated-cpp.md
+#: src/android/interoperability/cpp/bridge.md:17
+#: src/android/interoperability/cpp/generated-cpp.md:6
 msgid "// Rust types and signatures exposed to C++.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/rust-bridge.md
-#: src/android/interoperability/cpp/generated-cpp.md
-#: src/android/interoperability/cpp/rust-result.md
-#: src/chromium/interoperability-with-cpp/example-bindings.md
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/android/interoperability/cpp/bridge.md:18
+#: src/android/interoperability/cpp/rust-bridge.md:6
+#: src/android/interoperability/cpp/generated-cpp.md:7
+#: src/android/interoperability/cpp/rust-result.md:6
+#: src/chromium/interoperability-with-cpp/example-bindings.md:9
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:10
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:9
 msgid "\"Rust\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/bridge.md:24
+#: src/android/interoperability/cpp/cpp-bridge.md:6
 msgid "// C++ types and signatures exposed to Rust.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/cpp-bridge.md
-#: src/android/interoperability/cpp/cpp-exception.md
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/android/interoperability/cpp/bridge.md:25
+#: src/android/interoperability/cpp/cpp-bridge.md:7
+#: src/android/interoperability/cpp/cpp-exception.md:6
+#: src/chromium/interoperability-with-cpp/example-bindings.md:15
 msgid "\"C++\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/bridge.md:26
+#: src/android/interoperability/cpp/cpp-bridge.md:8
 msgid "\"include/blobstore.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:40
 msgid "The bridge is generally declared in an `ffi` module within your crate."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:41
 msgid ""
 "From the declarations made in the bridge module, CXX will generate matching "
 "Rust and C++ type/function definitions in order to expose those items to "
 "both languages."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:44
 msgid ""
 "To view the generated Rust code, use [cargo-expand](https://github.com/"
 "dtolnay/cargo-expand) to view the expanded proc macro. For most of the "
@@ -12405,33 +12321,33 @@ msgid ""
 "(though this doesn't apply for Android projects)."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:47
 msgid "To view the generated C++ code, look in `target/cxxbridge`."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:1
 msgid "Rust Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:7
 msgid "// Opaque type\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:8
 msgid "// Method on `MyType`\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:9
 msgid "// Free function\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:28
 msgid ""
 "Items declared in the `extern \"Rust\"` reference items that are in scope in "
 "the parent module."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:30
 msgid ""
 "The CXX code generator uses your `extern \"Rust\"` section(s) to produce a C+"
 "+ header file containing the corresponding C++ declarations. The generated "
@@ -12439,48 +12355,48 @@ msgid ""
 "except with a .rs.h file extension."
 msgstr ""
 
-#: src/android/interoperability/cpp/generated-cpp.md
+#: src/android/interoperability/cpp/generated-cpp.md:15
 msgid "Results in (roughly) the following C++:"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:1
 msgid "C++ Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:20
 msgid "Results in (roughly) the following Rust:"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:30
 msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:39
 msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:56
 msgid ""
 "The programmer does not need to promise that the signatures they have typed "
 "in are accurate. CXX performs static assertions that the signatures exactly "
 "correspond with what is declared in C++."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:59
 msgid ""
 "`unsafe extern` blocks allow you to declare C++ functions that are safe to "
 "call from Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md
+#: src/android/interoperability/cpp/shared-types.md:9
 msgid "// A=1, J=11, Q=12, K=13\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md
+#: src/android/interoperability/cpp/shared-types.md:23
 msgid "Only C-like (unit) enums are supported."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md
+#: src/android/interoperability/cpp/shared-types.md:24
 msgid ""
 "A limited number of traits are supported for `#[derive()]` on shared types. "
 "Corresponding functionality is also generated for the C++ code, e.g. if you "
@@ -12488,15 +12404,15 @@ msgid ""
 "corresponding C++ type."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md
+#: src/android/interoperability/cpp/shared-enums.md:15
 msgid "Generated Rust:"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md
+#: src/android/interoperability/cpp/shared-enums.md:33
 msgid "Generated C++:"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md
+#: src/android/interoperability/cpp/shared-enums.md:46
 msgid ""
 "On the Rust side, the code generated for shared enums is actually a struct "
 "wrapping a numeric value. This is because it is not UB in C++ for an enum "
@@ -12504,48 +12420,48 @@ msgid ""
 "Rust representation needs to have the same behavior."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:13
 msgid "\"fallible1 requires depth > 0\""
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:16
 msgid "\"Success!\""
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:22
 msgid ""
 "Rust functions that return `Result` are translated to exceptions on the C++ "
 "side."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:24
 msgid ""
 "The exception thrown will always be of type `rust::Error`, which primarily "
 "exposes a way to get the error message string. The error message will come "
 "from the error type's `Display` impl."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:27
 msgid ""
 "A panic unwinding from Rust to C++ will always cause the process to "
 "immediately terminate."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:7
 msgid "\"example/include/example.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:14
 msgid "\"Error: {}\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:22
 msgid ""
 "C++ functions declared to return a `Result` will catch any thrown exception "
 "on the C++ side and return it as an `Err` value to the calling Rust function."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:24
 msgid ""
 "If an exception is thrown from an extern \"C++\" function that is not "
 "declared by the CXX bridge to return `Result`, the program calls C++'s `std::"
@@ -12553,140 +12469,140 @@ msgid ""
 "through a `noexcept` C++ function."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:3
 msgid "C++ Type"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:5
 msgid "`rust::String`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:6
 msgid "`&str`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:6
 msgid "`rust::Str`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:7
 msgid "`CxxString`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:7
 msgid "`std::string`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:8
 msgid "`&[T]`/`&mut [T]`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:8
 msgid "`rust::Slice`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:9
 msgid "`rust::Box<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:10
 msgid "`UniquePtr<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:10
 msgid "`std::unique_ptr<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:11
 msgid "`rust::Vec<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:12
 msgid "`CxxVector<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:12
 msgid "`std::vector<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:16
 msgid ""
 "These types can be used in the fields of shared structs and the arguments "
 "and returns of extern functions."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:18
 msgid ""
 "Note that Rust's `String` does not map directly to `std::string`. There are "
 "a few reasons for this:"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:20
 msgid ""
 "`std::string` does not uphold the UTF-8 invariant that `String` requires."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:21
 msgid ""
 "The two types have different layouts in memory and so can't be passed "
 "directly between languages."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:23
 msgid ""
 "`std::string` requires move constructors that don't match Rust's move "
 "semantics, so a `std::string` can't be passed by value to Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-cpp-genrules.md
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-cpp.md:1
+#: src/android/interoperability/cpp/android-cpp-genrules.md:1
+#: src/android/interoperability/cpp/android-build-rust.md:1
 msgid "Building in Android"
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:3
 msgid ""
 "Create a `cc_library_static` to build the C++ library, including the CXX "
 "generated header and source file."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-cpp.md:8
+#: src/android/interoperability/cpp/android-build-rust.md:10
 msgid "\"libcxx_test_cpp\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:9
 msgid "\"cxx_test.cpp\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:11
 msgid "\"cxx-bridge-header\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-build-cpp.md:12
+#: src/android/interoperability/cpp/android-cpp-genrules.md:10
 msgid "\"libcxx_test_bridge_header\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-build-cpp.md:14
+#: src/android/interoperability/cpp/android-cpp-genrules.md:19
 msgid "\"libcxx_test_bridge_code\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:20
 msgid ""
 "Point out that `libcxx_test_bridge_header` and `libcxx_test_bridge_code` are "
 "the dependencies for the CXX-generated C++ bindings. We'll show how these "
 "are setup on the next slide."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:23
 msgid ""
 "Note that you also need to depend on the `cxx-bridge-header` library in "
 "order to pull in common CXX definitions."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:25
 msgid ""
 "Full docs for using CXX in Android can be found in [the Android docs]"
 "(https://source.android.com/docs/setup/build/rust/building-rust-modules/"
@@ -12695,179 +12611,184 @@ msgid ""
 "instructions again in the future."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:3
 msgid ""
 "Create two genrules: One to generate the CXX header, and one to generate the "
 "CXX source file. These are then used as inputs to the `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:7
 msgid ""
 "// Generate a C++ header containing the C++ bindings\n"
 "// to the Rust exported functions in lib.rs.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:11
+#: src/android/interoperability/cpp/android-cpp-genrules.md:20
 msgid "\"cxxbridge\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:12
 msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:13
+#: src/android/interoperability/cpp/android-cpp-genrules.md:22
+#: src/android/interoperability/cpp/android-build-rust.md:8
 msgid "\"lib.rs\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:14
 msgid "\"lib.rs.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:16
 msgid "// Generate the C++ code that Rust calls into.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:21
 msgid "\"$(location cxxbridge) $(in) > $(out)\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:23
 msgid "\"lib.rs.cc\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:29
 msgid ""
 "The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
 "bridge module. It is included in Android and available as a Soong tool."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:31
 msgid ""
 "By convention, if your Rust source file is `lib.rs` your header file will be "
 "named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
 "convention isn't enforced, though."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-rust.md:3
 msgid ""
 "Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-rust.md:7
 msgid "\"cxx_test\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-rust.md:9
 msgid "\"libcxx\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:1
 msgid "Interoperability with Java"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:3
 msgid ""
 "Java can load shared objects via [Java Native Interface (JNI)](https://en."
 "wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
 "jni/) allows you to create a compatible library."
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:8
 msgid "First, we create a Rust function to export to Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:10
 msgid "_interoperability/java/src/lib.rs_:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:13
 msgid "//! Rust <-> Java FFI demo.\n"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:18
 msgid "/// HelloWorld::hello method implementation.\n"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:21
 msgid "\"system\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:27
 msgid "\"Hello, {input}!\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:33
+#: src/android/interoperability/java.md:63
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:37
+#: src/android/interoperability/java.md:70
 msgid "\"libhello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:38
+#: src/android/interoperability/java.md:53
 msgid "\"hello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:40
 msgid "\"libjni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:44
 msgid "We then call this function from Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:46
 msgid "_interoperability/java/HelloWorld.java_:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:67
 msgid "\"helloworld_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:68
 msgid "\"HelloWorld.java\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:69
 msgid "\"HelloWorld\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:74
 msgid "Finally, you can build, sync, and run the binary:"
 msgstr ""
 
-#: src/exercises/android/morning.md
+#: src/exercises/android/morning.md:3
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
 "and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 
-#: src/exercises/android/morning.md
+#: src/exercises/android/morning.md:6
 msgid "Call your AIDL service with a client written in Rust."
 msgstr ""
 
-#: src/exercises/android/morning.md
+#: src/exercises/android/morning.md:8
 msgid "Move a function from your project to Rust and call it."
 msgstr ""
 
-#: src/exercises/android/morning.md
+#: src/exercises/android/morning.md:12
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
 "in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
-#: src/chromium.md
+#: src/chromium.md:1
 msgid "Welcome to Rust in Chromium"
 msgstr ""
 
-#: src/chromium.md
+#: src/chromium.md:3
 msgid ""
 "Rust is supported for third-party libraries in Chromium, with first-party "
 "glue code to connect between Rust and existing Chromium C++ code."
 msgstr ""
 
-#: src/chromium.md
+#: src/chromium.md:6
 msgid ""
 "Today, we'll call into Rust to do something silly with strings. If you've "
 "got a corner of the code where you're displaying a UTF8 string to the user, "
@@ -12875,35 +12796,35 @@ msgid ""
 "exact part we talk about."
 msgstr ""
 
-#: src/chromium/setup.md
+#: src/chromium/setup.md:3
 msgid ""
 "Make sure you can build and run Chromium. Any platform and set of build "
 "flags is OK, so long as your code is relatively recent (commit position "
 "1223636 onwards, corresponding to November 2023):"
 msgstr ""
 
-#: src/chromium/setup.md
+#: src/chromium/setup.md:13
 msgid ""
 "(A component, debug build is recommended for quickest iteration time. This "
 "is the default!)"
 msgstr ""
 
-#: src/chromium/setup.md
+#: src/chromium/setup.md:16
 msgid ""
 "See [How to build Chromium](https://www.chromium.org/developers/how-tos/get-"
 "the-code/) if you aren't already at that point. Be warned: setting up to "
 "build Chromium takes time."
 msgstr ""
 
-#: src/chromium/setup.md
+#: src/chromium/setup.md:21
 msgid "It's also recommended that you have Visual Studio code installed."
 msgstr ""
 
-#: src/chromium/setup.md
+#: src/chromium/setup.md:23
 msgid "About the exercises"
 msgstr ""
 
-#: src/chromium/setup.md
+#: src/chromium/setup.md:25
 msgid ""
 "This part of the course has a series of exercises which build on each other. "
 "We'll be doing them spread throughout the course instead of just at the end. "
@@ -12911,78 +12832,78 @@ msgid ""
 "catch up in the next slot."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:3
 msgid ""
 "The Rust community typically uses `cargo` and libraries from [crates.io]"
 "(https://crates.io/). Chromium is built using `gn` and `ninja` and a curated "
 "set of dependencies."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:6
 msgid "When writing code in Rust, your choices are:"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:8
 msgid ""
 "Use `gn` and `ninja` with the help of the templates from `//build/rust/*."
 "gni` (e.g. `rust_static_library` that we'll meet later). This uses "
 "Chromium's audited toolchain and crates."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:11
 msgid ""
 "Use `cargo`, but [restrict yourself to Chromium's audited toolchain and "
 "crates](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/"
 "docs/rust.md#Using-cargo)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:13
 msgid ""
 "Use `cargo`, trusting a [toolchain](https://rustup.rs/) and/or [crates "
 "downloaded from the internet](https://crates.io/)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:16
 msgid ""
 "From here on we'll be focusing on `gn` and `ninja`, because this is how Rust "
 "code can be built into the Chromium browser. At the same time, Cargo is an "
 "important part of the Rust ecosystem and you should keep it in your toolbox."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:20
 msgid "Mini exercise"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:22
 msgid "Split into small groups and:"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:24
 msgid ""
 "Brainstorm scenarios where `cargo` may offer an advantage and assess the "
 "risk profile of these scenarios."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:26
 msgid ""
 "Discuss which tools, libraries, and groups of people need to be trusted when "
 "using `gn` and `ninja`, offline `cargo`, etc."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:31
 msgid ""
 "Ask students to avoid peeking at the speaker notes before completing the "
 "exercise. Assuming folks taking the course are physically together, ask them "
 "to discuss in small groups of 3-4 people."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:35
 msgid ""
 "Notes/hints related to the first part of the exercise (\"scenarios where "
 "Cargo may offer an advantage\"):"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:38
 msgid ""
 "It's fantastic that when writing a tool, or prototyping a part of Chromium, "
 "one has access to the rich ecosystem of crates.io libraries. There is a "
@@ -12991,19 +12912,19 @@ msgid ""
 "from various formats, `itertools` for working with iterators, etc.)."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:44
 msgid ""
 "`cargo` makes it easy to try a library (just add a single line to `Cargo."
 "toml` and start writing code)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:46
 msgid ""
 "It may be worth comparing how CPAN helped make `perl` a popular choice. Or "
 "comparing with `python` + `pip`."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:49
 msgid ""
 "Development experience is made really nice not only by core Rust tools (e.g. "
 "using `rustup` to switch to a different `rustc` version when testing a crate "
@@ -13013,21 +12934,21 @@ msgid ""
 "streamlined way to run benchmarks)."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:56
 msgid ""
 "`cargo` makes it easy to add a tool via `cargo install --locked cargo-vet`."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:57
 msgid "It may be worth comparing with Chrome Extensions or VScode extensions."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:59
 msgid ""
 "Broad, generic examples of projects where `cargo` may be the right choice:"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:61
 msgid ""
 "Perhaps surprisingly, Rust is becoming increasingly popular in the industry "
 "for writing command line tools. The breadth and ergonomics of libraries is "
@@ -13036,7 +12957,7 @@ msgid ""
 "language)."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:66
 msgid ""
 "Participating in the Rust ecosystem requires using standard Rust tools like "
 "Cargo. Libraries that want to get external contributions, and want to be "
@@ -13044,95 +12965,95 @@ msgid ""
 "should probably use Cargo."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:71
 msgid "Examples of Chromium-related projects that are `cargo`\\-based:"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:72
 msgid ""
 "`serde_json_lenient` (experimented with in other parts of Google which "
 "resulted in PRs with performance improvements)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:74
 msgid "Fontations libraries like `font-types`"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:75
 msgid ""
 "`gnrt` tool (we will meet it later in the course) which depends on `clap` "
 "for command-line parsing and on `toml` for configuration files."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:77
 msgid ""
 "Disclaimer: a unique reason for using `cargo` was unavailability of `gn` "
 "when building and bootstrapping Rust standard library when building Rust "
 "toolchain."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:80
 msgid ""
 "`run_gnrt.py` uses Chromium's copy of `cargo` and `rustc`. `gnrt` depends on "
 "third-party libraries downloaded from the internet, but `run_gnrt.py` asks "
 "`cargo` that only `--locked` content is allowed via `Cargo.lock`.)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:84
 msgid ""
 "Students may identify the following items as being implicitly or explicitly "
 "trusted:"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:87
 msgid ""
 "`rustc` (the Rust compiler) which in turn depends on the LLVM libraries, the "
 "Clang compiler, the `rustc` sources (fetched from GitHub, reviewed by Rust "
 "compiler team), binary Rust compiler downloaded for bootstrapping"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:90
 msgid ""
 "`rustup` (it may be worth pointing out that `rustup` is developed under the "
 "umbrella of the https://github.com/rust-lang/ organization - same as `rustc`)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:92
 msgid "`cargo`, `rustfmt`, etc."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:93
 msgid ""
 "Various internal infrastructure (bots that build `rustc`, system for "
 "distributing the prebuilt toolchain to Chromium engineers, etc.)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:95
 msgid "Cargo tools like `cargo audit`, `cargo vet`, etc."
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:96
 msgid ""
 "Rust libraries vendored into `//third_party/rust` (audited by "
 "security@chromium.org)"
 msgstr ""
 
-#: src/chromium/cargo.md
+#: src/chromium/cargo.md:98
 msgid "Other Rust libraries (some niche, some quite popular and commonly used)"
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:1
 msgid "Chromium Rust policy"
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:3
 msgid ""
 "Chromium does not yet allow first-party Rust except in rare cases as "
 "approved by Chromium's [Area Tech Leads](https://source.chromium.org/"
 "chromium/chromium/src/+/main:ATL_OWNERS)."
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:7
 msgid ""
 "Chromium's policy on third party libraries is outlined [here](https://"
 "chromium.googlesource.com/chromium/src/+/main/docs/adding_to_third_party."
@@ -13141,14 +13062,14 @@ msgid ""
 "security."
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:12
 msgid ""
 "Very few Rust libraries directly expose a C/C++ API, so that means that "
 "nearly all such libraries will require a small amount of first-party glue "
 "code."
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:15
 msgid ""
 "```bob\n"
 "\"C++\"                           Rust\n"
@@ -13175,49 +13096,49 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:30
 msgid ""
 "First-party Rust glue code for a particular third-party crate should "
 "normally be kept in `third_party/rust/<crate>/<version>/wrapper`."
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:33
 msgid "Because of this, today's course will be heavily focused on:"
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:35
 msgid "Bringing in third-party Rust libraries (\"crates\")"
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:36
 msgid "Writing glue code to be able to use those crates from Chromium C++."
 msgstr ""
 
-#: src/chromium/policy.md
+#: src/chromium/policy.md:38
 msgid "If this policy changes over time, the course will evolve to keep up."
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:1
 msgid "Build rules"
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:3
 msgid ""
 "Rust code is usually built using `cargo`. Chromium builds with `gn` and "
 "`ninja` for efficiency --- its static rules allow maximum parallelism. Rust "
 "is no exception."
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:7
 msgid "Adding Rust code to Chromium"
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:9
 msgid ""
 "In some existing Chromium `BUILD.gn` file, declare a `rust_static_library`:"
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:11
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13229,13 +13150,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:20
 msgid ""
 "You can also add `deps` on other Rust targets. Later we'll use this to "
 "depend upon third party code."
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:25
 msgid ""
 "You must specify _both_ the crate root, _and_ a full list of sources. The "
 "`crate_root` is the file given to the Rust compiler representing the root "
@@ -13244,13 +13165,13 @@ msgid ""
 "rebuilds are necessary."
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:31
 msgid ""
 "(There's no such thing as a Rust `source_set`, because in Rust, an entire "
 "crate is a compilation unit. A `static_library` is the smallest unit.)"
 msgstr ""
 
-#: src/chromium/build-rules.md
+#: src/chromium/build-rules.md:34
 msgid ""
 "Students might be wondering why we need a gn template, rather than using "
 "[gn's built-in support for Rust static libraries](https://gn.googlesource."
@@ -13259,11 +13180,11 @@ msgid ""
 "tests, some of which we'll use later."
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md
+#: src/chromium/build-rules/unsafe.md:1
 msgid "Including `unsafe` Rust Code"
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md
+#: src/chromium/build-rules/unsafe.md:3
 msgid ""
 "Unsafe Rust code is forbidden in `rust_static_library` by default --- it "
 "won't compile. If you need unsafe Rust code, add `allow_unsafe = true` to "
@@ -13271,7 +13192,7 @@ msgid ""
 "necessary.)"
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md
+#: src/chromium/build-rules/unsafe.md:7
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13287,11 +13208,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules/depending.md
+#: src/chromium/build-rules/depending.md:3
 msgid "Simply add the above target to the `deps` of some Chromium C++ target."
 msgstr ""
 
-#: src/chromium/build-rules/depending.md
+#: src/chromium/build-rules/depending.md:5
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13308,107 +13229,107 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:3
 msgid ""
 "Types are elided in Rust code, which makes a good IDE even more useful than "
 "for C++. Visual Studio code works well for Rust in Chromium. To use it,"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:6
 msgid ""
 "Ensure your VSCode has the `rust-analyzer` extension, not earlier forms of "
 "Rust support"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:8
 msgid ""
 "`gn gen out/Debug --export-rust-project` (or equivalent for your output "
 "directory)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:10
 msgid "`ln -s out/Debug/rust-project.json rust-project.json`"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:16
 msgid ""
 "A demo of some of the code annotation and exploration features of rust-"
 "analyzer might be beneficial if the audience are naturally skeptical of IDEs."
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:19
 msgid ""
 "The following steps may help with the demo (but feel free to instead use a "
 "piece of Chromium-related Rust that you are most familiar with):"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:22
 msgid "Open `components/qr_code_generator/qr_code_generator_ffi_glue.rs`"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:23
 msgid ""
 "Place the cursor over the `QrCode::new` call (around line 26) in "
 "\\`qr_code_generator_ffi_glue.rs"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:25
 msgid ""
 "Demo **show documentation** (typical bindings: vscode = ctrl k i; vim/CoC = "
 "K)."
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:27
 msgid ""
 "Demo **go to definition** (typical bindings: vscode = F12; vim/CoC = g d). "
 "(This will take you to `//third_party/rust/.../qr_code-.../src/lib.rs`.)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:29
 msgid ""
 "Demo **outline** and navigate to the `QrCode::with_bits` method (around line "
 "164; the outline is in the file explorer pane in vscode; typical vim/CoC "
 "bindings = space o)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:32
 msgid ""
 "Demo **type annotations** (there are quote a few nice examples in the "
 "`QrCode::with_bits` method)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:35
 msgid ""
 "It may be worth pointing out that `gn gen ... --export-rust-project` will "
 "need to be rerun after editing `BUILD.gn` files (which we will do a few "
 "times throughout the exercises in this session)."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:1
 msgid "Build rules exercise"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:3
 msgid ""
 "In your Chromium build, add a new Rust target to `//ui/base/BUILD.gn` "
 "containing:"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:13
 msgid ""
 "**Important**: note that `no_mangle` here is considered a type of unsafety "
 "by the Rust compiler, so you'll need to allow unsafe code in your `gn` "
 "target."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:16
 msgid ""
 "Add this new Rust target as a dependency of `//ui/base:base`. Declare this "
 "function at the top of `ui/base/resource/resource_bundle.cc` (later, we'll "
 "see how this can be automated by bindings generation tools):"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:24
 msgid ""
 "Call this function from somewhere in `ui/base/resource/resource_bundle.cc` - "
 "we suggest the top of `ResourceBundle::MaybeMangleLocalizedString`. Build "
@@ -13416,50 +13337,50 @@ msgid ""
 "times."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:28
 msgid ""
 "If you use VSCode, now set up Rust to work well in VSCode. It will be useful "
 "in subsequent exercises. If you've succeeded, you will be able to use right-"
 "click \"Go to definition\" on `println!`."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/build-rules.md:32
+#: src/exercises/chromium/interoperability-with-cpp.md:48
 msgid "Where to find help"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:34
 msgid ""
 "The options available to the [`rust_static_library` gn template](https://"
 "source.chromium.org/chromium/chromium/src/+/main:build/rust/"
 "rust_static_library.gni;l=16)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:35
 msgid ""
 "Information about [`#[no_mangle]`](https://doc.rust-lang.org/beta/reference/"
 "abi.html#the-no_mangle-attribute)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:36
 msgid ""
 "Information about [`extern \"C\"`](https://doc.rust-lang.org/std/keyword."
 "extern.html)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:37
 msgid ""
 "Information about gn's [`--export-rust-project`](https://gn.googlesource.com/"
 "gn/+/main/docs/reference.md#compilation-database) switch"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:38
 msgid ""
 "[How to install rust-analyzer in VSCode](https://code.visualstudio.com/docs/"
 "languages/rust)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:44
 msgid ""
 "This example is unusual because it boils down to the lowest-common-"
 "denominator interop language, C. Both C++ and Rust can natively declare and "
@@ -13467,27 +13388,27 @@ msgid ""
 "Rust."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:48
 msgid ""
 "`allow_unsafe = true` is required here because `#[no_mangle]` might allow "
 "Rust to generate two functions with the same name, and Rust can no longer "
 "guarantee that the right one is called."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:52
 msgid ""
 "If you need a pure Rust executable, you can also do that using the "
 "`rust_executable` gn template."
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:3
 msgid ""
 "Rust community typically authors unit tests in a module placed in the same "
 "source file as the code being tested. This was covered [earlier](../testing."
 "md) in the course and looks like this:"
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:17
 msgid ""
 "In Chromium we place unit tests in a separate source file and we continue to "
 "follow this practice for Rust --- this makes tests consistently discoverable "
@@ -13495,45 +13416,45 @@ msgid ""
 "configuration)."
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:22
 msgid ""
 "This results in the following options for testing Rust code in Chromium:"
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:24
 msgid ""
 "Native Rust tests (i.e. `#[test]`). Discouraged outside of `//third_party/"
 "rust`."
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:26
 msgid ""
 "`gtest` tests authored in C++ and exercising Rust via FFI calls. Sufficient "
 "when Rust code is just a thin FFI layer and the existing unit tests provide "
 "sufficient coverage for the feature."
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:29
 msgid ""
 "`gtest` tests authored in Rust and using the crate under test through its "
 "public API (using `pub mod for_testing { ... }` if needed). This is the "
 "subject of the next few slides."
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:35
 msgid ""
 "Mention that native Rust tests of third-party crates should eventually be "
 "exercised by Chromium bots. (Such testing is needed rarely --- only after "
 "adding or updating third-party crates.)"
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:39
 msgid ""
 "Some examples may help illustrate when C++ `gtest` vs Rust `gtest` should be "
 "used:"
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:42
 msgid ""
 "QR has very little functionality in the first-party Rust layer (it's just a "
 "thin FFI glue) and therefore uses the existing C++ unit tests for testing "
@@ -13541,7 +13462,7 @@ msgid ""
 "enable or disable Rust using a `ScopedFeatureList`)."
 msgstr ""
 
-#: src/chromium/testing.md
+#: src/chromium/testing.md:47
 msgid ""
 "Hypothetical/WIP PNG integration may need to implement memory-safe "
 "implementation of pixel transformations that are provided by `libpng` but "
@@ -13549,35 +13470,35 @@ msgid ""
 "functionality may benefit from separate tests authored in Rust."
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
+#: src/chromium/testing/rust-gtest-interop.md:3
 msgid ""
 "The [`rust_gtest_interop`](https://chromium.googlesource.com/chromium/src/+/"
 "main/testing/rust_gtest_interop/README.md) library provides a way to:"
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
+#: src/chromium/testing/rust-gtest-interop.md:5
 msgid ""
 "Use a Rust function as a `gtest` testcase (using the `#[gtest(...)]` "
 "attribute)"
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
+#: src/chromium/testing/rust-gtest-interop.md:7
 msgid ""
 "Use `expect_eq!` and similar macros (similar to `assert_eq!` but not "
 "panicking and not terminating the test when the assertion fails)."
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
+#: src/chromium/testing/rust-gtest-interop.md:10
 msgid "Example:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:3
 msgid ""
 "The simplest way to build Rust `gtest` tests is to add them to an existing "
 "test binary that already contains tests authored in C++. For example:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:6
 msgid ""
 "```gn\n"
 "test(\"ui_base_unittests\") {\n"
@@ -13588,13 +13509,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:14
 msgid ""
 "Authoring Rust tests in a separate `static_library` also works, but requires "
 "manually declaring the dependency on the support libraries:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:17
 msgid ""
 "```gn\n"
 "rust_static_library(\"my_rust_lib_unittests\") {\n"
@@ -13615,7 +13536,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:3
 msgid ""
 "After adding `:my_rust_lib` to GN `deps`, we still need to learn how to "
 "import and use `my_rust_lib` from `my_rust_lib_unittest.rs`. We haven't "
@@ -13625,15 +13546,15 @@ msgid ""
 "from the automatically-imported `chromium` crate:"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:12
 msgid "\"//ui/base:my_rust_lib\""
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:18
 msgid "Under the covers the macro expands to something similar to:"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:26
 msgid ""
 "More information can be found in [the doc comment](https://source.chromium."
 "org/chromium/chromium/src/+/main:build/rust/chromium_prelude/"
@@ -13641,7 +13562,7 @@ msgid ""
 "third_party&ss=chromium%2Fchromium%2Fsrc) of the `chromium::import` macro."
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:31
 msgid ""
 "`rust_static_library` supports specifying an explicit name via `crate_name` "
 "property, but doing this is discouraged. And it is discouraged because the "
@@ -13650,65 +13571,65 @@ msgid ""
 "covered in a later section) use short crate names."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:1
 msgid "Testing exercise"
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:3
 msgid "Time for another exercise!"
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:5
 msgid "In your Chromium build:"
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:7
 msgid ""
 "Add a testable function next to `hello_from_rust`. Some suggestions: adding "
 "two integers received as arguments, computing the nth Fibonacci number, "
 "summing integers in a slice, etc."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:10
 msgid "Add a separate `..._unittest.rs` file with a test for the new function."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:11
 msgid "Add the new tests to `BUILD.gn`."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:12
 msgid "Build the tests, run them, and verify that the new test works."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:3
 msgid ""
 "The Rust community offers multiple options for C++/Rust interop, with new "
 "tools being developed all the time. At the moment, Chromium uses a tool "
 "called CXX."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:6
 msgid ""
 "You describe your whole language boundary in an interface definition "
 "language (which looks a lot like Rust) and then CXX tools generate "
 "declarations for functions and types in both Rust and C++."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:12
 msgid ""
 "See the [CXX tutorial](https://cxx.rs/tutorial.html) for a full example of "
 "using this."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:19
 msgid ""
 "Talk through the diagram. Explain that behind the scenes, this is doing just "
 "the same as you previously did. Point out that automating the process has "
 "the following benefits:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:23
 msgid ""
 "The tool guarantees that the C++ and Rust sides match (e.g. you get compile "
 "errors if the `#[cxx::bridge]` doesn't match the actual C++ or Rust "
@@ -13716,7 +13637,7 @@ msgid ""
 "Behavior)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:27
 msgid ""
 "The tool automates generation of FFI thunks (small, C-ABI-compatible, free "
 "functions) for non-C features (e.g. enabling FFI calls into Rust or C++ "
@@ -13724,11 +13645,11 @@ msgid ""
 "functions manually)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:31
 msgid "The tool and the library can handle a set of core types - for example:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:32
 msgid ""
 "`&[T]` can be passed across the FFI boundary, even though it doesn't "
 "guarantee any particular ABI or memory layout. With manual bindings `std::"
@@ -13737,7 +13658,7 @@ msgid ""
 "empty slices slightly differently)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:37
 msgid ""
 "Smart pointers like `std::unique_ptr<T>`, `std::shared_ptr<T>`, and/or `Box` "
 "are natively supported. With manual bindings, one would have to pass C-ABI-"
@@ -13745,7 +13666,7 @@ msgid ""
 "risks."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md
+#: src/chromium/interoperability-with-cpp.md:41
 msgid ""
 "`rust::String` and `CxxString` types understand and maintain differences in "
 "string representation across the languages (e.g. `rust::String::lossy` can "
@@ -13753,25 +13674,25 @@ msgid ""
 "terminate a string)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:3
 msgid ""
 "CXX requires that the whole C++/Rust boundary is declared in `cxx::bridge` "
 "modules inside `.rs` source code."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:16
 msgid "\"example/include/blobstore.h\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:24
 msgid "// Definitions of Rust types and functions go here\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:30
 msgid "Point out:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:32
 msgid ""
 "Although this looks like a regular Rust `mod`, the `#[cxx::bridge]` "
 "procedural macro does complex things to it. The generated code is quite a "
@@ -13779,23 +13700,23 @@ msgid ""
 "`ffi` in your code."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:36
 msgid "Native support for C++'s `std::unique_ptr` in Rust"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:37
 msgid "Native support for Rust slices in C++"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:38
 msgid "Calls from C++ to Rust, and Rust types (in the top part)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:39
 msgid "Calls from Rust to C++, and C++ types (in the bottom part)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:41
 msgid ""
 "**Common misconception**: It _looks_ like a C++ header is being parsed by "
 "Rust, but this is misleading. This header is never interpreted by Rust, but "
@@ -13803,35 +13724,35 @@ msgid ""
 "compilers."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:3
 msgid ""
 "By far the most useful page when using CXX is the [type reference](https://"
 "cxx.rs/bindings.html)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:5
 msgid "CXX fundamentally suits cases where:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:7
 msgid ""
 "Your Rust-C++ interface is sufficiently simple that you can declare all of "
 "it."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:8
 msgid ""
 "You're using only the types natively supported by CXX already, for example "
 "`std::unique_ptr`, `std::string`, `&[u8]` etc."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:11
 msgid ""
 "It has many limitations --- for example lack of support for Rust's `Option` "
 "type."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:14
 msgid ""
 "These limitations constrain us to using Rust in Chromium only for well "
 "isolated \"leaf nodes\" rather than for arbitrary Rust-C++ interop. When "
@@ -13840,75 +13761,75 @@ msgid ""
 "enough."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:26
 msgid ""
 "You should also discuss some of the other sticky points with CXX, for "
 "example:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:28
 msgid ""
 "Its error handling is based around C++ exceptions (given on the next slide)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:29
 msgid "Function pointers are awkward to use."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:3
 msgid ""
 "CXX's [support for `Result<T,E>`](https://cxx.rs/binding/result.html) relies "
 "on C++ exceptions, so we can't use that in Chromium. Alternatives:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:6
 msgid "The `T` part of `Result<T, E>` can be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:7
 msgid ""
 "Returned via out parameters (e.g. via `&mut T`). This requires that `T` can "
 "be passed across the FFI boundary - for example `T` has to be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:9
 msgid "A primitive type (like `u32` or `usize`)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:10
 msgid ""
 "A type natively supported by `cxx` (like `UniquePtr<T>`) that has a suitable "
 "default value to use in a failure case (_unlike_ `Box<T>`)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:12
 msgid ""
 "Retained on the Rust side, and exposed via reference. This may be needed "
 "when `T` is a Rust type, which cannot be passed across the FFI boundary, and "
 "cannot be stored in `UniquePtr<T>`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:16
 msgid "The `E` part of `Result<T, E>` can be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:17
 msgid ""
 "Returned as a boolean (e.g. `true` representing success, and `false` "
 "representing failure)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:19
 msgid ""
 "Preserving error details is in theory possible, but so far hasn't been "
 "needed in practice."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:1
 msgid "CXX Error Handling: QR Example"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:3
 msgid ""
 "The QR code generator is [an example](https://source.chromium.org/chromium/"
 "chromium/src/+/main:components/qr_code_generator/qr_code_generator_ffi_glue."
@@ -13917,11 +13838,11 @@ msgid ""
 "be passed across the FFI boundary:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:8
 msgid "\"qr_code_generator\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:23
 msgid ""
 "Students may be curious about the semantics of the `out_qr_size` output. "
 "This is not the size of the vector, but the size of the QR code (and "
@@ -13929,7 +13850,7 @@ msgid ""
 "the vector)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:27
 msgid ""
 "It may be worth pointing out the importance of initializing `out_qr_size` "
 "before calling into the Rust function. Creation of a Rust reference that "
@@ -13937,42 +13858,42 @@ msgid ""
 "when only the act of dereferencing such memory results in UB)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:32
 msgid ""
 "If students ask about `Pin`, then explain why CXX needs it for mutable "
 "references to C++ data: the answer is that C++ data can’t be moved around "
 "like Rust data, because it may contain self-referential pointers."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:1
 msgid "CXX Error Handling: PNG Example"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:3
 msgid ""
 "A prototype of a PNG decoder illustrates what can be done when the "
 "successful result cannot be passed across the FFI boundary:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:7
 msgid "\"gfx::rust_bindings\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:10
 msgid ""
 "/// This returns an FFI-friendly equivalent of `Result<PngReader<'a>,\n"
 "        /// ()>`.\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:14
 msgid "/// C++ bindings for the `crate::png::ResultOfPngReader` type.\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:21
 msgid "/// C++ bindings for the `crate::png::PngReader` type.\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:32
 msgid ""
 "`PngReader` and `ResultOfPngReader` are Rust types --- objects of these "
 "types cannot cross the FFI boundary without indirection of a `Box<T>`. We "
@@ -13980,7 +13901,7 @@ msgid ""
 "to store Rust objects by value."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:37
 msgid ""
 "This example illustrates that even though CXX doesn't support arbitrary "
 "generics nor templates, we can still pass them across the FFI boundary by "
@@ -13990,18 +13911,18 @@ msgid ""
 "`as_mut`)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:1
 msgid "Using cxx in Chromium"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:3
 msgid ""
 "In Chromium, we define an independent `#[cxx::bridge] mod` for each leaf-"
 "node where we want to use Rust. You'd typically have one for each "
 "`rust_static_library`. Just add"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:7
 msgid ""
 "```gn\n"
 "cxx_bindings = [ \"my_rust_file.rs\" ]\n"
@@ -14010,21 +13931,21 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:13
 msgid ""
 "to your existing `rust_static_library` target alongside `crate_root` and "
 "`sources`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:16
 msgid "C++ headers will be generated at a sensible location, so you can just"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:19
 msgid "\"ui/base/my_rust_file.rs.h\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:22
 msgid ""
 "You will find some utility functions in `//base` to convert to/from Chromium "
 "C++ types to CXX Rust types --- for example [`SpanToRustSlice`](https://"
@@ -14032,11 +13953,11 @@ msgid ""
 "l=21)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:27
 msgid "Students may ask --- why do we still need `allow_unsafe = true`?"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:29
 msgid ""
 "The broad answer is that no C/C++ code is \"safe\" by the normal Rust "
 "standards. Calling back and forth to C/C++ from Rust may do arbitrary things "
@@ -14047,7 +13968,7 @@ msgid ""
 "binary can cause unexpected behavior from Rust's perspective."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:36
 msgid ""
 "The narrow answer lies in the diagram at the top of [this page](../"
 "interoperability-with-cpp.md) --- behind the scenes, CXX generates Rust "
@@ -14055,151 +13976,151 @@ msgid ""
 "previous section."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:1
 msgid "Exercise: Interoperability with C++"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:3
 msgid "Part one"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:5
 msgid ""
 "In the Rust file you previously created, add a `#[cxx::bridge]` which "
 "specifies a single function, to be called from C++, called "
 "`hello_from_rust`, taking no parameters and returning no value."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:8
 msgid ""
 "Modify your previous `hello_from_rust` function to remove `extern \"C\"` and "
 "`#[no_mangle]`. This is now just a standard Rust function."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:10
 msgid "Modify your `gn` target to build these bindings."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:11
 msgid ""
 "In your C++ code, remove the forward-declaration of `hello_from_rust`. "
 "Instead, include the generated header file."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:13
 msgid "Build and run!"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:15
 msgid "Part two"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:17
 msgid ""
 "It's a good idea to play with CXX a little. It helps you think about how "
 "flexible Rust in Chromium actually is."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:20
 msgid "Some things to try:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:22
 msgid "Call back into C++ from Rust. You will need:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:23
 msgid ""
 "An additional header file which you can `include!` from your `cxx::bridge`. "
 "You'll need to declare your C++ function in that new header file."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:25
 msgid ""
 "An `unsafe` block to call such a function, or alternatively specify the "
 "`unsafe` keyword in your `#[cxx::bridge]` [as described here](https://cxx.rs/"
 "extern-c++.html#functions-and-member-functions)."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:27
 msgid ""
 "You may also need to `#include \"third_party/rust/cxx/v1/crate/include/cxx."
 "h\"`"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:29
 msgid "Pass a C++ string from C++ into Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:30
 msgid "Pass a reference to a C++ object into Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:31
 msgid ""
 "Intentionally get the Rust function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:33
 msgid ""
 "Intentionally get the C++ function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:35
 msgid ""
 "Pass a `std::unique_ptr` of some type from C++ into Rust, so that Rust can "
 "own some C++ object."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:37
 msgid ""
 "Create a Rust object and pass it into C++, so that C++ owns it. (Hint: you "
 "need a `Box`)."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:39
 msgid "Declare some methods on a C++ type. Call them from Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:40
 msgid "Declare some methods on a Rust type. Call them from C++."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:42
 msgid "Part three"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:44
 msgid ""
 "Now you understand the strengths and limitations of CXX interop, think of a "
 "couple of use-cases for Rust in Chromium where the interface would be "
 "sufficiently simple. Sketch how you might define that interface."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:50
 msgid "The [`cxx` binding reference](https://cxx.rs/bindings.html)"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:51
 msgid ""
 "The [`rust_static_library` gn template](https://source.chromium.org/chromium/"
 "chromium/src/+/main:build/rust/rust_static_library.gni;l=16)"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:57
 msgid "Some of the questions you may encounter:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:59
 msgid ""
 "I'm seeing a problem initializing a variable of type X with type Y, where X "
 "and Y are both function types. This is because your C++ function doesn't "
 "quite match the declaration in your `cxx::bridge`."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:62
 msgid ""
 "I seem to be able to freely convert C++ references into Rust references. "
 "Doesn't that risk UB? For CXX's _opaque_ types, no, because they are zero-"
@@ -14207,94 +14128,95 @@ msgid ""
 "CXX's design makes it quite difficult to craft such an example."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:3
 msgid ""
 "Rust libraries are called \"crates\" and are found at [crates.io](https://"
 "crates.io). It's _very easy_ for Rust crates to depend upon one another. So "
 "they do!"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:6
 msgid "Property"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:6
 msgid "C++ library"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:6
 msgid "Rust crate"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:8
 msgid "Build system"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:8
+#: src/chromium/adding-third-party-crates.md:10
 msgid "Lots"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:8
 msgid "Consistent: `Cargo.toml`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:9
 msgid "Typical library size"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:9
 msgid "Large-ish"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:9
 msgid "Small"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:10
 msgid "Transitive dependencies"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:10
 msgid "Few"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:12
 msgid "For a Chromium engineer, this has pros and cons:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:14
 msgid ""
 "All crates use a common build system so we can automate their inclusion into "
 "Chromium..."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:16
 msgid ""
 "... but, crates typically have transitive dependencies, so you will likely "
 "have to bring in multiple libraries."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:19
 msgid "We'll discuss:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:21
 msgid "How to put a crate in the Chromium source code tree"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:22
 msgid "How to make `gn` build rules for it"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md
+#: src/chromium/adding-third-party-crates.md:23
 msgid "How to audit its source code for sufficient safety."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:1
 msgid "Configuring the `Cargo.toml` file to add crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:3
 msgid ""
 "Chromium has a single set of centrally-managed direct crate dependencies. "
 "These are managed through a single [`Cargo.toml`](https://source.chromium."
@@ -14302,7 +14224,7 @@ msgid ""
 "toml):"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:6
 msgid ""
 "```toml\n"
 "[dependencies]\n"
@@ -14313,7 +14235,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:14
 msgid ""
 "As with any other `Cargo.toml`, you can specify [more details about the "
 "dependencies](https://doc.rust-lang.org/cargo/reference/specifying-"
@@ -14321,53 +14243,53 @@ msgid ""
 "that you wish to enable in the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:18
 msgid ""
 "When adding a crate to Chromium, you'll often need to provide some extra "
 "information in an additional file, `gnrt_config.toml`, which we'll meet next."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:3
 msgid ""
 "Alongside `Cargo.toml` is [`gnrt_config.toml`](https://source.chromium.org/"
 "chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/gnrt_config."
 "toml). This contains Chromium-specific extensions to crate handling."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:6
 msgid ""
 "If you add a new crate, you should specify at least the `group`. This is one "
 "of:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:15
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:15
 msgid "For instance,"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:22
 msgid ""
 "Depending on the crate source code layout, you may also need to use this "
 "file to specify where its `LICENSE` file(s) can be found."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:25
 msgid ""
 "Later, we'll see some other things you will need to configure in this file "
 "to resolve problems."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:3
 msgid ""
 "A tool called `gnrt` knows how to download crates and how to generate `BUILD."
 "gn` rules."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:6
 msgid "To start, download the crate you want like this:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:13
 msgid ""
 "Although the `gnrt` tool is part of the Chromium source code, by running "
 "this command you will be downloading and running its dependencies from "
@@ -14375,75 +14297,75 @@ msgid ""
 "decision."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:17
 msgid "This `vendor` command may download:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:19
 msgid "Your crate"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:20
 msgid "Direct and transitive dependencies"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:21
 msgid ""
 "New versions of other crates, as required by `cargo` to resolve the complete "
 "set of crates required by Chromium."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:24
 msgid ""
 "Chromium maintains patches for some crates, kept in `//third_party/rust/"
 "chromium_crates_io/patches`. These will be reapplied automatically, but if "
 "patching fails you may need to take manual action."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:3
 msgid ""
 "Once you've downloaded the crate, generate the `BUILD.gn` files like this:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:9
 msgid "Now run `git status`. You should find:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:11
 msgid ""
 "At least one new crate source code in `third_party/rust/chromium_crates_io/"
 "vendor`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:13
 msgid ""
 "At least one new `BUILD.gn` in `third_party/rust/<crate name>/v<major semver "
 "version>`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:15
 msgid "An appropriate `README.chromium`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:17
 msgid ""
 "The \"major semver version\" is a [Rust \"semver\" version number](https://"
 "doc.rust-lang.org/cargo/reference/semver.html)."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:19
 msgid ""
 "Take a close look, especially at the things generated in `third_party/rust`."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:23
 msgid ""
 "Talk a little about semver --- and specifically the way that in Chromium "
 "it's to allow multiple incompatible versions of a crate, which is "
 "discouraged but sometimes necessary in the Cargo ecosystem."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:3
 msgid ""
 "If your build fails, it may be because of a `build.rs`: programs which do "
 "arbitrary things at build time. This is fundamentally at odds with the "
@@ -14451,76 +14373,81 @@ msgid ""
 "to maximize parallelism and repeatability of builds."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:8
 msgid ""
 "Some `build.rs` actions are automatically supported; others require action:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
 msgid "build script effect"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
 msgid "Supported by our gn templates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
 msgid "Work required by you"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
 msgid "Checking rustc version to configure features on and off"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
 msgid "Yes"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
 msgid "None"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
 msgid "Checking platform or CPU to configure features on and off"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
 msgid "Generating code"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
 msgid "Yes - specify in `gnrt_config.toml`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
 msgid "Building C/C++"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
 msgid "No"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
 msgid "Patch around it"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
 msgid "Arbitrary other actions"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:18
 msgid ""
 "Fortunately, most crates don't contain a build script, and fortunately, most "
 "build scripts only do the top two actions."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:3
 msgid ""
 "If `ninja` complains about missing files, check the `build.rs` to see if it "
 "writes source code files."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:6
 msgid ""
 "If so, modify [`gnrt_config.toml`](../configuring-gnrt-config-toml.md) to "
 "add `build-script-outputs` to the crate. If this is a transitive dependency, "
@@ -14529,7 +14456,7 @@ msgid ""
 "file:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:11
 msgid ""
 "```toml\n"
 "[crate.unicode-linebreak]\n"
@@ -14538,14 +14465,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:17
 msgid ""
 "Now rerun [`gnrt.py -- gen`](../generating-gn-build-rules.md) to regenerate "
 "`BUILD.gn` files to inform ninja that this particular output file is input "
 "to subsequent build steps."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:3
 msgid ""
 "Some crates use the [`cc`](https://crates.io/crates/cc) crate to build and "
 "link C/C++ libraries. Other crates parse C/C++ using [`bindgen`](https://"
@@ -14554,19 +14481,19 @@ msgid ""
 "very specific in expressing relationships between build actions."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:8
 msgid "So, your options are:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:10
 msgid "Avoid these crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:11
 msgid "Apply a patch to the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:13
 msgid ""
 "Patches should be kept in `third_party/rust/chromium_crates_io/patches/"
 "<crate>` - see for example the [patches against the `cxx` crate](https://"
@@ -14575,18 +14502,18 @@ msgid ""
 "`gnrt` each time it upgrades the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:3
 msgid ""
 "Once you've added a third-party crate and generated build rules, depending "
 "on a crate is simple. Find your `rust_static_library` target, and add a "
 "`dep` on the `:lib` target within your crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:7
 msgid "Specifically,"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:9
 msgid ""
 "```bob\n"
 "                     +------------+      +----------------------+\n"
@@ -14596,7 +14523,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:17
 msgid ""
 "```gn\n"
 "rust_static_library(\"my_rust_lib\") {\n"
@@ -14607,11 +14534,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:1
 msgid "Auditing Third Party Crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:3
 msgid ""
 "Adding new libraries is subject to Chromium's standard [policies](https://"
 "chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/rust."
@@ -14621,18 +14548,18 @@ msgid ""
 "Rust code can have limited negative side effects. How should you review it?"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:9
 msgid ""
 "Over time Chromium aims to move to a process based around [cargo vet]"
 "(https://mozilla.github.io/cargo-vet/)."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:11
 msgid ""
 "Meanwhile, for each new crate addition, we are checking for the following:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:13
 msgid ""
 "Understand why each crate is used. What's the relationship between crates? "
 "If the build system for each crate contains a `build.rs` or procedural "
@@ -14640,11 +14567,11 @@ msgid ""
 "is normally built?"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:17
 msgid "Check each crate seems to be reasonably well maintained"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:18
 msgid ""
 "Use `cd third-party/rust/chromium_crates_io; cargo audit` to check for known "
 "vulnerabilities (first you'll need to `cargo install cargo-audit`, which "
@@ -14652,65 +14579,65 @@ msgid ""
 "cargo.md))"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:21
 msgid ""
 "Ensure any `unsafe` code is good enough for the [Rule of Two](https://"
 "chromium.googlesource.com/chromium/src/+/main/docs/security/rule-of-2."
 "md#unsafe-code-in-safe-languages)"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:22
 msgid "Check for any use of `fs` or `net` APIs"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:23
 msgid ""
 "Read all the code at a sufficient level to look for anything out of place "
 "that might have been maliciously inserted. (You can't realistically aim for "
 "100% perfection here: there's often just too much code.)"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:27
 msgid ""
 "These are just guidelines --- work with reviewers from `security@chromium."
 "org` to work out the right way to become confident of the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:1
 msgid "Checking Crates into Chromium Source Code"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:3
 msgid "`git status` should reveal:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:5
 msgid "Crate code in `//third_party/rust/chromium_crates_io`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:6
 msgid ""
 "Metadata (`BUILD.gn` and `README.chromium`) in `//third_party/rust/<crate>/"
 "<version>`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:9
 msgid "Please also add an `OWNERS` file in the latter location."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:11
 msgid ""
 "You should land all this, along with your `Cargo.toml` and `gnrt_config."
 "toml` changes, into the Chromium repo."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:14
 msgid ""
 "**Important**: you need to use `git add -f` because otherwise `.gitignore` "
 "files may result in some files being skipped."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:17
 msgid ""
 "As you do so, you might find presubmit checks fail because of non-inclusive "
 "language. This is because Rust crate data tends to include names of git "
@@ -14718,7 +14645,7 @@ msgid ""
 "you may need to run:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/keeping-up-to-date.md
+#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:3
 msgid ""
 "As the OWNER of any third party Chromium dependency, you are [expected to "
 "keep it up to date with any security fixes](https://chromium.googlesource."
@@ -14727,7 +14654,7 @@ msgid ""
 "still your responsibility just as it is for any other third party dependency."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:3
 msgid ""
 "Add [uwuify](https://crates.io/crates/uwuify) to Chromium, turning off the "
 "crate's [default features](https://doc.rust-lang.org/cargo/reference/"
@@ -14735,7 +14662,7 @@ msgid ""
 "shipping Chromium, but won't be used to handle untrustworthy input."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:7
 msgid ""
 "(In the next exercise we'll use uwuify from Chromium, but feel free to skip "
 "ahead and do that now if you like. Or, you could create a new "
@@ -14743,128 +14670,128 @@ msgid ""
 "+/main:build/rust/rust_executable.gni) which uses `uwuify`)."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:13
 msgid "Students will need to download lots of transitive dependencies."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:15
 msgid "The total crates needed are:"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:17
 msgid "`instant`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:18
 msgid "`lock_api`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:19
 msgid "`parking_lot`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:20
 msgid "`parking_lot_core`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:21
 msgid "`redox_syscall`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:22
 msgid "`scopeguard`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:23
 msgid "`smallvec`, and"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:24
 msgid "`uwuify`."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:26
 msgid ""
 "If students are downloading even more than that, they probably forgot to "
 "turn off the default features."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:29
 msgid ""
 "Thanks to [Daniel Liu](https://github.com/Daniel-Liu-c0deb0t) for this crate!"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:1
 msgid "Bringing It Together --- Exercise"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:3
 msgid ""
 "In this exercise, you're going to add a whole new Chromium feature, bringing "
 "together everything you already learned."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:6
 msgid "The Brief from Product Management"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:8
 msgid ""
 "A community of pixies has been discovered living in a remote rainforest. "
 "It's important that we get Chromium for Pixies delivered to them as soon as "
 "possible."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:11
 msgid ""
 "The requirement is to translate all Chromium's UI strings into Pixie "
 "language."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:13
 msgid ""
 "There's not time to wait for proper translations, but fortunately pixie "
 "language is very close to English, and it turns out there's a Rust crate "
 "which does the translation."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:17
 msgid ""
 "In fact, you already [imported that crate in the previous exercise](https://"
 "crates.io/crates/uwuify)."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:19
 msgid ""
 "(Obviously, real translations of Chrome require incredible care and "
 "diligence. Don't ship this!)"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:22
 msgid "Steps"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:24
 msgid ""
 "Modify `ResourceBundle::MaybeMangleLocalizedString` so that it uwuifies all "
 "strings before display. In this special build of Chromium, it should always "
 "do this irrespective of the setting of `mangle_localized_strings_`."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:28
 msgid ""
 "If you've done everything right across all these exercises, congratulations, "
 "you should have created Chrome for pixies!"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:36
 msgid ""
 "UTF16 vs UTF8. Students should be aware that Rust strings are always UTF8, "
 "and will probably decide that it's better to do the conversion on the C++ "
 "side using `base::UTF16ToUTF8` and back again."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:39
 msgid ""
 "If students decide to do the conversion on the Rust side, they'll need to "
 "consider [`String::from_utf16`](https://doc.rust-lang.org/std/string/struct."
@@ -14873,7 +14800,7 @@ msgid ""
 "slice.html)."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:42
 msgid ""
 "Students may design the C++/Rust boundary in several different ways, e.g. "
 "taking and returning strings by value, or taking a mutable reference to a "
@@ -14884,30 +14811,30 @@ msgid ""
 "around like Rust data, because it may contain self-referential pointers."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:49
 msgid ""
 "The C++ target containing `ResourceBundle::MaybeMangleLocalizedString` will "
 "need to depend on a `rust_static_library` target. The student probably "
 "already did this."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md
+#: src/exercises/chromium/bringing-it-together.md:52
 msgid ""
 "The `rust_static_library` target will need to depend on `//third_party/rust/"
 "uwuify/v0_2:lib`."
 msgstr ""
 
-#: src/exercises/chromium/solutions.md
+#: src/exercises/chromium/solutions.md:3
 msgid ""
 "Solutions to the Chromium exercises can be found in [this series of CLs]"
 "(https://chromium-review.googlesource.com/c/chromium/src/+/5096560)."
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:1
 msgid "Welcome to Bare Metal Rust"
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
 "who are familiar with the basics of Rust (perhaps from completing the "
@@ -14915,29 +14842,29 @@ msgid ""
 "metal programming in some other language such as C."
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:8
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
 "underneath us. This will be divided into several parts:"
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:11
 msgid "What is `no_std` Rust?"
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:12
 msgid "Writing firmware for microcontrollers."
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:13
 msgid "Writing bootloader / kernel code for application processors."
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:14
 msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:16
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
 "(https://microbit.org/) v2 as an example. It's a [development board](https://"
@@ -14946,318 +14873,318 @@ msgid ""
 "an on-board SWD debugger."
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:22
 msgid ""
 "To get started, install some tools we'll need later. On gLinux or Debian:"
 msgstr ""
 
-#: src/bare-metal.md
+#: src/bare-metal.md:34
 msgid ""
 "And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
 
-#: src/bare-metal.md src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal.md:44 src/bare-metal/microcontrollers/debugging.md:33
 msgid "On MacOS:"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:17
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:24
 msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:25
 msgid "`NonZeroU8`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:26
 msgid "`Option`, `Result`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:27
 msgid "`Display`, `Debug`, `write!`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:29
 msgid "`panic!`, `assert_eq!`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:30
 msgid "`NonNull` and all the usual pointer-related functions"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:31
 msgid "`Future` and `async`/`await`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:32
 msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:33
 msgid "`Duration`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:38
 msgid "`Box`, `Cow`, `Arc`, `Rc`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:39
 msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:40
 msgid "`String`, `CString`, `format!`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:45
 msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:47
 msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:48
 msgid "`File` and the rest of `fs`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:49
 msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:50
 msgid "`Path`, `OsString`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:51
 msgid "`net`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:52
 msgid "`Command`, `Child`, `ExitCode`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:53
 msgid "`spawn`, `sleep` and the rest of `thread`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:54
 msgid "`SystemTime`, `Instant`"
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:62
 msgid "`HashMap` depends on RNG."
 msgstr ""
 
-#: src/bare-metal/no_std.md
+#: src/bare-metal/no_std.md:63
 msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:1
 msgid "A minimal `no_std` program"
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:19
 msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:20
 msgid "`std` provides a panic handler; without it we must provide our own."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:21
 msgid "It can also be provided by another crate, such as `panic-halt`."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:22
 msgid ""
 "Depending on the target, you may need to compile with `panic = \"abort\"` to "
 "avoid an error about `eh_personality`."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:24
 msgid ""
 "Note that there is no `main` or any other entry point; it's up to you to "
 "define your own entry point. This will typically involve a linker script and "
 "some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:3
 msgid ""
 "To use `alloc` you must implement a [global (heap) allocator](https://doc."
 "rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
-#: src/bare-metal/alloc.md
-msgid ""
-"// Safe because `HEAP` is only used here and `entry` is only called once.\n"
+#: src/bare-metal/alloc.md:23
+msgid "// SAFETY: `HEAP` is only used here and `entry` is only called once.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:25
 msgid "// Give the allocator some memory to allocate.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:29
 msgid "// Now we can do things that require heap allocation.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:31
 msgid "\"A string\""
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:37
 msgid ""
 "`buddy_system_allocator` is a third-party crate implementing a basic buddy "
 "system allocator. Other crates are available, or you can write your own or "
 "hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:40
 msgid ""
 "The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
 "in this case it can allocate regions of up to 2\\*\\*32 bytes."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:42
 msgid ""
 "If any crate in your dependency tree depends on `alloc` then you must have "
 "exactly one global allocator defined in your binary. Usually this is done in "
 "the top-level binary crate."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:45
 msgid ""
 "`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
 "crate is linked in so we get its panic handler."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:47
 msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md
+#: src/bare-metal/microcontrollers.md:3
 msgid ""
 "The `cortex_m_rt` crate provides (among other things) a reset handler for "
 "Cortex M microcontrollers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md
+#: src/bare-metal/microcontrollers.md:24
 msgid ""
 "Next we'll look at how to access peripherals, with increasing levels of "
 "abstraction."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md
+#: src/bare-metal/microcontrollers.md:29
 msgid ""
 "The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
 "> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md
+#: src/bare-metal/microcontrollers.md:31
 msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
 "turning on an LED on our micro:bit:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:16
 msgid "/// GPIO port 0 peripheral address\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:19
 msgid "// GPIO peripheral offsets\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:24
 msgid "// PIN_CNF fields\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-#: src/bare-metal/microcontrollers/pacs.md
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/mmio.md:34
+#: src/bare-metal/microcontrollers/pacs.md:21
+#: src/bare-metal/microcontrollers/hals.md:26
 msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:37
+#: src/bare-metal/microcontrollers/mmio.md:59
 msgid ""
-"// Safe because the pointers are to valid peripheral control registers, and\n"
-"    // no aliases exist.\n"
+"// SAFETY: The pointers are to valid peripheral control registers, and no\n"
+"    // aliases exist.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-#: src/bare-metal/microcontrollers/pacs.md
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/mmio.md:56
+#: src/bare-metal/microcontrollers/pacs.md:39
+#: src/bare-metal/microcontrollers/hals.md:30
 msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:72
 msgid ""
 "GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
 "to the first row."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-#: src/bare-metal/microcontrollers/pacs.md
-#: src/bare-metal/microcontrollers/hals.md
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/mmio.md:75
+#: src/bare-metal/microcontrollers/pacs.md:61
+#: src/bare-metal/microcontrollers/hals.md:44
+#: src/bare-metal/microcontrollers/board-support.md:37
 msgid "Run the example with:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:1
 msgid "Peripheral Access Crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
 "wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
 "pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
 "SVD (System View Description) files are XML files typically provided by "
 "silicon vendors which describe the memory map of the device."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:51
 msgid ""
 "They are organised by peripheral, register, field and value, with names, "
 "descriptions, addresses and so on."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:53
 msgid ""
 "SVD files are often buggy and incomplete, so there are various projects "
 "which patch the mistakes, add missing details, and publish the generated "
 "crates."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:56
 msgid "`cortex-m-rt` provides the vector table, among other things."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:57
 msgid ""
 "If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
 "pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:1
 msgid "HAL crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
 "implementation-crates) for many microcontrollers provide wrappers around "
@@ -15265,72 +15192,72 @@ msgid ""
 "(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:23
 msgid "// Create HAL wrapper for GPIO port 0.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:40
 msgid ""
 "`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:41
 msgid ""
 "HAL crates exist for many Cortex-M and RISC-V devices, including various "
 "STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:1
 msgid "Board support crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:3
 msgid ""
 "Board support crates provide a further level of wrapping for a specific "
 "board for convenience."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:31
 msgid ""
 "In this case the board support crate is just providing more useful names, "
 "and a bit of initialisation."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:33
 msgid ""
 "The crate may also include drivers for some on-board devices outside of the "
 "microcontroller itself."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:35
 msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:1
 msgid "The type state pattern"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:11
 msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:19
 msgid "// pin_input.is_high(); // Error, moved.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:33
 msgid ""
 "Pins don't implement `Copy` or `Clone`, so only one instance of each can "
 "exist. Once a pin is moved out of the port struct nobody else can take it."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:35
 msgid ""
 "Changing the configuration of a pin consumes the old pin instance, so you "
 "can’t keep use the old instance afterwards."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:37
 msgid ""
 "The type of a value indicates the state that it is in: e.g. in this case, "
 "the configuration state of a GPIO pin. This encodes the state machine into "
@@ -15339,92 +15266,106 @@ msgid ""
 "caught at compile time."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:42
 msgid ""
 "You can call `is_high` on an input pin and `set_high` on an output pin, but "
 "not vice-versa."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:44
 msgid "Many HAL crates follow this pattern."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:6
 msgid "GPIO"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "ADC"
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "PWM"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "I2C, SPI, UART, CAN"
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "Delay timers"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "RNG"
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "I2C and SPI buses and devices"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "Timers"
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid ""
+"Similar traits for byte streams (e.g. UARTs), CAN buses and RNGs and broken "
+"out into [`embedded-io`](https://crates.io/crates/embedded-io), [`embedded-"
+"can`](https://crates.io/crates/embedded-can) and [`rand_core`](https://"
+"crates.io/crates/rand_core) respectively."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "Watchdogs"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:14
 msgid ""
 "Other crates then implement [drivers](https://github.com/rust-embedded/"
 "awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
-"accelerometer driver might need an I2C or SPI bus implementation."
+"accelerometer driver might need an I2C or SPI device instance."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:19
+msgid ""
+"The traits cover using the peripherals but not initialising or configuring "
+"them, as initialisation and configuration is usually highly platform-"
+"specific."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
 msgid ""
 "There are implementations for many microcontrollers, as well as other "
 "platforms such as Linux on Raspberry Pi."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:23
 msgid ""
-"There is work in progress on an `async` version of `embedded-hal`, but it "
-"isn't stable yet."
+"[`embedded-hal-async`](https://crates.io/crates/embedded-hal-async) provides "
+"async versions of the traits."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:24
+msgid ""
+"[`embedded-hal-nb`](https://crates.io/crates/embedded-hal-nb) provides "
+"another approach to non-blocking I/O, based on the [`nb`](https://crates.io/"
+"crates/nb) crate."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
 "like OpenOCD but better integrated."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:6
 msgid ""
 "SWD (Serial Wire Debug) and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:7
 msgid "GDB stub and Microsoft DAP (Debug Adapter Protocol) server"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:8
 msgid "Cargo integration"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:10
 msgid ""
 "`cargo-embed` is a cargo subcommand to build and flash binaries, log RTT "
 "(Real Time Transfers) output and connect GDB. It's configured by an `Embed."
 "toml` file in your project directory."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
 "[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
 "an Arm standard protocol over USB for an in-circuit debugger to access the "
@@ -15432,170 +15373,170 @@ msgid ""
 "on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:20
 msgid ""
 "ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
 "is a range from SEGGER."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:22
 msgid ""
 "The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
 "Serial Wire Debug."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:24
 msgid ""
 "probe-rs is a library which you can integrate into your own tools if you "
 "want to."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:26
 msgid ""
 "The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
 "adapter-protocol/) lets VSCode and other IDEs debug code running on any "
 "supported microcontroller."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:30
 msgid "cargo-embed is a binary built using the probe-rs library."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:31
 msgid ""
 "RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
 "host and the target through a number of ringbuffers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:3
 msgid "_Embed.toml_:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:15
 msgid "In one terminal under `src/bare-metal/microcontrollers/examples/`:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:23
 msgid "In another terminal in the same directory:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:25
 msgid "On gLinux or Debian:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:43
 msgid "In GDB, try running:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:1
+#: src/bare-metal/aps/other-projects.md:1
 msgid "Other projects"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:3
 msgid "[RTIC](https://rtic.rs/)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:4
 msgid "\"Real-Time Interrupt-driven Concurrency\""
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
 "Shared resource management, message passing, task scheduling, timer queue"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:6
 msgid "[Embassy](https://embassy.dev/)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:7
 msgid "`async` executors with priorities, timers, networking, USB"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:8
 msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:9
 msgid ""
 "Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
 "support"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:11
 msgid "[Hubris](https://hubris.oxide.computer/)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:12
 msgid ""
 "Microkernel RTOS from Oxide Computer Company with memory protection, "
 "unprivileged drivers, IPC"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:14
 msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:15
 msgid ""
 "Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
 "github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid "RTIC can be considered either an RTOS or a concurrency framework."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:21
 msgid "It doesn't include any HALs."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:22
 msgid ""
 "It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
 "scheduling rather than a proper kernel."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:24
 msgid "Cortex-M only."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:25
 msgid ""
 "Google uses TockOS on the Haven microcontroller for Titan security keys."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:26
 msgid ""
 "FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
 
-#: src/exercises/bare-metal/morning.md
+#: src/exercises/bare-metal/morning.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/morning.md src/exercises/concurrency/morning.md
+#: src/exercises/bare-metal/morning.md:8
 msgid ""
 "After looking at the exercises, you can look at the [solutions](solutions-"
 "morning.md) provided."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
 "serial port. If you have time, try displaying it on the LEDs somehow too, or "
 "use the buttons somehow."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:7
 msgid "Hints:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:9
 msgid ""
 "Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
 "latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
@@ -15603,123 +15544,123 @@ msgid ""
 "org/hardware/)."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:13
 msgid ""
 "The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:14
 msgid ""
 "TWI is another name for I2C, so the I2C master peripheral is called TWIM."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:15
 msgid ""
 "The LSM303AGR driver needs something implementing the `embedded_hal::"
 "blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
 "microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:19
 msgid ""
 "You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
 "struct.Board.html) struct with fields for the various pins and peripherals."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:22
 msgid ""
 "You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
 "com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
 "this exercise."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:26
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
 "look in the `compass` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/compass.md:29 src/exercises/bare-metal/rtc.md:22
 msgid "_src/main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/compass.md:71 src/exercises/bare-metal/rtc.md:393
 msgid "_Cargo.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:93
 msgid "_Embed.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/compass.md:109 src/exercises/bare-metal/rtc.md:1000
 msgid "_.cargo/config.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:122
 msgid "See the serial output on Linux with:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:130
 msgid ""
 "Or on Mac OS something like (the device name may be slightly different):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:138
 msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:1
 msgid "Bare Metal Rust Morning Exercise"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:5
 msgid "([back to exercise](compass.md))"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:34
 msgid "// Configure serial port.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:42
 msgid "// Use the system timer as a delay provider.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:45
 msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:46
 msgid "\"Setting up IMU...\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:64
 msgid "// Set up display and timer.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:71
 msgid "\"Ready.\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:74
 msgid "// Read compass data and log it to the serial port.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:82
 msgid "\"{},{},{}\\t{},{},{}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:120
 msgid ""
 "// If button A is pressed, switch to the next mode and briefly blink all "
 "LEDs\n"
 "        // on.\n"
 msgstr ""
 
-#: src/bare-metal/aps.md
+#: src/bare-metal/aps.md:1
 msgid "Application processors"
 msgstr ""
 
-#: src/bare-metal/aps.md
+#: src/bare-metal/aps.md:3
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
 "Now let's try writing something for Cortex-A. For simplicity we'll just work "
@@ -15727,26 +15668,26 @@ msgid ""
 "virt.html) board."
 msgstr ""
 
-#: src/bare-metal/aps.md
+#: src/bare-metal/aps.md:10
 msgid ""
 "Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
 "privilege (exception levels on Arm CPUs, rings on x86), while application "
 "processors do."
 msgstr ""
 
-#: src/bare-metal/aps.md
+#: src/bare-metal/aps.md:13
 msgid ""
 "QEMU supports emulating various different machines or board models for each "
 "architecture. The 'virt' board doesn't correspond to any particular real "
 "hardware, but is designed purely for virtual machines."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:3
 msgid ""
 "Before we can start running Rust code, we need to do some initialisation."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:5
 msgid ""
 "```armasm\n"
 ".section .init.entry, \"ax\"\n"
@@ -15822,13 +15763,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:77
 msgid ""
 "This is the same as it would be for C: initialising the processor state, "
 "zeroing the BSS, and setting up the stack pointer."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:79
 msgid ""
 "The BSS (block starting symbol, for historical reasons) is the part of the "
 "object file which containing statically allocated variables which are "
@@ -15837,19 +15778,19 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:84
 msgid ""
 "The BSS may already be zeroed, depending on how memory is initialised and "
 "the image is loaded, but we zero it to be sure."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:86
 msgid ""
 "We need to enable the MMU and cache before reading or writing any memory. If "
 "we don't:"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:88
 msgid ""
 "Unaligned accesses will fault. We build the Rust code for the `aarch64-"
 "unknown-none` target which sets `+strict-align` to prevent the compiler "
@@ -15857,7 +15798,7 @@ msgid ""
 "is not necessarily the case in general."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:92
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -15868,7 +15809,7 @@ msgid ""
 "not VA or IPA.)"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:99
 msgid ""
 "For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
 "identity maps the first 1 GiB of address space for devices, the next 1 GiB "
@@ -15876,86 +15817,86 @@ msgid ""
 "memory layout that QEMU uses."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:103
 msgid ""
 "We also set up the exception vector (`vbar_el1`), which we'll see more about "
 "later."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:105
 msgid ""
 "All examples this afternoon assume we will be running at exception level 1 "
 "(EL1). If you need to run at a different exception level you'll need to "
 "modify `entry.S` accordingly."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:1
 msgid "Inline assembly"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
 "Rust code. For example, to make an HVC (hypervisor call) to tell the "
 "firmware to power off the system:"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:20
 msgid ""
-"// Safe because this only uses the declared registers and doesn't do\n"
-"    // anything with memory.\n"
+"// SAFETY: this only uses the declared registers and doesn't do anything\n"
+"    // with memory.\n"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:23
 msgid "\"hvc #0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:24
 msgid "\"w0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:25
 msgid "\"w1\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:26
 msgid "\"w2\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:27
 msgid "\"w3\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:28
 msgid "\"w4\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:29
 msgid "\"w5\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:30
 msgid "\"w6\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:31
 msgid "\"w7\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:40
 msgid ""
 "(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
 "smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:45
 msgid ""
 "PSCI is the Arm Power State Coordination Interface, a standard set of "
 "functions to manage system and CPU power states, among other things. It is "
 "implemented by EL3 firmware and hypervisors on many systems."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:48
 msgid ""
 "The `0 => _` syntax means initialise the register to 0 before running the "
 "inline assembly code, and ignore its contents afterwards. We need to use "
@@ -15963,13 +15904,13 @@ msgid ""
 "contents of the registers."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:52
 msgid ""
 "This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
 "it is called from our entry point in `entry.S`."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:54
 msgid ""
 "`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
 "used by the bootloader to pass things like a pointer to the device tree. "
@@ -15979,71 +15920,71 @@ msgid ""
 "special except make sure it doesn't change these registers."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:60
 msgid ""
 "Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:1
 msgid "Volatile memory access for MMIO"
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:3
 msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:4
 msgid "Never hold a reference."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
 "`addr_of!` lets you get fields of structs without creating an intermediate "
 "reference."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:10
 msgid ""
 "Volatile access: read or write operations may have side-effects, so prevent "
 "the compiler or hardware from reordering, duplicating or eliding them."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:12
 msgid ""
 "Usually if you write and then read, e.g. via a mutable reference, the "
 "compiler may assume that the value read is the same as the value just "
 "written, and not bother actually reading memory."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:15
 msgid ""
 "Some existing crates for volatile access to hardware do hold references, but "
 "this is unsound. Whenever a reference exist, the compiler may choose to "
 "dereference it."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:18
 msgid ""
 "Use the `addr_of!` macro to get struct field pointers from a pointer to the "
 "struct."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:1
 msgid "Let's write a UART driver"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:3
 msgid ""
 "The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
 "documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:9
 msgid "/// Minimal driver for a PL011 UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/uart.md:17 src/bare-metal/aps/better-uart/driver.md:13
 msgid ""
 "/// Constructs a new instance of the UART driver for a PL011 device at the\n"
 "    /// given base address.\n"
@@ -16057,29 +15998,29 @@ msgid ""
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:25
 msgid "/// Writes a single byte to the UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:27
 msgid "// Wait until there is room in the TX buffer.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:34 src/bare-metal/aps/uart.md:46
 msgid ""
-"// Safe because we know that the base address points to the control\n"
+"// SAFETY: We know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:33
 msgid "// Write to the TX buffer.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:37
 msgid "// Wait until the UART is no longer busy.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:55
 msgid ""
 "Note that `Uart::new` is unsafe while the other methods are safe. This is "
 "because as long as the caller of `Uart::new` guarantees that its safety "
@@ -16089,54 +16030,53 @@ msgid ""
 "necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:61
 msgid ""
 "We could have done it the other way around (making `new` safe but "
 "`write_byte` unsafe), but that would be much less convenient to use as every "
 "place that calls `write_byte` would need to reason about the safety"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:64
 msgid ""
 "This is a common pattern for writing safe wrappers of unsafe code: moving "
 "the burden of proof for soundness from a large number of places to a smaller "
 "number of places."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:1
 msgid "More traits"
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:3
 msgid ""
 "We derived the `Debug` trait. It would be useful to implement a few more "
 "traits too."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/bare-metal/aps/uart/traits.md:17
 msgid ""
-"// Safe because it just contains a pointer to device memory, which can be\n"
+"// SAFETY: `Uart` just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:25
 msgid ""
 "Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
 "`Uart` type."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:27
 msgid ""
 "Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:1
 msgid "A better UART driver"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:3
 msgid ""
 "The PL011 actually has [a bunch more registers](https://developer.arm.com/"
 "documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
@@ -16145,212 +16085,213 @@ msgid ""
 "structured way."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:7
 msgid "Offset"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:7
 msgid "Register name"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:7
 msgid "Width"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:9
 msgid "0x00"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:9
 msgid "DR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:9
 msgid "12"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:10
 msgid "0x04"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:10
 msgid "RSR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:11
 msgid "0x18"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:11
 msgid "FR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:11
 msgid "9"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:12
 msgid "0x20"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:12
 msgid "ILPR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:13
 msgid "0x24"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:13
 msgid "IBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
 msgid "16"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:14
 msgid "0x28"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:14
 msgid "FBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:15
 msgid "0x2c"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:15
 msgid "LCR_H"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:16
 msgid "0x30"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:16
 msgid "CR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:17
 msgid "0x34"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:17
 msgid "IFLS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:18
 msgid "0x38"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:18
 msgid "IMSC"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
 msgid "11"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:19
 msgid "0x3c"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:19
 msgid "RIS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:20
 msgid "0x40"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:20
 msgid "MIS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:21
 msgid "0x44"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:21
 msgid "ICR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:22
 msgid "0x48"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:22
 msgid "DMACR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:26
 msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:3
 msgid ""
 "The [`bitflags`](https://crates.io/crates/bitflags) crate is useful for "
 "working with bitflags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:10
 msgid "/// Flags from the UART flag register.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:14
 msgid "/// Clear to send.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:16
 msgid "/// Data set ready.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:18
 msgid "/// Data carrier detect.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:20
 msgid "/// UART busy transmitting data.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:22
 msgid "/// Receive FIFO is empty.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:24
 msgid "/// Transmit FIFO is full.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:26
 msgid "/// Receive FIFO is full.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:28
 msgid "/// Transmit FIFO is empty.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:30
 msgid "/// Ring indicator.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:38
 msgid ""
 "The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
 "with a bunch of method implementations to get and set flags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md
+#: src/bare-metal/aps/better-uart/registers.md:1
 msgid "Multiple registers"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md
+#: src/bare-metal/aps/better-uart/registers.md:3
 msgid ""
 "We can use a struct to represent the memory layout of the UART's registers."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md
+#: src/bare-metal/aps/better-uart/registers.md:43
 msgid ""
 "[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
 "representation) tells the compiler to lay the struct fields out in order, "
@@ -16359,131 +16300,143 @@ msgid ""
 "(among other things) reorder fields however it sees fit."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:3
 msgid "Now let's use the new `Registers` struct in our driver."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:6
 msgid "/// Driver for a PL011 UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:30
+#: src/bare-metal/aps/better-uart/driver.md:56
 msgid ""
-"// Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
+"// SAFETY: We know that self.registers points to the control registers\n"
+"        // of a PL011 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:41
 msgid ""
 "/// Reads and returns a pending byte, or `None` if nothing has been\n"
 "    /// received.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:47
+msgid ""
+"// SAFETY: We know that self.registers points to the control\n"
+"            // registers of a PL011 device which is appropriately mapped.\n"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:50
 msgid "// TODO: Check for error conditions in bits 8-11.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:65
 msgid ""
 "Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
 "fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/better-uart/using.md:1
+#: src/bare-metal/aps/logging/using.md:1
 msgid "Using it"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
 "and echo incoming bytes."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/bare-metal/aps/better-uart/using.md:19
+#: src/bare-metal/aps/logging/using.md:18
+#: src/exercises/bare-metal/solutions-afternoon.md:33
 msgid "/// Base address of the primary PL011 UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/bare-metal/aps/better-uart/using.md:25
+#: src/bare-metal/aps/logging/using.md:24
+#: src/exercises/bare-metal/solutions-afternoon.md:44
 msgid ""
-"// Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
-"    // and nothing else accesses that address range.\n"
+"// SAFETY: `PL011_BASE_ADDRESS` is the base address of a PL011 device, and\n"
+"    // nothing else accesses that address range.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/better-uart/using.md:29
+#: src/bare-metal/aps/logging/using.md:29
 msgid "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:35
 msgid "b'\\r'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/async/pitfalls/cancellation.md
+#: src/bare-metal/aps/better-uart/using.md:36
+#: src/concurrency/async-pitfalls/cancellation.md:27
 msgid "b'\\n'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:38
 msgid "b'q'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:44
 msgid "\"Bye!\""
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:51
 msgid ""
 "As in the [inline assembly](../inline-assembly.md) example, this `main` "
 "function is called from our entry point code in `entry.S`. See the speaker "
 "notes there for details."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:54
 msgid ""
 "Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md
+#: src/bare-metal/aps/logging.md:3
 msgid ""
 "It would be nice to be able to use the logging macros from the [`log`]"
 "(https://crates.io/crates/log) crate. We can do this by implementing the "
 "`Log` trait."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md
+#: src/bare-metal/aps/logging.md:26
 msgid "\"[{}] {}\""
 msgstr ""
 
-#: src/bare-metal/aps/logging.md
+#: src/bare-metal/aps/logging.md:35
 msgid "/// Initialises UART logger.\n"
 msgstr ""
 
-#: src/bare-metal/aps/logging.md
+#: src/bare-metal/aps/logging.md:48
 msgid ""
 "The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/logging/using.md:3
 msgid "We need to initialise the logger before we use it."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/bare-metal/aps/logging/using.md:38
+#: src/exercises/bare-metal/solutions-afternoon.md:115
 msgid "\"{info}\""
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/logging/using.md:46
 msgid "Note that our panic handler can now log details of panics."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/logging/using.md:47
 msgid ""
 "Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:3
 msgid ""
 "AArch64 defines an exception vector table with 16 entries, for 4 types of "
 "exceptions (synchronous, IRQ, FIQ, SError) from 4 states (current EL with "
@@ -16492,23 +16445,23 @@ msgid ""
 "calling into Rust code:"
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:67
 msgid "EL is exception level; all our examples this afternoon run in EL1."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:68
 msgid ""
 "For simplicity we aren't distinguishing between SP0 and SPx for the current "
 "EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:70
 msgid ""
 "For this example we just log the exception and power down, as we don't "
 "expect any of them to actually happen."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:72
 msgid ""
 "We can think of exception handlers and our main execution context more or "
 "less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
@@ -16518,55 +16471,55 @@ msgid ""
 "it in something like a `Mutex` and put it in a static."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:3
 msgid "[oreboot](https://github.com/oreboot/oreboot)"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:4
 msgid "\"coreboot without the C\""
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:5
 msgid "Supports x86, aarch64 and RISC-V."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:6
 msgid "Relies on LinuxBoot rather than having many drivers itself."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:7
 msgid ""
 "[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
 "raspberrypi-OS-tutorials)"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:8
 msgid ""
 "Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
 "exception handling, page tables"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:10
 msgid ""
 "Some dodginess around cache maintenance and initialisation in Rust, not "
 "necessarily a good example to copy for production code."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:12
 msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:13
 msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:17
 msgid ""
 "The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
 "enabled. This will read and write memory (e.g. the stack). However:"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:19
 msgid ""
 "Without the MMU and cache, unaligned accesses will fault. It builds with "
 "`aarch64-unknown-none` which sets `+strict-align` to prevent the compiler "
@@ -16574,7 +16527,7 @@ msgid ""
 "necessarily the case in general."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:23
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -16585,94 +16538,94 @@ msgid ""
 "hypervisor), but isn't a good pattern in general."
 msgstr ""
 
-#: src/bare-metal/useful-crates.md
+#: src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md
+#: src/bare-metal/useful-crates.md:3
 msgid ""
 "We'll go over a few crates which solve some common problems in bare-metal "
 "programming."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
 "The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
 "traits and macros for safely converting between byte sequences and other "
 "types."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:42
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
 "but can be useful for working with structures shared with hardware e.g. by "
 "DMA, or sent over some external interface."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:48
 msgid ""
 "`FromBytes` can be implemented for types for which any byte pattern is "
 "valid, and so can safely be converted from an untrusted sequence of bytes."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:50
 msgid ""
 "Attempting to derive `FromBytes` for these types would fail, because "
 "`RequestType` doesn't use all possible u32 values as discriminants, so not "
 "all byte patterns are valid."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:53
 msgid ""
 "`zerocopy::byteorder` has types for byte-order aware numeric primitives."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:54
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "zerocopy-example/`. (It won't run in the Playground because of the crate "
 "dependency.)"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
 "The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
 "you create page tables according to the AArch64 Virtual Memory System "
 "Architecture."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:14
 msgid "// Create a new page table with identity mapping.\n"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:16
 msgid "// Map a 2 MiB region of memory as read-only.\n"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:21
 msgid "// Set `TTBR0_EL1` to activate the page table.\n"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
 "For now it only supports EL1, but support for other exception levels should "
 "be straightforward to add."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
 msgid ""
 "This is used in Android for the [Protected VM Firmware](https://cs.android."
 "com/android/platform/superproject/+/master:packages/modules/Virtualization/"
 "pvmfw/)."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
 msgid ""
 "There's no easy way to run this example, as it needs to run on real hardware "
 "or under QEMU."
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
 "[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
 "is a third-party crate implementing a basic buddy system allocator. It can "
@@ -16684,18 +16637,18 @@ msgid ""
 "space for PCI BARs:"
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:29
 msgid "PCI BARs always have alignment equal to their size."
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "allocator-example/`. (It won't run in the Playground because of the crate "
 "dependency.)"
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md
+#: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
 "heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
@@ -16704,53 +16657,53 @@ msgid ""
 "and panics if you try to use more than are allocated."
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md
+#: src/bare-metal/useful-crates/tinyvec.md:25
 msgid ""
 "`tinyvec` requires that the element type implement `Default` for "
 "initialisation."
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md
+#: src/bare-metal/useful-crates/tinyvec.md:27
 msgid ""
 "The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
 "are not available in `core` or `alloc`. How can we manage synchronisation or "
 "interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:7
 msgid ""
 "The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
 "equivalents of many of these primitives."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:26
 msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:27
 msgid ""
 "`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
 "`Barrier` and `Once` from `std::sync`; and `Lazy` for lazy initialisation."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:29
 msgid ""
 "The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
 "useful types for late initialisation with a slightly different approach to "
 "`spin::once::Once`."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:31
 msgid ""
 "The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
 
-#: src/bare-metal/android.md
+#: src/bare-metal/android.md:3
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
 "`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
@@ -16758,11 +16711,11 @@ msgid ""
 "to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:3
 msgid ""
 "For VMs running under crosvm on aarch64, the [vmbase](https://android."
 "googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
@@ -16770,224 +16723,229 @@ msgid ""
 "build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:24
 msgid ""
 "The `main!` macro marks your main function, to be called from the `vmbase` "
 "entry point."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:26
 msgid ""
 "The `vmbase` entry point handles console initialisation, and issues a "
 "PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
-#: src/exercises/bare-metal/afternoon.md
+#: src/exercises/bare-metal/afternoon.md:3
 msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
-#: src/exercises/bare-metal/afternoon.md src/exercises/concurrency/afternoon.md
+#: src/exercises/bare-metal/afternoon.md:7
 msgid ""
 "After looking at the exercises, you can look at the [solutions](solutions-"
 "afternoon.md) provided."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/rtc.md:1
+#: src/exercises/bare-metal/solutions-afternoon.md:3
 msgid "RTC driver"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:3
 msgid ""
 "The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
 "documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
 "you should write a driver for it."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:6
 msgid ""
 "Use it to print the current time to the serial console. You can use the "
 "[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:8
 msgid ""
 "Use the match register and raw interrupt status to busy-wait until a given "
 "time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
 "doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:11
 msgid ""
 "_Extension if you have time:_ Enable and handle the interrupt generated by "
 "the RTC match. You can use the driver provided in the [`arm-gic`](https://"
 "docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:14
 msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:15
 msgid ""
 "Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
 "wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:19
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
 "look in the `rtc` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:79
 msgid ""
 "_src/exceptions.rs_ (you should only need to change this for the 3rd part of "
 "the exercise):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:156
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:216
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:419
 msgid "_build.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:456
 msgid "_entry.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:606
 msgid "_exceptions.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:792
 msgid "_idmap.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:842
 msgid "_image.ld_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:954
 msgid "_Makefile_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:1011
 msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:5
 msgid "([back to exercise](rtc.md))"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:7
 msgid "_main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:29
 msgid "/// Base addresses of the GICv3.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:36
 msgid "/// Base address of the PL031 RTC.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:38
 msgid "/// The IRQ used by the PL031 RTC.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:49
 msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:51
 msgid ""
-"// Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
+"// SAFETY: `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:57
 msgid ""
-"// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
-"    // and nothing else accesses that address range.\n"
+"// SAFETY: `PL031_BASE_ADDRESS` is the base address of a PL031 device, and\n"
+"    // nothing else accesses that address range.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:62
 msgid "\"RTC: {time}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:70
 msgid "// Wait for 3 seconds, without interrupts.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:73
+#: src/exercises/bare-metal/solutions-afternoon.md:91
 msgid "\"Waiting for {}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:75
+#: src/exercises/bare-metal/solutions-afternoon.md:83
+#: src/exercises/bare-metal/solutions-afternoon.md:96
+#: src/exercises/bare-metal/solutions-afternoon.md:104
 msgid "\"matched={}, interrupt_pending={}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:87
+#: src/exercises/bare-metal/solutions-afternoon.md:108
 msgid "\"Finished waiting\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:89
 msgid "// Wait another 3 seconds for an interrupt.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:121
 msgid "_pl031.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:128
 msgid "/// Data register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:130
 msgid "/// Match register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:132
 msgid "/// Load register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:134
 msgid "/// Control register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:137
 msgid "/// Interrupt Mask Set or Clear register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:140
 msgid "/// Raw Interrupt Status\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:143
 msgid "/// Masked Interrupt Status\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:146
 msgid "/// Interrupt Clear Register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:150
 msgid "/// Driver for a PL031 real-time clock.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:158
 msgid ""
 "/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
 "    /// given base address.\n"
@@ -17001,30 +16959,35 @@ msgid ""
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:170
 msgid "/// Reads the current RTC value.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:172
+#: src/exercises/bare-metal/solutions-afternoon.md:180
+#: src/exercises/bare-metal/solutions-afternoon.md:188
+#: src/exercises/bare-metal/solutions-afternoon.md:199
+#: src/exercises/bare-metal/solutions-afternoon.md:211
+#: src/exercises/bare-metal/solutions-afternoon.md:218
 msgid ""
-"// Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
+"// SAFETY: We know that self.registers points to the control registers\n"
+"        // of a PL031 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:177
 msgid ""
 "/// Writes a match value. When the RTC value matches this then an interrupt\n"
 "    /// will be generated (if it is enabled).\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:185
 msgid ""
 "/// Returns whether the match register matches the RTC value, whether or "
 "not\n"
 "    /// the interrupt is enabled.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:194
 msgid ""
 "/// Returns whether there is currently an interrupt pending.\n"
 "    ///\n"
@@ -17032,7 +16995,7 @@ msgid ""
 "    /// interrupt is masked.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:205
 msgid ""
 "/// Sets or clears the interrupt mask.\n"
 "    ///\n"
@@ -17041,358 +17004,395 @@ msgid ""
 "    /// interrupt is disabled.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:216
 msgid "/// Clears a pending interrupt, if any.\n"
 msgstr ""
 
-#: src/concurrency.md
+#: src/exercises/bare-metal/solutions-afternoon.md:223
+msgid ""
+"// SAFETY: `Rtc` just contains a pointer to device memory, which can be\n"
+"// accessed from any context.\n"
+msgstr ""
+
+#: src/concurrency/welcome.md:1
 msgid "Welcome to Concurrency in Rust"
 msgstr ""
 
-#: src/concurrency.md
+#: src/concurrency/welcome.md:3
 msgid ""
 "Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 
-#: src/concurrency.md
+#: src/concurrency/welcome.md:6
 msgid ""
 "The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
 "you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 
-#: src/concurrency.md
+#: src/concurrency/welcome.md:12 src/concurrency/welcome-async.md:29
+msgid ""
+"Including 10 minute breaks, this session should take about 3 hours and 20 "
+"minutes. It contains:"
+msgstr ""
+"Buổi học nên kéo dài khoảng 3 tiếng và 20 phút, bao gồm thời gian 10 phút "
+"nghỉ trưa. Nội dung buổi học bao gồm:"
+
+#: src/concurrency/welcome.md:25
 msgid ""
 "Rust lets us access OS concurrency toolkit: threads, sync. primitives, etc."
 msgstr ""
 
-#: src/concurrency.md
+#: src/concurrency/welcome.md:26
 msgid ""
 "The type system gives us safety for concurrency without any special features."
 msgstr ""
 
-#: src/concurrency.md
+#: src/concurrency/welcome.md:27
 msgid ""
 "The same tools that help with \"concurrent\" access in a single thread (e."
 "g., a called function that might mutate an argument or save references to it "
 "to read later) save us from multi-threading issues."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads.md:3 src/concurrency/shared-state.md:3
+#: src/concurrency/async.md:3
+msgid "This segment should take about 30 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 30 phút, bao gồm:"
+
+#: src/concurrency/threads/plain.md:3
 msgid "Rust threads work similarly to threads in other languages:"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:12
 msgid "\"Count in thread: {i}!\""
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:18
 msgid "\"Main thread: {i}\""
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:24
 msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:25
 msgid "Thread panics are independent of each other."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:26
 msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:31
 msgid "Rust thread APIs look not too different from e.g. C++ ones."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:33
 msgid "Run the example."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:34
 msgid ""
 "5ms timing is loose enough that main and spawned threads stay mostly in "
 "lockstep."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:36
 msgid "Notice that the program ends before the spawned thread reaches 10!"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:37
 msgid ""
 "This is because main ends the program and spawned threads do not make it "
 "persist."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:39
 msgid "Compare to pthreads/C++ std::thread/boost::thread if desired."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:41
 msgid "How do we wait around for the spawned thread to complete?"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:42
 msgid ""
 "[`thread::spawn`](https://doc.rust-lang.org/std/thread/fn.spawn.html) "
 "returns a `JoinHandle`. Look at the docs."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:43
 msgid ""
 "`JoinHandle` has a [`.join()`](https://doc.rust-lang.org/std/thread/struct."
 "JoinHandle.html#method.join) method that blocks."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:45
 msgid ""
 "Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
 "the thread to finish and have the program count all the way to 10."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:48
 msgid "Now what if we want to return a value?"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:49
 msgid "Look at docs again:"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:50
 msgid ""
 "[`thread::spawn`](https://doc.rust-lang.org/std/thread/fn.spawn.html)'s "
 "closure returns `T`"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:51
 msgid ""
 "`JoinHandle` [`.join()`](https://doc.rust-lang.org/std/thread/struct."
 "JoinHandle.html#method.join) returns `thread::Result<T>`"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:53
 msgid ""
 "Use the `Result` return value from `handle.join()` to get access to the "
 "returned value."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:56
 msgid "Ok, what about the other case?"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:57
 msgid "Trigger a panic in the thread. Note that this doesn't panic `main`."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:58
 msgid ""
 "Access the panic payload. This is a good time to talk about [`Any`](https://"
 "doc.rust-lang.org/std/any/index.html)."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:60
 msgid "Now we can return values from threads! What about taking inputs?"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:61
 msgid "Capture something by reference in the thread closure."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:62
 msgid "An error message indicates we must move it."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:63
 msgid "Move it in, see we can compute and then return a derived value."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:65
 msgid "If we want to borrow?"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:66
 msgid ""
 "Main kills child threads when it returns, but another function would just "
 "return and leave them running."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:68
 msgid "That would be stack use-after-return, which violates memory safety!"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:69
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md:3
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md:20
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md:41
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md:43
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels.md:3 src/concurrency/async-control-flow.md:3
+msgid "This segment should take about 20 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 20 phút, bao gồm:"
+
+#: src/concurrency/channels/senders-receivers.md:3
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
 "parts are connected via the channel, but you only see the end-points."
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md:15
+#: src/concurrency/channels/senders-receivers.md:16
+#: src/concurrency/channels/senders-receivers.md:20
 msgid "\"Received: {:?}\""
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md:27
 msgid ""
 "`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
 "implement `Clone` (so you can make multiple producers) but `Receiver` does "
 "not."
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md:30
 msgid ""
 "`send()` and `recv()` return `Result`. If they return `Err`, it means the "
 "counterpart `Sender` or `Receiver` is dropped and the channel is closed."
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md
+#: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:16
+#: src/concurrency/channels/bounded.md:16
 msgid "\"Message {i}\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:17
+#: src/concurrency/channels/bounded.md:17
 msgid "\"{thread_id:?}: sent Message {i}\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:19
+#: src/concurrency/channels/bounded.md:19
 msgid "\"{thread_id:?}: done\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:24
+#: src/concurrency/channels/bounded.md:24
 msgid "\"Main: got {msg}\""
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:3
 msgid ""
 "With bounded (synchronous) channels, `send` can block the current thread:"
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:32
 msgid ""
 "Calling `send` will block the current thread until there is space in the "
 "channel for the new message. The thread can be blocked indefinitely if there "
 "is nobody who reads from the channel."
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:35
 msgid ""
 "A call to `send` will abort with an error (that is why it returns `Result`) "
 "if the channel is closed. A channel is closed when the receiver is dropped."
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:37
 msgid ""
 "A bounded channel with a size of zero is called a \"rendezvous channel\". "
 "Every send will block the current thread until another thread calls `recv`."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync.md:8
+msgid "Send"
+msgstr ""
+
+#: src/concurrency/send-sync.md:9
+msgid "Sync"
+msgstr ""
+
+#: src/concurrency/send-sync/marker-traits.md:3
 msgid ""
 "How does Rust know to forbid shared access across threads? The answer is in "
 "two traits:"
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:6
 msgid ""
 "[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
 "is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:8
 msgid ""
 "[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
 "is `Sync` if it is safe to move a `&T` across a thread boundary."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:11
 msgid ""
-"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
-"compiler will automatically derive them for your types as long as they only "
-"contain `Send` and `Sync` types. You can also implement them manually when "
-"you know it is valid."
+"`Send` and `Sync` are [unsafe traits](../../unsafe-rust/unsafe-traits.md). "
+"The compiler will automatically derive them for your types as long as they "
+"only contain `Send` and `Sync` types. You can also implement them manually "
+"when you know it is valid."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:22
 msgid ""
 "One can think of these traits as markers that the type has certain thread-"
 "safety properties."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:24
 msgid "They can be used in the generic constraints as normal traits."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md
+#: src/concurrency/send-sync/send.md:3
 msgid ""
 "A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
 "if it is safe to move a `T` value to another thread."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md
+#: src/concurrency/send-sync/send.md:5
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
 "run in that thread. So the question is when you can allocate a value in one "
 "thread and deallocate it in another."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md
+#: src/concurrency/send-sync/send.md:14
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
 "a single thread."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:3
 msgid ""
 "A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
 "if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:6
 msgid "More precisely, the definition is:"
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:8
 msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:15
 msgid ""
 "This statement is essentially a shorthand way of saying that if a type is "
 "thread-safe for shared use, it is also thread-safe to pass references of it "
 "across threads."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:19
 msgid ""
 "This is because if a type is Sync it means that it can be shared across "
 "multiple threads without the risk of data races or other synchronization "
@@ -17401,167 +17401,158 @@ msgid ""
 "be accessed from any thread safely."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:3
 msgid "`Send + Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:5
 msgid "Most types you come across are `Send + Sync`:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:7
 msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:8
 msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:9
 msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:10
 msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:11
 msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:12
+msgid "`mpsc::Sender<T>`: As of 1.72.0."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:13
 msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:15
 msgid ""
 "The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:18
 msgid "`Send + !Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:20
 msgid ""
 "These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
-msgid "`mpsc::Sender<T>`"
-msgstr ""
-
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:23
 msgid "`mpsc::Receiver<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:24
 msgid "`Cell<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:25
 msgid "`RefCell<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:27
 msgid "`!Send + Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:29
 msgid ""
 "These types are thread-safe, but they cannot be moved to another thread:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:31
 msgid ""
 "`MutexGuard<T: Sync>`: Uses OS level primitives which must be deallocated on "
 "the thread which created them."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:34
 msgid "`!Send + !Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:36
 msgid "These types are not thread-safe and cannot be moved to other threads:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:38
 msgid ""
 "`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
 "atomic reference count."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:40
 msgid ""
 "`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
 "considerations."
 msgstr ""
 
-#: src/concurrency/shared_state.md
-msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This is "
-"primarily done via two types:"
+#: src/concurrency/shared-state.md:7
+msgid "Arc"
 msgstr ""
 
-#: src/concurrency/shared_state.md
-msgid ""
-"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
-"reference counted `T`: handles sharing between threads and takes care to "
-"deallocate `T` when the last reference is dropped,"
+#: src/concurrency/shared-state.md:8
+msgid "Mutex"
 msgstr ""
 
-#: src/concurrency/shared_state.md
-msgid ""
-"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
-"mutually exclusive access to the `T` value."
-msgstr ""
-
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:3
 msgid ""
 "[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
 "read-only access via `Arc::clone`:"
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:16
 msgid "\"{thread_id:?}: {v:?}\""
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/arc.md:21
+#: src/concurrency/shared-state/example.md:17
+#: src/concurrency/shared-state/example.md:46
 msgid "\"v: {v:?}\""
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:30
 msgid ""
 "`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
 "that uses atomic operations."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:32
 msgid ""
 "`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
 "and `Sync` if and only if `T` implements them both."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:34
 msgid ""
 "`Arc::clone()` has the cost of atomic operations that get executed, but "
 "after that the use of the `T` is free."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:36
 msgid ""
 "Beware of reference cycles, `Arc` does not use a garbage collector to detect "
 "them."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:38
 msgid "`std::sync::Weak` can help."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:3
 msgid ""
 "[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
 "mutual exclusion _and_ allows mutable access to `T` behind a read-only "
@@ -17569,50 +17560,51 @@ msgid ""
 "mutability)):"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:12
+#: src/concurrency/shared-state/mutex.md:19
 msgid "\"v: {:?}\""
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:23
 msgid ""
 "Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
 "lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:33
 msgid ""
 "`Mutex` in Rust looks like a collection with just one element --- the "
 "protected data."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:35
 msgid ""
 "It is not possible to forget to acquire the mutex before accessing the "
 "protected data."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:37
 msgid ""
 "You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
 "`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:39
 msgid ""
 "`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
 "implements `Send`."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:41
 msgid "A read-write lock counterpart: `RwLock`."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:42
 msgid "Why does `lock()` return a `Result`?"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:43
 msgid ""
 "If the thread that held the `Mutex` panicked, the `Mutex` becomes "
 "\"poisoned\" to signal that the data it protected might be in an "
@@ -17621,65 +17613,55 @@ msgid ""
 "You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:3
 msgid "Let us see `Arc` and `Mutex` in action:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:6
 msgid "// use std::sync::{Arc, Mutex};\n"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:24
 msgid "Possible solution:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:50
 msgid "Notable parts:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:52
 msgid ""
 "`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
 "orthogonal."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:54
 msgid ""
 "Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
 "between threads."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:56
 msgid ""
 "`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
 "thread. Note `move` was added to the lambda signature."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:58
 msgid ""
 "Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
 
-#: src/exercises/concurrency/morning.md
-msgid "Let us practice our new concurrency skills with"
-msgstr ""
+#: src/concurrency/sync-exercises.md:3 src/concurrency/async-exercises.md:3
+msgid "This segment should take about 1 hour and 10 minutes. It contains:"
+msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 10 phút, bao gồm:"
 
-#: src/exercises/concurrency/morning.md
-msgid "Dining philosophers: a classic problem in concurrency."
-msgstr ""
-
-#: src/exercises/concurrency/morning.md
-msgid ""
-"Multi-threaded link checker: a larger project where you'll use Cargo to "
-"download dependencies and then check links in parallel."
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:3
 msgid "The dining philosophers problem is a classic problem in concurrency:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:5
 msgid ""
 "Five philosophers dine together at the same table. Each philosopher has "
 "their own place at the table. There is a fork between each plate. The dish "
@@ -17691,102 +17673,102 @@ msgid ""
 "down both forks."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:13
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
 "for this exercise. Copy the code below to a file called `src/main.rs`, fill "
 "out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:28
+#: src/concurrency/async-exercises/dining-philosophers.md:23
 msgid ""
 "// left_fork: ...\n"
 "    // right_fork: ...\n"
 "    // thoughts: ...\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:36
+#: src/concurrency/sync-exercises/solutions.md:22
+#: src/concurrency/async-exercises/dining-philosophers.md:31
+#: src/concurrency/async-exercises/solutions.md:23
 msgid "\"Eureka! {} has a new idea!\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:41
+#: src/concurrency/async-exercises/solutions.md:31
 msgid "// Pick up forks...\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:42
+#: src/concurrency/sync-exercises/solutions.md:31
+#: src/concurrency/async-exercises/dining-philosophers.md:38
+#: src/concurrency/async-exercises/solutions.md:51
 msgid "\"{} is eating...\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Socrates\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Hypatia\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Plato\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Aristotle\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Pythagoras\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:51
+#: src/concurrency/async-exercises/dining-philosophers.md:48
+#: src/concurrency/async-exercises/solutions.md:63
 msgid "// Create forks\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:53
+#: src/concurrency/async-exercises/dining-philosophers.md:50
+#: src/concurrency/async-exercises/solutions.md:67
 msgid "// Create philosophers\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:55
 msgid "// Make each of them think and eat 100 times\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:57
+#: src/concurrency/async-exercises/dining-philosophers.md:54
+#: src/concurrency/async-exercises/solutions.md:95
 msgid "// Output their thoughts\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:61
 msgid "You can use the following `Cargo.toml`:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:65
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -17796,7 +17778,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:3
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
 "should start at a webpage and check that links on the page are valid. It "
@@ -17804,36 +17786,30 @@ msgid ""
 "until all pages have been validated."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:8
 msgid ""
 "For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
-"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
+"reqwest/). You will also need a way to find links, we can use [`scraper`]"
+"(https://docs.rs/scraper/). Finally, we'll need some way of handling errors, "
+"we will use [`thiserror`](https://docs.rs/thiserror/)."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:12
+msgid "Create a new Cargo project and `reqwest` it as a dependency with:"
+msgstr ""
+
+#: src/concurrency/sync-exercises/link-checker.md:22
 msgid ""
 "If `cargo add` fails with `error: no such subcommand`, then please edit the "
 "`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-msgid ""
-"You will also need a way to find links. We can use [`scraper`](https://docs."
-"rs/scraper/) for that:"
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md
-msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`]"
-"(https://docs.rs/thiserror/) for that:"
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:25
 msgid ""
 "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:29
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -17850,130 +17826,114 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:42
 msgid ""
 "You can now download the start page. Try with a small site such as `https://"
 "www.google.org/`."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:45
 msgid "Your `src/main.rs` file should look something like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:57
+#: src/concurrency/sync-exercises/solutions.md:93
 msgid "\"request error: {0}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:59
+#: src/concurrency/sync-exercises/solutions.md:95
 msgid "\"bad http response: {0}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:70
+#: src/concurrency/sync-exercises/solutions.md:106
 msgid "\"Checking {:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:88
+#: src/concurrency/sync-exercises/solutions.md:124
 msgid "\"href\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:95
+#: src/concurrency/sync-exercises/solutions.md:131
 msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:104
+#: src/concurrency/sync-exercises/solutions.md:241
 msgid "\"https://www.google.org\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:107
 msgid "\"Links: {links:#?}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:108
 msgid "\"Could not extract links: {err:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:113
 msgid "Run the code in `src/main.rs` with"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:121
 msgid ""
 "Use threads to check the links in parallel: send the URLs to be checked to a "
 "channel and let a few threads check the URLs in parallel."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:123
 msgid ""
 "Extend this to recursively extract links from all pages on the `www.google."
 "org` domain. Put an upper limit of 100 pages or so so that you don't end up "
 "being blocked by the site."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
-msgid "Concurrency Morning Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md
-msgid "([back to exercise](dining-philosophers.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:27
 msgid "\"{} is trying to eat\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:51
 msgid ""
 "// To avoid a deadlock, we have to break the symmetry\n"
 "        // somewhere. This will swap the forks without deinitializing\n"
 "        // either of them.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:75
 msgid "\"{thought}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:80
 msgid "Link Checker"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
-msgid "([back to exercise](link-checker.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:150
 msgid ""
 "/// Determine whether links within the given page should be extracted.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:158
 msgid ""
 "/// Mark the given page as visited, returning false if it had already\n"
 "    /// been visited.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:184
 msgid "// The sender got dropped. No more commands coming in.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:225
 msgid "\"Got crawling error: {:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:243
 msgid "\"Bad URLs: {:#?}\""
 msgstr ""
 
-#: src/async.md
-msgid "Async Rust"
-msgstr ""
-
-#: src/async.md
+#: src/concurrency/welcome-async.md:3
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
 "concurrently by executing each task until it would block, then switching to "
@@ -17983,88 +17943,92 @@ msgid ""
 "primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md:10
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
 "that may be completed in the future. Futures are \"polled\" until they "
 "signal that they are complete."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md:14
 msgid ""
 "Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md:19
 msgid ""
 "Python has a similar model in its `asyncio`. However, its `Future` type is "
 "callback-based, and not polled. Async Python programs require a \"loop\", "
 "similar to a runtime in Rust."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md:23
 msgid ""
 "JavaScript's `Promise` is similar, but again callback-based. The language "
 "runtime implements the event loop, so many of the details of Promise "
 "resolution are hidden."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async.md:7
+msgid "async/await"
+msgstr ""
+
+#: src/concurrency/async/async-await.md:3
 msgid ""
 "At a high level, async Rust code looks very much like \"normal\" sequential "
 "code:"
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:10
 msgid "\"Count is: {i}!\""
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:28
 msgid ""
 "Note that this is a simplified example to show the syntax. There is no long "
 "running operation or any real concurrency in it!"
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:31
 msgid "What is the return type of an async call?"
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:32
 msgid "Use `let future: () = async_main(10);` in `main` to see the type."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:34
 msgid ""
 "The \"async\" keyword is syntactic sugar. The compiler replaces the return "
 "type with a future."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:37
 msgid ""
 "You cannot make `main` async, without additional instructions to the "
 "compiler on how to use the returned future."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:40
 msgid ""
 "You need an executor to run async code. `block_on` blocks the current thread "
 "until the provided future has run to completion."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:43
 msgid ""
 "`.await` asynchronously waits for the completion of another operation. "
 "Unlike `block_on`, `.await` doesn't block the current thread."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:46
 msgid ""
 "`.await` can only be used inside an `async` function (or block; these are "
 "introduced later)."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:3
 msgid ""
 "[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
 "trait, implemented by objects that represent an operation that may not be "
@@ -18072,7 +18036,7 @@ msgid ""
 "doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
 "uncommon) to implement `Future` for your own types. For example, the "
@@ -18080,76 +18044,76 @@ msgid ""
 "joining to it."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
 "to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:33
 msgid ""
 "The `Future` and `Poll` types are implemented exactly as shown; click the "
 "links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:36
 msgid ""
 "We will not get to `Pin` and `Context`, as we will focus on writing async "
 "code, rather than building new async primitives. Briefly:"
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:39
 msgid ""
 "`Context` allows a Future to schedule itself to be polled again when an "
 "event occurs."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:42
 msgid ""
 "`Pin` ensures that the Future isn't moved in memory, so that pointers into "
 "that future remain valid. This is required to allow references to remain "
 "valid after an `.await`."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:3
 msgid ""
 "A _runtime_ provides support for performing operations asynchronously (a "
 "_reactor_) and is responsible for executing futures (an _executor_). Rust "
 "does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:7
 msgid ""
 "[Tokio](https://tokio.rs/): performant, with a well-developed ecosystem of "
 "functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
 "github.com/hyperium/tonic) for gRPC."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:10
 msgid ""
 "[async-std](https://async.rs/): aims to be a \"std for async\", and includes "
 "a basic runtime in `async::task`."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:12
 msgid "[smol](https://docs.rs/smol/latest/smol/): simple and lightweight"
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:14
 msgid ""
 "Several larger applications have their own runtimes. For example, [Fuchsia]"
 "(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
 "async/src/lib.rs) already has one."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:21
 msgid ""
 "Note that of the listed runtimes, only Tokio is supported in the Rust "
 "playground. The playground also does not permit any I/O, so most interesting "
 "async things can't run in the playground."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:25
 msgid ""
 "Futures are \"inert\" in that they do not do anything (not even start an I/O "
 "operation) unless there is an executor polling them. This differs from JS "
@@ -18157,66 +18121,66 @@ msgid ""
 "used."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:3
 msgid "Tokio provides:"
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:5
 msgid "A multi-threaded runtime for executing asynchronous code."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:6
 msgid "An asynchronous version of the standard library."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:7
 msgid "A large ecosystem of libraries."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:14
 msgid "\"Count in task: {i}!\""
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:24
 msgid "\"Main task: {i}\""
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:32
 msgid "With the `tokio::main` macro we can now make `main` async."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:34
 msgid "The `spawn` function creates a new, concurrent \"task\"."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:36
 msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:38
 msgid "**Further exploration:**"
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:40
 msgid ""
 "Why does `count_to` not (usually) get to 10? This is an example of async "
 "cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
 "until it finishes."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:44
 msgid "Try `count_to(10).await` instead of spawning."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:46
 msgid "Try awaiting the task returned from `tokio::spawn`."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:3
 msgid "Rust has a task system, which is a form of lightweight threading."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:5
 msgid ""
 "A task has a single top-level future which the executor polls to make "
 "progress. That future may have one or more nested futures that its `poll` "
@@ -18225,170 +18189,153 @@ msgid ""
 "and an I/O operation."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:16
 msgid "\"127.0.0.1:0\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:17
 msgid "\"listening on port {}\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:22
 msgid "\"connection from {addr:?}\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:25
 msgid "b\"Who are you?\\n\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:25 src/concurrency/async/tasks.md:28
+#: src/concurrency/async/tasks.md:31
 msgid "\"socket error\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:30
 msgid "\"Thanks for dialing in, {name}!\\n\""
 msgstr ""
 
-#: src/async/tasks.md src/async/control-flow/join.md
+#: src/concurrency/async/tasks.md:40
+#: src/concurrency/async-control-flow/join.md:37
 msgid ""
 "Copy this example into your prepared `src/main.rs` and run it from there."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:42
 msgid ""
 "Try connecting to it with a TCP connection tool like [nc](https://www.unix."
 "com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
 "telnet/)."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:46
 msgid ""
 "Ask students to visualize what the state of the example server would be with "
 "a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:49
 msgid ""
 "This is the first time we've seen an `async` block. This is similar to a "
 "closure, but does not take any arguments. Its return value is a Future, "
 "similar to an `async fn`."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:53
 msgid ""
 "Refactor the async block into a function, and improve the error handling "
 "using `?`."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:3
 msgid ""
 "Several crates have support for asynchronous channels. For instance `tokio`:"
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:13
 msgid "\"Received {count} pings so far.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:16
 msgid "\"ping_handler complete\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:24
 msgid "\"Failed to send ping.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:25
 msgid "\"Sent {} pings so far.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:29
 msgid "\"Something went wrong in ping handler task.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:36
 msgid "Change the channel size to `3` and see how it affects the execution."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:38
 msgid ""
 "Overall, the interface is similar to the `sync` channels as seen in the "
 "[morning class](concurrency/channels.md)."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:41
 msgid "Try removing the `std::mem::drop` call. What happens? Why?"
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:43
 msgid ""
 "The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
 "implement both `sync` and `async` `send` and `recv`. This can be convenient "
 "for complex applications with both IO and heavy CPU processing tasks."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:47
 msgid ""
 "What makes working with `async` channels preferable is the ability to "
 "combine them with other `future`s to combine them and create complex control "
 "flow."
 msgstr ""
 
-#: src/async/control-flow.md
-msgid "Futures Control Flow"
-msgstr ""
-
-#: src/async/control-flow.md
-msgid ""
-"Futures can be combined together to produce concurrent compute flow graphs. "
-"We have already seen tasks, that function as independent threads of "
-"execution."
-msgstr ""
-
-#: src/async/control-flow.md
-msgid "[Join](control-flow/join.md)"
-msgstr ""
-
-#: src/async/control-flow.md
-msgid "[Select](control-flow/select.md)"
-msgstr ""
-
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:3
 msgid ""
 "A join operation waits until all of a set of futures are ready, and returns "
 "a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:21
 msgid "\"https://google.com\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:22
 msgid "\"https://httpbin.org/ip\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:23
 msgid "\"https://play.rust-lang.org/\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:24
 msgid "\"BAD_URL\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:39
 msgid ""
 "For multiple futures of disjoint types, you can use `std::future::join!` but "
 "you must know how many futures you will have at compile time. This is "
 "currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:43
 msgid ""
 "The risk of `join` is that one of the futures may never resolve, this would "
 "cause your program to stall."
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:46
 msgid ""
 "You can also combine `join_all` with `join!` for instance to join all "
 "requests to an http service as well as a database query. Try adding a "
@@ -18397,7 +18344,7 @@ msgid ""
 "demonstrates `join!`."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
 "responds to that future's result. In JavaScript, this is similar to `Promise."
@@ -18405,7 +18352,7 @@ msgid ""
 "FIRST_COMPLETED)`."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:8
 msgid ""
 "Similar to a match statement, the body of `select!` has a number of arms, "
 "each of the form `pattern = future => statement`. When a `future` is ready, "
@@ -18414,27 +18361,27 @@ msgid ""
 "of the `select!` macro."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:40
 msgid "\"Felix\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:40
 msgid "\"Failed to send cat.\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:44
 msgid "\"Failed to send dog.\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:49
 msgid "\"Failed to receive winner\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:51
 msgid "\"Winner is {winner:?}\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:58
 msgid ""
 "In this example, we have a race between a cat and a dog. "
 "`first_animal_to_finish_race` listens to both channels and will pick "
@@ -18442,63 +18389,47 @@ msgid ""
 "that take 500ms."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:63
 msgid ""
 "You can use `oneshot` channels in this example as the channels are supposed "
 "to receive only one `send`."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:66
 msgid ""
 "Try adding a deadline to the race, demonstrating selecting different sorts "
 "of futures."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:69
 msgid ""
 "Note that `select!` drops unmatched branches, which cancels their futures. "
 "It is easiest to use when every execution of `select!` creates new futures."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:72
 msgid ""
 "An alternative is to pass `&mut future` instead of the future itself, but "
 "this can lead to issues, further discussed in the pinning slide."
 msgstr ""
 
-#: src/async/pitfalls.md
-msgid "Pitfalls of async/await"
-msgstr ""
-
-#: src/async/pitfalls.md
+#: src/concurrency/async-pitfalls.md:3
 msgid ""
 "Async / await provides convenient and efficient abstraction for concurrent "
 "asynchronous programming. However, the async/await model in Rust also comes "
 "with its share of pitfalls and footguns. We illustrate some of them in this "
-"chapter:"
+"chapter."
 msgstr ""
 
-#: src/async/pitfalls.md
-msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+#: src/concurrency/async-pitfalls.md:12
+msgid "Pin"
 msgstr ""
 
-#: src/async/pitfalls.md
-msgid "[Pin](pitfalls/pin.md)"
-msgstr ""
-
-#: src/async/pitfalls.md
-msgid "[Async Traits](pitfalls/async-traits.md)"
-msgstr ""
-
-#: src/async/pitfalls.md
-msgid "[Cancellation](pitfalls/cancellation.md)"
-msgstr ""
-
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:1
 msgid "Blocking the executor"
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:3
 msgid ""
 "Most async runtimes only allow IO tasks to run concurrently. This means that "
 "CPU blocking tasks will block the executor and prevent other tasks from "
@@ -18506,39 +18437,39 @@ msgid ""
 "possible."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:14
 msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:19
 msgid "\"current_thread\""
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:30
 msgid ""
 "Run the code and see that the sleeps happen consecutively rather than "
 "concurrently."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:33
 msgid ""
 "The `\"current_thread\"` flavor puts all tasks on a single thread. This "
 "makes the effect more obvious, but the bug is still present in the multi-"
 "threaded flavor."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:37
 msgid ""
 "Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:39
 msgid ""
 "Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
 "thread and transforms its handle into a future without blocking the executor."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:42
 msgid ""
 "You should not think of tasks as OS threads. They do not map 1 to 1 and most "
 "executors will allow many tasks to run on a single OS thread. This is "
@@ -18548,27 +18479,27 @@ msgid ""
 "situations."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:48
 msgid ""
 "Use sync mutexes with care. Holding a mutex over an `.await` may cause "
 "another task to block, and that task may be running on the same thread."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:3
 msgid ""
 "Async blocks and functions return types implementing the `Future` trait. The "
 "type returned is the result of a compiler transformation which turns local "
 "variables into data stored inside the future."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:7
 msgid ""
 "Some of those variables can hold pointers to other local variables. Because "
 "of that, the future should never be moved to a different memory location, as "
 "it would invalidate those pointers."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:11
 msgid ""
 "To prevent moving the future type in memory, it can only be polled through a "
 "pinned pointer. `Pin` is a wrapper around a reference that disallows all "
@@ -18576,95 +18507,95 @@ msgid ""
 "location."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:20
 msgid ""
 "// A work item. In this case, just sleep for the given time and respond\n"
 "// with a message on the `respond_on` channel.\n"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:28
 msgid "// A worker which listens for work on a queue and performs it.\n"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:35
 msgid "// Pretend to work.\n"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:38
 msgid "\"failed to send response\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:41
 msgid "// TODO: report number of iterations every 100ms\n"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:45
 msgid "// A requester which requests work and waits for it to complete.\n"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:52
 msgid "\"failed to send on work queue\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:53
 msgid "\"failed waiting for response\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:62
 msgid "\"work result for iteration {i}: {resp}\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:70
 msgid ""
 "You may recognize this as an example of the actor pattern. Actors typically "
 "call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:73
 msgid ""
 "This serves as a summation of a few of the previous lessons, so take your "
 "time with it."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:76
 msgid ""
 "Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
 "the `select!`. This will never execute. Why?"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:79
 msgid ""
 "Instead, add a `timeout_fut` containing that future outside of the `loop`:"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:90
 msgid ""
 "This still doesn't work. Follow the compiler errors, adding `&mut` to the "
 "`timeout_fut` in the `select!` to work around the move, then using `Box::"
 "pin`:"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:104
 msgid ""
 "This compiles, but once the timeout expires it is `Poll::Ready` on every "
 "iteration (a fused future would help with this). Update to reset "
 "`timeout_fut` every time it expires."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:108
 msgid ""
 "Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
 "stabilized, with older code often using `tokio::pin!`) is also an option, "
 "but that is difficult to use for a future that is reassigned."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:112
 msgid ""
 "Another alternative is to not use `pin` at all but spawn another task that "
 "will send to a `oneshot` channel every 100ms."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:115
 msgid ""
 "Data that contains pointers to itself is called self-referential. Normally, "
 "the Rust borrow checker would prevent self-referential data from being "
@@ -18673,21 +18604,21 @@ msgid ""
 "borrow checker."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:121
 msgid ""
 "`Pin` is a wrapper around a reference. An object cannot be moved from its "
 "place using a pinned pointer. However, it can still be moved through an "
 "unpinned pointer."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:125
 msgid ""
 "The `poll` method of the `Future` trait uses `Pin<&mut Self>` instead of "
 "`&mut Self` to refer to the instance. That's why it can only be called on a "
 "pinned pointer."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:3
 msgid ""
 "Async methods in traits are were stabilized only recently, in the 1.75 "
 "release. This required support for using return-position `impl Trait` (RPIT) "
@@ -18695,46 +18626,46 @@ msgid ""
 "= ...>`."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:7
 msgid ""
 "However, even with the native support today there are some pitfalls around "
 "`async fn` and RPIT in traits:"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:10
 msgid ""
 "Return-position impl Trait captures all in-scope lifetimes (so some patterns "
 "of borrowing cannot be expressed)"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:13
 msgid ""
 "Traits whose methods use return-position `impl trait` or `async` are not "
 "`dyn` compatible."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:16
 msgid ""
 "If we do need `dyn` support, the crate [async_trait](https://docs.rs/async-"
 "trait/latest/async_trait/) provides a workaround through a macro, with some "
 "caveats:"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:46
 msgid "\"running all sleepers..\""
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:50
 msgid "\"slept for {}ms\""
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:68
 msgid ""
 "`async_trait` is easy to use, but note that it's using heap allocations to "
 "achieve this. This heap allocation has performance overhead."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:71
 msgid ""
 "The challenges in language support for `async trait` are deep Rust and "
 "probably not worth describing in-depth. Niko Matsakis did a good job of "
@@ -18743,13 +18674,13 @@ msgid ""
 "digging deeper."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:77
 msgid ""
 "Try creating a new sleeper struct that will sleep for a random amount of "
 "time and adding it to the Vec."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:3
 msgid ""
 "Dropping a future implies it can never be polled again. This is called "
 "_cancellation_ and it can occur at any `await` point. Care is needed to "
@@ -18757,123 +18688,106 @@ msgid ""
 "example, it shouldn't deadlock or lose data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:35
 msgid "\"not UTF-8\""
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:51
 msgid "\"hi\\nthere\\n\""
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:57
 msgid "\"tick!\""
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:73
 msgid ""
 "The compiler doesn't help with cancellation-safety. You need to read API "
 "documentation and consider what state your `async fn` holds."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:76
 msgid ""
 "Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
 "error-handling)."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:79
 msgid "The example loses parts of the string."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:81
 msgid ""
 "Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
 "dropped."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:84
 msgid ""
 "`LinesReader` can be made cancellation-safe by making `buf` part of the "
 "struct:"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:98
 msgid "// prefix buf and bytes with self.\n"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:107
 msgid ""
 "[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
 "html#method.tick) is cancellation-safe because it keeps track of whether a "
 "tick has been 'delivered'."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:111
 msgid ""
 "[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
 "AsyncReadExt.html#method.read) is cancellation-safe because it either "
 "returns or doesn't read data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:114
 msgid ""
 "[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
 "AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
 "cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
 
-#: src/exercises/concurrency/afternoon.md
-msgid ""
-"To practice your Async Rust skills, we have again two exercises for you:"
-msgstr ""
-
-#: src/exercises/concurrency/afternoon.md
-msgid ""
-"Dining philosophers: we already saw this problem in the morning. This time "
-"you are going to implement it with Async Rust."
-msgstr ""
-
-#: src/exercises/concurrency/afternoon.md
-msgid ""
-"A Broadcast Chat Application: this is a larger project that allows you "
-"experiment with more advanced Async Rust features."
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/dining-philosophers.md:1
+#: src/concurrency/async-exercises/solutions.md:3
 msgid "Dining Philosophers --- Async"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:3
 msgid ""
 "See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:6
 msgid ""
 "As before, you will need a local [Cargo installation](../../cargo/running-"
 "locally.md) for this exercise. Copy the code below to a file called `src/"
 "main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/dining-philosophers.md:37
+#: src/concurrency/async-exercises/solutions.md:29
 msgid "// Keep trying until we have both forks\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/dining-philosophers.md:52
+#: src/concurrency/async-exercises/solutions.md:85
 msgid "// Make them think and eat\n"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:58
 msgid ""
 "Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:63
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -18887,17 +18801,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:73
 msgid ""
 "Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:79
 msgid "Can you make your implementation single-threaded?"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:3
 msgid ""
 "In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
@@ -18906,7 +18820,7 @@ msgid ""
 "that it receives to all the clients."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:9
 msgid ""
 "For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
 "sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
@@ -18914,15 +18828,15 @@ msgid ""
 "and the server."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:12
 msgid "Create a new Cargo project and add the following dependencies:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:14
 msgid "_Cargo.toml_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:18
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -18933,55 +18847,55 @@ msgid ""
 "[dependencies]\n"
 "futures-util = { version = \"0.3.30\", features = [\"sink\"] }\n"
 "http = \"1.1.0\"\n"
-"tokio = { version = \"1.36.0\", features = [\"full\"] }\n"
-"tokio-websockets = { version = \"0.7.0\", features = [\"client\", "
+"tokio = { version = \"1.37.0\", features = [\"full\"] }\n"
+"tokio-websockets = { version = \"0.8.2\", features = [\"client\", "
 "\"fastrand\", \"server\", \"sha1_smol\"] }\n"
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:31
 msgid "The required APIs"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:33
 msgid ""
 "You are going to need the following functions from `tokio` and "
 "[`tokio_websockets`](https://docs.rs/tokio-websockets/). Spend a few minutes "
 "to familiarize yourself with the API."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:37
 msgid ""
 "[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
 "trait.StreamExt.html#method.next) implemented by `WebSocketStream`: for "
 "asynchronously reading messages from a Websocket Stream."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:39
 msgid ""
 "[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
 "trait.SinkExt.html#method.send) implemented by `WebSocketStream`: for "
 "asynchronously sending messages on a Websocket Stream."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:41
 msgid ""
 "[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
 "html#method.next_line): for asynchronously reading user messages from the "
 "standard input."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:43
 msgid ""
 "[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
 "struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:45
 msgid "Two binaries"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:47
 msgid ""
 "Normally in a Cargo project, you can have only one binary, and one `src/main."
 "rs` file. In this project, we need two binaries. One for the client, and one "
@@ -18992,80 +18906,81 @@ msgid ""
 "targets.html#binaries))."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:54
 msgid ""
 "Copy the following server and client code into `src/bin/server.rs` and `src/"
 "bin/client.rs`, respectively. Your task is to complete these files as "
 "described below."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:58
+#: src/concurrency/async-exercises/solutions.md:104
 msgid "_src/bin/server.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:77
+#: src/concurrency/async-exercises/chat-app.md:124
 msgid "// TODO: For a hint, see the description of the task below.\n"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:85
+#: src/concurrency/async-exercises/solutions.md:154
 msgid "\"127.0.0.1:2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:86
+#: src/concurrency/async-exercises/solutions.md:155
 msgid "\"listening on port 2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:90
+#: src/concurrency/async-exercises/solutions.md:159
 msgid "\"New connection from {addr:?}\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:93
+#: src/concurrency/async-exercises/solutions.md:162
 msgid "// Wrap the raw TCP stream into a websocket.\n"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:102
+#: src/concurrency/async-exercises/solutions.md:171
 msgid "_src/bin/client.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:116
+#: src/concurrency/async-exercises/solutions.md:183
 msgid "\"ws://127.0.0.1:2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:129
 msgid "Running the binaries"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:131
 msgid "Run the server with:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:137
 msgid "and the client with:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:145
 msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:146
 msgid ""
 "Hint: Use `tokio::select!` for concurrently performing two tasks in a "
 "continuous loop. One task receives messages from the client and broadcasts "
 "them. The other sends messages received by the server to the client."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:149
 msgid "Complete the main function in `src/bin/client.rs`."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:150
 msgid ""
 "Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
 "performing two tasks: (1) reading user messages from standard input and "
@@ -19073,78 +18988,66 @@ msgid ""
 "displaying them for the user."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:154
 msgid ""
 "Optional: Once you are done, change the code to broadcast messages to all "
 "clients, but the sender of the message."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "Concurrency Afternoon Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "([back to exercise](dining-philosophers-async.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:35
 msgid ""
 "// If we didn't get the left fork, drop the right fork if we\n"
 "                // have it and let other tasks make progress.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:42
 msgid ""
 "// If we didn't get the right fork, drop the left fork and let\n"
 "                // other tasks make progress.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:54
 msgid "// The locks are dropped here\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:82
 msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:97
 msgid "\"Here is a thought: {thought}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "([back to exercise](chat-app.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:122
 msgid "\"Welcome to chat! Type a message\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:126
 msgid ""
 "// A continuous loop for concurrently performing two tasks: (1) receiving\n"
 "    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
 "    // messages on `bcast_rx` and sending them to the client.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:135
 msgid "\"From client {addr:?} {text:?}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:190
 msgid "// Continuous loop for concurrently sending and receiving messages.\n"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:197
 msgid "\"From server: {}\""
 msgstr ""
 
-#: src/thanks.md
+#: src/thanks.md:3
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
 "that it was useful."
 msgstr ""
 
-#: src/thanks.md
+#: src/thanks.md:6
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
 "perfect, so if you spotted any mistakes or have ideas for improvements, "
@@ -19153,7 +19056,7 @@ msgid ""
 msgstr ""
 
 # this is a translation, so the second part of the sentence need not be translated
-#: src/glossary.md
+#: src/glossary.md:5
 msgid ""
 "The following is a glossary which aims to give a short definition of many "
 "Rust terms. For translations, this also serves to connect the term back to "
@@ -19161,7 +19064,7 @@ msgid ""
 msgstr ""
 "Bảng từ vựng dưới đây cung cấp định nghĩa ngắn gọn của nhiều thuật ngữ Rust. "
 
-#: src/glossary.md
+#: src/glossary.md:31
 msgid ""
 "allocate:  \n"
 "Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md)."
@@ -19169,7 +19072,7 @@ msgstr ""
 "allocate:  \n"
 "Cấp phát bộ nhớ động trên [bộ nhớ heap](memory-management/stack-vs-heap.md)."
 
-#: src/glossary.md
+#: src/glossary.md:33
 msgid ""
 "argument:  \n"
 "Information that is passed into a function or method."
@@ -19177,7 +19080,7 @@ msgstr ""
 "argument:  \n"
 "Giá trị được truyền vào một hàm. Có thể được gọi là tham số."
 
-#: src/glossary.md
+#: src/glossary.md:35
 msgid ""
 "Bare-metal Rust:  \n"
 "Low-level Rust development, often deployed to a system without an operating "
@@ -19187,7 +19090,7 @@ msgstr ""
 "Việc phát triển chương trình Rust ở cấp thấp, thường để triển khai trên hệ "
 "thống không cần hệ điều hành. Xem [Bare-metal Rust](bare-metal.md)."
 
-#: src/glossary.md
+#: src/glossary.md:38
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
@@ -19195,7 +19098,7 @@ msgstr ""
 "block:  \n"
 "Xem [Blocks](control-flow/blocks.md) và _scope_."
 
-#: src/glossary.md
+#: src/glossary.md:40
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
@@ -19203,7 +19106,7 @@ msgstr ""
 "borrow:  \n"
 "Xem [Borrowing](ownership/borrowing.md)."
 
-#: src/glossary.md
+#: src/glossary.md:42
 msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
@@ -19212,7 +19115,7 @@ msgstr ""
 "Một bộ phận của Rust compiler kiểm tra xem tất cả các _borrow_ có hợp lệ hay "
 "không."
 
-#: src/glossary.md
+#: src/glossary.md:44
 msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
@@ -19220,7 +19123,7 @@ msgstr ""
 "brace:  \n"
 "`{` và `}`. Được gọi là dấu _ngoặc nhọn_, phân chia các _block_."
 
-#: src/glossary.md
+#: src/glossary.md:46
 msgid ""
 "build:  \n"
 "The process of converting source code into executable code or a usable "
@@ -19229,7 +19132,7 @@ msgstr ""
 "build:  \n"
 "Quá trình chuyển đổi mã nguồn thành một chương trình executable."
 
-#: src/glossary.md
+#: src/glossary.md:49
 msgid ""
 "call:  \n"
 "To invoke or execute a function or method."
@@ -19237,7 +19140,7 @@ msgstr ""
 "call:  \n"
 "Gọi hoặc thực thi hàm."
 
-#: src/glossary.md
+#: src/glossary.md:51
 msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
@@ -19246,7 +19149,7 @@ msgstr ""
 "Dùng để truyền thông điệp một cách an toàn [giữa các _thread_](concurrency/"
 "channels.md)."
 
-#: src/glossary.md
+#: src/glossary.md:53
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
@@ -19254,7 +19157,7 @@ msgstr ""
 "Comprehensive Rust 🦀:  \n"
 "Các khóa học ở đây được gọi chung là Comprehensive Rust 🦀."
 
-#: src/glossary.md
+#: src/glossary.md:55
 msgid ""
 "concurrency:  \n"
 "The execution of multiple tasks or processes at the same time."
@@ -19262,7 +19165,7 @@ msgstr ""
 "concurrency:  \n"
 "Quá trình thực thi nhiều tác vụ hoặc process cùng một lúc."
 
-#: src/glossary.md
+#: src/glossary.md:57
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
@@ -19270,7 +19173,7 @@ msgstr ""
 "Concurrency in Rust:  \n"
 "Xem [Concurrency trong Rust](concurrency.md)."
 
-#: src/glossary.md
+#: src/glossary.md:59
 msgid ""
 "constant:  \n"
 "A value that does not change during the execution of a program."
@@ -19279,7 +19182,7 @@ msgstr ""
 "Một giá trị không thay đổi trong quá trình thực thi của chương trình. Còn "
 "được gọi là _hằng số_."
 
-#: src/glossary.md
+#: src/glossary.md:61
 msgid ""
 "control flow:  \n"
 "The order in which the individual statements or instructions are executed in "
@@ -19289,7 +19192,7 @@ msgstr ""
 "Thứ tự thực thi của các câu lệnh trong một chương trình. Một vài sách gọi từ "
 "này là _luồng điều khiển_."
 
-#: src/glossary.md
+#: src/glossary.md:64
 msgid ""
 "crash:  \n"
 "An unexpected and unhandled failure or termination of a program."
@@ -19297,7 +19200,7 @@ msgstr ""
 "crash:  \n"
 "Khi chương trình gặp lỗi không xử lý được và bị dừng đột ngột."
 
-#: src/glossary.md
+#: src/glossary.md:66
 msgid ""
 "enumeration:  \n"
 "A data type that holds one of several named constants, possibly with an "
@@ -19307,7 +19210,7 @@ msgstr ""
 "Môt kiểu dữ liệu chứa một hoặc nhiều hằng số, có thể kèm theo một _tuple_ "
 "hoặc một _struct_."
 
-#: src/glossary.md
+#: src/glossary.md:69
 msgid ""
 "error:  \n"
 "An unexpected condition or result that deviates from the expected behavior."
@@ -19315,7 +19218,7 @@ msgstr ""
 "error:  \n"
 "Khi gặp phải một hành vi hoặc kết quả không như dự kiến."
 
-#: src/glossary.md
+#: src/glossary.md:71
 msgid ""
 "error handling:  \n"
 "The process of managing and responding to errors that occur during program "
@@ -19324,7 +19227,7 @@ msgstr ""
 "error handling:  \n"
 "Quá trình quản lý và xử lý lỗi xảy ra trong quá trình thực thi chương trình."
 
-#: src/glossary.md
+#: src/glossary.md:74
 msgid ""
 "exercise:  \n"
 "A task or problem designed to practice and test programming skills."
@@ -19333,7 +19236,7 @@ msgstr ""
 "Bài tập được thiết kế giúp học viên luyện tập và kiểm tra năng lực lập "
 "trình. "
 
-#: src/glossary.md
+#: src/glossary.md:76
 msgid ""
 "function:  \n"
 "A reusable block of code that performs a specific task."
@@ -19342,7 +19245,7 @@ msgstr ""
 "Một đoạn code có thể được tái sử dụng, nhằm thực hiện một nhiệm vụ cụ thể."
 "Còn được gọi là _hàm_."
 
-#: src/glossary.md
+#: src/glossary.md:78
 msgid ""
 "garbage collector:  \n"
 "A mechanism that automatically frees up memory occupied by objects that are "
@@ -19352,7 +19255,7 @@ msgstr ""
 "Một cơ chế tự động giải phóng bộ nhớ bị chiếm bởi các biến không còn được sử "
 "dụng nữa."
 
-#: src/glossary.md
+#: src/glossary.md:81
 msgid ""
 "generics:  \n"
 "A feature that allows writing code with placeholders for types, enabling "
@@ -19363,7 +19266,7 @@ msgstr ""
 "cần phải định rõ kiểu dữ liệu, giúp tái sử dụng code với nhiều kiểu dữ liệu "
 "khác nhau."
 
-#: src/glossary.md
+#: src/glossary.md:84
 msgid ""
 "immutable:  \n"
 "Unable to be changed after creation."
@@ -19371,7 +19274,7 @@ msgstr ""
 "immutable:  \n"
 "Không thể thay đổi sau khi tạo. Có thể được dịch là _bất biến_."
 
-#: src/glossary.md
+#: src/glossary.md:86
 msgid ""
 "integration test:  \n"
 "A type of test that verifies the interactions between different parts or "
@@ -19381,7 +19284,7 @@ msgstr ""
 "Một quy trình _test_ code để kiểm tra sự tương tác giữa các thành phần của "
 "hệ thống."
 
-#: src/glossary.md
+#: src/glossary.md:89
 msgid ""
 "keyword:  \n"
 "A reserved word in a programming language that has a specific meaning and "
@@ -19391,7 +19294,7 @@ msgstr ""
 "Một từ khóa trong ngôn ngữ lập trình, có ý nghĩa cụ thể và không thể sử dụng "
 "như một _identifier_ (tên biến)."
 
-#: src/glossary.md
+#: src/glossary.md:92
 msgid ""
 "library:  \n"
 "A collection of precompiled routines or code that can be used by programs."
@@ -19400,7 +19303,7 @@ msgstr ""
 "Một bộ sưu tập các hàm hoặc code đã được biên dịch trước, có thể được sử "
 "dụng trong chương trình. Thường được gọi là _thư viện_."
 
-#: src/glossary.md
+#: src/glossary.md:94
 msgid ""
 "macro:  \n"
 "Rust macros can be recognized by a `!` in the name. Macros are used when "
@@ -19414,7 +19317,7 @@ msgstr ""
 "tham số không cố định (có thể 1 tham số, 2 tham số, hay thậm chí là không có "
 "tham số nào). Hàm thông thường trong Rust không làm được điều này."
 
-#: src/glossary.md
+#: src/glossary.md:98
 msgid ""
 "`main` function:  \n"
 "Rust programs start executing with the `main` function."
@@ -19422,7 +19325,7 @@ msgstr ""
 "`main` function:  \n"
 "Điểm bắt đầu của mọi chương trình Rust là hàm `main`."
 
-#: src/glossary.md
+#: src/glossary.md:100
 msgid ""
 "match:  \n"
 "A control flow construct in Rust that allows for pattern matching on the "
@@ -19432,7 +19335,7 @@ msgstr ""
 "Một _control flow_ trong Rust cho phép so sánh một giá trị với một số "
 "_pattern_ cho trước."
 
-#: src/glossary.md
+#: src/glossary.md:103
 msgid ""
 "memory leak:  \n"
 "A situation where a program fails to release memory that is no longer "
@@ -19442,7 +19345,7 @@ msgstr ""
 "Khi chương trình không giải phóng bộ nhớ của biến không còn cần thiết, dẫn "
 "đến việc bộ nhớ sử dụng tăng dần trong quá trình thực thi."
 
-#: src/glossary.md
+#: src/glossary.md:106
 msgid ""
 "method:  \n"
 "A function associated with an object or a type in Rust."
@@ -19450,7 +19353,7 @@ msgstr ""
 "method:  \n"
 "Một hàm liên kết với một đối tượng hoặc một kiểu dữ liệu trong Rust."
 
-#: src/glossary.md
+#: src/glossary.md:108
 msgid ""
 "module:  \n"
 "A namespace that contains definitions, such as functions, types, or traits, "
@@ -19460,7 +19363,7 @@ msgstr ""
 "Một phương pháp đẻ nhóm các định nghĩa, như hàm, kiểu dữ liệu, hoặc traits, "
 "trong Rust."
 
-#: src/glossary.md
+#: src/glossary.md:111
 msgid ""
 "move:  \n"
 "The transfer of ownership of a value from one variable to another in Rust."
@@ -19469,7 +19372,7 @@ msgstr ""
 "Chuyển quyền sở hữu của một giá trị từ một biến sang một biến khác trong "
 "Rust."
 
-#: src/glossary.md
+#: src/glossary.md:113
 msgid ""
 "mutable:  \n"
 "A property in Rust that allows variables to be modified after they have been "
@@ -19479,7 +19382,7 @@ msgstr ""
 "Một thuộc tính trong Rust cho phép biến có thể được thay đổi sau khi đã được "
 "khai báo."
 
-#: src/glossary.md
+#: src/glossary.md:116
 msgid ""
 "ownership:  \n"
 "The concept in Rust that defines which part of the code is responsible for "
@@ -19489,7 +19392,7 @@ msgstr ""
 "Một khái niệm trong Rust xác định phần nào của code chịu trách nhiệm quản lý "
 "bộ nhớ liên quan đến một giá trị."
 
-#: src/glossary.md
+#: src/glossary.md:119
 msgid ""
 "panic:  \n"
 "An unrecoverable error condition in Rust that results in the termination of "
@@ -19499,7 +19402,7 @@ msgstr ""
 "Khi chương trình gặp phải một lỗi không thể phục hồi được, dẫn đến việc dừng "
 "chương trình."
 
-#: src/glossary.md
+#: src/glossary.md:122
 msgid ""
 "parameter:  \n"
 "A value that is passed into a function or method when it is called."
@@ -19507,7 +19410,7 @@ msgstr ""
 "parameter:  \n"
 "Giá trị được truyền vào một hàm khi hàm đó được gọi. Còn được gọi là tham số."
 
-#: src/glossary.md
+#: src/glossary.md:124
 msgid ""
 "pattern:  \n"
 "A combination of values, literals, or structures that can be matched against "
@@ -19517,7 +19420,7 @@ msgstr ""
 "Cách sử dụng giá trị, hằng số, hoặc cấu trúc để so sánh với một biểu thức "
 "trong Rust."
 
-#: src/glossary.md
+#: src/glossary.md:127
 msgid ""
 "payload:  \n"
 "The data or information carried by a message, event, or data structure."
@@ -19526,7 +19429,7 @@ msgstr ""
 "Dữ liệu hoặc thông tin được chuyển đi, thường sử dụng khi nhắc đến việc "
 "chuyển dữ liệu qua mạng."
 
-#: src/glossary.md
+#: src/glossary.md:129
 msgid ""
 "program:  \n"
 "A set of instructions that a computer can execute to perform a specific task "
@@ -19536,7 +19439,7 @@ msgstr ""
 "Một tập hợp các dòng lệnh máy tính có thể thực thi để thực hiện một nhiệm vụ "
 "hoặc giải quyết một vấn đề cụ thể. Còn được gọi là _chương trình_."
 
-#: src/glossary.md
+#: src/glossary.md:132
 msgid ""
 "programming language:  \n"
 "A formal system used to communicate instructions to a computer, such as Rust."
@@ -19545,7 +19448,7 @@ msgstr ""
 "Một hệ thống ngôn ngữ được sử dụng để truyền thông điệp cho máy tính, như "
 "Rust."
 
-#: src/glossary.md
+#: src/glossary.md:134
 msgid ""
 "receiver:  \n"
 "The first parameter in a Rust method that represents the instance on which "
@@ -19555,7 +19458,7 @@ msgstr ""
 "Tham số đầu tiên trong một _method_ của Rust, đại diện cho biến mà _method_ "
 "đó gọi lên."
 
-#: src/glossary.md
+#: src/glossary.md:137
 msgid ""
 "reference counting:  \n"
 "A memory management technique in which the number of references to an object "
@@ -19566,7 +19469,7 @@ msgstr ""
 "được theo dõi, và đối tượng được giải phóng khi số lượng tham chiếu giảm về "
 "0."
 
-#: src/glossary.md
+#: src/glossary.md:140
 msgid ""
 "return:  \n"
 "A keyword in Rust used to indicate the value to be returned from a function."
@@ -19574,7 +19477,7 @@ msgstr ""
 "return:  \n"
 "Một từ khóa trong Rust dùng để chỉ ra giá trị trả về của một hàm."
 
-#: src/glossary.md
+#: src/glossary.md:142
 msgid ""
 "Rust:  \n"
 "A systems programming language that focuses on safety, performance, and "
@@ -19583,7 +19486,7 @@ msgstr ""
 "Rust:  \n"
 "Ngôn ngữ lập trình hệ thống chú trọng vào an toàn và hiệu suất."
 
-#: src/glossary.md
+#: src/glossary.md:145
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 4 of this course."
@@ -19591,7 +19494,7 @@ msgstr ""
 "Rust Fundamentals:  \n"
 "Ngày 1 đến ngày 4 của khóa học này."
 
-#: src/glossary.md
+#: src/glossary.md:147
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
@@ -19599,7 +19502,7 @@ msgstr ""
 "Rust in Android:  \n"
 "Xem [Sử dụng Rust trong Android](android.md)."
 
-#: src/glossary.md
+#: src/glossary.md:149
 msgid ""
 "Rust in Chromium:  \n"
 "See [Rust in Chromium](chromium.md)."
@@ -19607,7 +19510,7 @@ msgstr ""
 "Rust in Chromium:  \n"
 "Xem [Sử dụng Rust trong Chromium](chromium.md)."
 
-#: src/glossary.md
+#: src/glossary.md:151
 msgid ""
 "safe:  \n"
 "Refers to code that adheres to Rust's ownership and borrowing rules, "
@@ -19617,7 +19520,7 @@ msgstr ""
 "Đoạn code tuân thủ các quy tắc về _ownership_ và _borrowing_ của Rust, ngăn "
 "chặn lỗi liên quan đến bộ nhớ."
 
-#: src/glossary.md
+#: src/glossary.md:154
 msgid ""
 "scope:  \n"
 "The region of a program where a variable is valid and can be used."
@@ -19625,7 +19528,7 @@ msgstr ""
 "scope:  \n"
 "Một phạm vi trong chương trình mà một biến có thể được sử dụng."
 
-#: src/glossary.md
+#: src/glossary.md:156
 msgid ""
 "standard library:  \n"
 "A collection of modules providing essential functionality in Rust."
@@ -19634,7 +19537,7 @@ msgstr ""
 "Một bộ sưu tập các _module_ cung cấp các chức năng cần thiết trong Rust. Một "
 "số sách gọi là _thư viện chuẩn_."
 
-#: src/glossary.md
+#: src/glossary.md:158
 msgid ""
 "static:  \n"
 "A keyword in Rust used to define static variables or items with a `'static` "
@@ -19644,7 +19547,7 @@ msgstr ""
 "Một từ khóa trong Rust dùng để định nghĩa biến tĩnh hoặc các phần tử với "
 "_lifetime_ là `'static`."
 
-#: src/glossary.md
+#: src/glossary.md:161
 msgid ""
 "string:  \n"
 "A data type storing textual data. See [`String` vs `str`](basic-syntax/"
@@ -19654,7 +19557,7 @@ msgstr ""
 "Một kiểu dữ liệu lưu trữ dữ liệu văn bản. Xem [`String` vs `str`](basic-"
 "syntax/string-slices.html) để biết thêm chi tiết. Còn được gọi là _chuỗi_."
 
-#: src/glossary.md
+#: src/glossary.md:164
 msgid ""
 "struct:  \n"
 "A composite data type in Rust that groups together variables of different "
@@ -19664,7 +19567,7 @@ msgstr ""
 "Một kiểu dữ liệu trong Rust, dùng để nhóm các biến khác nhau với nhau thành "
 "một kiểu dữ liệu mới."
 
-#: src/glossary.md
+#: src/glossary.md:167
 msgid ""
 "test:  \n"
 "A Rust module containing functions that test the correctness of other "
@@ -19673,7 +19576,7 @@ msgstr ""
 "test:  \n"
 "Một _module_ trong Rust chứa các hàm kiểm tra sự chính xác của các hàm khác."
 
-#: src/glossary.md
+#: src/glossary.md:170
 msgid ""
 "thread:  \n"
 "A separate sequence of execution in a program, allowing concurrent execution."
@@ -19682,7 +19585,7 @@ msgstr ""
 "Một cơ chế cho phép thực thi nhiều tác vụ cùng một lúc trong chương trình. "
 "Còn được gọi là _luồng_."
 
-#: src/glossary.md
+#: src/glossary.md:172
 msgid ""
 "thread safety:  \n"
 "The property of a program that ensures correct behavior in a multithreaded "
@@ -19692,7 +19595,7 @@ msgstr ""
 "Thuộc tính của chương trình đảm bảo chương trình hoạt động chuẩn xác trong "
 "môi trường đa luồng."
 
-#: src/glossary.md
+#: src/glossary.md:175
 msgid ""
 "trait:  \n"
 "A collection of methods defined for an unknown type, providing a way to "
@@ -19701,7 +19604,7 @@ msgstr ""
 "trait:  \n"
 "Một tập hợp các hành vi mà ta muốn một kiểu dữ liệu cụ thể phải có."
 
-#: src/glossary.md
+#: src/glossary.md:178
 msgid ""
 "trait bound:  \n"
 "An abstraction where you can require types to implement some traits of your "
@@ -19710,7 +19613,7 @@ msgstr ""
 "trait bound:  \n"
 "Một cách để yêu cầu một kiểu dữ liệu phải _implement_ một số _trait_ cụ thể."
 
-#: src/glossary.md
+#: src/glossary.md:181
 msgid ""
 "tuple:  \n"
 "A composite data type that contains variables of different types. Tuple "
@@ -19720,7 +19623,7 @@ msgstr ""
 "Một kiểu dữ liệu trong Rust chứa các biến khác nhau. Các trường của _tuple_ "
 "không có tên, và được truy cập bằng số thứ tự."
 
-#: src/glossary.md
+#: src/glossary.md:184
 msgid ""
 "type:  \n"
 "A classification that specifies which operations can be performed on values "
@@ -19730,7 +19633,7 @@ msgstr ""
 "Một cơ chế giúp xác định các thao tác có thể thực hiện trên giá trị của một "
 "kiểu dữ liệu cụ thể trong Rust."
 
-#: src/glossary.md
+#: src/glossary.md:187
 msgid ""
 "type inference:  \n"
 "The ability of the Rust compiler to deduce the type of a variable or "
@@ -19740,7 +19643,7 @@ msgstr ""
 "Một chức năng của Rust compiler giúp suy luận kiểu dữ liệu của biến hoặc "
 "biểu thức, thay vì phải khai báo kiểu dữ liệu cho từng biến."
 
-#: src/glossary.md
+#: src/glossary.md:190
 msgid ""
 "undefined behavior:  \n"
 "Actions or conditions in Rust that have no specified result, often leading "
@@ -19750,7 +19653,7 @@ msgstr ""
 "Một số hành vi và điều kiện trong Rust không có kết quả cụ thể, thường dẫn "
 "đến việc chương trình hoạt động bất thường."
 
-#: src/glossary.md
+#: src/glossary.md:193
 msgid ""
 "union:  \n"
 "A data type that can hold values of different types but only one at a time."
@@ -19759,7 +19662,7 @@ msgstr ""
 "Một kiểu dữ liệu có thể chứa giá trị của nhiều kiểu dữ liệu khác nhau, nhưng "
 "chỉ một giá trị một lúc."
 
-#: src/glossary.md
+#: src/glossary.md:195
 msgid ""
 "unit test:  \n"
 "Rust comes with built-in support for running small unit tests and larger "
@@ -19769,7 +19672,7 @@ msgstr ""
 "Một loại _test_ trong Rust, giúp kiểm tra từng phần nhỏ của chương trình. "
 "Xem [Unit Tests](testing/unit-tests.html)."
 
-#: src/glossary.md
+#: src/glossary.md:198
 msgid ""
 "unit type:  \n"
 "Type that holds no data, written as a tuple with no members."
@@ -19777,7 +19680,7 @@ msgstr ""
 "unit type:  \n"
 "Kiểu dữ liệu không chứa dữ liệu, ký hiệu bằng `()`."
 
-#: src/glossary.md
+#: src/glossary.md:200
 msgid ""
 "unsafe:  \n"
 "The subset of Rust which allows you to trigger _undefined behavior_. See "
@@ -19787,7 +19690,7 @@ msgstr ""
 "Một phần của Rust cho phép người lập trình gây ra _undefined behavior_. Xem "
 "[Unsafe Rust](unsafe.html)."
 
-#: src/glossary.md
+#: src/glossary.md:203
 msgid ""
 "variable:  \n"
 "A memory location storing data. Variables are valid in a _scope_."
@@ -19796,32 +19699,32 @@ msgstr ""
 "Một vùng bộ nhớ lưu trữ dữ liệu. Có thể được sử dụng trong một _scope_. Còn "
 "được gọi là _biến_."
 
-#: src/other-resources.md
+#: src/other-resources.md:1
 msgid "Other Rust Resources"
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:3
 msgid ""
 "The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:6
 msgid "Official Documentation"
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:8
 msgid "The Rust project hosts many resources. These cover Rust in general:"
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:10
 msgid ""
 "[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
 "canonical free book about Rust. Covers the language in detail and includes a "
 "few projects for people to build."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:13
 msgid ""
 "[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
 "Rust syntax via a series of examples which showcase different constructs. "
@@ -19829,78 +19732,78 @@ msgid ""
 "in the examples."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:17
 msgid ""
 "[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
 "of the standard library for Rust."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:19
 msgid ""
 "[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
 "book which describes the Rust grammar and memory model."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:22
 msgid "More specialized guides hosted on the official Rust site:"
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:24
 msgid ""
 "[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
 "including working with raw pointers and interfacing with other languages "
 "(FFI)."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:27
 msgid ""
 "[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
 "covers the new asynchronous programming model which was introduced after the "
 "Rust Book was written."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:30
 msgid ""
 "[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
 "an introduction to using Rust on embedded devices without an operating "
 "system."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:33
 msgid "Unofficial Learning Material"
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:35
 msgid "A small selection of other guides and tutorial for Rust:"
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:37
 msgid ""
 "[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
 "from the perspective of low-level C programmers."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:39
 msgid ""
 "[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
 "rust_for_c/): covers Rust from the perspective of developers who write "
 "firmware in C."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:41
 msgid ""
 "[Rust for professionals](https://overexact.com/rust-for-professionals/): "
 "covers the syntax of Rust using side-by-side comparisons with other "
 "languages such as C, C++, Java, JavaScript, and Python."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:44
 msgid ""
 "[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
 "you learn Rust."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:46
 msgid ""
 "[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
 "material/index.html): a series of small presentations covering both basic "
@@ -19908,7 +19811,15 @@ msgid ""
 "and async/await are also covered."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:50
+msgid ""
+"[Advanced testing for Rust applications](https://github.com/mainmatter/rust-"
+"advanced-testing-workshop): a self-paced workshop that goes beyond Rust's "
+"built-in testing framework. It covers `googletest`, snapshot testing, "
+"mocking as well as how to write your own custom test harness."
+msgstr ""
+
+#: src/other-resources.md:54
 msgid ""
 "[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
 "series-to-rust/) and [Take your first steps with Rust](https://docs."
@@ -19917,38 +19828,38 @@ msgid ""
 "11 modules which covers Rust syntax and basic constructs."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:60
 msgid ""
 "[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
 "github.io/too-many-lists/): in-depth exploration of Rust's memory management "
 "rules, through implementing a few different types of list structures."
 msgstr ""
 
-#: src/other-resources.md
+#: src/other-resources.md:65
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
 "for even more Rust books."
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:3
 msgid ""
 "The material here builds on top of the many great sources of Rust "
 "documentation. See the page on [other resources](other-resources.md) for a "
 "full list of useful resources."
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:7
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
 "2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
 "rust/blob/main/LICENSE) for details."
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:12
 msgid "Rust by Example"
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:14
 msgid ""
 "Some examples and exercises have been copied and adapted from [Rust by "
 "Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
@@ -19956,24 +19867,169 @@ msgid ""
 "terms."
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:19
 msgid "Rust on Exercism"
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:21
 msgid ""
 "Some exercises have been copied and adapted from [Rust on Exercism](https://"
 "exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
 "directory for details, including the license terms."
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:26
 msgid "CXX"
 msgstr ""
 
-#: src/credits.md
+#: src/credits.md:28
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
 "uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
 "directory for details, including the license terms."
 msgstr ""
+
+#~ msgid "[Welcome](../welcome-day-1.md) (5 minutes)"
+#~ msgstr "[Lời Chào Mừng](../welcome-day-1.md) (5 phút)"
+
+#~ msgid "[Hello, World](../hello-world.md) (15 minutes)"
+#~ msgstr "[Hello, World](../hello-world.md) (15 phút)"
+
+#~ msgid "[Types and Values](../types-and-values.md) (40 minutes)"
+#~ msgstr "[Kiểu Dữ Liệu và Giá Trị](../types-and-values.md) (40 phút)"
+
+#~ msgid "[Control Flow Basics](../control-flow-basics.md) (40 minutes)"
+#~ msgstr "[Điều Khiển Luồng Căn Bản](../control-flow-basics.md) (40 phút)"
+
+#~ msgid "[Tuples and Arrays](../tuples-and-arrays.md) (35 minutes)"
+#~ msgstr "[Tuples và Mảng](../tuples-and-arrays.md) (35 phút)"
+
+#~ msgid "[References](../references.md) (55 minutes)"
+#~ msgstr "[Tham Chiếu](../references.md) (55 phút)"
+
+#~ msgid "[User-Defined Types](../user-defined-types.md) (50 minutes)"
+#~ msgstr "[Kiểu Dữ Liệu Tự Định Nghĩa](../user-defined-types.md) (50 phút)"
+
+#~ msgid "[Welcome](../welcome-day-2.md) (3 minutes)"
+#~ msgstr "[Lời Chào Mừng](../welcome-day-2.md) (3 phút)"
+
+#~ msgid "[Pattern Matching](../pattern-matching.md) (1 hour)"
+#~ msgstr "[So Khớp Mẫu (Pattern Matching)](../pattern-matching.md) (1 tiếng)"
+
+#~ msgid "[Methods and Traits](../methods-and-traits.md) (50 minutes)"
+#~ msgstr "[Phương Thức và Traits](../methods-and-traits.md) (50 phút)"
+
+#~ msgid "[Generics](../generics.md) (40 minutes)"
+#~ msgstr "[Tham Số Hóa Kiểu Dữ Liệu (Generics)](../generics.md) (40 phút)"
+
+#~ msgid "[Standard Library Types](../std-types.md) (1 hour and 20 minutes)"
+#~ msgstr ""
+#~ "[Thư Viện Kiểu Dữ Liệu Tiêu Chuẩn (Standard Library Types)](../std-types."
+#~ "md) (1 tiếng và 20 phút)"
+
+#~ msgid "[Standard Library Traits](../std-traits.md) (1 hour and 40 minutes)"
+#~ msgstr ""
+#~ "[Thư Viện Traits Tiêu Chuẩn (Standard Library Traits)](../std-traits.md) "
+#~ "(1 tiếng và 40 phút)"
+
+#~ msgid "[Welcome](../welcome-day-3.md) (3 minutes)"
+#~ msgstr "[Lời Chào Mừng](../welcome-day-3.md) (3 phút)"
+
+#~ msgid "[Memory Management](../memory-management.md) (1 hour)"
+#~ msgstr "[Quản Lý Bộ Nhớ](../memory-management.md) (1 tiếng)"
+
+#~ msgid "[Smart Pointers](../smart-pointers.md) (55 minutes)"
+#~ msgstr "[Con Trỏ Thông Minh](../smart-pointers.md) (55 phút)"
+
+#~ msgid "[Borrowing](../borrowing.md) (50 minutes)"
+#~ msgstr "[Vay Mượn](../borrowing.md) (50 phút)"
+
+#~ msgid "[Lifetimes](../lifetimes.md) (50 minutes)"
+#~ msgstr "[Vòng đời](../lifetimes.md) (50 phút)"
+
+#~ msgid "[Welcome](../welcome-day-4.md) (3 minutes)"
+#~ msgstr "[Lời Chào Mừng](../welcome-day-4.md) (3 phút)"
+
+#~ msgid "[Iterators](../iterators.md) (45 minutes)"
+#~ msgstr "[Iterators](../iterators.md) (45 phút)"
+
+#~ msgid "[Modules](../modules.md) (40 minutes)"
+#~ msgstr "[Mô Đun](../modules.md) (40 phút)"
+
+#~ msgid "[Testing](../testing.md) (45 minutes)"
+#~ msgstr "[Kiểm Thử](../testing.md) (45 phút)"
+
+#~ msgid "[Error Handling](../error-handling.md) (55 minutes)"
+#~ msgstr "[Xử Lý Lỗi](../error-handling.md) (55 phút)"
+
+#~ msgid "[Unsafe Rust](../unsafe-rust.md) (1 hour and 5 minutes)"
+#~ msgstr "[Rust \"Không An Toàn\"](../unsafe-rust.md) (1 giờ và 5 phút)"
+
+#~ msgid "In this session:"
+#~ msgstr "Trong buổi này:"
+
+#~ msgid "[Welcome](./welcome-day-1.md) (5 minutes)"
+#~ msgstr "[Lời Chào Mừng](./welcome-day-1.md) (5 phút)"
+
+#~ msgid "[Hello, World](./hello-world.md) (15 minutes)"
+#~ msgstr "[Hello, World](./hello-world.md) (15 phút)"
+
+#~ msgid "[Types and Values](./types-and-values.md) (40 minutes)"
+#~ msgstr "[Kiểu Dữ Liệu Và Giá Trị](./types-and-values.md) (40 phút)"
+
+#~ msgid "[Control Flow Basics](./control-flow-basics.md) (40 minutes)"
+#~ msgstr "[Điều Khiển Luồng Cơ Bản](./control-flow-basics.md) (40 phút)"
+
+#~ msgid "[if Expressions](./control-flow-basics/if.md) (4 minutes)"
+#~ msgstr "[Lệnh if](./control-flow-basics/if.md) (4 phút)"
+
+#~ msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
+#~ msgstr "[Vòng lặp](./control-flow-basics/loops.md) (5 phút)"
+
+#~ msgid ""
+#~ "[break and continue](./control-flow-basics/break-continue.md) (4 minutes)"
+#~ msgstr ""
+#~ "[Lệnh break và lệnh continue](./control-flow-basics/break-continue.md) (4 "
+#~ "phút)"
+
+#~ msgid ""
+#~ "[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (5 "
+#~ "minutes)"
+#~ msgstr ""
+#~ "[Khối và phạm vi](./control-flow-basics/blocks-and-scopes.md) (5 phút)"
+
+#~ msgid "[Functions](./control-flow-basics/functions.md) (3 minutes)"
+#~ msgstr "[Hàm](./control-flow-basics/functions.md) (3 phút)"
+
+#~ msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
+#~ msgstr "[Macros](./control-flow-basics/macros.md) (2 phút)"
+
+#~ msgid ""
+#~ "[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (15 "
+#~ "minutes)"
+#~ msgstr ""
+#~ "[Bài tập: Chuỗi Collatz](./control-flow-basics/exercise.md) (15 phút)"
+
+#~ msgid "[Standard Library](./std-types/std.md) (3 minutes)"
+#~ msgstr "[Thư viện chuẩn](./std-types/std.md) (3 phút)"
+
+#~ msgid "[Documentation](./std-types/docs.md) (5 minutes)"
+#~ msgstr "[Tài liệu](./std-types/docs.md) (5 phút)"
+
+#~ msgid "[Option](./std-types/option.md) (10 minutes)"
+#~ msgstr "[Option](./std-types/option.md) (10 phút)"
+
+#~ msgid "[Result](./std-types/result.md) (10 minutes)"
+#~ msgstr "[Result](./std-types/result.md) (10 phút)"
+
+#~ msgid "[String](./std-types/string.md) (10 minutes)"
+#~ msgstr "[String](./std-types/string.md) (10 phút)"
+
+#~ msgid "[Vec](./std-types/vec.md) (10 minutes)"
+#~ msgstr "[Vec](./std-types/vec.md) (10 phút)"
+
+#~ msgid "[HashMap](./std-types/hashmap.md) (10 minutes)"
+#~ msgstr "[HashMap](./std-types/hashmap.md) (10 phút)"
+
+#~ msgid "[Exercise: Counter](./std-types/exercise.md) (20 minutes)"
+#~ msgstr "[Thực hành: Đếm số](./std-types/exercise.md) (20 phút)"

--- a/po/vi.po
+++ b/po/vi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2024-05-09T07:49:43+09:00\n"
+"POT-Creation-Date: 2024-05-21T22:14:00+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Vinh Tran <vinhdaitran@google.com>\n"
 "Language-Team: \n"
@@ -12,1376 +12,1317 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: src/SUMMARY.md:3 src/index.md:1
+#: src/SUMMARY.md src/index.md
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Chào mừng bạn đến với Comprehensive Rust"
 
-#: src/SUMMARY.md:5 src/running-the-course.md:1
+#: src/SUMMARY.md src/running-the-course.md
 msgid "Running the Course"
 msgstr "Hướng Dẫn Khóa Học"
 
-#: src/SUMMARY.md:6 src/running-the-course/course-structure.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
 msgid "Course Structure"
 msgstr "Cấu Trúc Khóa Học"
 
-#: src/SUMMARY.md:7 src/running-the-course/keyboard-shortcuts.md:1
+#: src/SUMMARY.md src/running-the-course/keyboard-shortcuts.md
 msgid "Keyboard Shortcuts"
 msgstr "Phím Tắt"
 
-#: src/SUMMARY.md:8 src/running-the-course/translations.md:1
+#: src/SUMMARY.md src/running-the-course/translations.md
 msgid "Translations"
 msgstr "Bản Dịch"
 
-#: src/SUMMARY.md:9 src/cargo.md:1
+#: src/SUMMARY.md src/cargo.md
 msgid "Using Cargo"
 msgstr "Sử Dụng Cargo"
 
-#: src/SUMMARY.md:10
+#: src/SUMMARY.md
 msgid "Rust Ecosystem"
 msgstr "Hệ Sinh Thái Rust"
 
-#: src/SUMMARY.md:11
+#: src/SUMMARY.md
 msgid "Code Samples"
 msgstr "Code Mẫu"
 
-#: src/SUMMARY.md:12
+#: src/SUMMARY.md
 msgid "Running Cargo Locally"
 msgstr "Chạy Cargo Trong Máy Của Bạn"
 
-#: src/SUMMARY.md:16
+#: src/SUMMARY.md
 msgid "Day 1: Morning"
 msgstr "Ngày 1: Buổi Sáng"
 
-#: src/SUMMARY.md:18 src/SUMMARY.md:47 src/SUMMARY.md:76 src/SUMMARY.md:96
-#: src/SUMMARY.md:130 src/SUMMARY.md:150 src/SUMMARY.md:169 src/SUMMARY.md:192
-#: src/SUMMARY.md:215 src/SUMMARY.md:264 src/SUMMARY.md:306 src/SUMMARY.md:357
-#: src/SUMMARY.md:381 src/running-the-course/course-structure.md:15
-#: src/running-the-course/course-structure.md:34
-#: src/running-the-course/course-structure.md:52
-#: src/running-the-course/course-structure.md:69 src/welcome-day-1.md:18
-#: src/welcome-day-2.md:18 src/welcome-day-3.md:15 src/welcome-day-4.md:17
-#: src/concurrency/welcome-async.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-1.md src/welcome-day-2.md src/welcome-day-3.md
+#: src/welcome-day-4.md src/concurrency/welcome-async.md
 msgid "Welcome"
 msgstr "Lời Chào Mừng"
 
-#: src/SUMMARY.md:19 src/SUMMARY.md:24
-#: src/running-the-course/course-structure.md:16 src/welcome-day-1.md:19
-#: src/hello-world.md:1 src/types-and-values.md:7
-#: src/types-and-values/hello-world.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-1.md src/hello-world.md src/types-and-values.md
+#: src/types-and-values/hello-world.md
 msgid "Hello, World"
 msgstr ""
 
-#: src/SUMMARY.md:20 src/hello-world.md:7 src/hello-world/what-is-rust.md:1
+#: src/SUMMARY.md src/hello-world.md src/hello-world/what-is-rust.md
 msgid "What is Rust?"
 msgstr "Rust là gì?"
 
-#: src/SUMMARY.md:21 src/hello-world.md:8 src/hello-world/benefits.md:1
+#: src/SUMMARY.md src/hello-world.md src/hello-world/benefits.md
 msgid "Benefits of Rust"
 msgstr ""
 
-#: src/SUMMARY.md:22 src/hello-world.md:9 src/hello-world/playground.md:1
+#: src/SUMMARY.md src/hello-world.md src/hello-world/playground.md
 msgid "Playground"
 msgstr "Sân chơi (*Playground*)"
 
-#: src/SUMMARY.md:23 src/running-the-course/course-structure.md:17
-#: src/welcome-day-1.md:20 src/types-and-values.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-1.md src/types-and-values.md
 msgid "Types and Values"
 msgstr ""
 
-#: src/SUMMARY.md:25 src/types-and-values.md:8
-#: src/types-and-values/variables.md:1
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/variables.md
 msgid "Variables"
 msgstr ""
 
-#: src/SUMMARY.md:26 src/types-and-values.md:9 src/types-and-values/values.md:1
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/values.md
 msgid "Values"
 msgstr ""
 
-#: src/SUMMARY.md:27 src/types-and-values.md:10
-#: src/types-and-values/arithmetic.md:1
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/arithmetic.md
 msgid "Arithmetic"
 msgstr ""
 
-#: src/SUMMARY.md:28 src/types-and-values.md:11
-#: src/types-and-values/inference.md:1
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/inference.md
 msgid "Type Inference"
 msgstr ""
 
-#: src/SUMMARY.md:29 src/types-and-values.md:12
-#: src/types-and-values/exercise.md:1
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/exercise.md
 msgid "Exercise: Fibonacci"
 msgstr ""
 
-#: src/SUMMARY.md:30 src/SUMMARY.md:43 src/SUMMARY.md:54 src/SUMMARY.md:61
-#: src/SUMMARY.md:70 src/SUMMARY.md:83 src/SUMMARY.md:92 src/SUMMARY.md:104
-#: src/SUMMARY.md:114 src/SUMMARY.md:124 src/SUMMARY.md:140 src/SUMMARY.md:146
-#: src/SUMMARY.md:157 src/SUMMARY.md:163 src/SUMMARY.md:175 src/SUMMARY.md:182
-#: src/SUMMARY.md:188 src/SUMMARY.md:200 src/SUMMARY.md:209
-#: src/types-and-values/solution.md:1 src/control-flow-basics/solution.md:1
-#: src/tuples-and-arrays/solution.md:1 src/references/solution.md:1
-#: src/user-defined-types/solution.md:1 src/pattern-matching/solution.md:1
-#: src/methods-and-traits/solution.md:1 src/generics/solution.md:1
-#: src/std-types/solution.md:1 src/std-traits/solution.md:1
-#: src/memory-management/solution.md:1 src/smart-pointers/solution.md:1
-#: src/borrowing/solution.md:1 src/lifetimes/solution.md:1
-#: src/iterators/solution.md:1 src/modules/solution.md:1
-#: src/testing/solution.md:1 src/error-handling/solution.md:1
-#: src/unsafe-rust/solution.md:1
+#: src/SUMMARY.md src/types-and-values/solution.md
+#: src/control-flow-basics/solution.md src/tuples-and-arrays/solution.md
+#: src/references/solution.md src/user-defined-types/solution.md
+#: src/pattern-matching/solution.md src/methods-and-traits/solution.md
+#: src/generics/solution.md src/std-types/solution.md
+#: src/std-traits/solution.md src/memory-management/solution.md
+#: src/smart-pointers/solution.md src/borrowing/solution.md
+#: src/lifetimes/solution.md src/iterators/solution.md src/modules/solution.md
+#: src/testing/solution.md src/error-handling/solution.md
+#: src/unsafe-rust/solution.md
 msgid "Solution"
 msgstr ""
 
-#: src/SUMMARY.md:31 src/running-the-course/course-structure.md:18
-#: src/welcome-day-1.md:21 src/control-flow-basics.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-1.md src/control-flow-basics.md
 msgid "Control Flow Basics"
 msgstr ""
 
-#: src/SUMMARY.md:32
+#: src/SUMMARY.md
 msgid "`if` Expressions"
 msgstr ""
 
-#: src/SUMMARY.md:33 src/control-flow-basics.md:8
-#: src/control-flow-basics/loops.md:1
+#: src/SUMMARY.md src/control-flow-basics.md src/control-flow-basics/loops.md
 msgid "Loops"
 msgstr "Vòng lặp"
 
-#: src/SUMMARY.md:34 src/control-flow-basics/loops/for.md:1
+#: src/SUMMARY.md src/control-flow-basics/loops/for.md
 msgid "`for`"
 msgstr "`for`"
 
-#: src/SUMMARY.md:35 src/control-flow-basics/loops/loop.md:1
+#: src/SUMMARY.md src/control-flow-basics/loops/loop.md
 msgid "`loop`"
 msgstr "`loop`"
 
-#: src/SUMMARY.md:36 src/control-flow-basics/break-continue.md:1
+#: src/SUMMARY.md src/control-flow-basics/break-continue.md
 msgid "`break` and `continue`"
 msgstr "`break` và `continue`"
 
-#: src/SUMMARY.md:37 src/control-flow-basics/break-continue/labels.md:1
+#: src/SUMMARY.md src/control-flow-basics/break-continue/labels.md
 msgid "Labels"
 msgstr "Labels (nhãn)"
 
-#: src/SUMMARY.md:38 src/control-flow-basics.md:10
-#: src/control-flow-basics/blocks-and-scopes.md:1
+#: src/SUMMARY.md src/control-flow-basics.md
+#: src/control-flow-basics/blocks-and-scopes.md
 msgid "Blocks and Scopes"
 msgstr ""
 
-#: src/SUMMARY.md:39 src/control-flow-basics/blocks-and-scopes/scopes.md:1
+#: src/SUMMARY.md src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid "Scopes and Shadowing"
 msgstr ""
 
-#: src/SUMMARY.md:40 src/control-flow-basics.md:11
-#: src/control-flow-basics/functions.md:1
+#: src/SUMMARY.md src/control-flow-basics.md
+#: src/control-flow-basics/functions.md
 msgid "Functions"
 msgstr ""
 
-#: src/SUMMARY.md:41 src/control-flow-basics.md:12
-#: src/control-flow-basics/macros.md:1
+#: src/SUMMARY.md src/control-flow-basics.md src/control-flow-basics/macros.md
 msgid "Macros"
 msgstr ""
 
-#: src/SUMMARY.md:42 src/control-flow-basics.md:13
-#: src/control-flow-basics/exercise.md:1
+#: src/SUMMARY.md src/control-flow-basics.md
+#: src/control-flow-basics/exercise.md
 msgid "Exercise: Collatz Sequence"
 msgstr ""
 
-#: src/SUMMARY.md:45
+#: src/SUMMARY.md
 msgid "Day 1: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:48 src/running-the-course/course-structure.md:25
-#: src/welcome-day-1-afternoon.md:7 src/tuples-and-arrays.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-1-afternoon.md src/tuples-and-arrays.md
 msgid "Tuples and Arrays"
 msgstr ""
 
-#: src/SUMMARY.md:49 src/tuples-and-arrays.md:7
-#: src/tuples-and-arrays/arrays.md:1
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/arrays.md
 msgid "Arrays"
 msgstr ""
 
-#: src/SUMMARY.md:50 src/tuples-and-arrays.md:8
-#: src/tuples-and-arrays/tuples.md:1
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/tuples.md
 msgid "Tuples"
 msgstr ""
 
-#: src/SUMMARY.md:51 src/tuples-and-arrays.md:9
-#: src/tuples-and-arrays/iteration.md:1
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/iteration.md
 msgid "Array Iteration"
 msgstr ""
 
-#: src/SUMMARY.md:52 src/tuples-and-arrays.md:10
-#: src/tuples-and-arrays/destructuring.md:1
+#: src/SUMMARY.md src/tuples-and-arrays.md
+#: src/tuples-and-arrays/destructuring.md
 msgid "Patterns and Destructuring"
 msgstr ""
 
-#: src/SUMMARY.md:53 src/tuples-and-arrays.md:11
-#: src/tuples-and-arrays/exercise.md:1
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/exercise.md
 msgid "Exercise: Nested Arrays"
 msgstr ""
 
-#: src/SUMMARY.md:55 src/running-the-course/course-structure.md:26
-#: src/welcome-day-1-afternoon.md:8 src/references.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-1-afternoon.md src/references.md
 msgid "References"
 msgstr ""
 
-#: src/SUMMARY.md:56 src/references.md:7 src/references/shared.md:1
+#: src/SUMMARY.md src/references.md src/references/shared.md
 msgid "Shared References"
 msgstr ""
 
-#: src/SUMMARY.md:57 src/references.md:8 src/references/exclusive.md:1
+#: src/SUMMARY.md src/references.md src/references/exclusive.md
 msgid "Exclusive References"
 msgstr ""
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md
 msgid "Slices: `&[T]`"
 msgstr ""
 
-#: src/SUMMARY.md:59 src/references.md:10 src/references/strings.md:5
+#: src/SUMMARY.md src/references.md src/references/strings.md
 msgid "Strings"
 msgstr ""
 
-#: src/SUMMARY.md:60 src/references.md:11 src/references/exercise.md:1
+#: src/SUMMARY.md src/references.md src/references/exercise.md
 msgid "Exercise: Geometry"
 msgstr ""
 
-#: src/SUMMARY.md:62 src/running-the-course/course-structure.md:27
-#: src/welcome-day-1-afternoon.md:9 src/user-defined-types.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-1-afternoon.md src/user-defined-types.md
 msgid "User-Defined Types"
 msgstr ""
 
-#: src/SUMMARY.md:63 src/user-defined-types.md:7
-#: src/user-defined-types/named-structs.md:1
+#: src/SUMMARY.md src/user-defined-types.md
+#: src/user-defined-types/named-structs.md
 msgid "Named Structs"
 msgstr ""
 
-#: src/SUMMARY.md:64 src/user-defined-types.md:8
-#: src/user-defined-types/tuple-structs.md:5
+#: src/SUMMARY.md src/user-defined-types.md
+#: src/user-defined-types/tuple-structs.md
 msgid "Tuple Structs"
 msgstr ""
 
-#: src/SUMMARY.md:65 src/user-defined-types.md:9
-#: src/user-defined-types/enums.md:1
-#: src/pattern-matching/destructuring-enums.md:1
+#: src/SUMMARY.md src/user-defined-types.md src/user-defined-types/enums.md
+#: src/pattern-matching/destructuring-enums.md
 msgid "Enums"
 msgstr ""
 
-#: src/SUMMARY.md:66 src/user-defined-types.md:10
+#: src/SUMMARY.md src/user-defined-types.md
 msgid "Static"
 msgstr ""
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md
 msgid "Const"
 msgstr ""
 
-#: src/SUMMARY.md:68 src/user-defined-types.md:11
-#: src/user-defined-types/aliases.md:1
+#: src/SUMMARY.md src/user-defined-types.md src/user-defined-types/aliases.md
 msgid "Type Aliases"
 msgstr ""
 
-#: src/SUMMARY.md:69 src/user-defined-types.md:12
-#: src/user-defined-types/exercise.md:1
+#: src/SUMMARY.md src/user-defined-types.md src/user-defined-types/exercise.md
 msgid "Exercise: Elevator Events"
 msgstr ""
 
-#: src/SUMMARY.md:74
+#: src/SUMMARY.md
 msgid "Day 2: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:77 src/running-the-course/course-structure.md:35
-#: src/welcome-day-2.md:19 src/pattern-matching.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-2.md src/pattern-matching.md
 msgid "Pattern Matching"
 msgstr ""
 
-#: src/SUMMARY.md:78 src/pattern-matching.md:7 src/pattern-matching/match.md:1
+#: src/SUMMARY.md src/pattern-matching.md src/pattern-matching/match.md
 msgid "Matching Values"
 msgstr ""
 
-#: src/SUMMARY.md:79 src/pattern-matching.md:8
+#: src/SUMMARY.md src/pattern-matching.md
 msgid "Destructuring Structs"
 msgstr ""
 
-#: src/SUMMARY.md:80 src/pattern-matching.md:9
+#: src/SUMMARY.md src/pattern-matching.md
 msgid "Destructuring Enums"
 msgstr ""
 
-#: src/SUMMARY.md:81 src/pattern-matching.md:10
-#: src/pattern-matching/let-control-flow.md:1
+#: src/SUMMARY.md src/pattern-matching.md
+#: src/pattern-matching/let-control-flow.md
 msgid "Let Control Flow"
 msgstr ""
 
-#: src/SUMMARY.md:82 src/pattern-matching.md:11
-#: src/pattern-matching/exercise.md:1
+#: src/SUMMARY.md src/pattern-matching.md src/pattern-matching/exercise.md
 msgid "Exercise: Expression Evaluation"
 msgstr ""
 
-#: src/SUMMARY.md:84 src/running-the-course/course-structure.md:36
-#: src/welcome-day-2.md:20 src/methods-and-traits.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-2.md src/methods-and-traits.md
 msgid "Methods and Traits"
 msgstr ""
 
-#: src/SUMMARY.md:85 src/methods-and-traits.md:7
-#: src/methods-and-traits/methods.md:1
+#: src/SUMMARY.md src/methods-and-traits.md src/methods-and-traits/methods.md
 msgid "Methods"
 msgstr ""
 
-#: src/SUMMARY.md:86 src/methods-and-traits.md:8
-#: src/methods-and-traits/traits.md:1
+#: src/SUMMARY.md src/methods-and-traits.md src/methods-and-traits/traits.md
 msgid "Traits"
 msgstr ""
 
-#: src/SUMMARY.md:87 src/methods-and-traits/traits/implementing.md:1
+#: src/SUMMARY.md src/methods-and-traits/traits/implementing.md
 msgid "Implementing Traits"
 msgstr ""
 
-#: src/SUMMARY.md:88 src/methods-and-traits/traits/supertraits.md:1
+#: src/SUMMARY.md src/methods-and-traits/traits/supertraits.md
 msgid "Supertraits"
 msgstr ""
 
-#: src/SUMMARY.md:89 src/methods-and-traits/traits/associated-types.md:1
+#: src/SUMMARY.md src/methods-and-traits/traits/associated-types.md
 msgid "Associated Types"
 msgstr ""
 
-#: src/SUMMARY.md:90 src/methods-and-traits.md:9
-#: src/methods-and-traits/deriving.md:1
+#: src/SUMMARY.md src/methods-and-traits.md src/methods-and-traits/deriving.md
 msgid "Deriving"
 msgstr ""
 
-#: src/SUMMARY.md:91 src/methods-and-traits.md:10
+#: src/SUMMARY.md src/methods-and-traits.md
 msgid "Exercise: Generic Logger"
 msgstr ""
 
-#: src/SUMMARY.md:94
+#: src/SUMMARY.md
 msgid "Day 2: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:97 src/running-the-course/course-structure.md:43
-#: src/welcome-day-2-afternoon.md:7 src/generics.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-2-afternoon.md src/generics.md
 msgid "Generics"
 msgstr ""
 
-#: src/SUMMARY.md:98 src/generics.md:7 src/generics/generic-functions.md:1
+#: src/SUMMARY.md src/generics.md src/generics/generic-functions.md
 msgid "Generic Functions"
 msgstr ""
 
-#: src/SUMMARY.md:99 src/generics.md:8 src/generics/generic-data.md:1
+#: src/SUMMARY.md src/generics.md src/generics/generic-data.md
 msgid "Generic Data Types"
 msgstr ""
 
-#: src/SUMMARY.md:100 src/generics/generic-traits.md:1
+#: src/SUMMARY.md src/generics/generic-traits.md
 msgid "Generic Traits"
 msgstr ""
 
-#: src/SUMMARY.md:101 src/generics.md:9 src/generics/trait-bounds.md:1
+#: src/SUMMARY.md src/generics.md src/generics/trait-bounds.md
 msgid "Trait Bounds"
 msgstr ""
 
-#: src/SUMMARY.md:102 src/generics/impl-trait.md:1
+#: src/SUMMARY.md src/generics/impl-trait.md
 msgid "`impl Trait`"
 msgstr ""
 
-#: src/SUMMARY.md:103 src/generics/exercise.md:1
+#: src/SUMMARY.md src/generics/exercise.md
 msgid "Exercise: Generic `min`"
 msgstr ""
 
-#: src/SUMMARY.md:105 src/running-the-course/course-structure.md:44
-#: src/welcome-day-2-afternoon.md:8 src/std-types.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-2-afternoon.md src/std-types.md
 msgid "Standard Library Types"
 msgstr ""
 
-#: src/SUMMARY.md:106 src/std-types.md:7 src/std-types/std.md:1
+#: src/SUMMARY.md src/std-types.md src/std-types/std.md
 msgid "Standard Library"
 msgstr ""
 
-#: src/SUMMARY.md:107 src/std-types.md:8 src/std-types/docs.md:1
+#: src/SUMMARY.md src/std-types.md src/std-types/docs.md
 msgid "Documentation"
 msgstr ""
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md
 msgid "`Option`"
 msgstr ""
 
-#: src/SUMMARY.md:109
+#: src/SUMMARY.md
 msgid "`Result`"
 msgstr ""
 
-#: src/SUMMARY.md:110 src/android/aidl/types/primitives.md:14
-#: src/android/interoperability/cpp/type-mapping.md:5
+#: src/SUMMARY.md src/android/aidl/types/primitives.md
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`String`"
 msgstr ""
 
-#: src/SUMMARY.md:111 src/std-types/vec.md:1
+#: src/SUMMARY.md src/std-types/vec.md
 msgid "`Vec`"
 msgstr ""
 
-#: src/SUMMARY.md:112 src/std-types/hashmap.md:1 src/bare-metal/no_std.md:46
+#: src/SUMMARY.md src/std-types/hashmap.md src/bare-metal/no_std.md
 msgid "`HashMap`"
 msgstr ""
 
-#: src/SUMMARY.md:113 src/std-types.md:14 src/std-types/exercise.md:1
+#: src/SUMMARY.md src/std-types.md src/std-types/exercise.md
 msgid "Exercise: Counter"
 msgstr ""
 
-#: src/SUMMARY.md:115 src/running-the-course/course-structure.md:45
-#: src/welcome-day-2-afternoon.md:9 src/std-traits.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-2-afternoon.md src/std-traits.md
 msgid "Standard Library Traits"
 msgstr ""
 
-#: src/SUMMARY.md:116 src/std-traits.md:7 src/std-traits/comparisons.md:1
-#: src/concurrency/welcome-async.md:17
+#: src/SUMMARY.md src/std-traits.md src/std-traits/comparisons.md
+#: src/concurrency/welcome-async.md
 msgid "Comparisons"
 msgstr ""
 
-#: src/SUMMARY.md:117 src/std-traits.md:8 src/std-traits/operators.md:1
+#: src/SUMMARY.md src/std-traits.md src/std-traits/operators.md
 msgid "Operators"
 msgstr ""
 
-#: src/SUMMARY.md:118 src/std-traits/from-and-into.md:1
+#: src/SUMMARY.md src/std-traits/from-and-into.md
 msgid "`From` and `Into`"
 msgstr ""
 
-#: src/SUMMARY.md:119 src/std-traits.md:10 src/std-traits/casting.md:1
+#: src/SUMMARY.md src/std-traits.md src/std-traits/casting.md
 msgid "Casting"
 msgstr ""
 
-#: src/SUMMARY.md:120 src/std-traits/read-and-write.md:1
+#: src/SUMMARY.md src/std-traits/read-and-write.md
 msgid "`Read` and `Write`"
 msgstr ""
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md
 msgid "`Default`, struct update syntax"
 msgstr ""
 
-#: src/SUMMARY.md:122 src/std-traits.md:13 src/std-traits/closures.md:1
+#: src/SUMMARY.md src/std-traits.md src/std-traits/closures.md
 msgid "Closures"
 msgstr ""
 
-#: src/SUMMARY.md:123 src/std-traits.md:14 src/std-traits/exercise.md:1
+#: src/SUMMARY.md src/std-traits.md src/std-traits/exercise.md
 msgid "Exercise: ROT13"
 msgstr ""
 
-#: src/SUMMARY.md:128
+#: src/SUMMARY.md
 msgid "Day 3: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:131 src/running-the-course/course-structure.md:53
-#: src/welcome-day-3.md:16 src/memory-management.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-3.md src/memory-management.md
 msgid "Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md:132 src/memory-management.md:7
-#: src/memory-management/review.md:1
+#: src/SUMMARY.md src/memory-management.md src/memory-management/review.md
 msgid "Review of Program Memory"
 msgstr ""
 
-#: src/SUMMARY.md:133 src/memory-management.md:8
-#: src/memory-management/approaches.md:1
+#: src/SUMMARY.md src/memory-management.md src/memory-management/approaches.md
 msgid "Approaches to Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md:134 src/memory-management.md:9
-#: src/memory-management/ownership.md:1
+#: src/SUMMARY.md src/memory-management.md src/memory-management/ownership.md
 msgid "Ownership"
 msgstr ""
 
-#: src/SUMMARY.md:135 src/memory-management.md:10
-#: src/memory-management/move.md:1
+#: src/SUMMARY.md src/memory-management.md src/memory-management/move.md
 msgid "Move Semantics"
 msgstr ""
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md
 msgid "`Clone`"
 msgstr ""
 
-#: src/SUMMARY.md:137 src/memory-management.md:12
-#: src/memory-management/copy-types.md:1
+#: src/SUMMARY.md src/memory-management.md src/memory-management/copy-types.md
 msgid "Copy Types"
 msgstr ""
 
-#: src/SUMMARY.md:138
+#: src/SUMMARY.md
 msgid "`Drop`"
 msgstr ""
 
-#: src/SUMMARY.md:139 src/memory-management.md:14
-#: src/memory-management/exercise.md:1
+#: src/SUMMARY.md src/memory-management.md src/memory-management/exercise.md
 msgid "Exercise: Builder Type"
 msgstr ""
 
-#: src/SUMMARY.md:141 src/running-the-course/course-structure.md:54
-#: src/welcome-day-3.md:17 src/smart-pointers.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-3.md src/smart-pointers.md
 msgid "Smart Pointers"
 msgstr ""
 
-#: src/SUMMARY.md:142 src/smart-pointers/box.md:1
-#: src/android/interoperability/cpp/type-mapping.md:9
+#: src/SUMMARY.md src/smart-pointers/box.md
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`Box<T>`"
 msgstr ""
 
-#: src/SUMMARY.md:143 src/smart-pointers/rc.md:1
+#: src/SUMMARY.md src/smart-pointers/rc.md
 msgid "`Rc`"
 msgstr ""
 
-#: src/SUMMARY.md:144 src/smart-pointers.md:9
-#: src/smart-pointers/trait-objects.md:1
+#: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/trait-objects.md
 msgid "Trait Objects"
 msgstr ""
 
-#: src/SUMMARY.md:145 src/smart-pointers.md:10 src/smart-pointers/exercise.md:1
+#: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/exercise.md
 msgid "Exercise: Binary Tree"
 msgstr ""
 
-#: src/SUMMARY.md:148
+#: src/SUMMARY.md
 msgid "Day 3: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:151 src/running-the-course/course-structure.md:61
-#: src/welcome-day-3-afternoon.md:7 src/borrowing.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-3-afternoon.md src/borrowing.md
 msgid "Borrowing"
 msgstr ""
 
-#: src/SUMMARY.md:152 src/borrowing.md:7 src/borrowing/shared.md:1
+#: src/SUMMARY.md src/borrowing.md src/borrowing/shared.md
 msgid "Borrowing a Value"
 msgstr ""
 
-#: src/SUMMARY.md:153 src/borrowing.md:8 src/borrowing/borrowck.md:1
+#: src/SUMMARY.md src/borrowing.md src/borrowing/borrowck.md
 msgid "Borrow Checking"
 msgstr ""
 
-#: src/SUMMARY.md:154 src/borrowing.md:9 src/borrowing/examples.md:1
+#: src/SUMMARY.md src/borrowing.md src/borrowing/examples.md
 msgid "Borrow Errors"
 msgstr ""
 
-#: src/SUMMARY.md:155 src/borrowing.md:10
-#: src/borrowing/interior-mutability.md:1
+#: src/SUMMARY.md src/borrowing.md src/borrowing/interior-mutability.md
 msgid "Interior Mutability"
 msgstr ""
 
-#: src/SUMMARY.md:156 src/borrowing.md:11 src/borrowing/exercise.md:1
+#: src/SUMMARY.md src/borrowing.md src/borrowing/exercise.md
 msgid "Exercise: Health Statistics"
 msgstr ""
 
-#: src/SUMMARY.md:158 src/running-the-course/course-structure.md:62
-#: src/welcome-day-3-afternoon.md:8 src/lifetimes.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-3-afternoon.md src/lifetimes.md
 msgid "Lifetimes"
 msgstr ""
 
-#: src/SUMMARY.md:159 src/lifetimes.md:7
-#: src/lifetimes/lifetime-annotations.md:1
+#: src/SUMMARY.md src/lifetimes.md src/lifetimes/lifetime-annotations.md
 msgid "Lifetime Annotations"
 msgstr ""
 
-#: src/SUMMARY.md:160 src/lifetimes.md:8
+#: src/SUMMARY.md src/lifetimes.md
 msgid "Lifetime Elision"
 msgstr ""
 
-#: src/SUMMARY.md:161 src/lifetimes.md:9
+#: src/SUMMARY.md src/lifetimes.md
 msgid "Struct Lifetimes"
 msgstr ""
 
-#: src/SUMMARY.md:162 src/lifetimes.md:10 src/lifetimes/exercise.md:1
+#: src/SUMMARY.md src/lifetimes.md src/lifetimes/exercise.md
 msgid "Exercise: Protobuf Parsing"
 msgstr ""
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md
 msgid "Day 4: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:170 src/running-the-course/course-structure.md:70
-#: src/welcome-day-4.md:18 src/iterators.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-4.md src/iterators.md
 msgid "Iterators"
 msgstr ""
 
-#: src/SUMMARY.md:171 src/iterators/iterator.md:1 src/bare-metal/no_std.md:28
+#: src/SUMMARY.md src/iterators/iterator.md src/bare-metal/no_std.md
 msgid "`Iterator`"
 msgstr ""
 
-#: src/SUMMARY.md:172 src/iterators/intoiterator.md:1
+#: src/SUMMARY.md src/iterators/intoiterator.md
 msgid "`IntoIterator`"
 msgstr ""
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md
 msgid "`FromIterator`"
 msgstr ""
 
-#: src/SUMMARY.md:174 src/iterators.md:10 src/iterators/exercise.md:1
+#: src/SUMMARY.md src/iterators.md src/iterators/exercise.md
 msgid "Exercise: Iterator Method Chaining"
 msgstr ""
 
-#: src/SUMMARY.md:176 src/SUMMARY.md:177
-#: src/running-the-course/course-structure.md:71 src/welcome-day-4.md:19
-#: src/modules.md:1 src/modules.md:7 src/modules/modules.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-4.md src/modules.md src/modules/modules.md
 msgid "Modules"
 msgstr ""
 
-#: src/SUMMARY.md:178 src/modules.md:8 src/modules/filesystem.md:1
+#: src/SUMMARY.md src/modules.md src/modules/filesystem.md
 msgid "Filesystem Hierarchy"
 msgstr ""
 
-#: src/SUMMARY.md:179 src/modules.md:9 src/modules/visibility.md:1
+#: src/SUMMARY.md src/modules.md src/modules/visibility.md
 msgid "Visibility"
 msgstr ""
 
-#: src/SUMMARY.md:180
+#: src/SUMMARY.md
 msgid "`use`, `super`, `self`"
 msgstr ""
 
-#: src/SUMMARY.md:181 src/modules.md:11 src/modules/exercise.md:1
+#: src/SUMMARY.md src/modules.md src/modules/exercise.md
 msgid "Exercise: Modules for a GUI Library"
 msgstr ""
 
-#: src/SUMMARY.md:183 src/SUMMARY.md:236 src/SUMMARY.md:273
-#: src/running-the-course/course-structure.md:72 src/welcome-day-4.md:20
-#: src/testing.md:1 src/chromium/testing.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-4.md src/testing.md src/chromium/testing.md
 msgid "Testing"
 msgstr ""
 
-#: src/SUMMARY.md:184 src/testing.md:7
+#: src/SUMMARY.md src/testing.md
 msgid "Test Modules"
 msgstr ""
 
-#: src/SUMMARY.md:185 src/testing.md:8 src/testing/other.md:1
+#: src/SUMMARY.md src/testing.md src/testing/other.md
 msgid "Other Types of Tests"
 msgstr ""
 
-#: src/SUMMARY.md:186 src/testing.md:9 src/testing/lints.md:1
+#: src/SUMMARY.md src/testing.md src/testing/lints.md
 msgid "Compiler Lints and Clippy"
 msgstr ""
 
-#: src/SUMMARY.md:187 src/testing.md:10 src/testing/exercise.md:1
+#: src/SUMMARY.md src/testing.md src/testing/exercise.md
 msgid "Exercise: Luhn Algorithm"
 msgstr ""
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md
 msgid "Day 4: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:193 src/running-the-course/course-structure.md:79
-#: src/welcome-day-4-afternoon.md:7 src/error-handling.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-4-afternoon.md src/error-handling.md
 msgid "Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md:194 src/error-handling.md:7 src/error-handling/panics.md:1
+#: src/SUMMARY.md src/error-handling.md src/error-handling/panics.md
 msgid "Panics"
 msgstr ""
 
-#: src/SUMMARY.md:195 src/error-handling.md:8 src/error-handling/try.md:1
+#: src/SUMMARY.md src/error-handling.md src/error-handling/try.md
 msgid "Try Operator"
 msgstr ""
 
-#: src/SUMMARY.md:196 src/error-handling.md:9
-#: src/error-handling/try-conversions.md:1
+#: src/SUMMARY.md src/error-handling.md src/error-handling/try-conversions.md
 msgid "Try Conversions"
 msgstr ""
 
-#: src/SUMMARY.md:197
+#: src/SUMMARY.md
 msgid "`Error` Trait"
 msgstr ""
 
-#: src/SUMMARY.md:198 src/error-handling/thiserror-and-anyhow.md:1
+#: src/SUMMARY.md src/error-handling/thiserror-and-anyhow.md
 msgid "`thiserror` and `anyhow`"
 msgstr ""
 
-#: src/SUMMARY.md:199
+#: src/SUMMARY.md
 msgid "Exercise: Rewriting with `Result`"
 msgstr ""
 
-#: src/SUMMARY.md:201 src/running-the-course/course-structure.md:80
-#: src/welcome-day-4-afternoon.md:8 src/unsafe-rust.md:1
-#: src/unsafe-rust/unsafe.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/welcome-day-4-afternoon.md src/unsafe-rust.md src/unsafe-rust/unsafe.md
 msgid "Unsafe Rust"
 msgstr ""
 
-#: src/SUMMARY.md:202 src/unsafe-rust.md:7
+#: src/SUMMARY.md src/unsafe-rust.md
 msgid "Unsafe"
 msgstr ""
 
-#: src/SUMMARY.md:203 src/unsafe-rust.md:8 src/unsafe-rust/dereferencing.md:1
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/dereferencing.md
 msgid "Dereferencing Raw Pointers"
 msgstr ""
 
-#: src/SUMMARY.md:204 src/unsafe-rust.md:9 src/unsafe-rust/mutable-static.md:1
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/mutable-static.md
 msgid "Mutable Static Variables"
 msgstr ""
 
-#: src/SUMMARY.md:205 src/unsafe-rust.md:10 src/unsafe-rust/unions.md:1
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unions.md
 msgid "Unions"
 msgstr ""
 
-#: src/SUMMARY.md:206 src/unsafe-rust.md:11
-#: src/unsafe-rust/unsafe-functions.md:1
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unsafe-functions.md
 msgid "Unsafe Functions"
 msgstr ""
 
-#: src/SUMMARY.md:207 src/unsafe-rust.md:12
+#: src/SUMMARY.md src/unsafe-rust.md
 msgid "Unsafe Traits"
 msgstr ""
 
-#: src/SUMMARY.md:208 src/unsafe-rust.md:13
+#: src/SUMMARY.md src/unsafe-rust.md
 msgid "Exercise: FFI Wrapper"
 msgstr ""
 
-#: src/SUMMARY.md:211 src/SUMMARY.md:347 src/bare-metal/android.md:1
+#: src/SUMMARY.md src/bare-metal/android.md
 msgid "Android"
 msgstr ""
 
-#: src/SUMMARY.md:216 src/SUMMARY.md:265 src/android/setup.md:1
-#: src/chromium/setup.md:1
+#: src/SUMMARY.md src/android/setup.md src/chromium/setup.md
 msgid "Setup"
 msgstr ""
 
-#: src/SUMMARY.md:217 src/SUMMARY.md:268 src/android/build-rules.md:1
+#: src/SUMMARY.md src/android/build-rules.md
 msgid "Build Rules"
 msgstr ""
 
-#: src/SUMMARY.md:218
+#: src/SUMMARY.md
 msgid "Binary"
 msgstr ""
 
-#: src/SUMMARY.md:219
+#: src/SUMMARY.md
 msgid "Library"
 msgstr ""
 
-#: src/SUMMARY.md:220 src/android/aidl.md:1
+#: src/SUMMARY.md src/android/aidl.md
 msgid "AIDL"
 msgstr ""
 
-#: src/SUMMARY.md:221 src/android/aidl/birthday-service.md:1
+#: src/SUMMARY.md src/android/aidl/birthday-service.md
 msgid "Birthday Service Tutorial"
 msgstr ""
 
-#: src/SUMMARY.md:222
+#: src/SUMMARY.md
 msgid "Interface"
 msgstr ""
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md
 msgid "Service API"
 msgstr ""
 
-#: src/SUMMARY.md:224
+#: src/SUMMARY.md
 msgid "Service"
 msgstr ""
 
-#: src/SUMMARY.md:225
+#: src/SUMMARY.md
 msgid "Server"
 msgstr ""
 
-#: src/SUMMARY.md:226 src/android/aidl/example-service/deploy.md:1
+#: src/SUMMARY.md src/android/aidl/example-service/deploy.md
 msgid "Deploy"
 msgstr ""
 
-#: src/SUMMARY.md:227
+#: src/SUMMARY.md
 msgid "Client"
 msgstr ""
 
-#: src/SUMMARY.md:228 src/android/aidl/example-service/changing-definition.md:1
+#: src/SUMMARY.md src/android/aidl/example-service/changing-definition.md
 msgid "Changing API"
 msgstr ""
 
-#: src/SUMMARY.md:229
+#: src/SUMMARY.md
 msgid "Updating Implementations"
 msgstr ""
 
-#: src/SUMMARY.md:230
+#: src/SUMMARY.md
 msgid "AIDL Types"
 msgstr ""
 
-#: src/SUMMARY.md:231 src/android/aidl/types/primitives.md:1
+#: src/SUMMARY.md src/android/aidl/types/primitives.md
 msgid "Primitive Types"
 msgstr ""
 
-#: src/SUMMARY.md:232 src/android/aidl/types/arrays.md:1
+#: src/SUMMARY.md src/android/aidl/types/arrays.md
 msgid "Array Types"
 msgstr ""
 
-#: src/SUMMARY.md:233 src/android/aidl/types/objects.md:1
+#: src/SUMMARY.md src/android/aidl/types/objects.md
 msgid "Sending Objects"
 msgstr ""
 
-#: src/SUMMARY.md:234 src/android/aidl/types/parcelables.md:1
+#: src/SUMMARY.md src/android/aidl/types/parcelables.md
 msgid "Parcelables"
 msgstr ""
 
-#: src/SUMMARY.md:235 src/android/aidl/types/file-descriptor.md:1
+#: src/SUMMARY.md src/android/aidl/types/file-descriptor.md
 msgid "Sending Files"
 msgstr ""
 
-#: src/SUMMARY.md:237 src/android/testing/googletest.md:1
+#: src/SUMMARY.md src/android/testing/googletest.md
 msgid "GoogleTest"
 msgstr ""
 
-#: src/SUMMARY.md:238 src/android/testing/mocking.md:1
+#: src/SUMMARY.md src/android/testing/mocking.md
 msgid "Mocking"
 msgstr ""
 
-#: src/SUMMARY.md:239 src/SUMMARY.md:337 src/android/logging.md:1
-#: src/bare-metal/aps/logging.md:1
+#: src/SUMMARY.md src/android/logging.md src/bare-metal/aps/logging.md
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md:240 src/android/interoperability.md:1
+#: src/SUMMARY.md src/android/interoperability.md
 msgid "Interoperability"
 msgstr ""
 
-#: src/SUMMARY.md:241
+#: src/SUMMARY.md
 msgid "With C"
 msgstr ""
 
-#: src/SUMMARY.md:242
+#: src/SUMMARY.md
 msgid "Calling C with Bindgen"
 msgstr ""
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md
 msgid "Calling Rust from C"
 msgstr ""
 
-#: src/SUMMARY.md:244 src/android/interoperability/cpp.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp.md
 msgid "With C++"
 msgstr ""
 
-#: src/SUMMARY.md:245 src/android/interoperability/cpp/bridge.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp/bridge.md
 msgid "The Bridge Module"
 msgstr ""
 
-#: src/SUMMARY.md:246
+#: src/SUMMARY.md
 msgid "Rust Bridge"
 msgstr ""
 
-#: src/SUMMARY.md:247 src/android/interoperability/cpp/generated-cpp.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp/generated-cpp.md
 msgid "Generated C++"
 msgstr ""
 
-#: src/SUMMARY.md:248
+#: src/SUMMARY.md
 msgid "C++ Bridge"
 msgstr ""
 
-#: src/SUMMARY.md:249 src/android/interoperability/cpp/shared-types.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp/shared-types.md
 msgid "Shared Types"
 msgstr ""
 
-#: src/SUMMARY.md:250 src/android/interoperability/cpp/shared-enums.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp/shared-enums.md
 msgid "Shared Enums"
 msgstr ""
 
-#: src/SUMMARY.md:251 src/android/interoperability/cpp/rust-result.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp/rust-result.md
 msgid "Rust Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md:252 src/android/interoperability/cpp/cpp-exception.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp/cpp-exception.md
 msgid "C++ Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md:253 src/android/interoperability/cpp/type-mapping.md:1
+#: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
 msgid "Additional Types"
 msgstr ""
 
-#: src/SUMMARY.md:254
+#: src/SUMMARY.md
 msgid "Building for Android: C++"
 msgstr ""
 
-#: src/SUMMARY.md:255
+#: src/SUMMARY.md
 msgid "Building for Android: Genrules"
 msgstr ""
 
-#: src/SUMMARY.md:256
+#: src/SUMMARY.md
 msgid "Building for Android: Rust"
 msgstr ""
 
-#: src/SUMMARY.md:257
+#: src/SUMMARY.md
 msgid "With Java"
 msgstr ""
 
-#: src/SUMMARY.md:258 src/SUMMARY.md:320 src/SUMMARY.md:349 src/SUMMARY.md:374
-#: src/SUMMARY.md:397 src/running-the-course/course-structure.md:155
-#: src/running-the-course/course-structure.md:165
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1 src/concurrency/welcome.md:20
-#: src/concurrency/sync-exercises.md:1 src/concurrency/welcome-async.md:36
-#: src/concurrency/async-exercises.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/exercises/android/morning.md src/exercises/bare-metal/morning.md
+#: src/exercises/bare-metal/afternoon.md src/concurrency/welcome.md
+#: src/concurrency/sync-exercises.md src/concurrency/welcome-async.md
+#: src/concurrency/async-exercises.md
 msgid "Exercises"
 msgstr ""
 
-#: src/SUMMARY.md:260
+#: src/SUMMARY.md
 msgid "Chromium"
 msgstr ""
 
-#: src/SUMMARY.md:266 src/chromium/cargo.md:1
+#: src/SUMMARY.md src/chromium/cargo.md
 msgid "Comparing Chromium and Cargo Ecosystems"
 msgstr ""
 
-#: src/SUMMARY.md:267
+#: src/SUMMARY.md
 msgid "Policy"
 msgstr ""
 
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md
 msgid "Unsafe Code"
 msgstr ""
 
-#: src/SUMMARY.md:270 src/chromium/build-rules/depending.md:1
+#: src/SUMMARY.md src/chromium/build-rules/depending.md
 msgid "Depending on Rust Code from Chromium C++"
 msgstr ""
 
-#: src/SUMMARY.md:271 src/chromium/build-rules/vscode.md:1
+#: src/SUMMARY.md src/chromium/build-rules/vscode.md
 msgid "Visual Studio Code"
 msgstr ""
 
-#: src/SUMMARY.md:272 src/SUMMARY.md:277 src/SUMMARY.md:285 src/SUMMARY.md:298
-#: src/exercises/chromium/third-party.md:1
+#: src/SUMMARY.md src/exercises/chromium/third-party.md
 msgid "Exercise"
 msgstr ""
 
-#: src/SUMMARY.md:274 src/chromium/testing/rust-gtest-interop.md:1
+#: src/SUMMARY.md src/chromium/testing/rust-gtest-interop.md
 msgid "`rust_gtest_interop` Library"
 msgstr ""
 
-#: src/SUMMARY.md:275 src/chromium/testing/build-gn.md:1
+#: src/SUMMARY.md src/chromium/testing/build-gn.md
 msgid "GN Rules for Rust Tests"
 msgstr ""
 
-#: src/SUMMARY.md:276 src/chromium/testing/chromium-import-macro.md:1
+#: src/SUMMARY.md src/chromium/testing/chromium-import-macro.md
 msgid "`chromium::import!` Macro"
 msgstr ""
 
-#: src/SUMMARY.md:278 src/chromium/interoperability-with-cpp.md:1
+#: src/SUMMARY.md src/chromium/interoperability-with-cpp.md
 msgid "Interoperability with C++"
 msgstr ""
 
-#: src/SUMMARY.md:279
-#: src/chromium/interoperability-with-cpp/example-bindings.md:1
+#: src/SUMMARY.md src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Example Bindings"
 msgstr ""
 
-#: src/SUMMARY.md:280
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:1
+#: src/SUMMARY.md src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "Limitations of CXX"
 msgstr ""
 
-#: src/SUMMARY.md:281
-#: src/chromium/interoperability-with-cpp/error-handling.md:1
+#: src/SUMMARY.md src/chromium/interoperability-with-cpp/error-handling.md
 msgid "CXX Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md:282
+#: src/SUMMARY.md
 msgid "Error Handling: QR Example"
 msgstr ""
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md
 msgid "Error Handling: PNG Example"
 msgstr ""
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md
 msgid "Using CXX in Chromium"
 msgstr ""
 
-#: src/SUMMARY.md:286 src/chromium/adding-third-party-crates.md:1
+#: src/SUMMARY.md src/chromium/adding-third-party-crates.md
 msgid "Adding Third Party Crates"
 msgstr ""
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md
 msgid "Configuring Cargo.toml"
 msgstr ""
 
-#: src/SUMMARY.md:288
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:1
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid "Configuring `gnrt_config.toml`"
 msgstr ""
 
-#: src/SUMMARY.md:289
-#: src/chromium/adding-third-party-crates/downloading-crates.md:1
+#: src/SUMMARY.md src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "Downloading Crates"
 msgstr ""
 
-#: src/SUMMARY.md:290
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:1
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid "Generating `gn` Build Rules"
 msgstr ""
 
-#: src/SUMMARY.md:291
-#: src/chromium/adding-third-party-crates/resolving-problems.md:1
+#: src/SUMMARY.md src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Resolving Problems"
 msgstr ""
 
-#: src/SUMMARY.md:292
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:1
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid "Build Scripts Which Generate Code"
 msgstr ""
 
-#: src/SUMMARY.md:293
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:1
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "Build Scripts Which Build C++ or Take Arbitrary Actions"
 msgstr ""
 
-#: src/SUMMARY.md:294
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:1
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid "Depending on a Crate"
 msgstr ""
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md
 msgid "Reviews and Audits"
 msgstr ""
 
-#: src/SUMMARY.md:296
+#: src/SUMMARY.md
 msgid "Checking into Chromium Source Code"
 msgstr ""
 
-#: src/SUMMARY.md:297
-#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:1
+#: src/SUMMARY.md src/chromium/adding-third-party-crates/keeping-up-to-date.md
 msgid "Keeping Crates Up to Date"
 msgstr ""
 
-#: src/SUMMARY.md:299
+#: src/SUMMARY.md
 msgid "Bringing It Together - Exercise"
 msgstr ""
 
-#: src/SUMMARY.md:300 src/exercises/chromium/solutions.md:1
+#: src/SUMMARY.md src/exercises/chromium/solutions.md
 msgid "Exercise Solutions"
 msgstr ""
 
-#: src/SUMMARY.md:302
+#: src/SUMMARY.md
 msgid "Bare Metal: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:307 src/bare-metal/no_std.md:1
+#: src/SUMMARY.md src/bare-metal/no_std.md
 msgid "`no_std`"
 msgstr ""
 
-#: src/SUMMARY.md:308
+#: src/SUMMARY.md
 msgid "A Minimal Example"
 msgstr ""
 
-#: src/SUMMARY.md:309 src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
+#: src/SUMMARY.md src/bare-metal/no_std.md src/bare-metal/alloc.md
 msgid "`alloc`"
 msgstr ""
 
-#: src/SUMMARY.md:310 src/bare-metal/microcontrollers.md:1
+#: src/SUMMARY.md src/bare-metal/microcontrollers.md
 msgid "Microcontrollers"
 msgstr ""
 
-#: src/SUMMARY.md:311 src/bare-metal/microcontrollers/mmio.md:1
+#: src/SUMMARY.md src/bare-metal/microcontrollers/mmio.md
 msgid "Raw MMIO"
 msgstr ""
 
-#: src/SUMMARY.md:312
+#: src/SUMMARY.md
 msgid "PACs"
 msgstr ""
 
-#: src/SUMMARY.md:313
+#: src/SUMMARY.md
 msgid "HAL Crates"
 msgstr ""
 
-#: src/SUMMARY.md:314
+#: src/SUMMARY.md
 msgid "Board Support Crates"
 msgstr ""
 
-#: src/SUMMARY.md:315
+#: src/SUMMARY.md
 msgid "The Type State Pattern"
 msgstr ""
 
-#: src/SUMMARY.md:316 src/bare-metal/microcontrollers/embedded-hal.md:1
+#: src/SUMMARY.md src/bare-metal/microcontrollers/embedded-hal.md
 msgid "`embedded-hal`"
 msgstr ""
 
-#: src/SUMMARY.md:317 src/bare-metal/microcontrollers/probe-rs.md:1
+#: src/SUMMARY.md src/bare-metal/microcontrollers/probe-rs.md
 msgid "`probe-rs` and `cargo-embed`"
 msgstr ""
 
-#: src/SUMMARY.md:318 src/bare-metal/microcontrollers/debugging.md:1
+#: src/SUMMARY.md src/bare-metal/microcontrollers/debugging.md
 msgid "Debugging"
 msgstr ""
 
-#: src/SUMMARY.md:319 src/SUMMARY.md:340
+#: src/SUMMARY.md
 msgid "Other Projects"
 msgstr ""
 
-#: src/SUMMARY.md:321 src/exercises/bare-metal/compass.md:1
-#: src/exercises/bare-metal/solutions-morning.md:3
+#: src/SUMMARY.md src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "Compass"
 msgstr ""
 
-#: src/SUMMARY.md:322 src/SUMMARY.md:351 src/SUMMARY.md:377 src/SUMMARY.md:400
-#: src/concurrency/sync-exercises.md:9
-#: src/concurrency/sync-exercises/solutions.md:1
-#: src/concurrency/async-exercises.md:9
-#: src/concurrency/async-exercises/solutions.md:1
+#: src/SUMMARY.md src/concurrency/sync-exercises.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "Solutions"
 msgstr ""
 
-#: src/SUMMARY.md:324
+#: src/SUMMARY.md
 msgid "Bare Metal: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:326
+#: src/SUMMARY.md
 msgid "Application Processors"
 msgstr ""
 
-#: src/SUMMARY.md:327 src/bare-metal/aps/entry-point.md:1
+#: src/SUMMARY.md src/bare-metal/aps/entry-point.md
 msgid "Getting Ready to Rust"
 msgstr ""
 
-#: src/SUMMARY.md:328
+#: src/SUMMARY.md
 msgid "Inline Assembly"
 msgstr ""
 
-#: src/SUMMARY.md:329
+#: src/SUMMARY.md
 msgid "MMIO"
 msgstr ""
 
-#: src/SUMMARY.md:330
+#: src/SUMMARY.md
 msgid "Let's Write a UART Driver"
 msgstr ""
 
-#: src/SUMMARY.md:331
+#: src/SUMMARY.md
 msgid "More Traits"
 msgstr ""
 
-#: src/SUMMARY.md:332
+#: src/SUMMARY.md
 msgid "A Better UART Driver"
 msgstr ""
 
-#: src/SUMMARY.md:333 src/bare-metal/aps/better-uart/bitflags.md:1
+#: src/SUMMARY.md src/bare-metal/aps/better-uart/bitflags.md
 msgid "Bitflags"
 msgstr ""
 
-#: src/SUMMARY.md:334
+#: src/SUMMARY.md
 msgid "Multiple Registers"
 msgstr ""
 
-#: src/SUMMARY.md:335 src/bare-metal/aps/better-uart/driver.md:1
+#: src/SUMMARY.md src/bare-metal/aps/better-uart/driver.md
 msgid "Driver"
 msgstr ""
 
-#: src/SUMMARY.md:336 src/SUMMARY.md:338
+#: src/SUMMARY.md
 msgid "Using It"
 msgstr ""
 
-#: src/SUMMARY.md:339 src/bare-metal/aps/exceptions.md:1
+#: src/SUMMARY.md src/bare-metal/aps/exceptions.md
 msgid "Exceptions"
 msgstr ""
 
-#: src/SUMMARY.md:341
+#: src/SUMMARY.md
 msgid "Useful Crates"
 msgstr ""
 
-#: src/SUMMARY.md:342 src/bare-metal/useful-crates/zerocopy.md:1
+#: src/SUMMARY.md src/bare-metal/useful-crates/zerocopy.md
 msgid "`zerocopy`"
 msgstr ""
 
-#: src/SUMMARY.md:343 src/bare-metal/useful-crates/aarch64-paging.md:1
+#: src/SUMMARY.md src/bare-metal/useful-crates/aarch64-paging.md
 msgid "`aarch64-paging`"
 msgstr ""
 
-#: src/SUMMARY.md:344 src/bare-metal/useful-crates/buddy_system_allocator.md:1
+#: src/SUMMARY.md src/bare-metal/useful-crates/buddy_system_allocator.md
 msgid "`buddy_system_allocator`"
 msgstr ""
 
-#: src/SUMMARY.md:345 src/bare-metal/useful-crates/tinyvec.md:1
+#: src/SUMMARY.md src/bare-metal/useful-crates/tinyvec.md
 msgid "`tinyvec`"
 msgstr ""
 
-#: src/SUMMARY.md:346 src/bare-metal/useful-crates/spin.md:1
+#: src/SUMMARY.md src/bare-metal/useful-crates/spin.md
 msgid "`spin`"
 msgstr ""
 
-#: src/SUMMARY.md:348
+#: src/SUMMARY.md
 msgid "`vmbase`"
 msgstr ""
 
-#: src/SUMMARY.md:350
+#: src/SUMMARY.md
 msgid "RTC Driver"
 msgstr ""
 
-#: src/SUMMARY.md:353
+#: src/SUMMARY.md
 msgid "Concurrency: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:358 src/running-the-course/course-structure.md:151
-#: src/concurrency/welcome.md:16 src/concurrency/threads.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/concurrency/welcome.md src/concurrency/threads.md
 msgid "Threads"
 msgstr ""
 
-#: src/SUMMARY.md:359 src/concurrency/threads.md:7
-#: src/concurrency/threads/plain.md:1
+#: src/SUMMARY.md src/concurrency/threads.md src/concurrency/threads/plain.md
 msgid "Plain Threads"
 msgstr ""
 
-#: src/SUMMARY.md:360 src/concurrency/threads.md:8
-#: src/concurrency/threads/scoped.md:1
+#: src/SUMMARY.md src/concurrency/threads.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
 msgstr ""
 
-#: src/SUMMARY.md:361 src/running-the-course/course-structure.md:152
-#: src/concurrency/welcome.md:17 src/concurrency/channels.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/concurrency/welcome.md src/concurrency/channels.md
 msgid "Channels"
 msgstr ""
 
-#: src/SUMMARY.md:362 src/concurrency/channels.md:7
-#: src/concurrency/channels/senders-receivers.md:1
+#: src/SUMMARY.md src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md
 msgid "Senders and Receivers"
 msgstr ""
 
-#: src/SUMMARY.md:363 src/concurrency/channels.md:8
-#: src/concurrency/channels/unbounded.md:1
+#: src/SUMMARY.md src/concurrency/channels.md
+#: src/concurrency/channels/unbounded.md
 msgid "Unbounded Channels"
 msgstr ""
 
-#: src/SUMMARY.md:364 src/concurrency/channels.md:9
-#: src/concurrency/channels/bounded.md:1
+#: src/SUMMARY.md src/concurrency/channels.md
+#: src/concurrency/channels/bounded.md
 msgid "Bounded Channels"
 msgstr ""
 
-#: src/SUMMARY.md:365 src/concurrency/send-sync.md:1
+#: src/SUMMARY.md src/concurrency/send-sync.md
 msgid "`Send` and `Sync`"
 msgstr ""
 
-#: src/SUMMARY.md:366 src/concurrency/send-sync.md:7
-#: src/concurrency/send-sync/marker-traits.md:1
+#: src/SUMMARY.md src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md
 msgid "Marker Traits"
 msgstr ""
 
-#: src/SUMMARY.md:367 src/concurrency/send-sync/send.md:1
+#: src/SUMMARY.md src/concurrency/send-sync/send.md
 msgid "`Send`"
 msgstr ""
 
-#: src/SUMMARY.md:368 src/concurrency/send-sync/sync.md:1
+#: src/SUMMARY.md src/concurrency/send-sync/sync.md
 msgid "`Sync`"
 msgstr ""
 
-#: src/SUMMARY.md:369 src/concurrency/send-sync.md:10
-#: src/concurrency/send-sync/examples.md:1
+#: src/SUMMARY.md src/concurrency/send-sync.md
+#: src/concurrency/send-sync/examples.md
 msgid "Examples"
 msgstr ""
 
-#: src/SUMMARY.md:370 src/running-the-course/course-structure.md:154
-#: src/concurrency/welcome.md:19 src/concurrency/shared-state.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/concurrency/welcome.md src/concurrency/shared-state.md
 msgid "Shared State"
 msgstr ""
 
-#: src/SUMMARY.md:371 src/concurrency/shared-state/arc.md:1
+#: src/SUMMARY.md src/concurrency/shared-state/arc.md
 msgid "`Arc`"
 msgstr ""
 
-#: src/SUMMARY.md:372 src/concurrency/shared-state/mutex.md:1
+#: src/SUMMARY.md src/concurrency/shared-state/mutex.md
 msgid "`Mutex`"
 msgstr ""
 
-#: src/SUMMARY.md:373 src/memory-management/review.md:16
-#: src/error-handling/try-conversions.md:23 src/concurrency/shared-state.md:9
-#: src/concurrency/shared-state/example.md:1
+#: src/SUMMARY.md src/memory-management/review.md
+#: src/error-handling/try-conversions.md src/concurrency/shared-state.md
+#: src/concurrency/shared-state/example.md
 msgid "Example"
 msgstr ""
 
-#: src/SUMMARY.md:375 src/SUMMARY.md:398 src/concurrency/sync-exercises.md:7
-#: src/concurrency/sync-exercises/dining-philosophers.md:1
-#: src/concurrency/sync-exercises/solutions.md:3
-#: src/concurrency/async-exercises.md:7
+#: src/SUMMARY.md src/concurrency/sync-exercises.md
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises.md
 msgid "Dining Philosophers"
 msgstr ""
 
-#: src/SUMMARY.md:376 src/concurrency/sync-exercises.md:8
-#: src/concurrency/sync-exercises/link-checker.md:1
+#: src/SUMMARY.md src/concurrency/sync-exercises.md
+#: src/concurrency/sync-exercises/link-checker.md
 msgid "Multi-threaded Link Checker"
 msgstr ""
 
-#: src/SUMMARY.md:379
+#: src/SUMMARY.md
 msgid "Concurrency: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:382 src/running-the-course/course-structure.md:162
-#: src/concurrency/welcome-async.md:33 src/concurrency/async.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/concurrency/welcome-async.md src/concurrency/async.md
 msgid "Async Basics"
 msgstr ""
 
-#: src/SUMMARY.md:383 src/concurrency/async/async-await.md:1
+#: src/SUMMARY.md src/concurrency/async/async-await.md
 msgid "`async`/`await`"
 msgstr ""
 
-#: src/SUMMARY.md:384 src/concurrency/async.md:8
-#: src/concurrency/async/futures.md:1
+#: src/SUMMARY.md src/concurrency/async.md src/concurrency/async/futures.md
 msgid "Futures"
 msgstr ""
 
-#: src/SUMMARY.md:385 src/concurrency/async.md:9
-#: src/concurrency/async/runtimes.md:1
+#: src/SUMMARY.md src/concurrency/async.md src/concurrency/async/runtimes.md
 msgid "Runtimes"
 msgstr ""
 
-#: src/SUMMARY.md:386 src/concurrency/async/runtimes/tokio.md:1
+#: src/SUMMARY.md src/concurrency/async/runtimes/tokio.md
 msgid "Tokio"
 msgstr ""
 
-#: src/SUMMARY.md:387 src/concurrency/sync-exercises/link-checker.md:119
-#: src/concurrency/async.md:10 src/concurrency/async/tasks.md:1
-#: src/concurrency/async-exercises/chat-app.md:143
+#: src/SUMMARY.md src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/async.md src/concurrency/async/tasks.md
+#: src/concurrency/async-exercises/chat-app.md
 msgid "Tasks"
 msgstr ""
 
-#: src/SUMMARY.md:388 src/running-the-course/course-structure.md:163
-#: src/concurrency/welcome-async.md:34 src/concurrency/async-control-flow.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/concurrency/welcome-async.md src/concurrency/async-control-flow.md
 msgid "Channels and Control Flow"
 msgstr ""
 
-#: src/SUMMARY.md:389 src/concurrency/async-control-flow.md:7
-#: src/concurrency/async-control-flow/channels.md:1
+#: src/SUMMARY.md src/concurrency/async-control-flow.md
+#: src/concurrency/async-control-flow/channels.md
 msgid "Async Channels"
 msgstr ""
 
-#: src/SUMMARY.md:390 src/concurrency/async-control-flow.md:8
-#: src/concurrency/async-control-flow/join.md:1
+#: src/SUMMARY.md src/concurrency/async-control-flow.md
+#: src/concurrency/async-control-flow/join.md
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:391 src/concurrency/async-control-flow.md:9
-#: src/concurrency/async-control-flow/select.md:1
+#: src/SUMMARY.md src/concurrency/async-control-flow.md
+#: src/concurrency/async-control-flow/select.md
 msgid "Select"
 msgstr ""
 
-#: src/SUMMARY.md:392 src/running-the-course/course-structure.md:164
-#: src/concurrency/welcome-async.md:35 src/concurrency/async-pitfalls.md:1
+#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/concurrency/welcome-async.md src/concurrency/async-pitfalls.md
 msgid "Pitfalls"
 msgstr ""
 
-#: src/SUMMARY.md:393 src/concurrency/async-pitfalls.md:11
+#: src/SUMMARY.md src/concurrency/async-pitfalls.md
 msgid "Blocking the Executor"
 msgstr ""
 
-#: src/SUMMARY.md:394 src/concurrency/async-pitfalls/pin.md:1
+#: src/SUMMARY.md src/concurrency/async-pitfalls/pin.md
 msgid "`Pin`"
 msgstr ""
 
-#: src/SUMMARY.md:395 src/concurrency/async-pitfalls.md:13
-#: src/concurrency/async-pitfalls/async-traits.md:1
+#: src/SUMMARY.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid "Async Traits"
 msgstr ""
 
-#: src/SUMMARY.md:396 src/concurrency/async-pitfalls.md:14
-#: src/concurrency/async-pitfalls/cancellation.md:1
+#: src/SUMMARY.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "Cancellation"
 msgstr ""
 
-#: src/SUMMARY.md:399 src/concurrency/async-exercises.md:8
-#: src/concurrency/async-exercises/chat-app.md:1
-#: src/concurrency/async-exercises/solutions.md:102
+#: src/SUMMARY.md src/concurrency/async-exercises.md
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "Broadcast Chat Application"
 msgstr ""
 
-#: src/SUMMARY.md:402
+#: src/SUMMARY.md
 msgid "Final Words"
 msgstr ""
 
-#: src/SUMMARY.md:406 src/thanks.md:1
+#: src/SUMMARY.md src/thanks.md
 msgid "Thanks!"
 msgstr ""
 
-#: src/SUMMARY.md:407 src/glossary.md:3
+#: src/SUMMARY.md src/glossary.md
 msgid "Glossary"
 msgstr "Chú giải thuật ngữ"
 
-#: src/SUMMARY.md:408
+#: src/SUMMARY.md
 msgid "Other Resources"
 msgstr ""
 
-#: src/SUMMARY.md:409 src/credits.md:1
+#: src/SUMMARY.md src/credits.md
 msgid "Credits"
 msgstr ""
 
-#: src/index.md:3
+#: src/index.md
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
@@ -1393,72 +1334,72 @@ msgid ""
 "com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
-#: src/index.md:7
+#: src/index.md
 msgid ""
 "This is a free Rust course developed by the Android team at Google. The "
 "course covers the full spectrum of Rust, from basic syntax to advanced "
 "topics like generics and error handling."
 msgstr ""
 
-#: src/index.md:11
+#: src/index.md
 msgid ""
 "The latest version of the course can be found at <https://google.github.io/"
 "comprehensive-rust/>. If you are reading somewhere else, please check there "
 "for updates."
 msgstr ""
 
-#: src/index.md:15
+#: src/index.md
 msgid "The course is also available [as a PDF](comprehensive-rust.pdf)."
 msgstr ""
 
-#: src/index.md:17
+#: src/index.md
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
 "anything about Rust and hope to:"
 msgstr ""
 
-#: src/index.md:20
+#: src/index.md
 msgid "Give you a comprehensive understanding of the Rust syntax and language."
 msgstr ""
 
-#: src/index.md:21
+#: src/index.md
 msgid "Enable you to modify existing programs and write new programs in Rust."
 msgstr ""
 
-#: src/index.md:22
+#: src/index.md
 msgid "Show you common Rust idioms."
 msgstr ""
 
-#: src/index.md:24
+#: src/index.md
 msgid "We call the first four course days Rust Fundamentals."
 msgstr ""
 
-#: src/index.md:26
+#: src/index.md
 msgid ""
 "Building on this, you're invited to dive into one or more specialized topics:"
 msgstr ""
 
-#: src/index.md:28
+#: src/index.md
 msgid ""
 "[Android](android.md): a half-day course on using Rust for Android platform "
 "development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
 
-#: src/index.md:30
+#: src/index.md
 msgid ""
 "[Chromium](chromium.md): a half-day course on using Rust within Chromium "
 "based browsers. This includes interoperability with C++ and how to include "
 "third-party crates in Chromium."
 msgstr ""
 
-#: src/index.md:33
+#: src/index.md
 msgid ""
 "[Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-metal "
 "(embedded) development. Both microcontrollers and application processors are "
 "covered."
 msgstr ""
 
-#: src/index.md:36
+#: src/index.md
 msgid ""
 "[Concurrency](concurrency.md): a whole-day class on concurrency in Rust. We "
 "cover both classical concurrency (preemptively scheduling using threads and "
@@ -1466,52 +1407,52 @@ msgid ""
 "futures)."
 msgstr ""
 
-#: src/index.md:40
+#: src/index.md
 msgid "Non-Goals"
 msgstr ""
 
-#: src/index.md:42
+#: src/index.md
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
 "days. Some non-goals of this course are:"
 msgstr ""
 
-#: src/index.md:45
+#: src/index.md
 msgid ""
 "Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
 "(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
 "(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
 
-#: src/index.md:50
+#: src/index.md
 msgid "Assumptions"
 msgstr ""
 
-#: src/index.md:52
+#: src/index.md
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
 "statically-typed language and we will sometimes make comparisons with C and "
 "C++ to better explain or contrast the Rust approach."
 msgstr ""
 
-#: src/index.md:56
+#: src/index.md
 msgid ""
 "If you know how to program in a dynamically-typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 
-#: src/index.md:61
+#: src/index.md
 msgid ""
 "This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
 "should cover as well as answers to typical questions which come up in class."
 msgstr ""
 
-#: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
+#: src/running-the-course.md src/running-the-course/course-structure.md
 msgid "This page is for the course instructor."
 msgstr "Trang này là dành cho người hướng dẫn khóa học."
 
-#: src/running-the-course.md:5
+#: src/running-the-course.md
 msgid ""
 "Here is a bit of background information about how we've been running the "
 "course internally at Google."
@@ -1519,7 +1460,7 @@ msgstr ""
 "Đây là một số thông tin cơ bản về cách chúng tôi triển khai khóa học trong "
 "nội bộ Google."
 
-#: src/running-the-course.md:8
+#: src/running-the-course.md
 msgid ""
 "We typically run classes from 9:00 am to 4:00 pm, with a 1 hour lunch break "
 "in the middle. This leaves 3 hours for the morning class and 3 hours for the "
@@ -1531,11 +1472,11 @@ msgstr ""
 "3 tiếng. Một buổi học sẽ được chia thành nhiều quãng nghỉ để học sinh có "
 "thời gian thực hành."
 
-#: src/running-the-course.md:13
+#: src/running-the-course.md
 msgid "Before you run the course, you will want to:"
 msgstr "Trước khi bắt đầu giảng dạy khóa học này, bạn sẽ cần:"
 
-#: src/running-the-course.md:15
+#: src/running-the-course.md
 msgid ""
 "Make yourself familiar with the course material. We've included speaker "
 "notes to help highlight the key points (please help us by contributing more "
@@ -1551,7 +1492,7 @@ msgstr ""
 "\"Speaker Notes\"). Làm vậy sẽ giúp bạn có thể  thuyết trình với slide rõ "
 "ràng nhất."
 
-#: src/running-the-course.md:21
+#: src/running-the-course.md
 msgid ""
 "Decide on the dates. Since the course takes four days, we recommend that you "
 "schedule the days over two weeks. Course participants have said that they "
@@ -1563,7 +1504,7 @@ msgstr ""
 "việc có những \"khoảng trống\" trong khóa rất có ích để họ có thể tiêu hóa "
 "hết lượng thông tin được cung cấp."
 
-#: src/running-the-course.md:26
+#: src/running-the-course.md
 msgid ""
 "Find a room large enough for your in-person participants. We recommend a "
 "class size of 15-25 people. That's small enough that people are comfortable "
@@ -1581,7 +1522,7 @@ msgstr ""
 "hành mẫu rất nhiều bài live-coding, nên một cái ghế sẽ có ích hơn là một cái "
 "bục giảng đó."
 
-#: src/running-the-course.md:34
+#: src/running-the-course.md
 msgid ""
 "On the day of your course, show up to the room a little early to set things "
 "up. We recommend presenting directly using `mdbook serve` running on your "
@@ -1597,7 +1538,7 @@ msgstr ""
 "ra mượt mà nhất, ngoài ra còn cho phép bạn sửa lỗi chính tả trực tiếp khi "
 "bạn hoặc ai đó phát hiện ra."
 
-#: src/running-the-course.md:40
+#: src/running-the-course.md
 msgid ""
 "Let people solve the exercises by themselves or in small groups. We "
 "typically spend 30-45 minutes on exercises in the morning and in the "
@@ -1615,7 +1556,7 @@ msgstr ""
 "gợi ý mọi người cách để tìm kiếm thông tin liên quan trong thư viện tiêu "
 "chuẩn."
 
-#: src/running-the-course.md:48
+#: src/running-the-course.md
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
 "for you as it has been for us!"
@@ -1624,7 +1565,7 @@ msgstr ""
 "hy vọng bạn có thể tìm thấy niềm vui như cách chúng tôi tìm thấy khi dạy "
 "khóa học này!"
 
-#: src/running-the-course.md:51
+#: src/running-the-course.md
 msgid ""
 "Please [provide feedback](https://github.com/google/comprehensive-rust/"
 "discussions/86) afterwards so that we can keep improving the course. We "
@@ -1639,11 +1580,11 @@ msgstr ""
 "bạn cũng có thể tích cực gửi feedback cho chúng tôi tại [đây](https://github."
 "com/google/comprehensive-rust/discussions/100)!"
 
-#: src/running-the-course/course-structure.md:5
+#: src/running-the-course/course-structure.md
 msgid "Rust Fundamentals"
 msgstr "Rust Căn Bản"
 
-#: src/running-the-course/course-structure.md:7
+#: src/running-the-course/course-structure.md
 msgid ""
 "The first four days make up [Rust Fundamentals](../welcome-day-1.md). The "
 "days are fast paced and we cover a lot of ground!"
@@ -1651,195 +1592,142 @@ msgstr ""
 "Ở bốn ngày học đầu tiên, ta sẽ nhanh chóng khái quát rất nhiều khía cạnh "
 "[căn bản](../welcome-day-1.md) của Rust!"
 
-#: src/running-the-course/course-structure.md:10
-#: src/running-the-course/course-structure.md:146
+#: src/running-the-course/course-structure.md
 msgid "Course schedule:"
 msgstr "Thời khóa biểu:"
 
-#: src/running-the-course/course-structure.md:11
+#: src/running-the-course/course-structure.md
 msgid "Day 1 Morning (2 hours and 5 minutes, including breaks)"
 msgstr "Ngày 1 Buổi Sáng (2 tiếng và 5 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:13
-#: src/running-the-course/course-structure.md:23
-#: src/running-the-course/course-structure.md:32
-#: src/running-the-course/course-structure.md:41
-#: src/running-the-course/course-structure.md:50
-#: src/running-the-course/course-structure.md:59
-#: src/running-the-course/course-structure.md:67
-#: src/running-the-course/course-structure.md:77
-#: src/running-the-course/course-structure.md:149
-#: src/running-the-course/course-structure.md:160 src/welcome-day-1.md:16
-#: src/welcome-day-1-afternoon.md:5 src/welcome-day-2.md:16
-#: src/welcome-day-2-afternoon.md:5 src/welcome-day-3.md:13
-#: src/welcome-day-3-afternoon.md:5 src/welcome-day-4.md:15
-#: src/welcome-day-4-afternoon.md:5 src/concurrency/welcome.md:14
-#: src/concurrency/welcome-async.md:31
+#: src/running-the-course/course-structure.md src/welcome-day-1.md
+#: src/welcome-day-1-afternoon.md src/welcome-day-2.md
+#: src/welcome-day-2-afternoon.md src/welcome-day-3.md
+#: src/welcome-day-3-afternoon.md src/welcome-day-4.md
+#: src/welcome-day-4-afternoon.md src/concurrency/welcome.md
+#: src/concurrency/welcome-async.md
 msgid "Segment"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:13
-#: src/running-the-course/course-structure.md:23
-#: src/running-the-course/course-structure.md:32
-#: src/running-the-course/course-structure.md:41
-#: src/running-the-course/course-structure.md:50
-#: src/running-the-course/course-structure.md:59
-#: src/running-the-course/course-structure.md:67
-#: src/running-the-course/course-structure.md:77
-#: src/running-the-course/course-structure.md:149
-#: src/running-the-course/course-structure.md:160 src/welcome-day-1.md:16
-#: src/hello-world.md:5 src/types-and-values.md:5 src/control-flow-basics.md:5
-#: src/welcome-day-1-afternoon.md:5 src/tuples-and-arrays.md:5
-#: src/references.md:5 src/user-defined-types.md:5 src/welcome-day-2.md:16
-#: src/pattern-matching.md:5 src/methods-and-traits.md:5
-#: src/welcome-day-2-afternoon.md:5 src/generics.md:5 src/std-types.md:5
-#: src/std-traits.md:5 src/welcome-day-3.md:13 src/memory-management.md:5
-#: src/smart-pointers.md:5 src/welcome-day-3-afternoon.md:5 src/borrowing.md:5
-#: src/lifetimes.md:5 src/welcome-day-4.md:15 src/iterators.md:5
-#: src/modules.md:5 src/testing.md:5 src/welcome-day-4-afternoon.md:5
-#: src/error-handling.md:5 src/unsafe-rust.md:5 src/concurrency/welcome.md:14
-#: src/concurrency/threads.md:5 src/concurrency/channels.md:5
-#: src/concurrency/send-sync.md:5 src/concurrency/shared-state.md:5
-#: src/concurrency/sync-exercises.md:5 src/concurrency/welcome-async.md:31
-#: src/concurrency/async.md:5 src/concurrency/async-control-flow.md:5
-#: src/concurrency/async-pitfalls.md:9 src/concurrency/async-exercises.md:5
+#: src/running-the-course/course-structure.md src/welcome-day-1.md
+#: src/hello-world.md src/types-and-values.md src/control-flow-basics.md
+#: src/welcome-day-1-afternoon.md src/tuples-and-arrays.md src/references.md
+#: src/user-defined-types.md src/welcome-day-2.md src/pattern-matching.md
+#: src/methods-and-traits.md src/welcome-day-2-afternoon.md src/generics.md
+#: src/std-types.md src/std-traits.md src/welcome-day-3.md
+#: src/memory-management.md src/smart-pointers.md
+#: src/welcome-day-3-afternoon.md src/borrowing.md src/lifetimes.md
+#: src/welcome-day-4.md src/iterators.md src/modules.md src/testing.md
+#: src/welcome-day-4-afternoon.md src/error-handling.md src/unsafe-rust.md
+#: src/concurrency/welcome.md src/concurrency/threads.md
+#: src/concurrency/channels.md src/concurrency/send-sync.md
+#: src/concurrency/shared-state.md src/concurrency/sync-exercises.md
+#: src/concurrency/welcome-async.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-exercises.md
 msgid "Duration"
 msgstr "Thời lượng"
 
-#: src/running-the-course/course-structure.md:15 src/welcome-day-1.md:18
-#: src/types-and-values.md:7 src/types-and-values.md:8
-#: src/types-and-values.md:9 src/control-flow-basics.md:8
-#: src/control-flow-basics.md:10 src/tuples-and-arrays.md:7
-#: src/tuples-and-arrays.md:8 src/tuples-and-arrays.md:10
-#: src/user-defined-types.md:9 src/user-defined-types.md:10 src/generics.md:7
-#: src/generics.md:10 src/std-types.md:8 src/std-traits.md:10
-#: src/std-traits.md:12 src/memory-management.md:7 src/memory-management.md:9
-#: src/memory-management.md:10 src/memory-management.md:12
-#: src/smart-pointers.md:8 src/lifetimes.md:8 src/lifetimes.md:9
-#: src/iterators.md:7 src/iterators.md:8 src/iterators.md:9 src/modules.md:8
-#: src/modules.md:9 src/testing.md:7 src/testing.md:8 src/error-handling.md:8
-#: src/error-handling.md:9 src/error-handling.md:10 src/error-handling.md:11
-#: src/unsafe-rust.md:7 src/unsafe-rust.md:9 src/unsafe-rust.md:10
-#: src/unsafe-rust.md:11 src/unsafe-rust.md:12
-#: src/concurrency/shared-state.md:7 src/concurrency/async-control-flow.md:9
-#: src/concurrency/async-pitfalls.md:13
+#: src/running-the-course/course-structure.md src/welcome-day-1.md
+#: src/types-and-values.md src/control-flow-basics.md src/tuples-and-arrays.md
+#: src/user-defined-types.md src/generics.md src/std-types.md src/std-traits.md
+#: src/memory-management.md src/smart-pointers.md src/lifetimes.md
+#: src/iterators.md src/modules.md src/testing.md src/error-handling.md
+#: src/unsafe-rust.md src/concurrency/shared-state.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
 msgid "5 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:16
-#: src/running-the-course/course-structure.md:153 src/welcome-day-1.md:19
-#: src/types-and-values.md:12 src/control-flow-basics.md:13
-#: src/tuples-and-arrays.md:11 src/references.md:11
-#: src/user-defined-types.md:12 src/methods-and-traits.md:8 src/modules.md:11
-#: src/concurrency/welcome.md:18 src/concurrency/threads.md:7
-#: src/concurrency/threads.md:8 src/concurrency/shared-state.md:8
+#: src/running-the-course/course-structure.md src/welcome-day-1.md
+#: src/types-and-values.md src/control-flow-basics.md src/tuples-and-arrays.md
+#: src/references.md src/user-defined-types.md src/methods-and-traits.md
+#: src/modules.md src/concurrency/welcome.md src/concurrency/threads.md
+#: src/concurrency/shared-state.md
 msgid "15 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:17
-#: src/running-the-course/course-structure.md:18
-#: src/running-the-course/course-structure.md:43
-#: src/running-the-course/course-structure.md:71 src/welcome-day-1.md:20
-#: src/welcome-day-1.md:21 src/welcome-day-2-afternoon.md:7
-#: src/welcome-day-4.md:19
+#: src/running-the-course/course-structure.md src/welcome-day-1.md
+#: src/welcome-day-2-afternoon.md src/welcome-day-4.md
 msgid "40 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:21
+#: src/running-the-course/course-structure.md
 msgid "Day 1 Afternoon (2 hours and 35 minutes, including breaks)"
 msgstr "Ngày 1 Buổi Chiều (2 tiếng và 35 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:25
-#: src/welcome-day-1-afternoon.md:7
+#: src/running-the-course/course-structure.md src/welcome-day-1-afternoon.md
 msgid "35 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:26
-#: src/running-the-course/course-structure.md:54
-#: src/running-the-course/course-structure.md:61
-#: src/running-the-course/course-structure.md:79
-#: src/running-the-course/course-structure.md:164
-#: src/welcome-day-1-afternoon.md:8 src/welcome-day-3.md:17
-#: src/welcome-day-3-afternoon.md:7 src/welcome-day-4-afternoon.md:7
-#: src/concurrency/welcome-async.md:35
+#: src/running-the-course/course-structure.md src/welcome-day-1-afternoon.md
+#: src/welcome-day-3.md src/welcome-day-3-afternoon.md
+#: src/welcome-day-4-afternoon.md src/concurrency/welcome-async.md
 msgid "55 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:27
-#: src/running-the-course/course-structure.md:36
-#: src/running-the-course/course-structure.md:62
-#: src/welcome-day-1-afternoon.md:9 src/welcome-day-2.md:20
-#: src/welcome-day-3-afternoon.md:8
+#: src/running-the-course/course-structure.md src/welcome-day-1-afternoon.md
+#: src/welcome-day-2.md src/welcome-day-3-afternoon.md
 msgid "50 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:30
+#: src/running-the-course/course-structure.md
 msgid "Day 2 Morning (2 hours and 10 minutes, including breaks)"
 msgstr "Ngày 2 Buổi Sáng (2 tiếng và 55 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:34
-#: src/running-the-course/course-structure.md:52
-#: src/running-the-course/course-structure.md:69 src/hello-world.md:8
-#: src/types-and-values.md:10 src/types-and-values.md:11
-#: src/control-flow-basics.md:11 src/tuples-and-arrays.md:9
-#: src/welcome-day-2.md:18 src/methods-and-traits.md:9 src/std-types.md:7
-#: src/welcome-day-3.md:15 src/borrowing.md:9 src/welcome-day-4.md:17
-#: src/modules.md:7 src/testing.md:9 src/error-handling.md:7
+#: src/running-the-course/course-structure.md src/hello-world.md
+#: src/types-and-values.md src/control-flow-basics.md src/tuples-and-arrays.md
+#: src/welcome-day-2.md src/methods-and-traits.md src/std-types.md
+#: src/welcome-day-3.md src/borrowing.md src/welcome-day-4.md src/modules.md
+#: src/testing.md src/error-handling.md
 msgid "3 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:35
-#: src/running-the-course/course-structure.md:53 src/welcome-day-2.md:19
-#: src/welcome-day-3.md:16
+#: src/running-the-course/course-structure.md src/welcome-day-2.md
+#: src/welcome-day-3.md
 msgid "1 hour"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:39
+#: src/running-the-course/course-structure.md
 msgid "Day 2 Afternoon (4 hours, including breaks)"
 msgstr "Ngày 2 Buổi Chiều (3 tiếng và 10 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:44
-#: src/welcome-day-2-afternoon.md:8
+#: src/running-the-course/course-structure.md src/welcome-day-2-afternoon.md
 msgid "1 hour and 20 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:45
-#: src/welcome-day-2-afternoon.md:9
+#: src/running-the-course/course-structure.md src/welcome-day-2-afternoon.md
 msgid "1 hour and 40 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:48
+#: src/running-the-course/course-structure.md
 msgid "Day 3 Morning (2 hours and 20 minutes, including breaks)"
 msgstr "Ngày 3 Buổi Sáng (2 tiếng và 20 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:57
+#: src/running-the-course/course-structure.md
 msgid "Day 3 Afternoon (1 hour and 55 minutes, including breaks)"
 msgstr "Ngày 3 Buổi Chiều (1 tiếng và 50 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:65
+#: src/running-the-course/course-structure.md
 msgid "Day 4 Morning (2 hours and 40 minutes, including breaks)"
 msgstr "Ngày 4 Buổi Sáng (2 tiếng và 40 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:70
-#: src/running-the-course/course-structure.md:72 src/welcome-day-4.md:18
-#: src/welcome-day-4.md:20
+#: src/running-the-course/course-structure.md src/welcome-day-4.md
 msgid "45 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:75
+#: src/running-the-course/course-structure.md
 msgid "Day 4 Afternoon (2 hours and 10 minutes, including breaks)"
 msgstr "Ngày 4 Buổi Chiều (2 tiếng và 10 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:80
-#: src/welcome-day-4-afternoon.md:8
+#: src/running-the-course/course-structure.md src/welcome-day-4-afternoon.md
 msgid "1 hour and 5 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:85
+#: src/running-the-course/course-structure.md
 msgid "Deep Dives"
 msgstr "Chuyên Sâu"
 
-#: src/running-the-course/course-structure.md:87
+#: src/running-the-course/course-structure.md
 msgid ""
 "In addition to the 4-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
@@ -1847,11 +1735,11 @@ msgstr ""
 "Ngoài lớp học \"4 ngày\" về Rust căn bản ra, chúng tôi còn cung cấp thêm một "
 "số chủ đề chuyên sâu sau:"
 
-#: src/running-the-course/course-structure.md:90
+#: src/running-the-course/course-structure.md
 msgid "Rust in Android"
 msgstr "Rust trong Android"
 
-#: src/running-the-course/course-structure.md:92
+#: src/running-the-course/course-structure.md
 msgid ""
 "The [Rust in Android](../android.md) deep dive is a half-day course on using "
 "Rust for Android platform development. This includes interoperability with "
@@ -1861,7 +1749,7 @@ msgstr ""
 "hướng dẫn sử dụng Rust cho phát triển trên nền tảng Android, bao gồm tính "
 "tương tác với C, C++ và Java."
 
-#: src/running-the-course/course-structure.md:96
+#: src/running-the-course/course-structure.md
 msgid ""
 "You will need an [AOSP checkout](https://source.android.com/docs/setup/"
 "download/downloading). Make a checkout of the [course repository](https://"
@@ -1876,7 +1764,7 @@ msgstr ""
 "thống build của Android tìm được file `Android.bp` trong thư mục `src/"
 "android/`."
 
-#: src/running-the-course/course-structure.md:101
+#: src/running-the-course/course-structure.md
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
 "all Android examples using `src/android/build_all.sh`. Read the script to "
@@ -1887,11 +1775,11 @@ msgstr ""
 "build_all.sh`. Bạn có thể đọc script để xem các lệnh mà nó chạy và xác nhận "
 "rằng mọi thứ đều hoạt động khi bạn kích hoạt bằng tay."
 
-#: src/running-the-course/course-structure.md:108
+#: src/running-the-course/course-structure.md
 msgid "Rust in Chromium"
 msgstr "Rust trong Chromium"
 
-#: src/running-the-course/course-structure.md:110
+#: src/running-the-course/course-structure.md
 msgid ""
 "The [Rust in Chromium](../chromium.md) deep dive is a half-day course on "
 "using Rust as part of the Chromium browser. It includes using Rust in "
@@ -1903,7 +1791,7 @@ msgstr ""
 "gồm hệ thống build `gn`, đưa vào thư viện bên thứ ba (\"crates\") và tính "
 "tương tác với C++."
 
-#: src/running-the-course/course-structure.md:115
+#: src/running-the-course/course-structure.md
 msgid ""
 "You will need to be able to build Chromium --- a debug, component build is "
 "[recommended](../chromium/setup.md) for speed but any build will work. "
@@ -1915,11 +1803,11 @@ msgstr ""
 "chỉ cần bạn đảm bảo rằng mình sẽ chạy được trình duyệt Chromium vừa build "
 "xong."
 
-#: src/running-the-course/course-structure.md:119
+#: src/running-the-course/course-structure.md
 msgid "Bare-Metal Rust"
 msgstr "Bare-Metal Rust"
 
-#: src/running-the-course/course-structure.md:121
+#: src/running-the-course/course-structure.md
 msgid ""
 "The [Bare-Metal Rust](../bare-metal.md) deep dive is a full day class on "
 "using Rust for bare-metal (embedded) development. Both microcontrollers and "
@@ -1929,7 +1817,7 @@ msgstr ""
 "hướng dẫn sử dụng Rust cho phát triển nhúng (bare-metal). Nội dung về vi "
 "điều khiển và bộ xử lý ứng dụng sẽ được bao quát trong phần này."
 
-#: src/running-the-course/course-structure.md:125
+#: src/running-the-course/course-structure.md
 msgid ""
 "For the microcontroller part, you will need to buy the [BBC micro:bit]"
 "(https://microbit.org/) v2 development board ahead of time. Everybody will "
@@ -1940,11 +1828,11 @@ msgstr ""
 "microbit.org/) v2. Mỗi người sẽ cần cài đặt một số packages dựa theo miêu tả "
 "ở [trang chào mừng](../bare-metal.md)."
 
-#: src/running-the-course/course-structure.md:130
+#: src/running-the-course/course-structure.md
 msgid "Concurrency in Rust"
 msgstr "Tính đồng thời trong Rust"
 
-#: src/running-the-course/course-structure.md:132
+#: src/running-the-course/course-structure.md
 msgid ""
 "The [Concurrency in Rust](../concurrency.md) deep dive is a full day class "
 "on classical as well as `async`/`await` concurrency."
@@ -1952,7 +1840,7 @@ msgstr ""
 "Chủ đề chuyên sâu [Tính đồng thời trong Rust](../concurrency.md) là khóa học "
 "một ngày hướng dẫn về khái niệm đồng thời `async`/`await` điển hình."
 
-#: src/running-the-course/course-structure.md:135
+#: src/running-the-course/course-structure.md
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
 "to go. You can then copy/paste the examples into `src/main.rs` to experiment "
@@ -1962,51 +1850,44 @@ msgstr ""
 "để sẵn sàng chạy. Rồi bạn có thể copy/paste các ví dụ vào `src/main.rs` để "
 "thử nghiệm:"
 
-#: src/running-the-course/course-structure.md:147
+#: src/running-the-course/course-structure.md
 msgid "Morning (3 hours and 20 minutes, including breaks)"
 msgstr "Ngày 3 Buổi Sáng (2 tiếng và 20 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:151
-#: src/running-the-course/course-structure.md:154
-#: src/running-the-course/course-structure.md:162 src/pattern-matching.md:11
-#: src/std-traits.md:14 src/smart-pointers.md:10 src/lifetimes.md:10
-#: src/iterators.md:10 src/testing.md:10 src/error-handling.md:12
-#: src/unsafe-rust.md:13 src/concurrency/welcome.md:16
-#: src/concurrency/welcome.md:19 src/concurrency/sync-exercises.md:9
-#: src/concurrency/welcome-async.md:33 src/concurrency/async-exercises.md:8
+#: src/running-the-course/course-structure.md src/pattern-matching.md
+#: src/std-traits.md src/smart-pointers.md src/lifetimes.md src/iterators.md
+#: src/testing.md src/error-handling.md src/unsafe-rust.md
+#: src/concurrency/welcome.md src/concurrency/sync-exercises.md
+#: src/concurrency/welcome-async.md src/concurrency/async-exercises.md
 msgid "30 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:152
-#: src/running-the-course/course-structure.md:163 src/methods-and-traits.md:10
-#: src/std-types.md:14 src/std-traits.md:13 src/memory-management.md:14
-#: src/borrowing.md:11 src/concurrency/welcome.md:17
-#: src/concurrency/sync-exercises.md:7 src/concurrency/sync-exercises.md:8
-#: src/concurrency/welcome-async.md:34 src/concurrency/async-pitfalls.md:12
-#: src/concurrency/async-pitfalls.md:14 src/concurrency/async-exercises.md:7
-#: src/concurrency/async-exercises.md:9
+#: src/running-the-course/course-structure.md src/methods-and-traits.md
+#: src/std-types.md src/std-traits.md src/memory-management.md src/borrowing.md
+#: src/concurrency/welcome.md src/concurrency/sync-exercises.md
+#: src/concurrency/welcome-async.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-exercises.md
 msgid "20 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:153 src/concurrency/welcome.md:18
+#: src/running-the-course/course-structure.md src/concurrency/welcome.md
 msgid "Send and Sync"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:155
-#: src/running-the-course/course-structure.md:165 src/concurrency/welcome.md:20
-#: src/concurrency/welcome-async.md:36
+#: src/running-the-course/course-structure.md src/concurrency/welcome.md
+#: src/concurrency/welcome-async.md
 msgid "1 hour and 10 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md:158
+#: src/running-the-course/course-structure.md
 msgid "Afternoon (3 hours and 20 minutes, including breaks)"
 msgstr "Buổi Chiều (3 tiếng và 20 phút, bao gồm thời gian nghỉ)"
 
-#: src/running-the-course/course-structure.md:170
+#: src/running-the-course/course-structure.md
 msgid "Format"
 msgstr "Quy Chuẩn"
 
-#: src/running-the-course/course-structure.md:172
+#: src/running-the-course/course-structure.md
 msgid ""
 "The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
@@ -2014,43 +1895,43 @@ msgstr ""
 "Khóa học này hướng tới tính tương tác cao nên chúng tôi khuyến khích để các "
 "câu hỏi dẫn bạn đi khám phá nhiều thứ thú vị của Rust!"
 
-#: src/running-the-course/keyboard-shortcuts.md:3
+#: src/running-the-course/keyboard-shortcuts.md
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Dưới đây là một vài phím tắt có ích cho việc sử dụng mdBook:"
 
-#: src/running-the-course/keyboard-shortcuts.md:5
+#: src/running-the-course/keyboard-shortcuts.md
 msgid "Arrow-Left"
 msgstr "Mũi tên trái"
 
-#: src/running-the-course/keyboard-shortcuts.md:5
+#: src/running-the-course/keyboard-shortcuts.md
 msgid ": Navigate to the previous page."
 msgstr ": Điều hướng tới trang trước."
 
-#: src/running-the-course/keyboard-shortcuts.md:6
+#: src/running-the-course/keyboard-shortcuts.md
 msgid "Arrow-Right"
 msgstr "Mũi tên phải"
 
-#: src/running-the-course/keyboard-shortcuts.md:6
+#: src/running-the-course/keyboard-shortcuts.md
 msgid ": Navigate to the next page."
 msgstr ": Điều hướng tới trang tiếp theo."
 
-#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+#: src/running-the-course/keyboard-shortcuts.md src/cargo/code-samples.md
 msgid "Ctrl + Enter"
 msgstr "Ctrl + Enter"
 
-#: src/running-the-course/keyboard-shortcuts.md:7
+#: src/running-the-course/keyboard-shortcuts.md
 msgid ": Execute the code sample that has focus."
 msgstr ": Chạy đoạn code mẫu chỉ định."
 
-#: src/running-the-course/keyboard-shortcuts.md:8
+#: src/running-the-course/keyboard-shortcuts.md
 msgid "s"
 msgstr "s"
 
-#: src/running-the-course/keyboard-shortcuts.md:8
+#: src/running-the-course/keyboard-shortcuts.md
 msgid ": Activate the search bar."
 msgstr ": Kích hoạt thanh tìm kiếm."
 
-#: src/running-the-course/translations.md:3
+#: src/running-the-course/translations.md
 msgid ""
 "The course has been translated into other languages by a set of wonderful "
 "volunteers:"
@@ -2058,7 +1939,7 @@ msgstr ""
 "Khóa học này đã được dịch ra các ngôn ngữ sau nhờ các tình nguyện viên tuyệt "
 "vời:"
 
-#: src/running-the-course/translations.md:6
+#: src/running-the-course/translations.md
 msgid ""
 "[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
 "by [@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
@@ -2070,7 +1951,7 @@ msgstr ""
 "github.com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), "
 "và [@henrif75](https://github.com/henrif75)."
 
-#: src/running-the-course/translations.md:8
+#: src/running-the-course/translations.md
 msgid ""
 "[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
 "by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
@@ -2086,7 +1967,7 @@ msgstr ""
 "github.com/superwhd), [@SketchK](https://github.com/SketchK), và [@nodmp]"
 "(https://github.com/nodmp)."
 
-#: src/running-the-course/translations.md:10
+#: src/running-the-course/translations.md
 msgid ""
 "[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
 "by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
@@ -2100,7 +1981,7 @@ msgstr ""
 "github.com/kuanhungchen), và [@johnathan79717](https://github.com/"
 "johnathan79717)."
 
-#: src/running-the-course/translations.md:12
+#: src/running-the-course/translations.md
 msgid ""
 "[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
 "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), "
@@ -2112,7 +1993,7 @@ msgstr ""
 "[@jooyunghan](https://github.com/jooyunghan), và [@namhyung](https://github."
 "com/namhyung)."
 
-#: src/running-the-course/translations.md:13
+#: src/running-the-course/translations.md
 msgid ""
 "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
 "(https://github.com/deavid)."
@@ -2120,18 +2001,18 @@ msgstr ""
 "[Tiếng Tây Ban Nha](https://google.github.io/comprehensive-rust/es/) và "
 "[@deavid](https://github.com/deavid)."
 
-#: src/running-the-course/translations.md:15
+#: src/running-the-course/translations.md
 msgid ""
 "Use the language picker in the top-right corner to switch between languages."
 msgstr ""
 "Sử dụng nút lựa chọn ngôn ngữ ở góc phía trên bên phải để đổi sang ngôn ngữ "
 "khác."
 
-#: src/running-the-course/translations.md:17
+#: src/running-the-course/translations.md
 msgid "Incomplete Translations"
 msgstr "Bản Dịch Chưa Hoàn Chỉnh"
 
-#: src/running-the-course/translations.md:19
+#: src/running-the-course/translations.md
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
@@ -2139,7 +2020,7 @@ msgstr ""
 "Hiện tại, vẫn còn một lượng lớn các bản dịch đang được tiến hành. Chúng tôi "
 "liên kết đến các bản dịch được cập nhật gần đây nhất:"
 
-#: src/running-the-course/translations.md:22
+#: src/running-the-course/translations.md
 msgid ""
 "[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
 "(https://github.com/raselmandol)."
@@ -2147,7 +2028,7 @@ msgstr ""
 "[Tiếng Bengal](https://google.github.io/comprehensive-rust/bn/) bởi "
 "[@raselmandol](https://github.com/raselmandol)."
 
-#: src/running-the-course/translations.md:23
+#: src/running-the-course/translations.md
 msgid ""
 "[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
 "(https://github.com/KookaS), [@vcaen](https://github.com/vcaen) and "
@@ -2157,7 +2038,7 @@ msgstr ""
 "(https://github.com/KookaS), [@vcaen](https://github.com/vcaen) và "
 "[@AdrienBaudemont](https://github.com/AdrienBaudemont)."
 
-#: src/running-the-course/translations.md:24
+#: src/running-the-course/translations.md
 msgid ""
 "[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
 "(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
@@ -2165,7 +2046,7 @@ msgstr ""
 "[Tiếng Đức](https://google.github.io/comprehensive-rust/de/) bởi [@Throvn]"
 "(https://github.com/Throvn) và [@ronaldfw](https://github.com/ronaldfw)."
 
-#: src/running-the-course/translations.md:25
+#: src/running-the-course/translations.md
 msgid ""
 "[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
 "(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
@@ -2175,7 +2056,7 @@ msgstr ""
 "JPN](https://github.com/CoinEZ) và [@momotaro1105](https://github.com/"
 "momotaro1105)."
 
-#: src/running-the-course/translations.md:26
+#: src/running-the-course/translations.md
 msgid ""
 "[Italian](https://google.github.io/comprehensive-rust/it/) by "
 "[@henrythebuilder](https://github.com/henrythebuilder) and [@detro](https://"
@@ -2185,7 +2066,7 @@ msgstr ""
 "[@henrythebuilder](https://github.com/henrythebuilder) và [@detro](https://"
 "github.com/detro)."
 
-#: src/running-the-course/translations.md:28
+#: src/running-the-course/translations.md
 msgid ""
 "If you want to help with this effort, please see [our instructions](https://"
 "github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
@@ -2198,7 +2079,7 @@ msgstr ""
 "một bản [issue tracker](https://github.com/google/comprehensive-rust/"
 "issues/1957)."
 
-#: src/cargo.md:3
+#: src/cargo.md
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
 "rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
@@ -2212,15 +2093,15 @@ msgstr ""
 "tóm tắt ngắn gọn Cargo là gì, nó phù hợp với hệ sinh thái rộng lớn hơn ra "
 "sao, và nó phù hợp với khóa đào tạo như thế nào."
 
-#: src/cargo.md:9
+#: src/cargo.md
 msgid "Installation"
 msgstr "Cài đặt"
 
-#: src/cargo.md:11
+#: src/cargo.md
 msgid "**Please follow the instructions on <https://rustup.rs/>.**"
 msgstr "**Vui lòng tuân theo hướng dẫn cài đặt tại <https://rustup.rs/>.**"
 
-#: src/cargo.md:13
+#: src/cargo.md
 msgid ""
 "This will give you the Cargo build tool (`cargo`) and the Rust compiler "
 "(`rustc`). You will also get `rustup`, a command line utility that you can "
@@ -2230,7 +2111,7 @@ msgstr ""
 "(`rustc`). Bạn cũng sẽ có `rustup`, một tiện ích dòng lệnh mà bạn có thể sử "
 "dụng để cài đặt các phiên bản khác nhau cho trình biên dịch."
 
-#: src/cargo.md:17
+#: src/cargo.md
 msgid ""
 "After installing Rust, you should configure your editor or IDE to work with "
 "Rust. Most editors do this by talking to [rust-analyzer](https://rust-"
@@ -2249,7 +2130,7 @@ msgstr ""
 "Bên cạnh đó, vẫn còn một IDE khác khá phổ biến được phát triển bởi JetBrains "
 "là [RustRover](https://www.jetbrains.com/rust/)."
 
-#: src/cargo.md:25
+#: src/cargo.md
 msgid ""
 "On Debian/Ubuntu, you can also install Cargo, the Rust source and the [Rust "
 "formatter](https://github.com/rust-lang/rustfmt) via `apt`. However, this "
@@ -2261,18 +2142,18 @@ msgstr ""
 "Tuy nhiên, bạn sẽ chỉ cài được phiên bản đã bị quá hạn và có thể dẫn tới "
 "những lỗi không mong muốn. Câu lệnh để cài sẽ là như sau:"
 
-#: src/cargo/rust-ecosystem.md:1
+#: src/cargo/rust-ecosystem.md
 msgid "The Rust Ecosystem"
 msgstr "Hệ Sinh Thái Rust"
 
-#: src/cargo/rust-ecosystem.md:3
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "The Rust ecosystem consists of a number of tools, of which the main ones are:"
 msgstr ""
 "Hệ sinh thái của Rust bao gồm một số lượng đáng kể các công cụ, trong đó nổi "
 "bật nhất như là:"
 
-#: src/cargo/rust-ecosystem.md:5
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
 "intermediate formats."
@@ -2280,7 +2161,7 @@ msgstr ""
 "`rustc`: trình biên dịch Rust, thứ mà sẽ \"dịch\" các file `.rs` sang dạng "
 "nhị phân hoặc các formats bậc trung khác."
 
-#: src/cargo/rust-ecosystem.md:8
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
 "download dependencies, usually hosted on <https://crates.io>, and it will "
@@ -2292,7 +2173,7 @@ msgstr ""
 "đưa chúng cho `rustc` khi bạn xây dựng dự án. Cargo còn có các trình chạy "
 "kiểm thử được cài sẵn phục vụ cho việc thực thi các đơn vị kiểm thử."
 
-#: src/cargo/rust-ecosystem.md:13
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "`rustup`: the Rust toolchain installer and updater. This tool is used to "
 "install and update `rustc` and `cargo` when new versions of Rust are "
@@ -2306,14 +2187,14 @@ msgstr ""
 "viện tiêu chuẩn. Bạn có thể cài đặt nhiều phiên bản Rust cùng lúc và "
 "`rustup` sẽ cho bạn chuyển đổi các phiên bản với nhau khi cần."
 
-#: src/cargo/rust-ecosystem.md:21 src/types-and-values/hello-world.md:26
-#: src/references/exclusive.md:20 src/memory-management/move.md:153
-#: src/error-handling/try.md:53 src/android/setup.md:18
-#: src/concurrency/async/async-await.md:26
+#: src/cargo/rust-ecosystem.md src/types-and-values/hello-world.md
+#: src/references/exclusive.md src/memory-management/move.md
+#: src/error-handling/try.md src/android/setup.md
+#: src/concurrency/async/async-await.md
 msgid "Key points:"
 msgstr "Các điểm chính:"
 
-#: src/cargo/rust-ecosystem.md:23
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "Rust has a rapid release schedule with a new release coming out every six "
 "weeks. New releases maintain backwards compatibility with old releases --- "
@@ -2323,12 +2204,12 @@ msgstr ""
 "sáu tuần. Các phiên bản mới bảo toàn tính tương thích với các phiên bản cũ "
 "--- cùng với đó chúng kích hoạt thêm các chức năng mới."
 
-#: src/cargo/rust-ecosystem.md:27
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "There are three release channels: \"stable\", \"beta\", and \"nightly\"."
 msgstr "Có tổng cộng ba kênh phát hành: \"stable\", \"beta\", và \"nightly\"."
 
-#: src/cargo/rust-ecosystem.md:29
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "New features are being tested on \"nightly\", \"beta\" is what becomes "
 "\"stable\" every six weeks."
@@ -2336,7 +2217,7 @@ msgstr ""
 "Các tính năng mới dang được thử nghiệm trên \"nightly\", còn \"beta\" sẽ trở "
 "thành \"stable\" sau mỗi sáu tuần."
 
-#: src/cargo/rust-ecosystem.md:32
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "Dependencies can also be resolved from alternative [registries](https://doc."
 "rust-lang.org/cargo/reference/registries.html), git, folders, and more."
@@ -2345,7 +2226,7 @@ msgstr ""
 "(https://doc.rust-lang.org/cargo/reference/registries.html) thay thế, git, "
 "các thư mục, v.v..."
 
-#: src/cargo/rust-ecosystem.md:35
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
 "current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
@@ -2353,7 +2234,7 @@ msgstr ""
 "Rust còn có nhiều [phiên bản lớn](https://doc.rust-lang.org/edition-guide/): "
 "Rust 2021 là bản hiện tại, Rust 2018, và Rust 2015."
 
-#: src/cargo/rust-ecosystem.md:38
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "The editions are allowed to make backwards incompatible changes to the "
 "language."
@@ -2361,7 +2242,7 @@ msgstr ""
 "Các phiên bản lớn được cho phép thực hiện các thay đổi không tương thích đối "
 "với ngôn ngữ."
 
-#: src/cargo/rust-ecosystem.md:41
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "To prevent breaking code, editions are opt-in: you select the edition for "
 "your crate via the `Cargo.toml` file."
@@ -2369,7 +2250,7 @@ msgstr ""
 "Để phòng trừ phá vỡ cấu trúc mã, các phiên bản lớn sẽ được chọn cho crate "
 "của bạn thông qua file `Cargo.toml`."
 
-#: src/cargo/rust-ecosystem.md:44
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "To avoid splitting the ecosystem, Rust compilers can mix code written for "
 "different editions."
@@ -2377,7 +2258,7 @@ msgstr ""
 "Nhằm tránh hệ sinh thái bị chia nhỏ ra, trình biên dịch Rust có thể trộn lẫn "
 "các đoạn mã được viết dưới các phiên bản lớn khác nhau."
 
-#: src/cargo/rust-ecosystem.md:47
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "Mention that it is quite rare to ever use the compiler directly not through "
 "`cargo` (most users never do)."
@@ -2386,7 +2267,7 @@ msgstr ""
 "không thông qua `cargo` là việc rất hiếm (hầu hết người dùng không bao giờ "
 "làm như vậy)."
 
-#: src/cargo/rust-ecosystem.md:50
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "It might be worth alluding that Cargo itself is an extremely powerful and "
 "comprehensive tool. It is capable of many advanced features including but "
@@ -2395,21 +2276,21 @@ msgstr ""
 "Nói không ngoa bản thân Cargo là một công cụ cự kỳ mạnh mẽ và toàn diện. Nó "
 "có khả năng bao gồm nhưng không giới hạn tới nhiều tính năng mở rộng sau:"
 
-#: src/cargo/rust-ecosystem.md:53
+#: src/cargo/rust-ecosystem.md
 msgid "Project/package structure"
 msgstr "Cấu trúc dự án/bộ phần mềm."
 
-#: src/cargo/rust-ecosystem.md:54
+#: src/cargo/rust-ecosystem.md
 msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
 msgstr ""
 "[Workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)."
 
-#: src/cargo/rust-ecosystem.md:55
+#: src/cargo/rust-ecosystem.md
 msgid "Dev Dependencies and Runtime Dependency management/caching"
 msgstr ""
 "Các Dev Dependencies và trình quản lý/bộ nhớ đệm cho Runtime Dependency."
 
-#: src/cargo/rust-ecosystem.md:56
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
 "html)"
@@ -2417,7 +2298,7 @@ msgstr ""
 "[Build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
 "html)."
 
-#: src/cargo/rust-ecosystem.md:57
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
 "html)"
@@ -2425,7 +2306,7 @@ msgstr ""
 "[Cài đặt trên toàn môi trường](https://doc.rust-lang.org/cargo/commands/"
 "cargo-install.html)."
 
-#: src/cargo/rust-ecosystem.md:58
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "It is also extensible with sub command plugins as well (such as [cargo "
 "clippy](https://github.com/rust-lang/rust-clippy))."
@@ -2433,16 +2314,16 @@ msgstr ""
 "Nó còn có khả năng mở rộng được với các lệnh con dưới dạng plugins (như là "
 "[cargo clippy](https://github.com/rust-lang/rust-clippy))."
 
-#: src/cargo/rust-ecosystem.md:60
+#: src/cargo/rust-ecosystem.md
 msgid ""
 "Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
 msgstr "Tham khảo thêm tại [The Cargo Book](https://doc.rust-lang.org/cargo/)."
 
-#: src/cargo/code-samples.md:1
+#: src/cargo/code-samples.md
 msgid "Code Samples in This Training"
 msgstr "Code Mẫu Trong Khóa Đào Tạo"
 
-#: src/cargo/code-samples.md:3
+#: src/cargo/code-samples.md
 msgid ""
 "For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
@@ -2453,7 +2334,7 @@ msgstr ""
 "việc chuẩn bị được thực hiện dễ dàng hơn và đảm bảo trải nghiệm đồng nhất "
 "với mọi người."
 
-#: src/cargo/code-samples.md:7
+#: src/cargo/code-samples.md
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
 "the exercises. On the last day, we will do a larger exercise which shows you "
@@ -2463,23 +2344,23 @@ msgstr ""
 "hơn. Trong ngày học cuối cùng, chúng tôi sẽ làm một bài tập lớn để cho bạn "
 "thấy cách làm việc với các gói phụ thuộc và bạn sẽ cần Cargo để làm nó."
 
-#: src/cargo/code-samples.md:11
+#: src/cargo/code-samples.md
 msgid "The code blocks in this course are fully interactive:"
 msgstr "Các khối code trong khóa học này hoàn toàn tương tác được:"
 
-#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:46
+#: src/cargo/code-samples.md src/cargo/running-locally.md
 msgid "\"Edit me!\""
 msgstr "\"Chỉnh sửa tôi đê!\""
 
-#: src/cargo/code-samples.md:19
+#: src/cargo/code-samples.md
 msgid "You can use "
 msgstr "Bạn có thể sử dụng "
 
-#: src/cargo/code-samples.md:19
+#: src/cargo/code-samples.md
 msgid " to execute the code when focus is in the text box."
 msgstr " để thực thi khối code đang chứa con trỏ soạn thảo của bạn."
 
-#: src/cargo/code-samples.md:24
+#: src/cargo/code-samples.md
 msgid ""
 "Most code samples are editable like shown above. A few code samples are not "
 "editable for various reasons:"
@@ -2487,7 +2368,7 @@ msgstr ""
 "Hầu hết các đoạn code mẫu đều có thể chỉnh sửa được như trên. Nhưng có một "
 "ít các đoạn mẫu lại không chỉnh sửa được vì vài lý do sau:"
 
-#: src/cargo/code-samples.md:27
+#: src/cargo/code-samples.md
 msgid ""
 "The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
 "open it in the real Playground to demonstrate unit tests."
@@ -2496,7 +2377,7 @@ msgstr ""
 "copy-paste đoạn code và mở nó trong một Playground thực sự để minh họa các "
 "thử nghiệm."
 
-#: src/cargo/code-samples.md:30
+#: src/cargo/code-samples.md
 msgid ""
 "The embedded playgrounds lose their state the moment you navigate away from "
 "the page! This is the reason that the students should solve the exercises "
@@ -2506,11 +2387,11 @@ msgstr ""
 "sang trang khác! Vì lý do này, các học sinh nên giải các bài thực hành sử "
 "dụng Rust đã được cài đặt trong máy tính riêng hoặc qua Playground thực sự."
 
-#: src/cargo/running-locally.md:1
+#: src/cargo/running-locally.md
 msgid "Running Code Locally with Cargo"
 msgstr "Chạy Cargo Trong Máy Tính Của Bạn"
 
-#: src/cargo/running-locally.md:3
+#: src/cargo/running-locally.md
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
 "need to first install Rust. Do this by following the [instructions in the "
@@ -2524,7 +2405,7 @@ msgstr ""
 "cách sử dụng `rustc` và `cargo` ở đây. Tại thời điểm bài này được viết, "
 "phiên bản ổn định mới nhất của Rust có các số phiên bản sau:"
 
-#: src/cargo/running-locally.md:16
+#: src/cargo/running-locally.md
 msgid ""
 "You can use any later version too since Rust maintains backwards "
 "compatibility."
@@ -2532,7 +2413,7 @@ msgstr ""
 "Bạn cũng có thể sử dụng bất kỳ phiên bản nào ra sau đó vì Rust luôn bảo trì "
 "khả năng tương thích ngược của nó."
 
-#: src/cargo/running-locally.md:18
+#: src/cargo/running-locally.md
 msgid ""
 "With this in place, follow these steps to build a Rust binary from one of "
 "the examples in this training:"
@@ -2540,25 +2421,25 @@ msgstr ""
 "Sau khi cài xong, tuân theo các bước sau đây để xây dựng tệp nhị phân Rust "
 "từ một trong các ví dụ trong khóa đào tạo:"
 
-#: src/cargo/running-locally.md:21
+#: src/cargo/running-locally.md
 msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr "Nhấn vào nút \"Copy to clipboard\" trong ví dụ mà bạn muốn copy."
 
-#: src/cargo/running-locally.md:23
+#: src/cargo/running-locally.md
 msgid ""
 "Use `cargo new exercise` to create a new `exercise/` directory for your code:"
 msgstr ""
 "Sử dụng `cargo new exercise` để tạo một thư mục `exercise/` mới cho code của "
 "bạn:"
 
-#: src/cargo/running-locally.md:30
+#: src/cargo/running-locally.md
 msgid ""
 "Navigate into `exercise/` and use `cargo run` to build and run your binary:"
 msgstr ""
 "Điều hướng tới `exercise/` và sử dụng `cargo run` để build và chạy tệp nhị "
 "phân của bạn:"
 
-#: src/cargo/running-locally.md:41
+#: src/cargo/running-locally.md
 msgid ""
 "Replace the boiler-plate code in `src/main.rs` with your own code. For "
 "example, using the example on the previous page, make `src/main.rs` look like"
@@ -2566,11 +2447,11 @@ msgstr ""
 "Thay thế khung code trong `src/main.rs` với code riêng của bạn. Chẳng hạn, "
 "sử dụng ví dụ ở trang trước, viết `src/main.rs` sao cho thành như sau"
 
-#: src/cargo/running-locally.md:50
+#: src/cargo/running-locally.md
 msgid "Use `cargo run` to build and run your updated binary:"
 msgstr "Sử dụng `cargo run` để build và chạy tệp nhị phân vừa được cập nhật:"
 
-#: src/cargo/running-locally.md:60
+#: src/cargo/running-locally.md
 msgid ""
 "Use `cargo check` to quickly check your project for errors, use `cargo "
 "build` to compile it without running it. You will find the output in `target/"
@@ -2582,7 +2463,7 @@ msgstr ""
 "`target/debug/` cho debug build thông thường. Sử dụng `cargo build --"
 "release` để xuất ra bản build tối ưu cho việc xuất bản ở `target/release/`."
 
-#: src/cargo/running-locally.md:65
+#: src/cargo/running-locally.md
 msgid ""
 "You can add dependencies for your project by editing `Cargo.toml`. When you "
 "run `cargo` commands, it will automatically download and compile missing "
@@ -2592,7 +2473,7 @@ msgstr ""
 "`Cargo.toml`. Khi bạn chạy các lệnh `cargo`, nó sẽ tự động tải về và biên "
 "dịch các gói phụ thuộc bị thiếu cho bạn."
 
-#: src/cargo/running-locally.md:73
+#: src/cargo/running-locally.md
 msgid ""
 "Try to encourage the class participants to install Cargo and use a local "
 "editor. It will make their life easier since they will have a normal "
@@ -2602,11 +2483,11 @@ msgstr ""
 "Editor ở máy riêng. Điều này sẽ giúp cuộc sống của họ dễ thở hơn một tý vì "
 "họ sẽ được làm việc trong một môi trường phát triển bình thường."
 
-#: src/welcome-day-1.md:1
+#: src/welcome-day-1.md
 msgid "Welcome to Day 1"
 msgstr "Chào mừng tới Ngày 1"
 
-#: src/welcome-day-1.md:3
+#: src/welcome-day-1.md
 msgid ""
 "This is the first day of Rust Fundamentals. We will cover a lot of ground "
 "today:"
@@ -2614,7 +2495,7 @@ msgstr ""
 "Đây là ngày học đầu tiên của Rust Căn Bản. Sẽ có rất nhiều nội dung mà chúng "
 "ta bao quát trong hôm nay:"
 
-#: src/welcome-day-1.md:5
+#: src/welcome-day-1.md
 msgid ""
 "Basic Rust syntax: variables, scalar and compound types, enums, structs, "
 "references, functions, and methods."
@@ -2622,29 +2503,29 @@ msgstr ""
 "Câu lệnh Rust cơ bản: các biến, kiểu dữ liệu đơn giản và phức hợp, enum, "
 "struct, tham chiếu, hàm và phương thức."
 
-#: src/welcome-day-1.md:7
+#: src/welcome-day-1.md
 msgid "Types and type inference."
 msgstr "Các kiểu dữ liệu và suy luận kiểu."
 
-#: src/welcome-day-1.md:8
+#: src/welcome-day-1.md
 msgid "Control flow constructs: loops, conditionals, and so on."
 msgstr "Các cấu trúc điều kiển luồng: vòng lặp, điều kiện, vân vân..."
 
-#: src/welcome-day-1.md:9
+#: src/welcome-day-1.md
 msgid "User-defined types: structs and enums."
 msgstr "Các kiểu dữ liệu tự định nghĩa: struct và enum."
 
-#: src/welcome-day-1.md:10
+#: src/welcome-day-1.md
 msgid "Pattern matching: destructuring enums, structs, and arrays."
 msgstr "So khớp mẫu: hủy enum, struct, và mảng."
 
-#: src/welcome-day-1.md:12 src/welcome-day-2.md:12 src/welcome-day-3.md:9
-#: src/welcome-day-4.md:11 src/concurrency/welcome.md:10
-#: src/concurrency/welcome-async.md:27
+#: src/welcome-day-1.md src/welcome-day-2.md src/welcome-day-3.md
+#: src/welcome-day-4.md src/concurrency/welcome.md
+#: src/concurrency/welcome-async.md
 msgid "Schedule"
 msgstr "Mục lục"
 
-#: src/welcome-day-1.md:14
+#: src/welcome-day-1.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 5 "
 "minutes. It contains:"
@@ -2652,22 +2533,22 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 2 tiếng và 5 phút, bao gồm thời gian 10 phút "
 "nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/welcome-day-1.md:27
+#: src/welcome-day-1.md
 msgid "Please remind the students that:"
 msgstr "Hãy lưu ý các học viên rằng:"
 
-#: src/welcome-day-1.md:29
+#: src/welcome-day-1.md
 msgid ""
 "They should ask questions when they get them, don't save them to the end."
 msgstr "Học viên nên đặt câu hỏi bất kì khi nào thay vì đợi đến cuối buổi học."
 
-#: src/welcome-day-1.md:30
+#: src/welcome-day-1.md
 msgid ""
 "The class is meant to be interactive and discussions are very much "
 "encouraged!"
 msgstr "Lớp học rất khuyến khích có nhiều sự tương tác và thảo luận!"
 
-#: src/welcome-day-1.md:31
+#: src/welcome-day-1.md
 msgid ""
 "As an instructor, you should try to keep the discussions relevant, i.e., "
 "keep the discussions related to how Rust does things vs some other language. "
@@ -2680,12 +2561,12 @@ msgstr ""
 "khăn, nhưng ta thà chấp nhận nó để học viên thấy hứng thú hơn là việc giao "
 "tiếp một chiều."
 
-#: src/welcome-day-1.md:35
+#: src/welcome-day-1.md
 msgid ""
 "The questions will likely mean that we talk about things ahead of the slides."
 msgstr "Một phần có thể bị hỏi trước khi ta học tới slide của phần đó."
 
-#: src/welcome-day-1.md:36
+#: src/welcome-day-1.md
 msgid ""
 "This is perfectly okay! Repetition is an important part of learning. "
 "Remember that the slides are just a support and you are free to skip them as "
@@ -2695,7 +2576,7 @@ msgstr ""
 "trọng của việc học. Hãy nhớ rằng các slides chỉ là công cụ hỗ trợ cho bạn và "
 "bạn có thể bỏ qua chúng nếu muốn."
 
-#: src/welcome-day-1.md:40
+#: src/welcome-day-1.md
 msgid ""
 "The idea for the first day is to show the \"basic\" things in Rust that "
 "should have immediate parallels in other languages. The more advanced parts "
@@ -2705,7 +2586,7 @@ msgstr ""
 "tương tự với các ngôn ngữ khác. Các phần nâng cao hơn sẽ được đề cập tới ở "
 "những ngày kế tiếp."
 
-#: src/welcome-day-1.md:44
+#: src/welcome-day-1.md
 msgid ""
 "If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. Note that there is an exercise at the end of each segment, "
@@ -2719,50 +2600,41 @@ msgstr ""
 "gian ở sau mỗi đề mục là nhằm giúp bạn giữ đúng tiến độ khóa học, nhưng bạn "
 "cũng có thể thoải mái điều chỉnh linh hoạt nếu cần thiết!"
 
-#: src/hello-world.md:3 src/concurrency/send-sync.md:3
+#: src/hello-world.md src/concurrency/send-sync.md
 msgid "This segment should take about 15 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 15 phút, bao gồm:"
 
-#: src/hello-world.md:5 src/types-and-values.md:5 src/control-flow-basics.md:5
-#: src/tuples-and-arrays.md:5 src/references.md:5 src/user-defined-types.md:5
-#: src/pattern-matching.md:5 src/methods-and-traits.md:5 src/generics.md:5
-#: src/std-types.md:5 src/std-traits.md:5 src/memory-management.md:5
-#: src/smart-pointers.md:5 src/borrowing.md:5 src/lifetimes.md:5
-#: src/iterators.md:5 src/modules.md:5 src/testing.md:5 src/error-handling.md:5
-#: src/unsafe-rust.md:5 src/concurrency/threads.md:5
-#: src/concurrency/channels.md:5 src/concurrency/send-sync.md:5
-#: src/concurrency/shared-state.md:5 src/concurrency/sync-exercises.md:5
-#: src/concurrency/async.md:5 src/concurrency/async-control-flow.md:5
-#: src/concurrency/async-pitfalls.md:9 src/concurrency/async-exercises.md:5
+#: src/hello-world.md src/types-and-values.md src/control-flow-basics.md
+#: src/tuples-and-arrays.md src/references.md src/user-defined-types.md
+#: src/pattern-matching.md src/methods-and-traits.md src/generics.md
+#: src/std-types.md src/std-traits.md src/memory-management.md
+#: src/smart-pointers.md src/borrowing.md src/lifetimes.md src/iterators.md
+#: src/modules.md src/testing.md src/error-handling.md src/unsafe-rust.md
+#: src/concurrency/threads.md src/concurrency/channels.md
+#: src/concurrency/send-sync.md src/concurrency/shared-state.md
+#: src/concurrency/sync-exercises.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-exercises.md
 msgid "Slide"
 msgstr ""
 
-#: src/hello-world.md:7 src/references.md:7 src/references.md:8
-#: src/references.md:9 src/references.md:10 src/user-defined-types.md:7
-#: src/user-defined-types.md:8 src/pattern-matching.md:7
-#: src/pattern-matching.md:10 src/methods-and-traits.md:7 src/generics.md:8
-#: src/generics.md:9 src/generics.md:11 src/std-types.md:9 src/std-types.md:10
-#: src/std-types.md:11 src/std-types.md:12 src/std-types.md:13
-#: src/std-traits.md:7 src/std-traits.md:8 src/std-traits.md:9
-#: src/std-traits.md:11 src/memory-management.md:8 src/memory-management.md:13
-#: src/smart-pointers.md:7 src/smart-pointers.md:9 src/borrowing.md:7
-#: src/borrowing.md:8 src/borrowing.md:10 src/lifetimes.md:7 src/modules.md:10
-#: src/unsafe-rust.md:8 src/concurrency/channels.md:7
-#: src/concurrency/channels.md:9 src/concurrency/send-sync.md:10
-#: src/concurrency/shared-state.md:9 src/concurrency/async.md:7
-#: src/concurrency/async.md:9 src/concurrency/async.md:10
-#: src/concurrency/async-control-flow.md:7 src/concurrency/async-pitfalls.md:11
+#: src/hello-world.md src/references.md src/user-defined-types.md
+#: src/pattern-matching.md src/methods-and-traits.md src/generics.md
+#: src/std-types.md src/std-traits.md src/memory-management.md
+#: src/smart-pointers.md src/borrowing.md src/lifetimes.md src/modules.md
+#: src/unsafe-rust.md src/concurrency/channels.md src/concurrency/send-sync.md
+#: src/concurrency/shared-state.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
 msgid "10 minutes"
 msgstr ""
 
-#: src/hello-world.md:9 src/control-flow-basics.md:12
-#: src/user-defined-types.md:11 src/memory-management.md:11
-#: src/concurrency/channels.md:8 src/concurrency/send-sync.md:7
-#: src/concurrency/send-sync.md:8 src/concurrency/send-sync.md:9
+#: src/hello-world.md src/control-flow-basics.md src/user-defined-types.md
+#: src/memory-management.md src/concurrency/channels.md
+#: src/concurrency/send-sync.md
 msgid "2 minutes"
 msgstr ""
 
-#: src/hello-world/what-is-rust.md:3
+#: src/hello-world/what-is-rust.md
 msgid ""
 "Rust is a new programming language which had its [1.0 release in 2015]"
 "(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
@@ -2770,15 +2642,15 @@ msgstr ""
 "Rust là một ngôn ngữ lập trình mới được phát hành [phiên bản 1.0 vào năm "
 "2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 
-#: src/hello-world/what-is-rust.md:5
+#: src/hello-world/what-is-rust.md
 msgid "Rust is a statically compiled language in a similar role as C++"
 msgstr "Rust là một ngôn ngữ được biên dịch tĩnh với vai trò tương tự như C++"
 
-#: src/hello-world/what-is-rust.md:6
+#: src/hello-world/what-is-rust.md
 msgid "`rustc` uses LLVM as its backend."
 msgstr "`rustc` sử dụng LLVM làm bộ dịch backend."
 
-#: src/hello-world/what-is-rust.md:7
+#: src/hello-world/what-is-rust.md
 msgid ""
 "Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
 "nightly/rustc/platform-support.html):"
@@ -2786,170 +2658,170 @@ msgstr ""
 "Rust hỗ trợ rất nhiều [nền tảng và kiểu kiến trúc](https://doc.rust-lang.org/"
 "nightly/rustc/platform-support.html):"
 
-#: src/hello-world/what-is-rust.md:9
+#: src/hello-world/what-is-rust.md
 msgid "x86, ARM, WebAssembly, ..."
 msgstr ""
 
-#: src/hello-world/what-is-rust.md:10
+#: src/hello-world/what-is-rust.md
 msgid "Linux, Mac, Windows, ..."
 msgstr ""
 
-#: src/hello-world/what-is-rust.md:11
+#: src/hello-world/what-is-rust.md
 msgid "Rust is used for a wide range of devices:"
 msgstr "Rust được sử dụng cho nhiều loại thiết bị:"
 
-#: src/hello-world/what-is-rust.md:12
+#: src/hello-world/what-is-rust.md
 msgid "firmware and boot loaders,"
 msgstr "firmware và các chương trình khởi động (*boot loaders*),"
 
-#: src/hello-world/what-is-rust.md:13
+#: src/hello-world/what-is-rust.md
 msgid "smart displays,"
 msgstr "màn hình thông minh,"
 
-#: src/hello-world/what-is-rust.md:14
+#: src/hello-world/what-is-rust.md
 msgid "mobile phones,"
 msgstr "điện thoại di động,"
 
-#: src/hello-world/what-is-rust.md:15
+#: src/hello-world/what-is-rust.md
 msgid "desktops,"
 msgstr "máy tính,"
 
-#: src/hello-world/what-is-rust.md:16
+#: src/hello-world/what-is-rust.md
 msgid "servers."
 msgstr "máy chủ."
 
-#: src/hello-world/what-is-rust.md:21
+#: src/hello-world/what-is-rust.md
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust phù hợp trong cùng lĩnh vực như C++:"
 
-#: src/hello-world/what-is-rust.md:23
+#: src/hello-world/what-is-rust.md
 msgid "High flexibility."
 msgstr "Độ linh hoạt cao."
 
-#: src/hello-world/what-is-rust.md:24
+#: src/hello-world/what-is-rust.md
 msgid "High level of control."
 msgstr "Có quyền điều khiển cao."
 
-#: src/hello-world/what-is-rust.md:25
+#: src/hello-world/what-is-rust.md
 msgid ""
 "Can be scaled down to very constrained devices such as microcontrollers."
 msgstr ""
 "Có thể ứng dụng với các thiết bị có tài nguyên hạn chế như vi điều khiển."
 
-#: src/hello-world/what-is-rust.md:26
+#: src/hello-world/what-is-rust.md
 msgid "Has no runtime or garbage collection."
 msgstr ""
 "Không có thời gian chạy (*runtime*) hay trình thu dọn rác (*garbage "
 "collection*)."
 
-#: src/hello-world/what-is-rust.md:27
+#: src/hello-world/what-is-rust.md
 msgid "Focuses on reliability and safety without sacrificing performance."
 msgstr ""
 "Tập trung vào tính đáng tin cậy và độ an toàn mà không làm giảm hiệu suất."
 
-#: src/hello-world/benefits.md:3
+#: src/hello-world/benefits.md
 msgid "Some unique selling points of Rust:"
 msgstr ""
 
-#: src/hello-world/benefits.md:5
+#: src/hello-world/benefits.md
 msgid ""
 "_Compile time memory safety_ - whole classes of memory bugs are prevented at "
 "compile time"
 msgstr ""
 
-#: src/hello-world/benefits.md:7
+#: src/hello-world/benefits.md
 msgid "No uninitialized variables."
 msgstr ""
 
-#: src/hello-world/benefits.md:8
+#: src/hello-world/benefits.md
 msgid "No double-frees."
 msgstr ""
 
-#: src/hello-world/benefits.md:9
+#: src/hello-world/benefits.md
 msgid "No use-after-free."
 msgstr ""
 
-#: src/hello-world/benefits.md:10
+#: src/hello-world/benefits.md
 msgid "No `NULL` pointers."
 msgstr ""
 
-#: src/hello-world/benefits.md:11
+#: src/hello-world/benefits.md
 msgid "No forgotten locked mutexes."
 msgstr ""
 
-#: src/hello-world/benefits.md:12
+#: src/hello-world/benefits.md
 msgid "No data races between threads."
 msgstr ""
 
-#: src/hello-world/benefits.md:13
+#: src/hello-world/benefits.md
 msgid "No iterator invalidation."
 msgstr ""
 
-#: src/hello-world/benefits.md:15
+#: src/hello-world/benefits.md
 msgid ""
 "_No undefined runtime behavior_ - what a Rust statement does is never left "
 "unspecified"
 msgstr ""
 
-#: src/hello-world/benefits.md:17
+#: src/hello-world/benefits.md
 msgid "Array access is bounds checked."
 msgstr ""
 
-#: src/hello-world/benefits.md:18
+#: src/hello-world/benefits.md
 msgid "Integer overflow is defined (panic or wrap-around)."
 msgstr ""
 
-#: src/hello-world/benefits.md:20
+#: src/hello-world/benefits.md
 msgid ""
 "_Modern language features_ - as expressive and ergonomic as higher-level "
 "languages"
 msgstr ""
 
-#: src/hello-world/benefits.md:22
+#: src/hello-world/benefits.md
 msgid "Enums and pattern matching."
 msgstr ""
 
-#: src/hello-world/benefits.md:23
+#: src/hello-world/benefits.md
 msgid "Generics."
 msgstr ""
 
-#: src/hello-world/benefits.md:24
+#: src/hello-world/benefits.md
 msgid "No overhead FFI."
 msgstr ""
 
-#: src/hello-world/benefits.md:25
+#: src/hello-world/benefits.md
 msgid "Zero-cost abstractions."
 msgstr ""
 
-#: src/hello-world/benefits.md:26
+#: src/hello-world/benefits.md
 msgid "Great compiler errors."
 msgstr ""
 
-#: src/hello-world/benefits.md:27
+#: src/hello-world/benefits.md
 msgid "Built-in dependency manager."
 msgstr ""
 
-#: src/hello-world/benefits.md:28
+#: src/hello-world/benefits.md
 msgid "Built-in support for testing."
 msgstr ""
 
-#: src/hello-world/benefits.md:29
+#: src/hello-world/benefits.md
 msgid "Excellent Language Server Protocol support."
 msgstr ""
 
-#: src/hello-world/benefits.md:34
+#: src/hello-world/benefits.md
 msgid ""
 "Do not spend much time here. All of these points will be covered in more "
 "depth later."
 msgstr ""
 
-#: src/hello-world/benefits.md:37
+#: src/hello-world/benefits.md
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
 "Depending on the answer you can highlight different features of Rust:"
 msgstr ""
 
-#: src/hello-world/benefits.md:40
+#: src/hello-world/benefits.md
 msgid ""
 "Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
 "via the borrow checker. You get performance like in C and C++, but you don't "
@@ -2957,7 +2829,7 @@ msgid ""
 "constructs like pattern matching and built-in dependency management."
 msgstr ""
 
-#: src/hello-world/benefits.md:45
+#: src/hello-world/benefits.md
 msgid ""
 "Experience with Java, Go, Python, JavaScript...: You get the same memory "
 "safety as in those languages, plus a similar high-level language feeling. In "
@@ -2965,7 +2837,7 @@ msgid ""
 "collector) as well as access to low-level hardware (should you need it)"
 msgstr ""
 
-#: src/hello-world/playground.md:3
+#: src/hello-world/playground.md
 msgid ""
 "The [Rust Playground](https://play.rust-lang.org/) provides an easy way to "
 "run short Rust programs, and is the basis for the examples and exercises in "
@@ -2978,7 +2850,7 @@ msgstr ""
 "chương trình “hello-world”. Rust Playground đi kèm với một vài tính năng hữu "
 "ích:"
 
-#: src/hello-world/playground.md:8
+#: src/hello-world/playground.md
 msgid ""
 "Under \"Tools\", use the `rustfmt` option to format your code in the "
 "\"standard\" way."
@@ -2986,7 +2858,7 @@ msgstr ""
 "Ở phần “Công cụ (*Tools*)”, sử dụng tuỳ chọn`rustfmt` để định dạng đoạn code "
 "của bạn theo cách “tiêu chuẩn”."
 
-#: src/hello-world/playground.md:11
+#: src/hello-world/playground.md
 msgid ""
 "Rust has two main \"profiles\" for generating code: Debug (extra runtime "
 "checks, less optimization) and Release (fewer runtime checks, lots of "
@@ -2997,7 +2869,7 @@ msgstr ""
 "(*Release*) (ít thông tin hỗ trợ trong quá trình chạy (*runtime*), tối ưu "
 "hoá nhiều hơn). Các tuỳ chọn này có trong mục “Gỡ lỗi (*Debug*)” ở phía trên."
 
-#: src/hello-world/playground.md:15
+#: src/hello-world/playground.md
 msgid ""
 "If you're interested, use \"ASM\" under \"...\" to see the generated "
 "assembly code."
@@ -3005,7 +2877,7 @@ msgstr ""
 "Nếu bạn quan tâm, bạn có thể sử dụng chế độ “ASM” ở trong phần “...” để xem "
 "đoạn code Assembly được tạo."
 
-#: src/hello-world/playground.md:21
+#: src/hello-world/playground.md
 msgid ""
 "As students head into the break, encourage them to open up the playground "
 "and experiment a little. Encourage them to keep the tab open and try things "
@@ -3019,69 +2891,69 @@ msgstr ""
 "những học viên nâng cao muốn biết thêm về tối ưu hoá của Rust và những đoạn "
 "code Assembly được tạo ra."
 
-#: src/types-and-values.md:3 src/control-flow-basics.md:3 src/generics.md:3
-#: src/modules.md:3
+#: src/types-and-values.md src/control-flow-basics.md src/generics.md
+#: src/modules.md
 msgid "This segment should take about 40 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 40 phút, bao gồm:"
 
-#: src/types-and-values/hello-world.md:3
+#: src/types-and-values/hello-world.md
 msgid ""
 "Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
 
-#: src/types-and-values/hello-world.md:8
+#: src/types-and-values/hello-world.md
 msgid "\"Hello 🌍!\""
 msgstr ""
 
-#: src/types-and-values/hello-world.md:12
+#: src/types-and-values/hello-world.md
 msgid "What you see:"
 msgstr ""
 
-#: src/types-and-values/hello-world.md:14
+#: src/types-and-values/hello-world.md
 msgid "Functions are introduced with `fn`."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:15
+#: src/types-and-values/hello-world.md
 msgid "Blocks are delimited by curly braces like in C and C++."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:16
+#: src/types-and-values/hello-world.md
 msgid "The `main` function is the entry point of the program."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:17
+#: src/types-and-values/hello-world.md
 msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:18
+#: src/types-and-values/hello-world.md
 msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:23
+#: src/types-and-values/hello-world.md
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
 "see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:28
+#: src/types-and-values/hello-world.md
 msgid ""
 "Rust is very much like other languages in the C/C++/Java tradition. It is "
 "imperative and it doesn't try to reinvent things unless absolutely necessary."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:31
+#: src/types-and-values/hello-world.md
 msgid "Rust is modern with full support for things like Unicode."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:33
+#: src/types-and-values/hello-world.md
 msgid ""
 "Rust uses macros for situations where you want to have a variable number of "
 "arguments (no function [overloading](../control-flow-basics/functions.md))."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:36
+#: src/types-and-values/hello-world.md
 msgid ""
 "Macros being 'hygienic' means they don't accidentally capture identifiers "
 "from the scope they are used in. Rust macros are actually only [partially "
@@ -3089,7 +2961,7 @@ msgid ""
 "html)."
 msgstr ""
 
-#: src/types-and-values/hello-world.md:40
+#: src/types-and-values/hello-world.md
 msgid ""
 "Rust is multi-paradigm. For example, it has powerful [object-oriented "
 "programming features](https://doc.rust-lang.org/book/ch17-00-oop.html), and, "
@@ -3097,164 +2969,164 @@ msgid ""
 "concepts](https://doc.rust-lang.org/book/ch13-00-functional-features.html)."
 msgstr ""
 
-#: src/types-and-values/variables.md:3
+#: src/types-and-values/variables.md
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are made with "
 "`let`:"
 msgstr ""
 
-#: src/types-and-values/variables.md:9 src/control-flow-basics/loops/for.md:9
-#: src/control-flow-basics/blocks-and-scopes.md:17
+#: src/types-and-values/variables.md src/control-flow-basics/loops/for.md
+#: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"x: {x}\""
 msgstr ""
 
-#: src/types-and-values/variables.md:10
+#: src/types-and-values/variables.md
 msgid ""
 "// x = 20;\n"
 "    // println!(\"x: {x}\");\n"
 msgstr ""
 
-#: src/types-and-values/variables.md:18
+#: src/types-and-values/variables.md
 msgid ""
 "Uncomment the `x = 20` to demonstrate that variables are immutable by "
 "default. Add the `mut` keyword to allow changes."
 msgstr ""
 
-#: src/types-and-values/variables.md:21
+#: src/types-and-values/variables.md
 msgid ""
 "The `i32` here is the type of the variable. This must be known at compile "
 "time, but type inference (covered later) allows the programmer to omit it in "
 "many cases."
 msgstr ""
 
-#: src/types-and-values/values.md:3
+#: src/types-and-values/values.md
 msgid ""
 "Here are some basic built-in types, and the syntax for literal values of "
 "each type."
 msgstr ""
 
-#: src/types-and-values/values.md:6 src/unsafe-rust/exercise.md:16
+#: src/types-and-values/values.md src/unsafe-rust/exercise.md
 msgid "Types"
 msgstr ""
 
-#: src/types-and-values/values.md:6
+#: src/types-and-values/values.md
 msgid "Literals"
 msgstr ""
 
-#: src/types-and-values/values.md:8
+#: src/types-and-values/values.md
 msgid "Signed integers"
 msgstr ""
 
-#: src/types-and-values/values.md:8
+#: src/types-and-values/values.md
 msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
 msgstr ""
 
-#: src/types-and-values/values.md:8
+#: src/types-and-values/values.md
 msgid "`-10`, `0`, `1_000`, `123_i64`"
 msgstr ""
 
-#: src/types-and-values/values.md:9
+#: src/types-and-values/values.md
 msgid "Unsigned integers"
 msgstr ""
 
-#: src/types-and-values/values.md:9
+#: src/types-and-values/values.md
 msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
 msgstr ""
 
-#: src/types-and-values/values.md:9
+#: src/types-and-values/values.md
 msgid "`0`, `123`, `10_u16`"
 msgstr ""
 
-#: src/types-and-values/values.md:10
+#: src/types-and-values/values.md
 msgid "Floating point numbers"
 msgstr ""
 
-#: src/types-and-values/values.md:10
+#: src/types-and-values/values.md
 msgid "`f32`, `f64`"
 msgstr ""
 
-#: src/types-and-values/values.md:10
+#: src/types-and-values/values.md
 msgid "`3.14`, `-10.0e20`, `2_f32`"
 msgstr ""
 
-#: src/types-and-values/values.md:11
+#: src/types-and-values/values.md
 msgid "Unicode scalar values"
 msgstr ""
 
-#: src/types-and-values/values.md:11 src/android/aidl/types/primitives.md:9
+#: src/types-and-values/values.md src/android/aidl/types/primitives.md
 msgid "`char`"
 msgstr ""
 
-#: src/types-and-values/values.md:11
+#: src/types-and-values/values.md
 msgid "`'a'`, `'α'`, `'∞'`"
 msgstr ""
 
-#: src/types-and-values/values.md:12
+#: src/types-and-values/values.md
 msgid "Booleans"
 msgstr ""
 
-#: src/types-and-values/values.md:12 src/android/aidl/types/primitives.md:7
+#: src/types-and-values/values.md src/android/aidl/types/primitives.md
 msgid "`bool`"
 msgstr ""
 
-#: src/types-and-values/values.md:12
+#: src/types-and-values/values.md
 msgid "`true`, `false`"
 msgstr ""
 
-#: src/types-and-values/values.md:14
+#: src/types-and-values/values.md
 msgid "The types have widths as follows:"
 msgstr ""
 
-#: src/types-and-values/values.md:16
+#: src/types-and-values/values.md
 msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
 msgstr ""
 
-#: src/types-and-values/values.md:17
+#: src/types-and-values/values.md
 msgid "`isize` and `usize` are the width of a pointer,"
 msgstr ""
 
-#: src/types-and-values/values.md:18
+#: src/types-and-values/values.md
 msgid "`char` is 32 bits wide,"
 msgstr ""
 
-#: src/types-and-values/values.md:19
+#: src/types-and-values/values.md
 msgid "`bool` is 8 bits wide."
 msgstr ""
 
-#: src/types-and-values/values.md:24
+#: src/types-and-values/values.md
 msgid "There are a few syntaxes which are not shown above:"
 msgstr ""
 
-#: src/types-and-values/values.md:26
+#: src/types-and-values/values.md
 msgid ""
 "All underscores in numbers can be left out, they are for legibility only. So "
 "`1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written "
 "as `123i64`."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md:9
+#: src/types-and-values/arithmetic.md
 msgid "\"result: {}\""
 msgstr ""
 
-#: src/types-and-values/arithmetic.md:16
+#: src/types-and-values/arithmetic.md
 msgid ""
 "This is the first time we've seen a function other than `main`, but the "
 "meaning should be clear: it takes three integers, and returns an integer. "
 "Functions will be covered in more detail later."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md:20
+#: src/types-and-values/arithmetic.md
 msgid "Arithmetic is very similar to other languages, with similar precedence."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md:22
+#: src/types-and-values/arithmetic.md
 msgid ""
 "What about integer overflow? In C and C++ overflow of _signed_ integers is "
 "actually undefined, and might do different things on different platforms or "
 "compilers. In Rust, it's defined."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md:26
+#: src/types-and-values/arithmetic.md
 msgid ""
 "Change the `i32`'s to `i16` to see an integer overflow, which panics "
 "(checked) in a debug build and wraps in a release build. There are other "
@@ -3263,23 +3135,23 @@ msgid ""
 "a)`."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md:31
+#: src/types-and-values/arithmetic.md
 msgid ""
 "In fact, the compiler will detect overflow of constant expressions, which is "
 "why the example requires a separate function."
 msgstr ""
 
-#: src/types-and-values/inference.md:3
+#: src/types-and-values/inference.md
 msgid "Rust will look at how the variable is _used_ to determine the type:"
 msgstr ""
 
-#: src/types-and-values/inference.md:29
+#: src/types-and-values/inference.md
 msgid ""
 "This slide demonstrates how the Rust compiler infers types based on "
 "constraints given by variable declarations and usages."
 msgstr ""
 
-#: src/types-and-values/inference.md:32
+#: src/types-and-values/inference.md
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
 "of some sort of dynamic \"any type\" that can hold any data. The machine "
@@ -3288,67 +3160,64 @@ msgid ""
 "code."
 msgstr ""
 
-#: src/types-and-values/inference.md:37
+#: src/types-and-values/inference.md
 msgid ""
 "When nothing constrains the type of an integer literal, Rust defaults to "
 "`i32`. This sometimes appears as `{integer}` in error messages. Similarly, "
 "floating-point literals default to `f64`."
 msgstr ""
 
-#: src/types-and-values/inference.md:46
+#: src/types-and-values/inference.md
 msgid "// ERROR: no implementation for `{float} == {integer}`\n"
 msgstr ""
 
-#: src/types-and-values/exercise.md:3
+#: src/types-and-values/exercise.md
 msgid ""
 "The Fibonacci sequence begins with `[0,1]`. For n>1, the n'th Fibonacci "
 "number is calculated recursively as the sum of the n-1'th and n-2'th "
 "Fibonacci numbers."
 msgstr ""
 
-#: src/types-and-values/exercise.md:6
+#: src/types-and-values/exercise.md
 msgid ""
 "Write a function `fib(n)` that calculates the n'th Fibonacci number. When "
 "will this function panic?"
 msgstr ""
 
-#: src/types-and-values/exercise.md:12
+#: src/types-and-values/exercise.md
 msgid "// The base case.\n"
 msgstr ""
 
-#: src/types-and-values/exercise.md:13 src/types-and-values/exercise.md:16
-#: src/control-flow-basics/exercise.md:27
-#: src/control-flow-basics/exercise.md:31
+#: src/types-and-values/exercise.md src/control-flow-basics/exercise.md
 msgid "\"Implement this\""
 msgstr ""
 
-#: src/types-and-values/exercise.md:15
+#: src/types-and-values/exercise.md
 msgid "// The recursive case.\n"
 msgstr ""
 
-#: src/types-and-values/exercise.md:22 src/types-and-values/solution.md:14
+#: src/types-and-values/exercise.md src/types-and-values/solution.md
 msgid "\"fib({n}) = {}\""
 msgstr ""
 
-#: src/control-flow-basics.md:7
+#: src/control-flow-basics.md
 msgid "if Expressions"
 msgstr "Lệnh `if`"
 
-#: src/control-flow-basics.md:7 src/control-flow-basics.md:9
-#: src/pattern-matching.md:8 src/pattern-matching.md:9
-#: src/concurrency/async.md:8 src/concurrency/async-control-flow.md:8
+#: src/control-flow-basics.md src/pattern-matching.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md
 msgid "4 minutes"
 msgstr ""
 
-#: src/control-flow-basics.md:9
+#: src/control-flow-basics.md
 msgid "break and continue"
 msgstr "`break` và `continue`"
 
-#: src/control-flow-basics/if.md:1
+#: src/control-flow-basics/if.md
 msgid "`if` expressions"
 msgstr "Lệnh `if`"
 
-#: src/control-flow-basics/if.md:3
+#: src/control-flow-basics/if.md
 msgid ""
 "You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
 "if-expr.html#if-expressions) exactly like `if` statements in other languages:"
@@ -3357,19 +3226,19 @@ msgstr ""
 "if-expr.html#if-expressions) giống hệt như lệnh `if` ở những ngôn ngữ lập "
 "trình khác"
 
-#: src/control-flow-basics/if.md:11
+#: src/control-flow-basics/if.md
 msgid "\"zero!\""
 msgstr "\"số không\""
 
-#: src/control-flow-basics/if.md:13
+#: src/control-flow-basics/if.md
 msgid "\"biggish\""
 msgstr "\"số lớn\""
 
-#: src/control-flow-basics/if.md:15
+#: src/control-flow-basics/if.md
 msgid "\"huge\""
 msgstr "\"số rất hơn\""
 
-#: src/control-flow-basics/if.md:20
+#: src/control-flow-basics/if.md
 msgid ""
 "In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
@@ -3377,19 +3246,19 @@ msgstr ""
 "Ngoài ra, học viên có thể sử dụng `if` như một biểu thức. Biểu thức cuối "
 "cùng của mỗi khối lệnh sẽ trở thành giá trị của biểu thức `if` đó"
 
-#: src/control-flow-basics/if.md:26
+#: src/control-flow-basics/if.md
 msgid "\"small\""
 msgstr "\"nhỏ\""
 
-#: src/control-flow-basics/if.md:26
+#: src/control-flow-basics/if.md
 msgid "\"large\""
 msgstr "\"lớn\""
 
-#: src/control-flow-basics/if.md:27
+#: src/control-flow-basics/if.md
 msgid "\"number size: {}\""
 msgstr "\"kích thước số: {}\""
 
-#: src/control-flow-basics/if.md:34
+#: src/control-flow-basics/if.md
 msgid ""
 "Because `if` is an expression and must have a particular type, both of its "
 "branch blocks must have the same type. Show what happens if you add `;` "
@@ -3399,7 +3268,7 @@ msgstr ""
 "nhánh khối lệnh phải có cùng một kiểu dữ liểu. Hãy trình bày nếu học viên "
 "thêm dấu `;` vào sau `\"nhỏ\"` ở ví dụ thứ hai"
 
-#: src/control-flow-basics/if.md:38
+#: src/control-flow-basics/if.md
 msgid ""
 "When `if` is used in an expression, the expression must have a `;` to "
 "separate it from the next statement. Remove the `;` before `println!` to see "
@@ -3409,15 +3278,15 @@ msgstr ""
 "tách biệt nó khỏi lệnh tiếp theo. Loại bỏ dấu `;` sau `println!` để thấy "
 "được lỗi biên dịch"
 
-#: src/control-flow-basics/loops.md:3
+#: src/control-flow-basics/loops.md
 msgid "There are three looping keywords in Rust: `while`, `loop`, and `for`:"
 msgstr "Có ba từ khóa cho vòng lặp trong Rust: while`, `loop` và `for`"
 
-#: src/control-flow-basics/loops.md:5
+#: src/control-flow-basics/loops.md
 msgid "`while`"
 msgstr "`while`"
 
-#: src/control-flow-basics/loops.md:7
+#: src/control-flow-basics/loops.md
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
 "expr.html#predicate-loops) works much like in other languages, executing the "
@@ -3427,22 +3296,22 @@ msgstr ""
 "html#predicate-loops) hoạt đông tương tự như những ngôn ngữ lập trình khác, "
 "thực hiện vòng lặp lại một khối lệnh trong khi điều kiện còn đúng"
 
-#: src/control-flow-basics/loops.md:18
+#: src/control-flow-basics/loops.md
 msgid "\"Final x: {x}\""
 msgstr "\"Số x cuối cùng: {x}\""
 
-#: src/control-flow-basics/loops/for.md:3
+#: src/control-flow-basics/loops/for.md
 msgid ""
 "The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) iterates "
 "over ranges of values or the items in a collection:"
 msgstr ""
 "[Từ khóa `for`] lặp lại qua chuỗi dữ liệu hoặc các phần tử trong một tập hợp:"
 
-#: src/control-flow-basics/loops/for.md:13
+#: src/control-flow-basics/loops/for.md
 msgid "\"elem: {elem}\""
 msgstr "\"elem: {elem}\""
 
-#: src/control-flow-basics/loops/for.md:20
+#: src/control-flow-basics/loops/for.md
 msgid ""
 "Under the hood `for` loops use a concept called \"iterators\" to handle "
 "iterating over different kinds of ranges/collections. Iterators will be "
@@ -3452,7 +3321,7 @@ msgstr ""
 "\"iterators\" để xử việc lặp lại qua nhiều dạng dãy/tập hợp khác nhau. "
 "Iterators sẽ được nhắc tới chi tiết sau."
 
-#: src/control-flow-basics/loops/for.md:23
+#: src/control-flow-basics/loops/for.md
 msgid ""
 "Note that the `for` loop only iterates to `4`. Show the `1..=5` syntax for "
 "an inclusive range."
@@ -3460,7 +3329,7 @@ msgstr ""
 "Lưu ý rằng vòng lặp `for` chỉ lặp tới `4`. Trình bày cú pháp `1..=5` để có "
 "một dãy bao gồm"
 
-#: src/control-flow-basics/loops/loop.md:3
+#: src/control-flow-basics/loops/loop.md
 msgid ""
 "The [`loop` statement](https://doc.rust-lang.org/std/keyword.loop.html) just "
 "loops forever, until a `break`."
@@ -3468,11 +3337,11 @@ msgstr ""
 "[Từ khóa `loop`](https://doc.rust-lang.org/std/keyword.loop.html) là một "
 "vòng lặp bất tận, cho tới khi `break`."
 
-#: src/control-flow-basics/loops/loop.md:11
+#: src/control-flow-basics/loops/loop.md
 msgid "\"{i}\""
 msgstr "\"{i}\""
 
-#: src/control-flow-basics/break-continue.md:3
+#: src/control-flow-basics/break-continue.md
 msgid ""
 "If you want to immediately start the next iteration use [`continue`](https://"
 "doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
@@ -3481,7 +3350,7 @@ msgstr ""
 "(https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-"
 "expressions)."
 
-#: src/control-flow-basics/break-continue.md:6
+#: src/control-flow-basics/break-continue.md
 msgid ""
 "If you want to exit any kind of loop early, use [`break`](https://doc.rust-"
 "lang.org/reference/expressions/loop-expr.html#break-expressions). For "
@@ -3493,17 +3362,16 @@ msgstr ""
 "với `loop`, từ khóa này có thể dùng một biểu thức tùy chọn trở thành giá trị "
 "của biểu thức `loop` "
 
-#: src/control-flow-basics/break-continue.md:22 src/std-traits/exercise.md:23
-#: src/std-traits/solution.md:29 src/smart-pointers/trait-objects.md:93
-#: src/smart-pointers/trait-objects.md:94
-#: src/borrowing/interior-mutability.md:47 src/modules/exercise.md:136
-#: src/modules/solution.md:78 src/android/build-rules/library.md:44
-#: src/android/interoperability/cpp/rust-bridge.md:17
-#: src/concurrency/async-pitfalls/cancellation.md:59
+#: src/control-flow-basics/break-continue.md src/std-traits/exercise.md
+#: src/std-traits/solution.md src/smart-pointers/trait-objects.md
+#: src/borrowing/interior-mutability.md src/modules/exercise.md
+#: src/modules/solution.md src/android/build-rules/library.md
+#: src/android/interoperability/cpp/rust-bridge.md
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "\"{}\""
 msgstr "\"{}\""
 
-#: src/control-flow-basics/break-continue/labels.md:3
+#: src/control-flow-basics/break-continue/labels.md
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
 "used to break out of nested loops:"
@@ -3511,11 +3379,11 @@ msgstr ""
 "Cả `continue` và `break` có thể sử dụng một nhãn tùy chọn để được sử dụng để "
 "thoát ra khỏi những vòng lặp lồng nhau"
 
-#: src/control-flow-basics/break-continue/labels.md:19
+#: src/control-flow-basics/break-continue/labels.md
 msgid "\"elements searched: {elements_searched}\""
 msgstr "\"elements searched: {elements_searched}\""
 
-#: src/control-flow-basics/break-continue/labels.md:25
+#: src/control-flow-basics/break-continue/labels.md
 msgid ""
 "Note that `loop` is the only looping construct which returns a non-trivial "
 "value. This is because it's guaranteed to be entered at least once (unlike "
@@ -3525,90 +3393,89 @@ msgstr ""
 "là vởi vì vòng lặp sẽ chắc chắn được nhập vào ít nhất một lần (không giống "
 "như vòng lặp `while` và `for`) "
 
-#: src/control-flow-basics/blocks-and-scopes.md:3
+#: src/control-flow-basics/blocks-and-scopes.md
 msgid "Blocks"
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md:5
+#: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
 "A block in Rust contains a sequence of expressions, enclosed by braces `{}`. "
 "Each block has a value and a type, which are those of the last expression of "
 "the block:"
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md:14
+#: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"y: {y}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md:21
+#: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
 "If the last expression ends with `;`, then the resulting value and type is "
 "`()`."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md:26
+#: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
 "You can show how the value of the block changes by changing the last line in "
 "the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:3
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid "A variable's scope is limited to the enclosing block."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:5
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
 "the same scope:"
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:11
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid "\"before: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:13
-#: src/generics/exercise.md:18 src/generics/solution.md:20
-#: src/std-traits/from-and-into.md:7 src/std-traits/from-and-into.md:19
-#: src/lifetimes/solution.md:225
+#: src/control-flow-basics/blocks-and-scopes/scopes.md src/generics/exercise.md
+#: src/generics/solution.md src/std-traits/from-and-into.md
+#: src/lifetimes/solution.md
 msgid "\"hello\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:14
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid "\"inner scope: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:17
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid "\"shadowed in inner scope: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:20
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid "\"after: {a}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:26
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid ""
 "Show that a variable's scope is limited by adding a `b` in the inner block "
 "in the last example, and then trying to access it outside that block."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:28
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid ""
 "Shadowing is different from mutation, because after shadowing both "
 "variable's memory locations exist at the same time. Both are available under "
 "the same name, depending where you use it in the code."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:31
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid "A shadowing variable can have a different type."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes/scopes.md:32
+#: src/control-flow-basics/blocks-and-scopes/scopes.md
 msgid ""
 "Shadowing looks obscure at first, but is convenient for holding on to values "
 "after `.unwrap()`."
 msgstr ""
 
-#: src/control-flow-basics/functions.md:22
+#: src/control-flow-basics/functions.md
 msgid ""
 "Declaration parameters are followed by a type (the reverse of some "
 "programming languages), then a return type."
@@ -3616,7 +3483,7 @@ msgstr ""
 "Những tham số phải được chú thích sau bằng một kiểu dữ liệu (ngược lại với "
 "một số ngôn ngữ lập trình khác), rồi một giá trị trả về."
 
-#: src/control-flow-basics/functions.md:24
+#: src/control-flow-basics/functions.md
 msgid ""
 "The last expression in a function body (or any block) becomes the return "
 "value. Simply omit the `;` at the end of the expression. The `return` "
@@ -3628,7 +3495,7 @@ msgstr ""
 "dụng để trả về sớm, nhưng \"giá trị trần (bare value)\" là triết lí ngôn ngữ "
 "(idiomatic) khi đặt ở cuối hàm (tái cấu trúc `gcd` dể sử dụng `return`)."
 
-#: src/control-flow-basics/functions.md:28
+#: src/control-flow-basics/functions.md
 msgid ""
 "Some functions have no return value, and return the 'unit type', `()`. The "
 "compiler will infer this if the `-> ()` return type is omitted."
@@ -3637,14 +3504,14 @@ msgstr ""
 "biên dịch sẽ kết luận rằng kiểu dữ liệu sẽ là `-> ()` nếu kiểu dữ liệu trả "
 "về được bỏ qua."
 
-#: src/control-flow-basics/functions.md:30
+#: src/control-flow-basics/functions.md
 msgid ""
 "Overloading is not supported -- each function has a single implementation."
 msgstr ""
 "Overloading (nạp chồng) không được hỗ trợ -- mỗi hàm chỉ có duy nhất một "
 "triển khai."
 
-#: src/control-flow-basics/functions.md:31
+#: src/control-flow-basics/functions.md
 msgid ""
 "Always takes a fixed number of parameters. Default arguments are not "
 "supported. Macros can be used to support variadic functions."
@@ -3652,7 +3519,7 @@ msgstr ""
 "Luôn luôn lấy một số những tham số nhất định. Đối số mặc định không đưọc hỗ "
 "trợ. Macros có thể sử dụng cho hỗ trợ hàm đa tham số."
 
-#: src/control-flow-basics/functions.md:33
+#: src/control-flow-basics/functions.md
 msgid ""
 "Always takes a single set of parameter types. These types can be generic, "
 "which will be covered later."
@@ -3660,237 +3527,232 @@ msgstr ""
 "Luôn luôn chỉ lấy một nhóm kiểu tham số dữ liệu. Những kiểu dữ liệu này có "
 "thể là generic (tổng quát), và sẽ được đề cập tới ở phần sau."
 
-#: src/control-flow-basics/macros.md:3
+#: src/control-flow-basics/macros.md
 msgid ""
 "Macros are expanded into Rust code during compilation, and can take a "
 "variable number of arguments. They are distinguished by a `!` at the end. "
 "The Rust standard library includes an assortment of useful macros."
 msgstr ""
 
-#: src/control-flow-basics/macros.md:7
+#: src/control-flow-basics/macros.md
 msgid ""
 "`println!(format, ..)` prints a line to standard output, applying formatting "
 "described in [`std::fmt`](https://doc.rust-lang.org/std/fmt/index.html)."
 msgstr ""
 
-#: src/control-flow-basics/macros.md:9
+#: src/control-flow-basics/macros.md
 msgid ""
 "`format!(format, ..)` works just like `println!` but returns the result as a "
 "string."
 msgstr ""
 
-#: src/control-flow-basics/macros.md:11
+#: src/control-flow-basics/macros.md
 msgid "`dbg!(expression)` logs the value of the expression and returns it."
 msgstr ""
 
-#: src/control-flow-basics/macros.md:12
+#: src/control-flow-basics/macros.md
 msgid ""
 "`todo!()` marks a bit of code as not-yet-implemented. If executed, it will "
 "panic."
 msgstr ""
 
-#: src/control-flow-basics/macros.md:14
+#: src/control-flow-basics/macros.md
 msgid ""
 "`unreachable!()` marks a bit of code as unreachable. If executed, it will "
 "panic."
 msgstr ""
 
-#: src/control-flow-basics/macros.md:32
+#: src/control-flow-basics/macros.md
 msgid "\"{n}! = {}\""
 msgstr ""
 
-#: src/control-flow-basics/macros.md:39
+#: src/control-flow-basics/macros.md
 msgid ""
 "The takeaway from this section is that these common conveniences exist, and "
 "how to use them. Why they are defined as macros, and what they expand to, is "
 "not especially critical."
 msgstr ""
 
-#: src/control-flow-basics/macros.md:43
+#: src/control-flow-basics/macros.md
 msgid ""
 "The course does not cover defining macros, but a later section will describe "
 "use of derive macros."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:3
+#: src/control-flow-basics/exercise.md
 msgid ""
 "The [Collatz Sequence](https://en.wikipedia.org/wiki/Collatz_conjecture) is "
 "defined as follows, for an arbitrary n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:4 src/control-flow-basics/exercise.md:10
+#: src/control-flow-basics/exercise.md
 msgid "1"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:4
+#: src/control-flow-basics/exercise.md
 msgid " greater than zero:"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:6 src/control-flow-basics/exercise.md:7
-#: src/control-flow-basics/exercise.md:8
+#: src/control-flow-basics/exercise.md
 msgid "If _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:6 src/control-flow-basics/exercise.md:7
-#: src/control-flow-basics/exercise.md:8
+#: src/control-flow-basics/exercise.md
 msgid "i"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:6
+#: src/control-flow-basics/exercise.md
 msgid "_ is 1, then the sequence terminates at _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:6
+#: src/control-flow-basics/exercise.md
 msgid "_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:7
+#: src/control-flow-basics/exercise.md
 msgid "_ is even, then _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:7 src/control-flow-basics/exercise.md:8
+#: src/control-flow-basics/exercise.md
 msgid "i+1"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:7
+#: src/control-flow-basics/exercise.md
 msgid " = n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:7
+#: src/control-flow-basics/exercise.md
 msgid " / 2_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:8
+#: src/control-flow-basics/exercise.md
 msgid "_ is odd, then _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:8
+#: src/control-flow-basics/exercise.md
 msgid " = 3 * n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:8
+#: src/control-flow-basics/exercise.md
 msgid " + 1_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:10
+#: src/control-flow-basics/exercise.md
 msgid "For example, beginning with _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:10
+#: src/control-flow-basics/exercise.md
 msgid "_ = 3:"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:12
+#: src/control-flow-basics/exercise.md
 msgid "3 is odd, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:12
+#: src/control-flow-basics/exercise.md
 msgid "2"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:12
+#: src/control-flow-basics/exercise.md
 msgid "_ = 3 * 3 + 1 = 10;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:13
+#: src/control-flow-basics/exercise.md
 msgid "10 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:13 src/bare-metal/aps/better-uart.md:22
+#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "3"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:13
+#: src/control-flow-basics/exercise.md
 msgid "_ = 10 / 2 = 5;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:14
+#: src/control-flow-basics/exercise.md
 msgid "5 is odd, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:14 src/bare-metal/aps/better-uart.md:10
+#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "4"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:14
+#: src/control-flow-basics/exercise.md
 msgid "_ = 3 * 5 + 1 = 16;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:15
+#: src/control-flow-basics/exercise.md
 msgid "16 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:15
+#: src/control-flow-basics/exercise.md
 msgid "5"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:15
+#: src/control-flow-basics/exercise.md
 msgid "_ = 16 / 2 = 8;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:16
+#: src/control-flow-basics/exercise.md
 msgid "8 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:16 src/bare-metal/aps/better-uart.md:14
-#: src/bare-metal/aps/better-uart.md:17
+#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "6"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:16
+#: src/control-flow-basics/exercise.md
 msgid "_ = 8 / 2 = 4;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:17
+#: src/control-flow-basics/exercise.md
 msgid "4 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:17
+#: src/control-flow-basics/exercise.md
 msgid "7"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:17
+#: src/control-flow-basics/exercise.md
 msgid "_ = 4 / 2 = 2;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:18
+#: src/control-flow-basics/exercise.md
 msgid "2 is even, so _n"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:18 src/bare-metal/aps/better-uart.md:12
-#: src/bare-metal/aps/better-uart.md:15
+#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "8"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:18
+#: src/control-flow-basics/exercise.md
 msgid "_ = 1; and"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:19
+#: src/control-flow-basics/exercise.md
 msgid "the sequence terminates."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:21
+#: src/control-flow-basics/exercise.md
 msgid ""
 "Write a function to calculate the length of the collatz sequence for a given "
 "initial `n`."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md:25 src/control-flow-basics/solution.md:4
+#: src/control-flow-basics/exercise.md src/control-flow-basics/solution.md
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
 msgstr ""
 
-#: src/control-flow-basics/solution.md:20 src/concurrency/threads/scoped.md:11
-#: src/concurrency/threads/scoped.md:30
+#: src/control-flow-basics/solution.md src/concurrency/threads/scoped.md
 msgid "\"Length: {}\""
 msgstr ""
 
-#: src/welcome-day-1-afternoon.md:1 src/welcome-day-2-afternoon.md:1
-#: src/welcome-day-3-afternoon.md:1 src/welcome-day-4-afternoon.md:1
+#: src/welcome-day-1-afternoon.md src/welcome-day-2-afternoon.md
+#: src/welcome-day-3-afternoon.md src/welcome-day-4-afternoon.md
 msgid "Welcome Back"
 msgstr ""
 
-#: src/welcome-day-1-afternoon.md:3
+#: src/welcome-day-1-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 35 "
 "minutes. It contains:"
@@ -3898,11 +3760,11 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 2 tiếng và 35 phút, bao gồm thời gian 10 phút "
 "nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/tuples-and-arrays.md:3
+#: src/tuples-and-arrays.md
 msgid "This segment should take about 35 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 35 phút, bao gồm:"
 
-#: src/tuples-and-arrays/arrays.md:16
+#: src/tuples-and-arrays/arrays.md
 msgid ""
 "A value of the array type `[T; N]` holds `N` (a compile-time constant) "
 "elements of the same type `T`. Note that the length of the array is _part of "
@@ -3911,18 +3773,18 @@ msgid ""
 "covered later."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md:22
+#: src/tuples-and-arrays/arrays.md
 msgid ""
 "Try accessing an out-of-bounds array element. Array accesses are checked at "
 "runtime. Rust can usually optimize these checks away, and they can be "
 "avoided using unsafe Rust."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md:26
+#: src/tuples-and-arrays/arrays.md
 msgid "We can use literals to assign values to arrays."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md:28
+#: src/tuples-and-arrays/arrays.md
 msgid ""
 "The `println!` macro asks for the debug implementation with the `?` format "
 "parameter: `{}` gives the default output, `{:?}` gives the debug output. "
@@ -3931,163 +3793,161 @@ msgid ""
 "here."
 msgstr ""
 
-#: src/tuples-and-arrays/arrays.md:33
+#: src/tuples-and-arrays/arrays.md
 msgid ""
 "Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
 "easier to read."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md:16
+#: src/tuples-and-arrays/tuples.md
 msgid "Like arrays, tuples have a fixed length."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md:18
+#: src/tuples-and-arrays/tuples.md
 msgid "Tuples group together values of different types into a compound type."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md:20
+#: src/tuples-and-arrays/tuples.md
 msgid ""
 "Fields of a tuple can be accessed by the period and the index of the value, "
 "e.g. `t.0`, `t.1`."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples.md:23
+#: src/tuples-and-arrays/tuples.md
 msgid ""
 "The empty tuple `()` is referred to as the \"unit type\" and signifies "
 "absence of a return value, akin to `void` in other languages."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md:3
+#: src/tuples-and-arrays/iteration.md
 msgid "The `for` statement supports iterating over arrays (but not tuples)."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md:19
+#: src/tuples-and-arrays/iteration.md
 msgid ""
 "This functionality uses the `IntoIterator` trait, but we haven't covered "
 "that yet."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md:22
+#: src/tuples-and-arrays/iteration.md
 msgid ""
 "The `assert_ne!` macro is new here. There are also `assert_eq!` and `assert!"
 "` macros. These are always checked while, debug-only variants like "
 "`debug_assert!` compile to nothing in release builds."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md:3
+#: src/tuples-and-arrays/destructuring.md
 msgid ""
 "When working with tuples and other structured values it's common to want to "
 "extract the inner values into local variables. This can be done manually by "
 "directly accessing the inner values:"
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md:11
-#: src/tuples-and-arrays/destructuring.md:21
+#: src/tuples-and-arrays/destructuring.md
 msgid "\"left: {left}, right: {right}\""
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md:15
+#: src/tuples-and-arrays/destructuring.md
 msgid ""
 "However, Rust also supports using pattern matching to destructure a larger "
 "value into its constituent parts:"
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md:28
+#: src/tuples-and-arrays/destructuring.md
 msgid ""
 "The patterns used here are \"irrefutable\", meaning that the compiler can "
 "statically verify that the value on the right of `=` has the same structure "
 "as the pattern."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md:31
+#: src/tuples-and-arrays/destructuring.md
 msgid ""
 "A variable name is an irrefutable pattern that always matches any value, "
 "hence why we can also use `let` to declare a single variable."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md:33
+#: src/tuples-and-arrays/destructuring.md
 msgid ""
 "Rust also supports using patterns in conditionals, allowing for equality "
 "comparison and destructuring to happen at the same time. This form of "
 "pattern matching will be discussed in more detail later."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md:36
+#: src/tuples-and-arrays/destructuring.md
 msgid ""
 "Edit the examples above to show the compiler error when the pattern doesn't "
 "match the value being matched on."
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:3
+#: src/tuples-and-arrays/exercise.md
 msgid "Arrays can contain other arrays:"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:9
+#: src/tuples-and-arrays/exercise.md
 msgid "What is the type of this variable?"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:11
+#: src/tuples-and-arrays/exercise.md
 msgid ""
 "Use an array such as the above to write a function `transpose` which will "
 "transpose a matrix (turn rows into columns):"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:22
+#: src/tuples-and-arrays/exercise.md
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and implement the "
 "function. This function only operates on 3x3 matrices."
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:26 src/borrowing/exercise.md:14
-#: src/unsafe-rust/exercise.md:51
+#: src/tuples-and-arrays/exercise.md src/borrowing/exercise.md
+#: src/unsafe-rust/exercise.md
 msgid "// TODO: remove this when you're done with your implementation.\n"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:36 src/tuples-and-arrays/exercise.md:44
-#: src/tuples-and-arrays/solution.md:17 src/tuples-and-arrays/solution.md:25
+#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "//\n"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:53 src/tuples-and-arrays/solution.md:34
+#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "// <-- the comment makes rustfmt add a newline\n"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:58 src/tuples-and-arrays/solution.md:39
+#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "\"matrix: {:#?}\""
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md:60 src/tuples-and-arrays/solution.md:41
+#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "\"transposed: {:#?}\""
 msgstr ""
 
-#: src/references.md:3 src/smart-pointers.md:3 src/borrowing.md:3
-#: src/error-handling.md:3 src/concurrency/async-pitfalls.md:7
+#: src/references.md src/smart-pointers.md src/borrowing.md
+#: src/error-handling.md src/concurrency/async-pitfalls.md
 msgid "This segment should take about 55 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 55 phút, bao gồm:"
 
-#: src/references.md:9
+#: src/references.md
 msgid "Slices: &\\[T\\]"
 msgstr ""
 
-#: src/references/shared.md:3
+#: src/references/shared.md
 msgid ""
 "A reference provides a way to access another value without taking "
 "responsibility for the value, and is also called \"borrowing\". Shared "
 "references are read-only, and the referenced data cannot change."
 msgstr ""
 
-#: src/references/shared.md:20
+#: src/references/shared.md
 msgid ""
 "A shared reference to a type `T` has type `&T`. A reference value is made "
 "with the `&` operator. The `*` operator \"dereferences\" a reference, "
 "yielding its value."
 msgstr ""
 
-#: src/references/shared.md:24
+#: src/references/shared.md
 msgid "Rust will statically forbid dangling references:"
 msgstr ""
 
-#: src/references/shared.md:38
+#: src/references/shared.md
 msgid ""
 "A reference is said to \"borrow\" the value it refers to, and this is a good "
 "model for students not familiar with pointers: code can use the reference to "
@@ -4095,7 +3955,7 @@ msgid ""
 "course will get into more detail on ownership in day 3."
 msgstr ""
 
-#: src/references/shared.md:43
+#: src/references/shared.md
 msgid ""
 "References are implemented as pointers, and a key advantage is that they can "
 "be much smaller than the thing they point to. Students familiar with C or C+"
@@ -4104,20 +3964,20 @@ msgid ""
 "pointers."
 msgstr ""
 
-#: src/references/shared.md:48
+#: src/references/shared.md
 msgid ""
 "Rust does not automatically create references for you - the `&` is always "
 "required."
 msgstr ""
 
-#: src/references/shared.md:51
+#: src/references/shared.md
 msgid ""
 "Rust will auto-dereference in some cases, in particular when invoking "
 "methods (try `r.is_ascii()`). There is no need for an `->` operator like in "
 "C++."
 msgstr ""
 
-#: src/references/shared.md:54
+#: src/references/shared.md
 msgid ""
 "In this example, `r` is mutable so that it can be reassigned (`r = &b`). "
 "Note that this re-binds `r`, so that it refers to something else. This is "
@@ -4125,13 +3985,13 @@ msgid ""
 "value."
 msgstr ""
 
-#: src/references/shared.md:58
+#: src/references/shared.md
 msgid ""
 "A shared reference does not allow modifying the value it refers to, even if "
 "that value was mutable. Try `*r = 'X'`."
 msgstr ""
 
-#: src/references/shared.md:61
+#: src/references/shared.md
 msgid ""
 "Rust is tracking the lifetimes of all references to ensure they live long "
 "enough. Dangling references cannot occur in safe Rust. `x_axis` would return "
@@ -4139,17 +3999,17 @@ msgid ""
 "returns, so this will not compile."
 msgstr ""
 
-#: src/references/shared.md:66
+#: src/references/shared.md
 msgid "We will talk more about borrowing when we get to ownership."
 msgstr ""
 
-#: src/references/exclusive.md:3
+#: src/references/exclusive.md
 msgid ""
 "Exclusive references, also known as mutable references, allow changing the "
 "value they refer to. They have type `&mut T`."
 msgstr ""
 
-#: src/references/exclusive.md:22
+#: src/references/exclusive.md
 msgid ""
 "\"Exclusive\" means that only this reference can be used to access the "
 "value. No other references (shared or exclusive) can exist at the same time, "
@@ -4158,7 +4018,7 @@ msgid ""
 "alive."
 msgstr ""
 
-#: src/references/exclusive.md:27
+#: src/references/exclusive.md
 msgid ""
 "Be sure to note the difference between `let mut x_coord: &i32` and `let "
 "x_coord: &mut i32`. The first one represents a shared reference which can be "
@@ -4166,60 +4026,60 @@ msgid ""
 "reference to a mutable value."
 msgstr ""
 
-#: src/references/slices.md:1
+#: src/references/slices.md
 msgid "Slices"
 msgstr ""
 
-#: src/references/slices.md:3
+#: src/references/slices.md
 msgid "A slice gives you a view into a larger collection:"
 msgstr ""
 
-#: src/references/slices.md:18
+#: src/references/slices.md
 msgid "Slices borrow data from the sliced type."
 msgstr ""
 
-#: src/references/slices.md:19
+#: src/references/slices.md
 msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
 msgstr ""
 
-#: src/references/slices.md:24
+#: src/references/slices.md
 msgid ""
 "We create a slice by borrowing `a` and specifying the starting and ending "
 "indexes in brackets."
 msgstr ""
 
-#: src/references/slices.md:27
+#: src/references/slices.md
 msgid ""
 "If the slice starts at index 0, Rust’s range syntax allows us to drop the "
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
 "identical."
 msgstr ""
 
-#: src/references/slices.md:31
+#: src/references/slices.md
 msgid ""
 "The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
 "identical."
 msgstr ""
 
-#: src/references/slices.md:34
+#: src/references/slices.md
 msgid ""
 "To easily create a slice of the full array, we can therefore use `&a[..]`."
 msgstr ""
 
-#: src/references/slices.md:36
+#: src/references/slices.md
 msgid ""
 "`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
 "computation on slices of different sizes."
 msgstr ""
 
-#: src/references/slices.md:40
+#: src/references/slices.md
 msgid ""
 "Slices always borrow from another object. In this example, `a` has to remain "
 "'alive' (in scope) for at least as long as our slice."
 msgstr ""
 
-#: src/references/slices.md:43
+#: src/references/slices.md
 msgid ""
 "The question about modifying `a[3]` can spark an interesting discussion, but "
 "the answer is that for memory safety reasons you cannot do it through `a` at "
@@ -4228,67 +4088,66 @@ msgid ""
 "`println`, when the slice is no longer used."
 msgstr ""
 
-#: src/references/strings.md:7
+#: src/references/strings.md
 msgid "We can now understand the two string types in Rust:"
 msgstr ""
 
-#: src/references/strings.md:9
+#: src/references/strings.md
 msgid "`&str` is a slice of UTF-8 encoded bytes, similar to `&[u8]`."
 msgstr ""
 
-#: src/references/strings.md:10
+#: src/references/strings.md
 msgid ""
 "`String` is an owned buffer of UTF-8 encoded bytes, similar to `Vec<T>`."
 msgstr ""
 
-#: src/references/strings.md:17 src/std-traits/read-and-write.md:36
+#: src/references/strings.md src/std-traits/read-and-write.md
 msgid "\"World\""
 msgstr ""
 
-#: src/references/strings.md:18
+#: src/references/strings.md
 msgid "\"s1: {s1}\""
 msgstr ""
 
-#: src/references/strings.md:20
+#: src/references/strings.md
 msgid "\"Hello \""
 msgstr ""
 
-#: src/references/strings.md:21 src/references/strings.md:23
-#: src/memory-management/move.md:9
+#: src/references/strings.md src/memory-management/move.md
 msgid "\"s2: {s2}\""
 msgstr ""
 
-#: src/references/strings.md:26
+#: src/references/strings.md
 msgid "\"s3: {s3}\""
 msgstr ""
 
-#: src/references/strings.md:33
+#: src/references/strings.md
 msgid ""
 "`&str` introduces a string slice, which is an immutable reference to UTF-8 "
 "encoded string data stored in a block of memory. String literals "
 "(`\"Hello\"`), are stored in the program’s binary."
 msgstr ""
 
-#: src/references/strings.md:37
+#: src/references/strings.md
 msgid ""
 "Rust's `String` type is a wrapper around a vector of bytes. As with a "
 "`Vec<T>`, it is owned."
 msgstr ""
 
-#: src/references/strings.md:40
+#: src/references/strings.md
 msgid ""
 "As with many other types `String::from()` creates a string from a string "
 "literal; `String::new()` creates a new empty string, to which string data "
 "can be added using the `push()` and `push_str()` methods."
 msgstr ""
 
-#: src/references/strings.md:44
+#: src/references/strings.md
 msgid ""
 "The `format!()` macro is a convenient way to generate an owned string from "
 "dynamic values. It accepts the same format specification as `println!()`."
 msgstr ""
 
-#: src/references/strings.md:47
+#: src/references/strings.md
 msgid ""
 "You can borrow `&str` slices from `String` via `&` and optionally range "
 "selection. If you select a byte range that is not aligned to character "
@@ -4296,7 +4155,7 @@ msgid ""
 "characters and is preferred over trying to get character boundaries right."
 msgstr ""
 
-#: src/references/strings.md:52
+#: src/references/strings.md
 msgid ""
 "For C++ programmers: think of `&str` as `std::string_view` from C++, but the "
 "one that always points to a valid string in memory. Rust `String` is a rough "
@@ -4304,25 +4163,25 @@ msgid ""
 "UTF-8 encoded bytes and will never use a small-string optimization)."
 msgstr ""
 
-#: src/references/strings.md:57
+#: src/references/strings.md
 msgid "Byte strings literals allow you to create a `&[u8]` value directly:"
 msgstr ""
 
-#: src/references/strings.md:67
+#: src/references/strings.md
 msgid ""
 "Raw strings allow you to create a `&str` value with escapes disabled: "
 "`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
 "amount of `#` on either side of the quotes:"
 msgstr ""
 
-#: src/references/exercise.md:3
+#: src/references/exercise.md
 msgid ""
 "We will create a few utility functions for 3-dimensional geometry, "
 "representing a point as `[f64;3]`. It is up to you to determine the function "
 "signatures."
 msgstr ""
 
-#: src/references/exercise.md:7
+#: src/references/exercise.md
 msgid ""
 "// Calculate the magnitude of a vector by summing the squares of its "
 "coordinates\n"
@@ -4331,240 +4190,238 @@ msgid ""
 "// root, like `v.sqrt()`.\n"
 msgstr ""
 
-#: src/references/exercise.md:15
+#: src/references/exercise.md
 msgid ""
 "// Normalize a vector by calculating its magnitude and dividing all of its\n"
 "// coordinates by that magnitude.\n"
 msgstr ""
 
-#: src/references/exercise.md:23
+#: src/references/exercise.md
 msgid "// Use the following `main` to test your work.\n"
 msgstr ""
 
-#: src/references/exercise.md:27 src/references/solution.md:22
+#: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of a unit vector: {}\""
 msgstr ""
 
-#: src/references/exercise.md:30 src/references/solution.md:25
+#: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of {v:?}: {}\""
 msgstr ""
 
-#: src/references/exercise.md:32 src/references/solution.md:27
+#: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of {v:?} after normalization: {}\""
 msgstr ""
 
-#: src/references/solution.md:4
+#: src/references/solution.md
 msgid "/// Calculate the magnitude of the given vector.\n"
 msgstr ""
 
-#: src/references/solution.md:12
+#: src/references/solution.md
 msgid ""
 "/// Change the magnitude of the vector to 1.0 without changing its "
 "direction.\n"
 msgstr ""
 
-#: src/user-defined-types.md:3 src/methods-and-traits.md:3 src/lifetimes.md:3
+#: src/user-defined-types.md src/methods-and-traits.md src/lifetimes.md
 msgid "This segment should take about 50 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 50 phút, bao gồm:"
 
-#: src/user-defined-types/named-structs.md:3
+#: src/user-defined-types/named-structs.md
 msgid "Like C and C++, Rust has support for custom structs:"
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:12
+#: src/user-defined-types/named-structs.md
 msgid "\"{} is {} years old\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:16
-#: src/android/interoperability/with-c/bindgen.md:87
+#: src/user-defined-types/named-structs.md
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"Peter\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:22
+#: src/user-defined-types/named-structs.md
 msgid "\"Avery\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:27
+#: src/user-defined-types/named-structs.md
 msgid "\"Jackie\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:35
-#: src/user-defined-types/enums.md:29 src/pattern-matching/match.md:38
-#: src/methods-and-traits/methods.md:69
+#: src/user-defined-types/named-structs.md src/user-defined-types/enums.md
+#: src/pattern-matching/match.md src/methods-and-traits/methods.md
 msgid "Key Points:"
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:37
+#: src/user-defined-types/named-structs.md
 msgid "Structs work like in C or C++."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:38
+#: src/user-defined-types/named-structs.md
 msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:39
+#: src/user-defined-types/named-structs.md
 msgid "Unlike in C++, there is no inheritance between structs."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:40
+#: src/user-defined-types/named-structs.md
 msgid ""
 "This may be a good time to let people know there are different types of "
 "structs."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:42
+#: src/user-defined-types/named-structs.md
 msgid ""
 "Zero-sized structs (e.g. `struct Foo;`) might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
 "value itself."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:45
+#: src/user-defined-types/named-structs.md
 msgid ""
 "The next slide will introduce Tuple structs, used when the field names are "
 "not important."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:47
+#: src/user-defined-types/named-structs.md
 msgid ""
 "If you already have variables with the right names, then you can create the "
 "struct using a shorthand."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md:49
+#: src/user-defined-types/named-structs.md
 msgid ""
 "The syntax `..avery` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:7
+#: src/user-defined-types/tuple-structs.md
 msgid "If the field names are unimportant, you can use a tuple struct:"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:14
+#: src/user-defined-types/tuple-structs.md
 msgid "\"({}, {})\""
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:18
+#: src/user-defined-types/tuple-structs.md
 msgid "This is often used for single-field wrappers (called newtypes):"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:25
+#: src/user-defined-types/tuple-structs.md
 msgid "\"Ask a rocket scientist at NASA\""
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:29
-#: src/android/interoperability/cpp/cpp-bridge.md:50
-#: src/bare-metal/microcontrollers/type-state.md:14
-#: src/concurrency/async-pitfalls/cancellation.md:99
-#: src/concurrency/async-pitfalls/cancellation.md:102
+#: src/user-defined-types/tuple-structs.md
+#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/bare-metal/microcontrollers/type-state.md
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "// ...\n"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:41
+#: src/user-defined-types/tuple-structs.md
 msgid ""
 "Newtypes are a great way to encode additional information about the value in "
 "a primitive type, for example:"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:43
+#: src/user-defined-types/tuple-structs.md
 msgid "The number is measured in some units: `Newtons` in the example above."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:44
+#: src/user-defined-types/tuple-structs.md
 msgid ""
 "The value passed some validation when it was created, so you no longer have "
 "to validate it again at every use: `PhoneNumber(String)` or `OddNumber(u32)`."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:47
+#: src/user-defined-types/tuple-structs.md
 msgid ""
 "Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
 "single field in the newtype."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:49
+#: src/user-defined-types/tuple-structs.md
 msgid ""
 "Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
 "for instance using booleans as integers."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:51
+#: src/user-defined-types/tuple-structs.md
 msgid "Operator overloading is discussed on Day 3 (generics)."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md:52
+#: src/user-defined-types/tuple-structs.md
 msgid ""
 "The example is a subtle reference to the [Mars Climate Orbiter](https://en."
 "wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
 
-#: src/user-defined-types/enums.md:3
+#: src/user-defined-types/enums.md
 msgid ""
 "The `enum` keyword allows the creation of a type which has a few different "
 "variants:"
 msgstr ""
 
-#: src/user-defined-types/enums.md:15
+#: src/user-defined-types/enums.md
 msgid "// Simple variant\n"
 msgstr ""
 
-#: src/user-defined-types/enums.md:16
+#: src/user-defined-types/enums.md
 msgid "// Tuple variant\n"
 msgstr ""
 
-#: src/user-defined-types/enums.md:17
+#: src/user-defined-types/enums.md
 msgid "// Struct variant\n"
 msgstr ""
 
-#: src/user-defined-types/enums.md:22
+#: src/user-defined-types/enums.md
 msgid "\"On this turn: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/enums.md:31
+#: src/user-defined-types/enums.md
 msgid "Enumerations allow you to collect a set of values under one type."
 msgstr ""
 
-#: src/user-defined-types/enums.md:32
+#: src/user-defined-types/enums.md
 msgid ""
 "`Direction` is a type with variants. There are two values of `Direction`: "
 "`Direction::Left` and `Direction::Right`."
 msgstr ""
 
-#: src/user-defined-types/enums.md:34
+#: src/user-defined-types/enums.md
 msgid ""
 "`PlayerMove` is a type with three variants. In addition to the payloads, "
 "Rust will store a discriminant so that it knows at runtime which variant is "
 "in a `PlayerMove` value."
 msgstr ""
 
-#: src/user-defined-types/enums.md:37
+#: src/user-defined-types/enums.md
 msgid "This might be a good time to compare structs and enums:"
 msgstr ""
 
-#: src/user-defined-types/enums.md:38
+#: src/user-defined-types/enums.md
 msgid ""
 "In both, you can have a simple version without fields (unit struct) or one "
 "with different types of fields (variant payloads)."
 msgstr ""
 
-#: src/user-defined-types/enums.md:40
+#: src/user-defined-types/enums.md
 msgid ""
 "You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum."
 msgstr ""
 
-#: src/user-defined-types/enums.md:43
+#: src/user-defined-types/enums.md
 msgid "Rust uses minimal space to store the discriminant."
 msgstr ""
 
-#: src/user-defined-types/enums.md:44
+#: src/user-defined-types/enums.md
 msgid "If necessary, it stores an integer of the smallest required size"
 msgstr ""
 
-#: src/user-defined-types/enums.md:45
+#: src/user-defined-types/enums.md
 msgid ""
 "If the allowed variant values do not cover all bit patterns, it will use "
 "invalid bit patterns to encode the discriminant (the \"niche "
@@ -4572,62 +4429,62 @@ msgid ""
 "integer or `NULL` for the `None` variant."
 msgstr ""
 
-#: src/user-defined-types/enums.md:49
+#: src/user-defined-types/enums.md
 msgid ""
 "You can control the discriminant if needed (e.g., for compatibility with C):"
 msgstr ""
 
-#: src/user-defined-types/enums.md:67
+#: src/user-defined-types/enums.md
 msgid ""
 "Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
 "bytes."
 msgstr ""
 
-#: src/user-defined-types/enums.md:70 src/user-defined-types/static.md:27
-#: src/memory-management/review.md:51 src/memory-management/move.md:100
-#: src/smart-pointers/box.md:85 src/borrowing/shared.md:33
+#: src/user-defined-types/enums.md src/user-defined-types/static.md
+#: src/memory-management/review.md src/memory-management/move.md
+#: src/smart-pointers/box.md src/borrowing/shared.md
 msgid "More to Explore"
 msgstr ""
 
-#: src/user-defined-types/enums.md:72
+#: src/user-defined-types/enums.md
 msgid ""
 "Rust has several optimizations it can employ to make enums take up less "
 "space."
 msgstr ""
 
-#: src/user-defined-types/enums.md:74
+#: src/user-defined-types/enums.md
 msgid ""
 "Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
 "option/#representation), Rust guarantees that `size_of::<T>()` equals "
 "`size_of::<Option<T>>()`."
 msgstr ""
 
-#: src/user-defined-types/enums.md:78
+#: src/user-defined-types/enums.md
 msgid ""
 "Example code if you want to show how the bitwise representation _may_ look "
 "like in practice. It's important to note that the compiler provides no "
 "guarantees regarding this representation, therefore this is totally unsafe."
 msgstr ""
 
-#: src/user-defined-types/static.md:1
+#: src/user-defined-types/static.md
 msgid "`static`"
 msgstr ""
 
-#: src/user-defined-types/static.md:3
+#: src/user-defined-types/static.md
 msgid ""
 "Static variables will live during the whole execution of the program, and "
 "therefore will not move:"
 msgstr ""
 
-#: src/user-defined-types/static.md:7
+#: src/user-defined-types/static.md
 msgid "\"Welcome to RustOS 3.14\""
 msgstr ""
 
-#: src/user-defined-types/static.md:10
+#: src/user-defined-types/static.md
 msgid "\"{BANNER}\""
 msgstr ""
 
-#: src/user-defined-types/static.md:14
+#: src/user-defined-types/static.md
 msgid ""
 "As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
 "vs-static.html), these are not inlined upon use and have an actual "
@@ -4637,74 +4494,74 @@ msgid ""
 "`const` is generally preferred."
 msgstr ""
 
-#: src/user-defined-types/static.md:23
+#: src/user-defined-types/static.md
 msgid "`static` is similar to mutable global variables in C++."
 msgstr ""
 
-#: src/user-defined-types/static.md:24
+#: src/user-defined-types/static.md
 msgid ""
 "`static` provides object identity: an address in memory and state as "
 "required by types with interior mutability such as `Mutex<T>`."
 msgstr ""
 
-#: src/user-defined-types/static.md:29
+#: src/user-defined-types/static.md
 msgid ""
 "Because `static` variables are accessible from any thread, they must be "
 "`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
 "lang.org/std/sync/struct.Mutex.html), atomic or similar."
 msgstr ""
 
-#: src/user-defined-types/static.md:34
+#: src/user-defined-types/static.md
 msgid "Thread-local data can be created with the macro `std::thread_local`."
 msgstr ""
 
-#: src/user-defined-types/const.md:1
+#: src/user-defined-types/const.md
 msgid "`const`"
 msgstr ""
 
-#: src/user-defined-types/const.md:3
+#: src/user-defined-types/const.md
 msgid ""
 "Constants are evaluated at compile time and their values are inlined "
 "wherever they are used:"
 msgstr ""
 
-#: src/user-defined-types/const.md:26
+#: src/user-defined-types/const.md
 msgid ""
 "According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
 "vs-static.html) these are inlined upon use."
 msgstr ""
 
-#: src/user-defined-types/const.md:28
+#: src/user-defined-types/const.md
 msgid ""
 "Only functions marked `const` can be called at compile time to generate "
 "`const` values. `const` functions can however be called at runtime."
 msgstr ""
 
-#: src/user-defined-types/const.md:33
+#: src/user-defined-types/const.md
 msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`"
 msgstr ""
 
-#: src/user-defined-types/const.md:34
+#: src/user-defined-types/const.md
 msgid ""
 "It isn't super common that one would need a runtime evaluated constant, but "
 "it is helpful and safer than using a static."
 msgstr ""
 
-#: src/user-defined-types/aliases.md:3
+#: src/user-defined-types/aliases.md
 msgid ""
 "A type alias creates a name for another type. The two types can be used "
 "interchangeably."
 msgstr ""
 
-#: src/user-defined-types/aliases.md:13
+#: src/user-defined-types/aliases.md
 msgid "// Aliases are more useful with long, complex types:\n"
 msgstr ""
 
-#: src/user-defined-types/aliases.md:23
+#: src/user-defined-types/aliases.md
 msgid "C programmers will recognize this as similar to a `typedef`."
 msgstr ""
 
-#: src/user-defined-types/exercise.md:3
+#: src/user-defined-types/exercise.md
 msgid ""
 "We will create a data structure to represent an event in an elevator control "
 "system. It is up to you to define the types and functions to construct "
@@ -4712,136 +4569,136 @@ msgid ""
 "with `{:?}`."
 msgstr ""
 
-#: src/user-defined-types/exercise.md:7
+#: src/user-defined-types/exercise.md
 msgid ""
 "This exercise only requires creating and populating data structures so that "
 "`main` runs without errors. The next part of the course will cover getting "
 "data out of these structures."
 msgstr ""
 
-#: src/user-defined-types/exercise.md:12 src/user-defined-types/solution.md:4
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid ""
 "/// An event in the elevator system that the controller must react to.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:15
+#: src/user-defined-types/exercise.md
 msgid "// TODO: add required variants\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:17 src/user-defined-types/solution.md:22
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// A direction of travel.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:24 src/user-defined-types/solution.md:39
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car has arrived on the given floor.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:29 src/user-defined-types/solution.md:44
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car doors have opened.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:34 src/user-defined-types/solution.md:49
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car doors have closed.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:39 src/user-defined-types/solution.md:54
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid ""
 "/// A directional button was pressed in an elevator lobby on the given "
 "floor.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:44 src/user-defined-types/solution.md:59
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// A floor button was pressed in the elevator car.\n"
 msgstr ""
 
-#: src/user-defined-types/exercise.md:52 src/user-defined-types/solution.md:67
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"A ground floor passenger has pressed the up button: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md:55 src/user-defined-types/solution.md:70
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car has arrived on the ground floor: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md:56 src/user-defined-types/solution.md:71
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car door opened: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md:58 src/user-defined-types/solution.md:73
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"A passenger has pressed the 3rd floor button: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md:61 src/user-defined-types/solution.md:76
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car door closed: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md:62 src/user-defined-types/solution.md:77
+#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car has arrived on the 3rd floor: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/solution.md:7
+#: src/user-defined-types/solution.md
 msgid "/// A button was pressed.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md:10
+#: src/user-defined-types/solution.md
 msgid "/// The car has arrived at the given floor.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md:13
+#: src/user-defined-types/solution.md
 msgid "/// The car's doors have opened.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md:16
+#: src/user-defined-types/solution.md
 msgid "/// The car's doors have closed.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md:19
+#: src/user-defined-types/solution.md
 msgid "/// A floor is represented as an integer.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md:29
+#: src/user-defined-types/solution.md
 msgid "/// A user-accessible button.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md:33
+#: src/user-defined-types/solution.md
 msgid "/// A button in the elevator lobby on the given floor.\n"
 msgstr ""
 
-#: src/user-defined-types/solution.md:36
+#: src/user-defined-types/solution.md
 msgid "/// A floor button within the car.\n"
 msgstr ""
 
-#: src/welcome-day-2.md:1
+#: src/welcome-day-2.md
 msgid "Welcome to Day 2"
 msgstr ""
 
-#: src/welcome-day-2.md:3
+#: src/welcome-day-2.md
 msgid ""
 "Now that we have seen a fair amount of Rust, today will focus on Rust's type "
 "system:"
 msgstr ""
 
-#: src/welcome-day-2.md:6
+#: src/welcome-day-2.md
 msgid "Pattern matching: extracting data from structures."
 msgstr ""
 
-#: src/welcome-day-2.md:7
+#: src/welcome-day-2.md
 msgid "Methods: associating functions with types."
 msgstr ""
 
-#: src/welcome-day-2.md:8
+#: src/welcome-day-2.md
 msgid "Traits: behaviors shared by multiple types."
 msgstr ""
 
-#: src/welcome-day-2.md:9
+#: src/welcome-day-2.md
 msgid "Generics: parameterizing types on other types."
 msgstr ""
 
-#: src/welcome-day-2.md:10
+#: src/welcome-day-2.md
 msgid ""
 "Standard library types and traits: a tour of Rust's rich standard library."
 msgstr ""
 
-#: src/welcome-day-2.md:14 src/welcome-day-4-afternoon.md:3
+#: src/welcome-day-2.md src/welcome-day-4-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 10 "
 "minutes. It contains:"
@@ -4849,135 +4706,130 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 2 tiếng và 10 phút, bao gồm thời gian 10 phút "
 "nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/pattern-matching.md:3 src/memory-management.md:3
+#: src/pattern-matching.md src/memory-management.md
 msgid "This segment should take about 1 hour. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 1 giờ, bao gồm:"
 
-#: src/pattern-matching/match.md:3
+#: src/pattern-matching/match.md
 msgid ""
 "The `match` keyword lets you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
-#: src/pattern-matching/match.md:6
+#: src/pattern-matching/match.md
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
 msgstr ""
 
-#: src/pattern-matching/match.md:11
+#: src/pattern-matching/match.md
 msgid "'x'"
 msgstr ""
 
-#: src/pattern-matching/match.md:13
+#: src/pattern-matching/match.md
 msgid "'q'"
 msgstr ""
 
-#: src/pattern-matching/match.md:13
+#: src/pattern-matching/match.md
 msgid "\"Quitting\""
 msgstr ""
 
-#: src/pattern-matching/match.md:14 src/generics/exercise.md:15
-#: src/generics/solution.md:17 src/std-traits/solution.md:16
-#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:75
-#: src/error-handling/solution.md:60 src/error-handling/solution.md:75
+#: src/pattern-matching/match.md src/generics/exercise.md
+#: src/generics/solution.md src/std-traits/solution.md
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'a'"
 msgstr ""
 
-#: src/pattern-matching/match.md:14
+#: src/pattern-matching/match.md
 msgid "'s'"
 msgstr ""
 
-#: src/pattern-matching/match.md:14
+#: src/pattern-matching/match.md
 msgid "'w'"
 msgstr ""
 
-#: src/pattern-matching/match.md:14
+#: src/pattern-matching/match.md
 msgid "'d'"
 msgstr ""
 
-#: src/pattern-matching/match.md:14
+#: src/pattern-matching/match.md
 msgid "\"Moving around\""
 msgstr ""
 
-#: src/pattern-matching/match.md:15 src/error-handling/exercise.md:51
-#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:74
-#: src/error-handling/solution.md:51 src/error-handling/solution.md:60
-#: src/error-handling/solution.md:74
+#: src/pattern-matching/match.md src/error-handling/exercise.md
+#: src/error-handling/solution.md
 msgid "'0'"
 msgstr ""
 
-#: src/pattern-matching/match.md:15 src/error-handling/exercise.md:51
-#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:74
-#: src/error-handling/solution.md:51 src/error-handling/solution.md:60
-#: src/error-handling/solution.md:74
+#: src/pattern-matching/match.md src/error-handling/exercise.md
+#: src/error-handling/solution.md
 msgid "'9'"
 msgstr ""
 
-#: src/pattern-matching/match.md:15
+#: src/pattern-matching/match.md
 msgid "\"Number input\""
 msgstr ""
 
-#: src/pattern-matching/match.md:16
+#: src/pattern-matching/match.md
 msgid "\"Lowercase: {key}\""
 msgstr ""
 
-#: src/pattern-matching/match.md:17
+#: src/pattern-matching/match.md
 msgid "\"Something else\""
 msgstr ""
 
-#: src/pattern-matching/match.md:22
+#: src/pattern-matching/match.md
 msgid ""
 "The `_` pattern is a wildcard pattern which matches any value. The "
 "expressions _must_ be exhaustive, meaning that it covers every possibility, "
 "so `_` is often used as the final catch-all case."
 msgstr ""
 
-#: src/pattern-matching/match.md:26
+#: src/pattern-matching/match.md
 msgid ""
 "Match can be used as an expression. Just like `if`, each match arm must have "
 "the same type. The type is the last expression of the block, if any. In the "
 "example above, the type is `()`."
 msgstr ""
 
-#: src/pattern-matching/match.md:30
+#: src/pattern-matching/match.md
 msgid ""
 "A variable in the pattern (`key` in this example) will create a binding that "
 "can be used within the match arm."
 msgstr ""
 
-#: src/pattern-matching/match.md:33
+#: src/pattern-matching/match.md
 msgid "A match guard causes the arm to match only if the condition is true."
 msgstr ""
 
-#: src/pattern-matching/match.md:40
+#: src/pattern-matching/match.md
 msgid ""
 "You might point out how some specific characters are being used when in a "
 "pattern"
 msgstr ""
 
-#: src/pattern-matching/match.md:42
+#: src/pattern-matching/match.md
 msgid "`|` as an `or`"
 msgstr ""
 
-#: src/pattern-matching/match.md:43
+#: src/pattern-matching/match.md
 msgid "`..` can expand as much as it needs to be"
 msgstr ""
 
-#: src/pattern-matching/match.md:44
+#: src/pattern-matching/match.md
 msgid "`1..=5` represents an inclusive range"
 msgstr ""
 
-#: src/pattern-matching/match.md:45
+#: src/pattern-matching/match.md
 msgid "`_` is a wild card"
 msgstr ""
 
-#: src/pattern-matching/match.md:47
+#: src/pattern-matching/match.md
 msgid ""
 "Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
 "allow."
 msgstr ""
 
-#: src/pattern-matching/match.md:49
+#: src/pattern-matching/match.md
 msgid ""
 "They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
@@ -4985,103 +4837,103 @@ msgid ""
 "result in other arms of the original `match` expression being considered."
 msgstr ""
 
-#: src/pattern-matching/match.md:53
+#: src/pattern-matching/match.md
 msgid ""
 "The condition defined in the guard applies to every expression in a pattern "
 "with an `|`."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:1
+#: src/pattern-matching/destructuring-structs.md
 msgid "Structs"
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:3
+#: src/pattern-matching/destructuring-structs.md
 msgid "Like tuples, Struct can also be destructured by matching:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:15
+#: src/pattern-matching/destructuring-structs.md
 msgid "\"x.0 = 1, b = {b}, y = {y}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:16
+#: src/pattern-matching/destructuring-structs.md
 msgid "\"y = 2, x = {i:?}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:17
+#: src/pattern-matching/destructuring-structs.md
 msgid "\"y = {y}, other fields were ignored\""
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:25
+#: src/pattern-matching/destructuring-structs.md
 msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:26
+#: src/pattern-matching/destructuring-structs.md
 msgid "Add a new field to `Foo` and make changes to the pattern as needed."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:27
+#: src/pattern-matching/destructuring-structs.md
 msgid ""
 "The distinction between a capture and a constant expression can be hard to "
 "spot. Try changing the `2` in the second arm to a variable, and see that it "
 "subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:3
+#: src/pattern-matching/destructuring-enums.md
 msgid "Like tuples, enums can also be destructured by matching:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:5
+#: src/pattern-matching/destructuring-enums.md
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
 "how you inspect the structure of your types. Let us start with a simple "
 "`enum` type:"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:18
+#: src/pattern-matching/destructuring-enums.md
 msgid "\"cannot divide {n} into two equal parts\""
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:25
+#: src/pattern-matching/destructuring-enums.md
 msgid "\"{n} divided in two is {half}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:26
+#: src/pattern-matching/destructuring-enums.md
 msgid "\"sorry, an error happened: {msg}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:31
+#: src/pattern-matching/destructuring-enums.md
 msgid ""
 "Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
 "arm, `msg` is bound to the error message."
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:38
+#: src/pattern-matching/destructuring-enums.md
 msgid ""
 "The `if`/`else` expression is returning an enum that is later unpacked with "
 "a `match`."
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:40
+#: src/pattern-matching/destructuring-enums.md
 msgid ""
 "You can try adding a third variant to the enum definition and displaying the "
 "errors when running the code. Point out the places where your code is now "
 "inexhaustive and how the compiler tries to give you hints."
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:43
+#: src/pattern-matching/destructuring-enums.md
 msgid ""
 "The values in the enum variants can only be accessed after being pattern "
 "matched."
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:45
+#: src/pattern-matching/destructuring-enums.md
 msgid ""
 "Demonstrate what happens when the search is inexhaustive. Note the advantage "
 "the Rust compiler provides by confirming when all cases are handled."
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:47
+#: src/pattern-matching/destructuring-enums.md
 msgid ""
 "Save the result of `divide_in_two` in the `result` variable and `match` it "
 "in a loop. That won't compile because `msg` is consumed when matched. To fix "
@@ -5091,41 +4943,40 @@ msgid ""
 "support older Rust, replace `msg` with `ref msg` in the pattern."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:3
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "Rust has a few control flow constructs which differ from other languages. "
 "They are used for pattern matching:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:6
-#: src/pattern-matching/let-control-flow.md:10
+#: src/pattern-matching/let-control-flow.md
 msgid "`if let` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:7
+#: src/pattern-matching/let-control-flow.md
 msgid "`while let` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:8
+#: src/pattern-matching/let-control-flow.md
 msgid "`match` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:12
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
 "expr.html#if-let-expressions) lets you execute different code depending on "
 "whether a value matches a pattern:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:22
+#: src/pattern-matching/let-control-flow.md
 msgid "\"slept for {:?}\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:32
+#: src/pattern-matching/let-control-flow.md
 msgid "`let else` expressions"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:34
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "For the common case of matching a pattern and returning from the function, "
 "use [`let else`](https://doc.rust-lang.org/rust-by-example/flow_control/"
@@ -5133,41 +4984,36 @@ msgid ""
 "- anything but falling off the end of the block)."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:44
-#: src/pattern-matching/let-control-flow.md:107
+#: src/pattern-matching/let-control-flow.md
 msgid "\"got None\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:50
-#: src/pattern-matching/let-control-flow.md:111
+#: src/pattern-matching/let-control-flow.md
 msgid "\"got empty string\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:56
-#: src/pattern-matching/let-control-flow.md:115
+#: src/pattern-matching/let-control-flow.md
 msgid "\"not a hex digit\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:61
-#: src/pattern-matching/solution.md:113
+#: src/pattern-matching/let-control-flow.md src/pattern-matching/solution.md
 msgid "\"result: {:?}\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:61 src/generics/trait-bounds.md:16
-#: src/smart-pointers/solution.md:87 src/smart-pointers/solution.md:90
-#: src/testing/solution.md:83 src/android/testing.md:40
-#: src/android/testing/googletest.md:11 src/android/testing/googletest.md:12
+#: src/pattern-matching/let-control-flow.md src/generics/trait-bounds.md
+#: src/smart-pointers/solution.md src/testing/solution.md
+#: src/android/testing.md src/android/testing/googletest.md
 msgid "\"foo\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:65
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
 "reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
 "repeatedly tests a value against a pattern:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:81
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "Here [`String::pop`](https://doc.rust-lang.org/stable/std/string/struct."
 "String.html#method.pop) returns `Some(c)` until the string is empty, after "
@@ -5175,62 +5021,62 @@ msgid ""
 "all items."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:89
+#: src/pattern-matching/let-control-flow.md
 msgid "if-let"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:91
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "Unlike `match`, `if let` does not have to cover all branches. This can make "
 "it more concise than `match`."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:93
+#: src/pattern-matching/let-control-flow.md
 msgid "A common usage is handling `Some` values when working with `Option`."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:94
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "Unlike `match`, `if let` does not support guard clauses for pattern matching."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:96
+#: src/pattern-matching/let-control-flow.md
 msgid "let-else"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:98
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "`if-let`s can pile up, as shown. The `let-else` construct supports "
 "flattening this nested code. Rewrite the awkward version for students, so "
 "they can see the transformation."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:102
+#: src/pattern-matching/let-control-flow.md
 msgid "The rewritten version is:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:122
+#: src/pattern-matching/let-control-flow.md
 msgid "while-let"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:124
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "Point out that the `while let` loop will keep going as long as the value "
 "matches the pattern."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md:126
+#: src/pattern-matching/let-control-flow.md
 msgid ""
 "You could rewrite the `while let` loop as an infinite loop with an if "
 "statement that breaks when there is no value to unwrap for `name.pop()`. The "
 "`while let` provides syntactic sugar for the above scenario."
 msgstr ""
 
-#: src/pattern-matching/exercise.md:3
+#: src/pattern-matching/exercise.md
 msgid "Let's write a simple recursive evaluator for arithmetic expressions."
 msgstr ""
 
-#: src/pattern-matching/exercise.md:5
+#: src/pattern-matching/exercise.md
 msgid ""
 "The `Box` type here is a smart pointer, and will be covered in detail later "
 "in the course. An expression can be \"boxed\" with `Box::new` as seen in the "
@@ -5238,7 +5084,7 @@ msgid ""
 "\"unbox\" it: `eval(*boxed_expr)`."
 msgstr ""
 
-#: src/pattern-matching/exercise.md:10
+#: src/pattern-matching/exercise.md
 msgid ""
 "Some expressions cannot be evaluated and will return an error. The standard "
 "[`Result<Value, String>`](https://doc.rust-lang.org/std/result/enum.Result."
@@ -5247,7 +5093,7 @@ msgid ""
 "later."
 msgstr ""
 
-#: src/pattern-matching/exercise.md:15
+#: src/pattern-matching/exercise.md
 msgid ""
 "Copy and paste the code into the Rust playground, and begin implementing "
 "`eval`. The final product should pass the tests. It may be helpful to use "
@@ -5255,98 +5101,97 @@ msgid ""
 "temporarily with `#[ignore]`:"
 msgstr ""
 
-#: src/pattern-matching/exercise.md:26
+#: src/pattern-matching/exercise.md
 msgid ""
 "If you finish early, try writing a test that results in division by zero or "
 "integer overflow. How could you handle this with `Result` instead of a panic?"
 msgstr ""
 
-#: src/pattern-matching/exercise.md:30 src/pattern-matching/solution.md:4
+#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An operation to perform on two subexpressions.\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md:38 src/pattern-matching/solution.md:12
+#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An expression, in tree form.\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md:42 src/pattern-matching/solution.md:16
+#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An operation on two subexpressions.\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md:45 src/pattern-matching/solution.md:19
+#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// A literal value\n"
 msgstr ""
 
-#: src/pattern-matching/exercise.md:104 src/pattern-matching/solution.md:40
-#: src/pattern-matching/solution.md:102
+#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "\"division by zero\""
 msgstr ""
 
-#: src/pattern-matching/solution.md:112
+#: src/pattern-matching/solution.md
 msgid "\"expr: {:?}\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md:3
+#: src/methods-and-traits/methods.md
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
 "an `impl` block:"
 msgstr ""
 
-#: src/methods-and-traits/methods.md:14
+#: src/methods-and-traits/methods.md
 msgid "// No receiver, a static method\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md:19
+#: src/methods-and-traits/methods.md
 msgid "// Exclusive borrowed read-write access to self\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md:24
+#: src/methods-and-traits/methods.md
 msgid "// Shared and read-only borrowed access to self\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md:26
+#: src/methods-and-traits/methods.md
 msgid "\"Recorded {} laps for {}:\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md:28
+#: src/methods-and-traits/methods.md
 msgid "\"Lap {idx}: {lap} sec\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md:32
+#: src/methods-and-traits/methods.md
 msgid "// Exclusive ownership of self\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md:35
+#: src/methods-and-traits/methods.md
 msgid "\"Race {} is finished, total lap time: {}\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md:40
+#: src/methods-and-traits/methods.md
 msgid "\"Monaco Grand Prix\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md:47
+#: src/methods-and-traits/methods.md
 msgid "// race.add_lap(42);\n"
 msgstr ""
 
-#: src/methods-and-traits/methods.md:51
+#: src/methods-and-traits/methods.md
 msgid ""
 "The `self` arguments specify the \"receiver\" - the object the method acts "
 "on. There are several common receivers for a method:"
 msgstr ""
 
-#: src/methods-and-traits/methods.md:54
+#: src/methods-and-traits/methods.md
 msgid ""
 "`&self`: borrows the object from the caller using a shared and immutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:56
+#: src/methods-and-traits/methods.md
 msgid ""
 "`&mut self`: borrows the object from the caller using a unique and mutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:58
+#: src/methods-and-traits/methods.md
 msgid ""
 "`self`: takes ownership of the object and moves it away from the caller. The "
 "method becomes the owner of the object. The object will be dropped "
@@ -5354,211 +5199,211 @@ msgid ""
 "transmitted. Complete ownership does not automatically mean mutability."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:62
+#: src/methods-and-traits/methods.md
 msgid "`mut self`: same as above, but the method can mutate the object."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:63
+#: src/methods-and-traits/methods.md
 msgid ""
 "No receiver: this becomes a static method on the struct. Typically used to "
 "create constructors which are called `new` by convention."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:71
+#: src/methods-and-traits/methods.md
 msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:72
+#: src/methods-and-traits/methods.md
 msgid ""
 "Methods are called on an instance of a type (such as a struct or enum), the "
 "first parameter represents the instance as `self`."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:74
+#: src/methods-and-traits/methods.md
 msgid ""
 "Developers may choose to use methods to take advantage of method receiver "
 "syntax and to help keep them more organized. By using methods we can keep "
 "all the implementation code in one predictable place."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:77
+#: src/methods-and-traits/methods.md
 msgid "Point out the use of the keyword `self`, a method receiver."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:78
+#: src/methods-and-traits/methods.md
 msgid ""
 "Show that it is an abbreviated term for `self: Self` and perhaps show how "
 "the struct name could also be used."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:80
+#: src/methods-and-traits/methods.md
 msgid ""
 "Explain that `Self` is a type alias for the type the `impl` block is in and "
 "can be used elsewhere in the block."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:82
+#: src/methods-and-traits/methods.md
 msgid ""
 "Note how `self` is used like other structs and dot notation can be used to "
 "refer to individual fields."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:84
+#: src/methods-and-traits/methods.md
 msgid ""
 "This might be a good time to demonstrate how the `&self` differs from `self` "
 "by trying to run `finish` twice."
 msgstr ""
 
-#: src/methods-and-traits/methods.md:86
+#: src/methods-and-traits/methods.md
 msgid ""
 "Beyond variants on `self`, there are also [special wrapper types](https://"
 "doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
 "receiver types, such as `Box<Self>`."
 msgstr ""
 
-#: src/methods-and-traits/traits.md:3
+#: src/methods-and-traits/traits.md
 msgid ""
 "Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
-#: src/methods-and-traits/traits.md:7
+#: src/methods-and-traits/traits.md
 msgid "/// Return a sentence from this pet.\n"
 msgstr ""
 
-#: src/methods-and-traits/traits.md:10
+#: src/methods-and-traits/traits.md
 msgid "/// Print a string to the terminal greeting this pet.\n"
 msgstr ""
 
-#: src/methods-and-traits/traits.md:18
+#: src/methods-and-traits/traits.md
 msgid ""
 "A trait defines a number of methods that types must have in order to "
 "implement the trait."
 msgstr ""
 
-#: src/methods-and-traits/traits.md:21
+#: src/methods-and-traits/traits.md
 msgid ""
 "In the \"Generics\" segment, next, we will see how to build functionality "
 "that is generic over all types implementing a trait."
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md:8
+#: src/methods-and-traits/traits/implementing.md
 msgid "\"Oh you're a cutie! What's your name? {}\""
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md:19
-#: src/smart-pointers/trait-objects.md:20
+#: src/methods-and-traits/traits/implementing.md
+#: src/smart-pointers/trait-objects.md
 msgid "\"Woof, my name is {}!\""
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md:24
-#: src/smart-pointers/trait-objects.md:33
+#: src/methods-and-traits/traits/implementing.md
+#: src/smart-pointers/trait-objects.md
 msgid "\"Fido\""
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md:31
+#: src/methods-and-traits/traits/implementing.md
 msgid ""
 "To implement `Trait` for `Type`, you use an `impl Trait for Type { .. }` "
 "block."
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md:34
+#: src/methods-and-traits/traits/implementing.md
 msgid ""
 "Unlike Go interfaces, just having matching methods is not enough: a `Cat` "
 "type with a `talk()` method would not automatically satisfy `Pet` unless it "
 "is in an `impl Pet` block."
 msgstr ""
 
-#: src/methods-and-traits/traits/implementing.md:38
+#: src/methods-and-traits/traits/implementing.md
 msgid ""
 "Traits may provide default implementations of some methods. Default "
 "implementations can rely on all the methods of the trait. In this case, "
 "`greet` is provided, and relies on `talk`."
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md:3
+#: src/methods-and-traits/traits/supertraits.md
 msgid ""
 "A trait can require that types implementing it also implement other traits, "
 "called _supertraits_. Here, any type implementing `Pet` must implement "
 "`Animal`."
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md:30
-#: src/concurrency/async-control-flow/select.md:44
+#: src/methods-and-traits/traits/supertraits.md
+#: src/concurrency/async-control-flow/select.md
 msgid "\"Rex\""
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md:31
+#: src/methods-and-traits/traits/supertraits.md
 msgid "\"{} has {} legs\""
 msgstr ""
 
-#: src/methods-and-traits/traits/supertraits.md:37
+#: src/methods-and-traits/traits/supertraits.md
 msgid ""
 "This is sometimes called \"trait inheritance\" but students should not "
 "expect this to behave like OO inheritance. It just specifies an additional "
 "requirement on implementations of a trait."
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md:3
+#: src/methods-and-traits/traits/associated-types.md
 msgid ""
 "Associated types are placeholder types which are supplied by the trait "
 "implementation."
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md:25
-#: src/concurrency/async-control-flow/join.md:30
+#: src/methods-and-traits/traits/associated-types.md
+#: src/concurrency/async-control-flow/join.md
 msgid "\"{:?}\""
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md:31
+#: src/methods-and-traits/traits/associated-types.md
 msgid ""
 "Associated types are sometimes also called \"output types\". The key "
 "observation is that the implementer, not the caller, chooses this type."
 msgstr ""
 
-#: src/methods-and-traits/traits/associated-types.md:34
+#: src/methods-and-traits/traits/associated-types.md
 msgid ""
 "Many standard library traits have associated types, including arithmetic "
 "operators and `Iterator`."
 msgstr ""
 
-#: src/methods-and-traits/deriving.md:3
+#: src/methods-and-traits/deriving.md
 msgid ""
 "Supported traits can be automatically implemented for your custom types, as "
 "follows:"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md:15
+#: src/methods-and-traits/deriving.md
 msgid "// Default trait adds `default` constructor.\n"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md:16
+#: src/methods-and-traits/deriving.md
 msgid "// Clone trait adds `clone` method.\n"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md:17
+#: src/methods-and-traits/deriving.md
 msgid "\"EldurScrollz\""
 msgstr ""
 
-#: src/methods-and-traits/deriving.md:18
+#: src/methods-and-traits/deriving.md
 msgid "// Debug trait adds support for printing with `{:?}`.\n"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md:19
+#: src/methods-and-traits/deriving.md
 msgid "\"{:?} vs. {:?}\""
 msgstr ""
 
-#: src/methods-and-traits/deriving.md:26
+#: src/methods-and-traits/deriving.md
 msgid ""
 "Derivation is implemented with macros, and many crates provide useful derive "
 "macros to add useful functionality. For example, `serde` can derive "
 "serialization support for a struct using `#[derive(Serialize)]`."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:1
+#: src/methods-and-traits/exercise.md
 msgid "Exercise: Logger Trait"
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:3
+#: src/methods-and-traits/exercise.md
 msgid ""
 "Let's design a simple logging utility, using a trait `Logger` with a `log` "
 "method. Code which might log its progress can then take an `&impl Logger`. "
@@ -5566,45 +5411,45 @@ msgid ""
 "production build it would send messages to a log server."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:8
+#: src/methods-and-traits/exercise.md
 msgid ""
 "However, the `StderrLogger` given below logs all messages, regardless of "
 "verbosity. Your task is to write a `VerbosityFilter` type that will ignore "
 "messages above a maximum verbosity."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:12
+#: src/methods-and-traits/exercise.md
 msgid ""
 "This is a common pattern: a struct wrapping a trait implementation and "
 "implementing that same trait, adding behavior in the process. What other "
 "kinds of wrappers might be useful in a logging utility?"
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:20 src/methods-and-traits/solution.md:7
+#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "/// Log a message at the given verbosity level.\n"
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:28 src/methods-and-traits/solution.md:15
+#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"verbosity={verbosity}: {message}\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:33 src/methods-and-traits/solution.md:20
+#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"FYI\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:34 src/methods-and-traits/solution.md:21
+#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"Uhoh\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md:36
+#: src/methods-and-traits/exercise.md
 msgid "// TODO: Define and implement `VerbosityFilter`.\n"
 msgstr ""
 
-#: src/methods-and-traits/solution.md:23
+#: src/methods-and-traits/solution.md
 msgid "/// Only log messages up to the given verbosity level.\n"
 msgstr ""
 
-#: src/welcome-day-2-afternoon.md:3
+#: src/welcome-day-2-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 4 hours. It "
 "contains:"
@@ -5612,47 +5457,47 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 4 tiếng, bao gồm thời gian 10 phút nghỉ trưa. "
 "Nội dung buổi học bao gồm:"
 
-#: src/generics.md:10
+#: src/generics.md
 msgid "impl Trait"
 msgstr ""
 
-#: src/generics.md:11
+#: src/generics.md
 msgid "Exercise: Generic min"
 msgstr ""
 
-#: src/generics/generic-functions.md:3
+#: src/generics/generic-functions.md
 msgid ""
 "Rust supports generics, which lets you abstract algorithms or data "
 "structures (such as sorting or a binary tree) over the types used or stored."
 msgstr ""
 
-#: src/generics/generic-functions.md:7
+#: src/generics/generic-functions.md
 msgid "/// Pick `even` or `odd` depending on the value of `n`.\n"
 msgstr ""
 
-#: src/generics/generic-functions.md:17
+#: src/generics/generic-functions.md
 msgid "\"picked a number: {:?}\""
 msgstr ""
 
-#: src/generics/generic-functions.md:18
+#: src/generics/generic-functions.md
 msgid "\"picked a tuple: {:?}\""
 msgstr ""
 
-#: src/generics/generic-functions.md:18
+#: src/generics/generic-functions.md
 msgid "\"dog\""
 msgstr ""
 
-#: src/generics/generic-functions.md:18
+#: src/generics/generic-functions.md
 msgid "\"cat\""
 msgstr ""
 
-#: src/generics/generic-functions.md:25
+#: src/generics/generic-functions.md
 msgid ""
 "Rust infers a type for T based on the types of the arguments and return "
 "value."
 msgstr ""
 
-#: src/generics/generic-functions.md:27
+#: src/generics/generic-functions.md
 msgid ""
 "This is similar to C++ templates, but Rust partially compiles the generic "
 "function immediately, so that function must be valid for all types matching "
@@ -5661,98 +5506,98 @@ msgid ""
 "still considers it invalid. C++ would let you do this."
 msgstr ""
 
-#: src/generics/generic-functions.md:33
+#: src/generics/generic-functions.md
 msgid ""
 "Generic code is turned into non-generic code based on the call sites. This "
 "is a zero-cost abstraction: you get exactly the same result as if you had "
 "hand-coded the data structures without the abstraction."
 msgstr ""
 
-#: src/generics/generic-data.md:3
+#: src/generics/generic-data.md
 msgid "You can use generics to abstract over the concrete field type:"
 msgstr ""
 
-#: src/generics/generic-data.md:25
+#: src/generics/generic-data.md
 msgid "\"{integer:?} and {float:?}\""
 msgstr ""
 
-#: src/generics/generic-data.md:26
+#: src/generics/generic-data.md
 msgid "\"coords: {:?}\""
 msgstr ""
 
-#: src/generics/generic-data.md:33
+#: src/generics/generic-data.md
 msgid ""
 "_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
 "redundant?"
 msgstr ""
 
-#: src/generics/generic-data.md:35
+#: src/generics/generic-data.md
 msgid ""
 "This is because it is a generic implementation section for generic type. "
 "They are independently generic."
 msgstr ""
 
-#: src/generics/generic-data.md:37
+#: src/generics/generic-data.md
 msgid "It means these methods are defined for any `T`."
 msgstr ""
 
-#: src/generics/generic-data.md:38
+#: src/generics/generic-data.md
 msgid "It is possible to write `impl Point<u32> { .. }`."
 msgstr ""
 
-#: src/generics/generic-data.md:39
+#: src/generics/generic-data.md
 msgid ""
 "`Point` is still generic and you can use `Point<f64>`, but methods in this "
 "block will only be available for `Point<u32>`."
 msgstr ""
 
-#: src/generics/generic-data.md:42
+#: src/generics/generic-data.md
 msgid ""
 "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`. Update the "
 "code to allow points that have elements of different types, by using two "
 "type variables, e.g., `T` and `U`."
 msgstr ""
 
-#: src/generics/generic-traits.md:3
+#: src/generics/generic-traits.md
 msgid ""
 "Traits can also be generic, just like types and functions. A trait's "
 "parameters get concrete types when it is used."
 msgstr ""
 
-#: src/generics/generic-traits.md:12
+#: src/generics/generic-traits.md
 msgid "\"Converted from integer: {from}\""
 msgstr ""
 
-#: src/generics/generic-traits.md:18
+#: src/generics/generic-traits.md
 msgid "\"Converted from bool: {from}\""
 msgstr ""
 
-#: src/generics/generic-traits.md:25
+#: src/generics/generic-traits.md
 msgid "\"{from_int:?}, {from_bool:?}\""
 msgstr ""
 
-#: src/generics/generic-traits.md:31
+#: src/generics/generic-traits.md
 msgid ""
 "The `From` trait will be covered later in the course, but its [definition in "
 "the `std` docs](https://doc.rust-lang.org/std/convert/trait.From.html) is "
 "simple."
 msgstr ""
 
-#: src/generics/generic-traits.md:35
+#: src/generics/generic-traits.md
 msgid ""
 "Implementations of the trait do not need to cover all possible type "
 "parameters. Here, `Foo::From(\"hello\")` would not compile because there is "
 "no `From<&str>` implementation for `Foo`."
 msgstr ""
 
-#: src/generics/generic-traits.md:39
+#: src/generics/generic-traits.md
 msgid ""
 "Generic traits take types as \"input\", while associated types are a kind of "
 "\"output\" type. A trait can have multiple implementations for different "
 "input types."
 msgstr ""
 
-#: src/generics/generic-traits.md:43
+#: src/generics/generic-traits.md
 msgid ""
 "In fact, Rust requires that at most one implementation of a trait match for "
 "any type T. Unlike some other languages, Rust has no heuristic for choosing "
@@ -5761,100 +5606,100 @@ msgid ""
 "html)."
 msgstr ""
 
-#: src/generics/trait-bounds.md:3
+#: src/generics/trait-bounds.md
 msgid ""
 "When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 
-#: src/generics/trait-bounds.md:6
+#: src/generics/trait-bounds.md
 msgid "You can do this with `T: Trait` or `impl Trait`:"
 msgstr ""
 
-#: src/generics/trait-bounds.md:12
+#: src/generics/trait-bounds.md
 msgid "// struct NotClonable;\n"
 msgstr ""
 
-#: src/generics/trait-bounds.md:18
+#: src/generics/trait-bounds.md
 msgid "\"{pair:?}\""
 msgstr ""
 
-#: src/generics/trait-bounds.md:25
+#: src/generics/trait-bounds.md
 msgid "Try making a `NonClonable` and passing it to `duplicate`."
 msgstr ""
 
-#: src/generics/trait-bounds.md:27
+#: src/generics/trait-bounds.md
 msgid "When multiple traits are necessary, use `+` to join them."
 msgstr ""
 
-#: src/generics/trait-bounds.md:29
+#: src/generics/trait-bounds.md
 msgid "Show a `where` clause, students will encounter it when reading code."
 msgstr ""
 
-#: src/generics/trait-bounds.md:40
+#: src/generics/trait-bounds.md
 msgid "It declutters the function signature if you have many parameters."
 msgstr ""
 
-#: src/generics/trait-bounds.md:41
+#: src/generics/trait-bounds.md
 msgid "It has additional features making it more powerful."
 msgstr ""
 
-#: src/generics/trait-bounds.md:42
+#: src/generics/trait-bounds.md
 msgid ""
 "If someone asks, the extra feature is that the type on the left of \":\" can "
 "be arbitrary, like `Option<T>`."
 msgstr ""
 
-#: src/generics/trait-bounds.md:45
+#: src/generics/trait-bounds.md
 msgid ""
 "Note that Rust does not (yet) support specialization. For example, given the "
 "original `duplicate`, it is invalid to add a specialized `duplicate(a: u32)`."
 msgstr ""
 
-#: src/generics/impl-trait.md:3
+#: src/generics/impl-trait.md
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 
-#: src/generics/impl-trait.md:7
+#: src/generics/impl-trait.md
 msgid ""
 "// Syntactic sugar for:\n"
 "//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
 msgstr ""
 
-#: src/generics/impl-trait.md:19
+#: src/generics/impl-trait.md
 msgid "\"{many}\""
 msgstr ""
 
-#: src/generics/impl-trait.md:21
+#: src/generics/impl-trait.md
 msgid "\"{many_more}\""
 msgstr ""
 
-#: src/generics/impl-trait.md:23
+#: src/generics/impl-trait.md
 msgid "\"debuggable: {debuggable:?}\""
 msgstr ""
 
-#: src/generics/impl-trait.md:30
+#: src/generics/impl-trait.md
 msgid ""
 "`impl Trait` allows you to work with types which you cannot name. The "
 "meaning of `impl Trait` is a bit different in the different positions."
 msgstr ""
 
-#: src/generics/impl-trait.md:33
+#: src/generics/impl-trait.md
 msgid ""
 "For a parameter, `impl Trait` is like an anonymous generic parameter with a "
 "trait bound."
 msgstr ""
 
-#: src/generics/impl-trait.md:36
+#: src/generics/impl-trait.md
 msgid ""
 "For a return type, it means that the return type is some concrete type that "
 "implements the trait, without naming the type. This can be useful when you "
 "don't want to expose the concrete type in a public API."
 msgstr ""
 
-#: src/generics/impl-trait.md:40
+#: src/generics/impl-trait.md
 msgid ""
 "Inference is hard in return position. A function returning `impl Foo` picks "
 "the concrete type it returns, without writing it out in the source. A "
@@ -5864,81 +5709,80 @@ msgid ""
 "<Vec<_>>()`."
 msgstr ""
 
-#: src/generics/impl-trait.md:47
+#: src/generics/impl-trait.md
 msgid ""
 "What is the type of `debuggable`? Try `let debuggable: () = ..` to see what "
 "the error message shows."
 msgstr ""
 
-#: src/generics/exercise.md:3
+#: src/generics/exercise.md
 msgid ""
 "In this short exercise, you will implement a generic `min` function that "
 "determines the minimum of two values, using the [`Ord`](https://doc.rust-"
 "lang.org/stable/std/cmp/trait.Ord.html) trait."
 msgstr ""
 
-#: src/generics/exercise.md:8
+#: src/generics/exercise.md
 msgid "// TODO: implement the `min` function used in `main`.\n"
 msgstr ""
 
-#: src/generics/exercise.md:15 src/generics/solution.md:17
-#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:75
-#: src/error-handling/solution.md:60 src/error-handling/solution.md:75
+#: src/generics/exercise.md src/generics/solution.md
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'z'"
 msgstr ""
 
-#: src/generics/exercise.md:16 src/generics/solution.md:18
+#: src/generics/exercise.md src/generics/solution.md
 msgid "'7'"
 msgstr ""
 
-#: src/generics/exercise.md:16 src/generics/solution.md:18
+#: src/generics/exercise.md src/generics/solution.md
 msgid "'1'"
 msgstr ""
 
-#: src/generics/exercise.md:18 src/generics/solution.md:20
+#: src/generics/exercise.md src/generics/solution.md
 msgid "\"goodbye\""
 msgstr ""
 
-#: src/generics/exercise.md:19 src/generics/solution.md:21
+#: src/generics/exercise.md src/generics/solution.md
 msgid "\"bat\""
 msgstr ""
 
-#: src/generics/exercise.md:19 src/generics/solution.md:21
+#: src/generics/exercise.md src/generics/solution.md
 msgid "\"armadillo\""
 msgstr ""
 
-#: src/generics/exercise.md:26
+#: src/generics/exercise.md
 msgid ""
 "Show students the [`Ord`](https://doc.rust-lang.org/stable/std/cmp/trait.Ord."
 "html) trait and [`Ordering`](https://doc.rust-lang.org/stable/std/cmp/enum."
 "Ordering.html) enum."
 msgstr ""
 
-#: src/std-types.md:3
+#: src/std-types.md
 msgid "This segment should take about 1 hour and 20 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 20 phút, bao gồm:"
 
-#: src/std-types.md:9 src/std-types/option.md:1
+#: src/std-types.md src/std-types/option.md
 msgid "Option"
 msgstr "Option"
 
-#: src/std-types.md:10 src/std-types/result.md:1
+#: src/std-types.md src/std-types/result.md
 msgid "Result"
 msgstr "Result"
 
-#: src/std-types.md:11 src/std-types/string.md:1
+#: src/std-types.md src/std-types/string.md
 msgid "String"
 msgstr ""
 
-#: src/std-types.md:12
+#: src/std-types.md
 msgid "Vec"
 msgstr ""
 
-#: src/std-types.md:13
+#: src/std-types.md
 msgid "HashMap"
 msgstr ""
 
-#: src/std-types.md:19
+#: src/std-types.md
 msgid ""
 "For each of the slides in this section, spend some time reviewing the "
 "documentation pages, highlighting some of the more common methods."
@@ -5946,7 +5790,7 @@ msgstr ""
 "Hãy dành thời gian xem lại tài liệu cho từng trang trong phần này, đặc biệt "
 "là những hàm phổ biến."
 
-#: src/std-types/std.md:3
+#: src/std-types/std.md
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
 "types used by Rust libraries and programs. This way, two libraries can work "
@@ -5956,7 +5800,7 @@ msgstr ""
 "Nhờ đó, hai thư viện có thể hoạt động cùng nhau một cách mượt mà vì cả hai "
 "đều sử dụng cùng một kiểu `String` của thư viện chuẩn."
 
-#: src/std-types/std.md:7
+#: src/std-types/std.md
 msgid ""
 "In fact, Rust contains several layers of the Standard Library: `core`, "
 "`alloc` and `std`."
@@ -5964,7 +5808,7 @@ msgstr ""
 "Trong thực tế, thư viện chuẩn của Rust chứa nhiều tầng riêng biệt: `core`, "
 "`alloc` và `std`."
 
-#: src/std-types/std.md:10
+#: src/std-types/std.md
 msgid ""
 "`core` includes the most basic types and functions that don't depend on "
 "`libc`, allocator or even the presence of an operating system."
@@ -5972,7 +5816,7 @@ msgstr ""
 "`core` bao gồm các kiểu dữ liệu và hàm cơ bản nhất không phụ thuộc vào "
 "`libc`, bộ cấp phát bộ nhớ hoặc thậm chí là hệ điều hành."
 
-#: src/std-types/std.md:12
+#: src/std-types/std.md
 msgid ""
 "`alloc` includes types which require a global heap allocator, such as `Vec`, "
 "`Box` and `Arc`."
@@ -5980,17 +5824,17 @@ msgstr ""
 "`alloc` bao gồm các kiểu dữ liệu yêu cầu phải được cấp phát trên bộ nhớ "
 "heap, như `Vec`, `Box` và `Arc`."
 
-#: src/std-types/std.md:14
+#: src/std-types/std.md
 msgid ""
 "Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
 "Phần mềm nhúng viết bằng Rust thường chỉ sử dụng `core`, và đôi khi `alloc`."
 
-#: src/std-types/docs.md:3
+#: src/std-types/docs.md
 msgid "Rust comes with extensive documentation. For example:"
 msgstr "Rust đi kèm với một bộ tài liệu rất chi tiết. Ví dụ:"
 
-#: src/std-types/docs.md:5
+#: src/std-types/docs.md
 msgid ""
 "All of the details about [loops](https://doc.rust-lang.org/stable/reference/"
 "expressions/loop-expr.html)."
@@ -5998,7 +5842,7 @@ msgstr ""
 "Tất cả chi tiết về [vòng lặp](https://doc.rust-lang.org/stable/reference/"
 "expressions/loop-expr.html)."
 
-#: src/std-types/docs.md:7
+#: src/std-types/docs.md
 msgid ""
 "Primitive types like [`u8`](https://doc.rust-lang.org/stable/std/primitive."
 "u8.html)."
@@ -6006,7 +5850,7 @@ msgstr ""
 "Các kiểu dữ liệu cơ bản như [`u8`](https://doc.rust-lang.org/stable/std/"
 "primitive.u8.html)."
 
-#: src/std-types/docs.md:9
+#: src/std-types/docs.md
 msgid ""
 "Standard library types like [`Option`](https://doc.rust-lang.org/stable/std/"
 "option/enum.Option.html) or [`BinaryHeap`](https://doc.rust-lang.org/stable/"
@@ -6016,11 +5860,11 @@ msgstr ""
 "lang.org/stable/std/option/enum.Option.html) hoặc [`BinaryHeap`](https://doc."
 "rust-lang.org/stable/std/collections/struct.BinaryHeap.html)."
 
-#: src/std-types/docs.md:13
+#: src/std-types/docs.md
 msgid "In fact, you can document your own code:"
 msgstr "Ngoài ra, bạn cũng có thể tự viết tài liệu cho code của bản thân:"
 
-#: src/std-types/docs.md:16
+#: src/std-types/docs.md
 msgid ""
 "/// Determine whether the first argument is divisible by the second "
 "argument.\n"
@@ -6031,7 +5875,7 @@ msgstr ""
 "///\n"
 "/// Nếu tham số thứ hai bằng không, trả về kết quả là sai.\n"
 
-#: src/std-types/docs.md:27
+#: src/std-types/docs.md
 msgid ""
 "The contents are treated as Markdown. All published Rust library crates are "
 "automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
@@ -6044,7 +5888,7 @@ msgstr ""
 "(https://docs.rs). Tất cả thành phần công khai trong một API nên được viết "
 "tài liệu theo phương pháp này."
 
-#: src/std-types/docs.md:32
+#: src/std-types/docs.md
 msgid ""
 "To document an item from inside the item (such as inside a module), use `//!"
 "` or `/*! .. */`, called \"inner doc comments\":"
@@ -6053,7 +5897,7 @@ msgstr ""
 "trong một module), hãy sử dụng `//!` hoặc `/*! .. */`. Cú pháp trên thường "
 "được gọi là \"inner doc comments\":"
 
-#: src/std-types/docs.md:36
+#: src/std-types/docs.md
 msgid ""
 "//! This module contains functionality relating to divisibility of "
 "integers.\n"
@@ -6061,7 +5905,7 @@ msgstr ""
 "//! Module này chứa các chức năng liên quan đến việc kiểm tra quan hệ chia "
 "hết của các số nguyên.\n"
 
-#: src/std-types/docs.md:42
+#: src/std-types/docs.md
 msgid ""
 "Show students the generated docs for the `rand` crate at <https://docs.rs/"
 "rand>."
@@ -6069,7 +5913,7 @@ msgstr ""
 "Cho học sinh xem tài liệu được viết cho thư viện `rand` tại <https://docs.rs/"
 "rand>."
 
-#: src/std-types/option.md:3
+#: src/std-types/option.md
 msgid ""
 "We have already seen some use of `Option<T>`. It stores either a value of "
 "type `T` or nothing. For example, [`String::find`](https://doc.rust-lang.org/"
@@ -6080,32 +5924,32 @@ msgstr ""
 "(https://doc.rust-lang.org/stable/std/string/struct.String.html#method.find) "
 "trả về một `Option<usize>`."
 
-#: src/std-types/option.md:10
+#: src/std-types/option.md
 msgid "\"Löwe 老虎 Léopard Gepardi\""
 msgstr "Hoàng Hữu Văn A"
 
-#: src/std-types/option.md:11
+#: src/std-types/option.md
 msgid "'é'"
 msgstr "ă"
 
-#: src/std-types/option.md:12 src/std-types/option.md:15
+#: src/std-types/option.md
 msgid "\"find returned {position:?}\""
 msgstr "\"find trả về {position:?}\""
 
-#: src/std-types/option.md:14
+#: src/std-types/option.md
 msgid "'Z'"
 msgstr "'Z'"
 
-#: src/std-types/option.md:16
+#: src/std-types/option.md
 msgid "\"Character not found\""
 msgstr "\"Không tìm thấy ký tự\""
 
-#: src/std-types/option.md:23
+#: src/std-types/option.md
 msgid "`Option` is widely used, not just in the standard library."
 msgstr ""
 "`Option` được sử dụng rộng rãi ở nhiều nơi, không chỉ trong thư viện chuẩn."
 
-#: src/std-types/option.md:24
+#: src/std-types/option.md
 msgid ""
 "`unwrap` will return the value in an `Option`, or panic. `expect` is similar "
 "but takes an error message."
@@ -6113,7 +5957,7 @@ msgstr ""
 "`unwrap` sẽ trả về giá trị của `Option` hoặc panic. `expect` hoạt động tương "
 "tự nhưng có thể truyền thêm một thông báo lỗi."
 
-#: src/std-types/option.md:26
+#: src/std-types/option.md
 msgid ""
 "You can panic on None, but you can't \"accidentally\" forget to check for "
 "None."
@@ -6121,7 +5965,7 @@ msgstr ""
 "Chương trình có thể panic khi gặp phải giá trị `None`, nhưng bạn không thể "
 "\"vô tình\" quên kiểm tra `None`."
 
-#: src/std-types/option.md:28
+#: src/std-types/option.md
 msgid ""
 "It's common to `unwrap`/`expect` all over the place when hacking something "
 "together, but production code typically handles `None` in a nicer fashion."
@@ -6130,14 +5974,14 @@ msgstr ""
 "một ý tưởng mới, nhưng code production thường xử lý `None` một cách an toàn "
 "hơn."
 
-#: src/std-types/option.md:30
+#: src/std-types/option.md
 msgid ""
 "The niche optimization means that `Option<T>` often has the same size in "
 "memory as `T`."
 msgstr ""
 "`Option<T>` được tối ưu để chiếm bằng bộ nhớ như `T`trong đa số trường hợp."
 
-#: src/std-types/result.md:3
+#: src/std-types/result.md
 msgid ""
 "`Result` is similar to `Option`, but indicates the success or failure of an "
 "operation, each with a different type. This is similar to the `Res` defined "
@@ -6151,23 +5995,23 @@ msgstr ""
 "trong đó `T` được sử dụng trong trường hợp `Ok` và `E` xuất hiện trong "
 "trường hợp `Err`."
 
-#: src/std-types/result.md:13
+#: src/std-types/result.md
 msgid "\"diary.txt\""
 msgstr "\"nhat_ky.txt\""
 
-#: src/std-types/result.md:18
+#: src/std-types/result.md
 msgid "\"Dear diary: {contents} ({bytes} bytes)\""
 msgstr "\"Hôm nay, tôi đã: {contents} ({bytes} bytes)\""
 
-#: src/std-types/result.md:20
+#: src/std-types/result.md
 msgid "\"Could not read file content\""
 msgstr "\"Không thể đọc nội dung tập tin\""
 
-#: src/std-types/result.md:24
+#: src/std-types/result.md
 msgid "\"The diary could not be opened: {err}\""
 msgstr "\"Không thể mở nhật ký: {err}\""
 
-#: src/std-types/result.md:33
+#: src/std-types/result.md
 msgid ""
 "As with `Option`, the successful value sits inside of `Result`, forcing the "
 "developer to explicitly extract it. This encourages error checking. In the "
@@ -6180,7 +6024,7 @@ msgstr ""
 "không thể xảy ra, `unwrap()` hoặc `expect()` có thể được gọi, bày tỏ rõ ràng "
 "ý định của người viết là lỗi không thể xảy ra."
 
-#: src/std-types/result.md:37
+#: src/std-types/result.md
 msgid ""
 "`Result` documentation is a recommended read. Not during the course, but it "
 "is worth mentioning. It contains a lot of convenience methods and functions "
@@ -6190,7 +6034,7 @@ msgstr ""
 "trong khóa học, nhưng đáng đề cập đến. Tài liệu này chứa nhiều hàm khá tiện "
 "lợi, hỗ trợ việc lập trình theo functional-style programming."
 
-#: src/std-types/result.md:40
+#: src/std-types/result.md
 msgid ""
 "`Result` is the standard type to implement error handling as we will see on "
 "Day 4."
@@ -6198,59 +6042,58 @@ msgstr ""
 "`Result` là kiểu dữ liệu chuẩn để xử lý lỗi như chúng ta sẽ thấy trong ngày "
 "4."
 
-#: src/std-types/string.md:3
+#: src/std-types/string.md
 msgid ""
 "[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is a "
 "growable UTF-8 encoded string:"
 msgstr ""
 
-#: src/std-types/string.md:8 src/std-traits/read-and-write.md:35
-#: src/memory-management/review.md:23 src/memory-management/review.md:58
-#: src/testing/unit-tests.md:32 src/testing/unit-tests.md:37
-#: src/concurrency/threads/scoped.md:9 src/concurrency/threads/scoped.md:26
+#: src/std-types/string.md src/std-traits/read-and-write.md
+#: src/memory-management/review.md src/testing/unit-tests.md
+#: src/concurrency/threads/scoped.md
 msgid "\"Hello\""
 msgstr ""
 
-#: src/std-types/string.md:9
+#: src/std-types/string.md
 msgid "\"s1: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/string.md:13
+#: src/std-types/string.md
 msgid "'!'"
 msgstr ""
 
-#: src/std-types/string.md:14
+#: src/std-types/string.md
 msgid "\"s2: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/string.md:16
+#: src/std-types/string.md
 msgid "\"🇨🇭\""
 msgstr ""
 
-#: src/std-types/string.md:17
+#: src/std-types/string.md
 msgid "\"s3: len = {}, number of chars = {}\""
 msgstr ""
 
-#: src/std-types/string.md:21
+#: src/std-types/string.md
 msgid ""
 "`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
 "string/struct.String.html#deref-methods-str), which means that you can call "
 "all `str` methods on a `String`."
 msgstr ""
 
-#: src/std-types/string.md:30
+#: src/std-types/string.md
 msgid ""
 "`String::new` returns a new empty string, use `String::with_capacity` when "
 "you know how much data you want to push to the string."
 msgstr ""
 
-#: src/std-types/string.md:32
+#: src/std-types/string.md
 msgid ""
 "`String::len` returns the size of the `String` in bytes (which can be "
 "different from its length in characters)."
 msgstr ""
 
-#: src/std-types/string.md:34
+#: src/std-types/string.md
 msgid ""
 "`String::chars` returns an iterator over the actual characters. Note that a "
 "`char` can be different from what a human will consider a \"character\" due "
@@ -6258,58 +6101,58 @@ msgid ""
 "unicode_segmentation/struct.Graphemes.html)."
 msgstr ""
 
-#: src/std-types/string.md:37
+#: src/std-types/string.md
 msgid ""
 "When people refer to strings they could either be talking about `&str` or "
 "`String`."
 msgstr ""
 
-#: src/std-types/string.md:39
+#: src/std-types/string.md
 msgid ""
 "When a type implements `Deref<Target = T>`, the compiler will let you "
 "transparently call methods from `T`."
 msgstr ""
 
-#: src/std-types/string.md:41
+#: src/std-types/string.md
 msgid ""
 "We haven't discussed the `Deref` trait yet, so at this point this mostly "
 "explains the structure of the sidebar in the documentation."
 msgstr ""
 
-#: src/std-types/string.md:43
+#: src/std-types/string.md
 msgid ""
 "`String` implements `Deref<Target = str>` which transparently gives it "
 "access to `str`'s methods."
 msgstr ""
 
-#: src/std-types/string.md:45
+#: src/std-types/string.md
 msgid "Write and compare `let s3 = s1.deref();` and `let s3 = &*s1;`."
 msgstr ""
 
-#: src/std-types/string.md:46
+#: src/std-types/string.md
 msgid ""
 "`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
 "with some extra guarantees."
 msgstr ""
 
-#: src/std-types/string.md:49
+#: src/std-types/string.md
 msgid "Compare the different ways to index a `String`:"
 msgstr ""
 
-#: src/std-types/string.md:50
+#: src/std-types/string.md
 msgid ""
 "To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
 "out-of-bounds."
 msgstr ""
 
-#: src/std-types/string.md:52
+#: src/std-types/string.md
 msgid ""
 "To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
-#: src/std-types/string.md:54
+#: src/std-types/string.md
 msgid ""
 "Many types can be converted to a string with the [`to_string`](https://doc."
 "rust-lang.org/std/string/trait.ToString.html#tymethod.to_string) method. "
@@ -6318,146 +6161,145 @@ msgid ""
 "string."
 msgstr ""
 
-#: src/std-types/vec.md:3
+#: src/std-types/vec.md
 msgid ""
 "[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
 "resizable heap-allocated buffer:"
 msgstr ""
 
-#: src/std-types/vec.md:9
+#: src/std-types/vec.md
 msgid "\"v1: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/vec.md:14
+#: src/std-types/vec.md
 msgid "\"v2: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/vec.md:16
+#: src/std-types/vec.md
 msgid "// Canonical macro to initialize a vector with elements.\n"
 msgstr ""
 
-#: src/std-types/vec.md:19
+#: src/std-types/vec.md
 msgid "// Retain only the even elements.\n"
 msgstr ""
 
-#: src/std-types/vec.md:21 src/std-types/vec.md:25
+#: src/std-types/vec.md
 msgid "\"{v3:?}\""
 msgstr ""
 
-#: src/std-types/vec.md:23
+#: src/std-types/vec.md
 msgid "// Remove consecutive duplicates.\n"
 msgstr ""
 
-#: src/std-types/vec.md:29
+#: src/std-types/vec.md
 msgid ""
 "`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
 "struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
 
-#: src/std-types/vec.md:38
+#: src/std-types/vec.md
 msgid ""
 "`Vec` is a type of collection, along with `String` and `HashMap`. The data "
 "it contains is stored on the heap. This means the amount of data doesn't "
 "need to be known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std-types/vec.md:41
+#: src/std-types/vec.md
 msgid ""
 "Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
 "explicitly. As always with Rust type inference, the `T` was established "
 "during the first `push` call."
 msgstr ""
 
-#: src/std-types/vec.md:44
+#: src/std-types/vec.md
 msgid ""
 "`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
 "supports adding initial elements to the vector."
 msgstr ""
 
-#: src/std-types/vec.md:46
+#: src/std-types/vec.md
 msgid ""
 "To index the vector you use `[` `]`, but they will panic if out of bounds. "
 "Alternatively, using `get` will return an `Option`. The `pop` function will "
 "remove the last element."
 msgstr ""
 
-#: src/std-types/vec.md:49
+#: src/std-types/vec.md
 msgid ""
 "Slices are covered on day 3. For now, students only need to know that a "
 "value of type `Vec` gives access to all of the documented slice methods, too."
 msgstr ""
 
-#: src/std-types/hashmap.md:3
+#: src/std-types/hashmap.md
 msgid "Standard hash map with protection against HashDoS attacks:"
 msgstr ""
 
-#: src/std-types/hashmap.md:10
+#: src/std-types/hashmap.md
 msgid "\"Adventures of Huckleberry Finn\""
 msgstr ""
 
-#: src/std-types/hashmap.md:11
+#: src/std-types/hashmap.md
 msgid "\"Grimms' Fairy Tales\""
 msgstr ""
 
-#: src/std-types/hashmap.md:12 src/std-types/hashmap.md:21
-#: src/std-types/hashmap.md:29
+#: src/std-types/hashmap.md
 msgid "\"Pride and Prejudice\""
 msgstr ""
 
-#: src/std-types/hashmap.md:14
+#: src/std-types/hashmap.md
 msgid "\"Les Misérables\""
 msgstr ""
 
-#: src/std-types/hashmap.md:16
+#: src/std-types/hashmap.md
 msgid "\"We know about {} books, but not Les Misérables.\""
 msgstr ""
 
-#: src/std-types/hashmap.md:21 src/std-types/hashmap.md:29
+#: src/std-types/hashmap.md
 msgid "\"Alice's Adventure in Wonderland\""
 msgstr ""
 
-#: src/std-types/hashmap.md:23
+#: src/std-types/hashmap.md
 msgid "\"{book}: {count} pages\""
 msgstr ""
 
-#: src/std-types/hashmap.md:24
+#: src/std-types/hashmap.md
 msgid "\"{book} is unknown.\""
 msgstr ""
 
-#: src/std-types/hashmap.md:28
+#: src/std-types/hashmap.md
 msgid "// Use the .entry() method to insert a value if nothing is found.\n"
 msgstr ""
 
-#: src/std-types/hashmap.md:34
+#: src/std-types/hashmap.md
 msgid "\"{page_counts:#?}\""
 msgstr ""
 
-#: src/std-types/hashmap.md:41
+#: src/std-types/hashmap.md
 msgid ""
 "`HashMap` is not defined in the prelude and needs to be brought into scope."
 msgstr ""
 
-#: src/std-types/hashmap.md:42
+#: src/std-types/hashmap.md
 msgid ""
 "Try the following lines of code. The first line will see if a book is in the "
 "hashmap and if not return an alternative value. The second line will insert "
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
 
-#: src/std-types/hashmap.md:48 src/std-types/hashmap.md:60
+#: src/std-types/hashmap.md
 msgid "\"Harry Potter and the Sorcerer's Stone\""
 msgstr ""
 
-#: src/std-types/hashmap.md:51 src/std-types/hashmap.md:61
+#: src/std-types/hashmap.md
 msgid "\"The Hunger Games\""
 msgstr ""
 
-#: src/std-types/hashmap.md:54
+#: src/std-types/hashmap.md
 msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
 msgstr ""
 
-#: src/std-types/hashmap.md:55
+#: src/std-types/hashmap.md
 msgid ""
 "Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
 "doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
@@ -6465,26 +6307,26 @@ msgid ""
 "us to easily initialize a hash map from a literal array:"
 msgstr ""
 
-#: src/std-types/hashmap.md:65
+#: src/std-types/hashmap.md
 msgid ""
 "Alternatively HashMap can be built from any `Iterator` which yields key-"
 "value tuples."
 msgstr ""
 
-#: src/std-types/hashmap.md:67
+#: src/std-types/hashmap.md
 msgid ""
 "We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
 "examples easier. Using references in collections can, of course, be done, "
 "but it can lead into complications with the borrow checker."
 msgstr ""
 
-#: src/std-types/hashmap.md:70
+#: src/std-types/hashmap.md
 msgid ""
 "Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
-#: src/std-types/hashmap.md:73
+#: src/std-types/hashmap.md
 msgid ""
 "This type has several \"method-specific\" return types, such as `std::"
 "collections::hash_map::Keys`. These types often appear in searches of the "
@@ -6492,7 +6334,7 @@ msgid ""
 "to the `keys` method."
 msgstr ""
 
-#: src/std-types/exercise.md:3
+#: src/std-types/exercise.md
 msgid ""
 "In this exercise you will take a very simple data structure and make it "
 "generic. It uses a [`std::collections::HashMap`](https://doc.rust-lang.org/"
@@ -6500,200 +6342,198 @@ msgid ""
 "have been seen and how many times each one has appeared."
 msgstr ""
 
-#: src/std-types/exercise.md:9
+#: src/std-types/exercise.md
 msgid ""
 "The initial version of `Counter` is hard coded to only work for `u32` "
 "values. Make the struct and its methods generic over the type of value being "
 "tracked, that way `Counter` can track any type of value."
 msgstr ""
 
-#: src/std-types/exercise.md:13
+#: src/std-types/exercise.md
 msgid ""
 "If you finish early, try using the [`entry`](https://doc.rust-lang.org/"
 "stable/std/collections/struct.HashMap.html#method.entry) method to halve the "
 "number of hash lookups required to implement the `count` method."
 msgstr ""
 
-#: src/std-types/exercise.md:20 src/std-types/solution.md:6
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid ""
 "/// Counter counts the number of times each value of type T has been seen.\n"
 msgstr ""
 
-#: src/std-types/exercise.md:27 src/std-types/solution.md:13
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Create a new Counter.\n"
 msgstr ""
 
-#: src/std-types/exercise.md:34 src/std-types/solution.md:18
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Count an occurrence of the given value.\n"
 msgstr ""
 
-#: src/std-types/exercise.md:43 src/std-types/solution.md:23
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Return the number of times the given value has been seen.\n"
 msgstr ""
 
-#: src/std-types/exercise.md:59 src/std-types/solution.md:39
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"saw {} values equal to {}\""
 msgstr ""
 
-#: src/std-types/exercise.md:63 src/std-types/exercise.md:65
-#: src/std-types/exercise.md:66 src/std-types/solution.md:43
-#: src/std-types/solution.md:45 src/std-types/solution.md:46
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"apple\""
 msgstr ""
 
-#: src/std-types/exercise.md:64 src/std-types/solution.md:44
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"orange\""
 msgstr ""
 
-#: src/std-types/exercise.md:66 src/std-types/solution.md:46
+#: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"got {} apples\""
 msgstr ""
 
-#: src/std-traits.md:3
+#: src/std-traits.md
 msgid "This segment should take about 1 hour and 40 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 40 phút, bao gồm:"
 
-#: src/std-traits.md:9
+#: src/std-traits.md
 msgid "From and Into"
 msgstr ""
 
-#: src/std-traits.md:11
+#: src/std-traits.md
 msgid "Read and Write"
 msgstr ""
 
-#: src/std-traits.md:12
+#: src/std-traits.md
 msgid "Default, struct update syntax"
 msgstr ""
 
-#: src/std-traits.md:19
+#: src/std-traits.md
 msgid ""
 "As with the standard-library types, spend time reviewing the documentation "
 "for each trait."
 msgstr ""
 
-#: src/std-traits.md:22
+#: src/std-traits.md
 msgid "This section is long. Take a break midway through."
 msgstr ""
 
-#: src/std-traits/comparisons.md:3
+#: src/std-traits/comparisons.md
 msgid ""
 "These traits support comparisons between values. All traits can be derived "
 "for types containing fields that implement these traits."
 msgstr ""
 
-#: src/std-traits/comparisons.md:6
+#: src/std-traits/comparisons.md
 msgid "`PartialEq` and `Eq`"
 msgstr ""
 
-#: src/std-traits/comparisons.md:8
+#: src/std-traits/comparisons.md
 msgid ""
 "`PartialEq` is a partial equivalence relation, with required method `eq` and "
 "provided method `ne`. The `==` and `!=` operators will call these methods."
 msgstr ""
 
-#: src/std-traits/comparisons.md:23
+#: src/std-traits/comparisons.md
 msgid ""
 "`Eq` is a full equivalence relation (reflexive, symmetric, and transitive) "
 "and implies `PartialEq`. Functions that require full equivalence will use "
 "`Eq` as a trait bound."
 msgstr ""
 
-#: src/std-traits/comparisons.md:27
+#: src/std-traits/comparisons.md
 msgid "`PartialOrd` and `Ord`"
 msgstr ""
 
-#: src/std-traits/comparisons.md:29
+#: src/std-traits/comparisons.md
 msgid ""
 "`PartialOrd` defines a partial ordering, with a `partial_cmp` method. It is "
 "used to implement the `<`, `<=`, `>=`, and `>` operators."
 msgstr ""
 
-#: src/std-traits/comparisons.md:49
+#: src/std-traits/comparisons.md
 msgid "`Ord` is a total ordering, with `cmp` returning `Ordering`."
 msgstr ""
 
-#: src/std-traits/comparisons.md:54
+#: src/std-traits/comparisons.md
 msgid ""
 "`PartialEq` can be implemented between different types, but `Eq` cannot, "
 "because it is reflexive:"
 msgstr ""
 
-#: src/std-traits/comparisons.md:69
+#: src/std-traits/comparisons.md
 msgid ""
 "In practice, it's common to derive these traits, but uncommon to implement "
 "them."
 msgstr ""
 
-#: src/std-traits/operators.md:3
+#: src/std-traits/operators.md
 msgid ""
 "Operator overloading is implemented via traits in [`std::ops`](https://doc."
 "rust-lang.org/std/ops/index.html):"
 msgstr ""
 
-#: src/std-traits/operators.md:23
+#: src/std-traits/operators.md
 msgid "\"{:?} + {:?} = {:?}\""
 msgstr ""
 
-#: src/std-traits/operators.md:30 src/memory-management/drop.md:48
+#: src/std-traits/operators.md src/memory-management/drop.md
 msgid "Discussion points:"
 msgstr ""
 
-#: src/std-traits/operators.md:32
+#: src/std-traits/operators.md
 msgid ""
 "You could implement `Add` for `&Point`. In which situations is that useful?"
 msgstr ""
 
-#: src/std-traits/operators.md:33
+#: src/std-traits/operators.md
 msgid ""
 "Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
 "the operator is not `Copy`, you should consider overloading the operator for "
 "`&T` as well. This avoids unnecessary cloning on the call site."
 msgstr ""
 
-#: src/std-traits/operators.md:36
+#: src/std-traits/operators.md
 msgid ""
 "Why is `Output` an associated type? Could it be made a type parameter of the "
 "method?"
 msgstr ""
 
-#: src/std-traits/operators.md:38
+#: src/std-traits/operators.md
 msgid ""
 "Short answer: Function type parameters are controlled by the caller, but "
 "associated types (like `Output`) are controlled by the implementer of a "
 "trait."
 msgstr ""
 
-#: src/std-traits/operators.md:41
+#: src/std-traits/operators.md
 msgid ""
 "You could implement `Add` for two different types, e.g. `impl Add<(i32, "
 "i32)> for Point` would add a tuple to a `Point`."
 msgstr ""
 
-#: src/std-traits/from-and-into.md:3
+#: src/std-traits/from-and-into.md
 msgid ""
 "Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
 "html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
 "facilitate type conversions:"
 msgstr ""
 
-#: src/std-traits/from-and-into.md:11 src/std-traits/from-and-into.md:23
+#: src/std-traits/from-and-into.md
 msgid "\"{s}, {addr}, {one}, {bigger}\""
 msgstr ""
 
-#: src/std-traits/from-and-into.md:15
+#: src/std-traits/from-and-into.md
 msgid ""
 "[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
 "automatically implemented when [`From`](https://doc.rust-lang.org/std/"
 "convert/trait.From.html) is implemented:"
 msgstr ""
 
-#: src/std-traits/from-and-into.md:30
+#: src/std-traits/from-and-into.md
 msgid ""
 "That's why it is common to only implement `From`, as your type will get "
 "`Into` implementation too."
 msgstr ""
 
-#: src/std-traits/from-and-into.md:32
+#: src/std-traits/from-and-into.md
 msgid ""
 "When declaring a function argument input type like \"anything that can be "
 "converted into a `String`\", the rule is opposite, you should use `Into`. "
@@ -6701,32 +6541,32 @@ msgid ""
 "implement `Into`."
 msgstr ""
 
-#: src/std-traits/casting.md:3
+#: src/std-traits/casting.md
 msgid ""
 "Rust has no _implicit_ type conversions, but does support explicit casts "
 "with `as`. These generally follow C semantics where those are defined."
 msgstr ""
 
-#: src/std-traits/casting.md:9
+#: src/std-traits/casting.md
 msgid "\"as u16: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md:10
+#: src/std-traits/casting.md
 msgid "\"as i16: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md:11
+#: src/std-traits/casting.md
 msgid "\"as u8: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md:15
+#: src/std-traits/casting.md
 msgid ""
 "The results of `as` are _always_ defined in Rust and consistent across "
 "platforms. This might not match your intuition for changing sign or casting "
 "to a smaller type -- check the docs, and comment for clarity."
 msgstr ""
 
-#: src/std-traits/casting.md:19
+#: src/std-traits/casting.md
 msgid ""
 "Casting with `as` is a relatively sharp tool that is easy to use "
 "incorrectly, and can be a source of subtle bugs as future maintenance work "
@@ -6736,7 +6576,7 @@ msgid ""
 "was in the high bits)."
 msgstr ""
 
-#: src/std-traits/casting.md:25
+#: src/std-traits/casting.md
 msgid ""
 "For infallible casts (e.g. `u32` to `u64`), prefer using `From` or `Into` "
 "over `as` to confirm that the cast is in fact infallible. For fallible "
@@ -6744,124 +6584,124 @@ msgid ""
 "that fit differently from those that don't."
 msgstr ""
 
-#: src/std-traits/casting.md:33
+#: src/std-traits/casting.md
 msgid "Consider taking a break after this slide."
 msgstr ""
 
-#: src/std-traits/casting.md:35
+#: src/std-traits/casting.md
 msgid ""
 "`as` is similar to a C++ static cast. Use of `as` in cases where data might "
 "be lost is generally discouraged, or at least deserves an explanatory "
 "comment."
 msgstr ""
 
-#: src/std-traits/casting.md:38
+#: src/std-traits/casting.md
 msgid "This is common in casting integers to `usize` for use as an index."
 msgstr ""
 
-#: src/std-traits/read-and-write.md:3
+#: src/std-traits/read-and-write.md
 msgid ""
 "Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
 "[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
 "abstract over `u8` sources:"
 msgstr ""
 
-#: src/std-traits/read-and-write.md:14
+#: src/std-traits/read-and-write.md
 msgid "b\"foo\\nbar\\nbaz\\n\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md:15
+#: src/std-traits/read-and-write.md
 msgid "\"lines in slice: {}\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md:18
+#: src/std-traits/read-and-write.md
 msgid "\"lines in file: {}\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md:23
+#: src/std-traits/read-and-write.md
 msgid ""
 "Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
 "you abstract over `u8` sinks:"
 msgstr ""
 
-#: src/std-traits/read-and-write.md:30
+#: src/std-traits/read-and-write.md
 msgid "\"\\n\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md:37
+#: src/std-traits/read-and-write.md
 msgid "\"Logged: {:?}\""
 msgstr ""
 
-#: src/std-traits/default.md:1
+#: src/std-traits/default.md
 msgid "The `Default` Trait"
 msgstr ""
 
-#: src/std-traits/default.md:3
+#: src/std-traits/default.md
 msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
 "produces a default value for a type."
 msgstr ""
 
-#: src/std-traits/default.md:18
+#: src/std-traits/default.md
 msgid "\"John Smith\""
 msgstr ""
 
-#: src/std-traits/default.md:24
+#: src/std-traits/default.md
 msgid "\"{default_struct:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md:27
+#: src/std-traits/default.md
 msgid "\"Y is set!\""
 msgstr ""
 
-#: src/std-traits/default.md:28
+#: src/std-traits/default.md
 msgid "\"{almost_default_struct:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md:31 src/lifetimes/exercise.md:211
-#: src/lifetimes/solution.md:214
+#: src/std-traits/default.md src/lifetimes/exercise.md
+#: src/lifetimes/solution.md
 msgid "\"{:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md:38
+#: src/std-traits/default.md
 msgid ""
 "It can be implemented directly or it can be derived via `#[derive(Default)]`."
 msgstr ""
 
-#: src/std-traits/default.md:39
+#: src/std-traits/default.md
 msgid ""
 "A derived implementation will produce a value where all fields are set to "
 "their default values."
 msgstr ""
 
-#: src/std-traits/default.md:41
+#: src/std-traits/default.md
 msgid "This means all types in the struct must implement `Default` too."
 msgstr ""
 
-#: src/std-traits/default.md:42
+#: src/std-traits/default.md
 msgid ""
 "Standard Rust types often implement `Default` with reasonable values (e.g. "
 "`0`, `\"\"`, etc)."
 msgstr ""
 
-#: src/std-traits/default.md:44
+#: src/std-traits/default.md
 msgid "The partial struct initialization works nicely with default."
 msgstr ""
 
-#: src/std-traits/default.md:45
+#: src/std-traits/default.md
 msgid ""
 "The Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
 
-#: src/std-traits/default.md:47
+#: src/std-traits/default.md
 msgid ""
 "The `..` syntax is called [struct update syntax](https://doc.rust-lang.org/"
 "book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
 "with-struct-update-syntax)."
 msgstr ""
 
-#: src/std-traits/closures.md:3
+#: src/std-traits/closures.md
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
 "they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
@@ -6869,87 +6709,86 @@ msgid ""
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
-#: src/std-traits/closures.md:10
+#: src/std-traits/closures.md
 msgid "\"Calling function on {input}\""
 msgstr ""
 
-#: src/std-traits/closures.md:16 src/std-traits/closures.md:17
+#: src/std-traits/closures.md
 msgid "\"add_3: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md:24 src/std-traits/closures.md:25
+#: src/std-traits/closures.md
 msgid "\"accumulate: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md:28
+#: src/std-traits/closures.md
 msgid "\"multiply_sum: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md:35
+#: src/std-traits/closures.md
 msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
 "perhaps captures nothing at all. It can be called multiple times "
 "concurrently."
 msgstr ""
 
-#: src/std-traits/closures.md:38
+#: src/std-traits/closures.md
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
 "multiple times, but not concurrently."
 msgstr ""
 
-#: src/std-traits/closures.md:41
+#: src/std-traits/closures.md
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
 "might consume captured values."
 msgstr ""
 
-#: src/std-traits/closures.md:44
+#: src/std-traits/closures.md
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
 "I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
 "use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 
-#: src/std-traits/closures.md:48
+#: src/std-traits/closures.md
 msgid ""
 "When you define a function that takes a closure, you should take `FnOnce` if "
 "you can (i.e. you call it once), or `FnMut` else, and last `Fn`. This allows "
 "the most flexibility for the caller."
 msgstr ""
 
-#: src/std-traits/closures.md:52
+#: src/std-traits/closures.md
 msgid ""
 "In contrast, when you have a closure, the most flexible you can have is `Fn` "
 "(it can be passed everywhere), then `FnMut`, and lastly `FnOnce`."
 msgstr ""
 
-#: src/std-traits/closures.md:55
+#: src/std-traits/closures.md
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
 "`multiply_sum`), depending on what the closure captures."
 msgstr ""
 
-#: src/std-traits/closures.md:58
+#: src/std-traits/closures.md
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
 "keyword makes them capture by value."
 msgstr ""
 
-#: src/std-traits/closures.md:63 src/smart-pointers/trait-objects.md:91
-#: src/smart-pointers/trait-objects.md:92
+#: src/std-traits/closures.md src/smart-pointers/trait-objects.md
 msgid "\"{} {}\""
 msgstr ""
 
-#: src/std-traits/closures.md:67
+#: src/std-traits/closures.md
 msgid "\"Hi\""
 msgstr ""
 
-#: src/std-traits/closures.md:68
+#: src/std-traits/closures.md
 msgid "\"Greg\""
 msgstr ""
 
-#: src/std-traits/exercise.md:3
+#: src/std-traits/exercise.md
 msgid ""
 "In this example, you will implement the classic [\"ROT13\" cipher](https://"
 "en.wikipedia.org/wiki/ROT13). Copy this code to the playground, and "
@@ -6957,48 +6796,47 @@ msgid ""
 "ensure the result is still valid UTF-8."
 msgstr ""
 
-#: src/std-traits/exercise.md:15
+#: src/std-traits/exercise.md
 msgid "// Implement the `Read` trait for `RotDecoder`.\n"
 msgstr ""
 
-#: src/std-traits/exercise.md:20 src/std-traits/exercise.md:33
-#: src/std-traits/solution.md:26 src/std-traits/solution.md:39
+#: src/std-traits/exercise.md src/std-traits/solution.md
 msgid "\"Gb trg gb gur bgure fvqr!\""
 msgstr ""
 
-#: src/std-traits/exercise.md:36 src/std-traits/solution.md:42
+#: src/std-traits/exercise.md src/std-traits/solution.md
 msgid "\"To get to the other side!\""
 msgstr ""
 
-#: src/std-traits/exercise.md:55
+#: src/std-traits/exercise.md
 msgid ""
 "What happens if you chain two `RotDecoder` instances together, each rotating "
 "by 13 characters?"
 msgstr ""
 
-#: src/std-traits/solution.md:16
+#: src/std-traits/solution.md
 msgid "'A'"
 msgstr ""
 
-#: src/welcome-day-3.md:1
+#: src/welcome-day-3.md
 msgid "Welcome to Day 3"
 msgstr ""
 
-#: src/welcome-day-3.md:3
+#: src/welcome-day-3.md
 msgid "Today, we will cover:"
 msgstr ""
 
-#: src/welcome-day-3.md:5
+#: src/welcome-day-3.md
 msgid ""
 "Memory management, lifetimes, and the borrow checker: how Rust ensures "
 "memory safety."
 msgstr ""
 
-#: src/welcome-day-3.md:7
+#: src/welcome-day-3.md
 msgid "Smart pointers: standard library pointer types."
 msgstr ""
 
-#: src/welcome-day-3.md:11
+#: src/welcome-day-3.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 20 "
 "minutes. It contains:"
@@ -7006,67 +6844,67 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 2 tiếng và 20 phút, bao gồm thời gian 10 phút "
 "nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/memory-management.md:11 src/memory-management/clone.md:1
+#: src/memory-management.md src/memory-management/clone.md
 msgid "Clone"
 msgstr ""
 
-#: src/memory-management.md:13
+#: src/memory-management.md
 msgid "Drop"
 msgstr ""
 
-#: src/memory-management/review.md:3
+#: src/memory-management/review.md
 msgid "Programs allocate memory in two ways:"
 msgstr ""
 
-#: src/memory-management/review.md:5
+#: src/memory-management/review.md
 msgid "Stack: Continuous area of memory for local variables."
 msgstr ""
 
-#: src/memory-management/review.md:6
+#: src/memory-management/review.md
 msgid "Values have fixed sizes known at compile time."
 msgstr ""
 
-#: src/memory-management/review.md:7
+#: src/memory-management/review.md
 msgid "Extremely fast: just move a stack pointer."
 msgstr ""
 
-#: src/memory-management/review.md:8
+#: src/memory-management/review.md
 msgid "Easy to manage: follows function calls."
 msgstr ""
 
-#: src/memory-management/review.md:9
+#: src/memory-management/review.md
 msgid "Great memory locality."
 msgstr ""
 
-#: src/memory-management/review.md:11
+#: src/memory-management/review.md
 msgid "Heap: Storage of values outside of function calls."
 msgstr ""
 
-#: src/memory-management/review.md:12
+#: src/memory-management/review.md
 msgid "Values have dynamic sizes determined at runtime."
 msgstr ""
 
-#: src/memory-management/review.md:13
+#: src/memory-management/review.md
 msgid "Slightly slower than the stack: some book-keeping needed."
 msgstr ""
 
-#: src/memory-management/review.md:14
+#: src/memory-management/review.md
 msgid "No guarantee of memory locality."
 msgstr ""
 
-#: src/memory-management/review.md:18
+#: src/memory-management/review.md
 msgid ""
 "Creating a `String` puts fixed-sized metadata on the stack and dynamically "
 "sized data, the actual string, on the heap:"
 msgstr ""
 
-#: src/memory-management/review.md:44
+#: src/memory-management/review.md
 msgid ""
 "Mention that a `String` is backed by a `Vec`, so it has a capacity and "
 "length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/review.md:47
+#: src/memory-management/review.md
 msgid ""
 "If students ask about it, you can mention that the underlying memory is heap "
 "allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
@@ -7074,21 +6912,21 @@ msgid ""
 "[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
 
-#: src/memory-management/review.md:53
+#: src/memory-management/review.md
 msgid ""
 "We can inspect the memory layout with `unsafe` Rust. However, you should "
 "point out that this is rightfully unsafe!"
 msgstr ""
 
-#: src/memory-management/review.md:59 src/testing/unit-tests.md:15
+#: src/memory-management/review.md src/testing/unit-tests.md
 msgid "' '"
 msgstr ""
 
-#: src/memory-management/review.md:60
+#: src/memory-management/review.md
 msgid "\"world\""
 msgstr ""
 
-#: src/memory-management/review.md:61
+#: src/memory-management/review.md
 msgid ""
 "// DON'T DO THIS AT HOME! For educational purposes only.\n"
 "    // String provides no guarantees about its layout, so this could lead "
@@ -7096,76 +6934,76 @@ msgid ""
 "    // undefined behavior.\n"
 msgstr ""
 
-#: src/memory-management/review.md:66
+#: src/memory-management/review.md
 msgid "\"capacity = {capacity}, ptr = {ptr:#x}, len = {len}\""
 msgstr ""
 
-#: src/memory-management/approaches.md:3
+#: src/memory-management/approaches.md
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr ""
 
-#: src/memory-management/approaches.md:5
+#: src/memory-management/approaches.md
 msgid "Full control via manual memory management: C, C++, Pascal, ..."
 msgstr ""
 
-#: src/memory-management/approaches.md:6
+#: src/memory-management/approaches.md
 msgid "Programmer decides when to allocate or free heap memory."
 msgstr ""
 
-#: src/memory-management/approaches.md:7
+#: src/memory-management/approaches.md
 msgid ""
 "Programmer must determine whether a pointer still points to valid memory."
 msgstr ""
 
-#: src/memory-management/approaches.md:8
+#: src/memory-management/approaches.md
 msgid "Studies show, programmers make mistakes."
 msgstr ""
 
-#: src/memory-management/approaches.md:9
+#: src/memory-management/approaches.md
 msgid ""
 "Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
 
-#: src/memory-management/approaches.md:11
+#: src/memory-management/approaches.md
 msgid ""
 "A runtime system ensures that memory is not freed until it can no longer be "
 "referenced."
 msgstr ""
 
-#: src/memory-management/approaches.md:13
+#: src/memory-management/approaches.md
 msgid ""
 "Typically implemented with reference counting, garbage collection, or RAII."
 msgstr ""
 
-#: src/memory-management/approaches.md:15
+#: src/memory-management/approaches.md
 msgid "Rust offers a new mix:"
 msgstr ""
 
-#: src/memory-management/approaches.md:17
+#: src/memory-management/approaches.md
 msgid ""
 "Full control _and_ safety via compile time enforcement of correct memory "
 "management."
 msgstr ""
 
-#: src/memory-management/approaches.md:20
+#: src/memory-management/approaches.md
 msgid "It does this with an explicit ownership concept."
 msgstr ""
 
-#: src/memory-management/approaches.md:25
+#: src/memory-management/approaches.md
 msgid ""
 "This slide is intended to help students coming from other languages to put "
 "Rust in context."
 msgstr ""
 
-#: src/memory-management/approaches.md:28
+#: src/memory-management/approaches.md
 msgid ""
 "C must manage heap manually with `malloc` and `free`. Common errors include "
 "forgetting to call `free`, calling it multiple times for the same pointer, "
 "or dereferencing a pointer after the memory it points to has been freed."
 msgstr ""
 
-#: src/memory-management/approaches.md:32
+#: src/memory-management/approaches.md
 msgid ""
 "C++ has tools like smart pointers (`unique_ptr`, `shared_ptr`) that take "
 "advantage of language guarantees about calling destructors to ensure memory "
@@ -7173,7 +7011,7 @@ msgid ""
 "tools and create similar bugs to C."
 msgstr ""
 
-#: src/memory-management/approaches.md:37
+#: src/memory-management/approaches.md
 msgid ""
 "Java, Go, and Python rely on the garbage collector to identify memory that "
 "is no longer reachable and discard it. This guarantees that any pointer can "
@@ -7181,7 +7019,7 @@ msgid ""
 "GC has a runtime cost and is difficult to tune properly."
 msgstr ""
 
-#: src/memory-management/approaches.md:42
+#: src/memory-management/approaches.md
 msgid ""
 "Rust's ownership and borrowing model can, in many cases, get the performance "
 "of C, with alloc and free operations precisely where they are required -- "
@@ -7191,64 +7029,64 @@ msgid ""
 "(not covered in this class)."
 msgstr ""
 
-#: src/memory-management/ownership.md:3
+#: src/memory-management/ownership.md
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
 "to use a variable outside its scope:"
 msgstr ""
 
-#: src/memory-management/ownership.md:20
+#: src/memory-management/ownership.md
 msgid ""
 "We say that the variable _owns_ the value. Every Rust value has precisely "
 "one owner at all times."
 msgstr ""
 
-#: src/memory-management/ownership.md:23
+#: src/memory-management/ownership.md
 msgid ""
 "At the end of the scope, the variable is _dropped_ and the data is freed. A "
 "destructor can run here to free up resources."
 msgstr ""
 
-#: src/memory-management/ownership.md:29
+#: src/memory-management/ownership.md
 msgid ""
 "Students familiar with garbage-collection implementations will know that a "
 "garbage collector starts with a set of \"roots\" to find all reachable "
 "memory. Rust's \"single owner\" principle is a similar idea."
 msgstr ""
 
-#: src/memory-management/move.md:3
+#: src/memory-management/move.md
 msgid "An assignment will transfer _ownership_ between variables:"
 msgstr ""
 
-#: src/memory-management/move.md:7
+#: src/memory-management/move.md
 msgid "\"Hello!\""
 msgstr ""
 
-#: src/memory-management/move.md:10
+#: src/memory-management/move.md
 msgid "// println!(\"s1: {s1}\");\n"
 msgstr ""
 
-#: src/memory-management/move.md:14
+#: src/memory-management/move.md
 msgid "The assignment of `s1` to `s2` transfers ownership."
 msgstr ""
 
-#: src/memory-management/move.md:15
+#: src/memory-management/move.md
 msgid "When `s1` goes out of scope, nothing happens: it does not own anything."
 msgstr ""
 
-#: src/memory-management/move.md:16
+#: src/memory-management/move.md
 msgid "When `s2` goes out of scope, the string data is freed."
 msgstr ""
 
-#: src/memory-management/move.md:18
+#: src/memory-management/move.md
 msgid "Before move to `s2`:"
 msgstr ""
 
-#: src/memory-management/move.md:35
+#: src/memory-management/move.md
 msgid "After move to `s2`:"
 msgstr ""
 
-#: src/memory-management/move.md:37
+#: src/memory-management/move.md
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -7272,122 +7110,122 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management/move.md:58
+#: src/memory-management/move.md
 msgid ""
 "When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 
-#: src/memory-management/move.md:63 src/memory-management/clone.md:8
+#: src/memory-management/move.md src/memory-management/clone.md
 msgid "\"Hello {name}\""
 msgstr ""
 
-#: src/memory-management/move.md:67 src/memory-management/clone.md:12
-#: src/android/interoperability/java.md:57
+#: src/memory-management/move.md src/memory-management/clone.md
+#: src/android/interoperability/java.md
 msgid "\"Alice\""
 msgstr ""
 
-#: src/memory-management/move.md:69
+#: src/memory-management/move.md
 msgid "// say_hello(name);\n"
 msgstr ""
 
-#: src/memory-management/move.md:76
+#: src/memory-management/move.md
 msgid ""
 "Mention that this is the opposite of the defaults in C++, which copies by "
 "value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
 
-#: src/memory-management/move.md:79
+#: src/memory-management/move.md
 msgid ""
 "It is only the ownership that moves. Whether any machine code is generated "
 "to manipulate the data itself is a matter of optimization, and such copies "
 "are aggressively optimized away."
 msgstr ""
 
-#: src/memory-management/move.md:83
+#: src/memory-management/move.md
 msgid ""
 "Simple values (such as integers) can be marked `Copy` (see later slides)."
 msgstr ""
 
-#: src/memory-management/move.md:85
+#: src/memory-management/move.md
 msgid "In Rust, clones are explicit (by using `clone`)."
 msgstr ""
 
-#: src/memory-management/move.md:87
+#: src/memory-management/move.md
 msgid "In the `say_hello` example:"
 msgstr ""
 
-#: src/memory-management/move.md:89
+#: src/memory-management/move.md
 msgid ""
 "With the first call to `say_hello`, `main` gives up ownership of `name`. "
 "Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
 
-#: src/memory-management/move.md:91
+#: src/memory-management/move.md
 msgid ""
 "The heap memory allocated for `name` will be freed at the end of the "
 "`say_hello` function."
 msgstr ""
 
-#: src/memory-management/move.md:93
+#: src/memory-management/move.md
 msgid ""
 "`main` can retain ownership if it passes `name` as a reference (`&name`) and "
 "if `say_hello` accepts a reference as a parameter."
 msgstr ""
 
-#: src/memory-management/move.md:95
+#: src/memory-management/move.md
 msgid ""
 "Alternatively, `main` can pass a clone of `name` in the first call (`name."
 "clone()`)."
 msgstr ""
 
-#: src/memory-management/move.md:97
+#: src/memory-management/move.md
 msgid ""
 "Rust makes it harder than C++ to inadvertently create copies by making move "
 "semantics the default, and by forcing programmers to make clones explicit."
 msgstr ""
 
-#: src/memory-management/move.md:102
+#: src/memory-management/move.md
 msgid "Defensive Copies in Modern C++"
 msgstr ""
 
-#: src/memory-management/move.md:104
+#: src/memory-management/move.md
 msgid "Modern C++ solves this differently:"
 msgstr ""
 
-#: src/memory-management/move.md:107
+#: src/memory-management/move.md
 msgid "\"Cpp\""
 msgstr ""
 
-#: src/memory-management/move.md:108
+#: src/memory-management/move.md
 msgid "// Duplicate the data in s1.\n"
 msgstr ""
 
-#: src/memory-management/move.md:111
+#: src/memory-management/move.md
 msgid ""
 "The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
 
-#: src/memory-management/move.md:112
+#: src/memory-management/move.md
 msgid "When `s1` and `s2` go out of scope, they each free their own memory."
 msgstr ""
 
-#: src/memory-management/move.md:114
+#: src/memory-management/move.md
 msgid "Before copy-assignment:"
 msgstr ""
 
-#: src/memory-management/move.md:130
+#: src/memory-management/move.md
 msgid "After copy-assignment:"
 msgstr ""
 
-#: src/memory-management/move.md:155
+#: src/memory-management/move.md
 msgid ""
 "C++ has made a slightly different choice than Rust. Because `=` copies data, "
 "the string data has to be cloned. Otherwise we would get a double-free when "
 "either string goes out of scope."
 msgstr ""
 
-#: src/memory-management/move.md:159
+#: src/memory-management/move.md
 msgid ""
 "C++ also has [`std::move`](https://en.cppreference.com/w/cpp/utility/move), "
 "which is used to indicate when a value may be moved from. If the example had "
@@ -7396,172 +7234,171 @@ msgid ""
 "programmer is allowed to keep using `s1`."
 msgstr ""
 
-#: src/memory-management/move.md:164
+#: src/memory-management/move.md
 msgid ""
 "Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
 "which is being copied or moved."
 msgstr ""
 
-#: src/memory-management/clone.md:3
+#: src/memory-management/clone.md
 msgid ""
 "Sometimes you _want_ to make a copy of a value. The `Clone` trait "
 "accomplishes this."
 msgstr ""
 
-#: src/memory-management/clone.md:21
+#: src/memory-management/clone.md
 msgid ""
 "The idea of `Clone` is to make it easy to spot where heap allocations are "
 "occurring. Look for `.clone()` and a few others like `vec!` or `Box::new`."
 msgstr ""
 
-#: src/memory-management/clone.md:24
+#: src/memory-management/clone.md
 msgid ""
 "It's common to \"clone your way out\" of problems with the borrow checker, "
 "and return later to try to optimize those clones away."
 msgstr ""
 
-#: src/memory-management/clone.md:27
+#: src/memory-management/clone.md
 msgid ""
 "`clone` generally performs a deep copy of the value, meaning that if you e."
 "g. clone an array, all of the elements of the array are cloned as well."
 msgstr ""
 
-#: src/memory-management/clone.md:30
+#: src/memory-management/clone.md
 msgid ""
 "The behavior for `clone` is user-defined, so it can perform custom cloning "
 "logic if needed."
 msgstr ""
 
-#: src/memory-management/copy-types.md:3
+#: src/memory-management/copy-types.md
 msgid ""
 "While move semantics are the default, certain types are copied by default:"
 msgstr ""
 
-#: src/memory-management/copy-types.md:16
+#: src/memory-management/copy-types.md
 msgid "These types implement the `Copy` trait."
 msgstr ""
 
-#: src/memory-management/copy-types.md:18
+#: src/memory-management/copy-types.md
 msgid "You can opt-in your own types to use copy semantics:"
 msgstr ""
 
-#: src/memory-management/copy-types.md:34
+#: src/memory-management/copy-types.md
 msgid "After the assignment, both `p1` and `p2` own their own data."
 msgstr ""
 
-#: src/memory-management/copy-types.md:35
+#: src/memory-management/copy-types.md
 msgid "We can also use `p1.clone()` to explicitly copy the data."
 msgstr ""
 
-#: src/memory-management/copy-types.md:40
+#: src/memory-management/copy-types.md
 msgid "Copying and cloning are not the same thing:"
 msgstr ""
 
-#: src/memory-management/copy-types.md:42
+#: src/memory-management/copy-types.md
 msgid ""
 "Copying refers to bitwise copies of memory regions and does not work on "
 "arbitrary objects."
 msgstr ""
 
-#: src/memory-management/copy-types.md:44
+#: src/memory-management/copy-types.md
 msgid ""
 "Copying does not allow for custom logic (unlike copy constructors in C++)."
 msgstr ""
 
-#: src/memory-management/copy-types.md:45
+#: src/memory-management/copy-types.md
 msgid ""
 "Cloning is a more general operation and also allows for custom behavior by "
 "implementing the `Clone` trait."
 msgstr ""
 
-#: src/memory-management/copy-types.md:47
+#: src/memory-management/copy-types.md
 msgid "Copying does not work on types that implement the `Drop` trait."
 msgstr ""
 
-#: src/memory-management/copy-types.md:49
+#: src/memory-management/copy-types.md
 msgid "In the above example, try the following:"
 msgstr ""
 
-#: src/memory-management/copy-types.md:51
+#: src/memory-management/copy-types.md
 msgid ""
 "Add a `String` field to `struct Point`. It will not compile because `String` "
 "is not a `Copy` type."
 msgstr ""
 
-#: src/memory-management/copy-types.md:53
+#: src/memory-management/copy-types.md
 msgid ""
 "Remove `Copy` from the `derive` attribute. The compiler error is now in the "
 "`println!` for `p1`."
 msgstr ""
 
-#: src/memory-management/copy-types.md:55
+#: src/memory-management/copy-types.md
 msgid "Show that it works if you clone `p1` instead."
 msgstr ""
 
-#: src/memory-management/drop.md:1
+#: src/memory-management/drop.md
 msgid "The `Drop` Trait"
 msgstr ""
 
-#: src/memory-management/drop.md:3
+#: src/memory-management/drop.md
 msgid ""
 "Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
 "html) can specify code to run when they go out of scope:"
 msgstr ""
 
-#: src/memory-management/drop.md:13
+#: src/memory-management/drop.md
 msgid "\"Dropping {}\""
 msgstr ""
 
-#: src/memory-management/drop.md:18
-#: src/concurrency/sync-exercises/link-checker.md:85
-#: src/concurrency/sync-exercises/solutions.md:121
+#: src/memory-management/drop.md src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"a\""
 msgstr ""
 
-#: src/memory-management/drop.md:20 src/android/testing/googletest.md:12
+#: src/memory-management/drop.md src/android/testing/googletest.md
 msgid "\"b\""
 msgstr ""
 
-#: src/memory-management/drop.md:22
+#: src/memory-management/drop.md
 msgid "\"c\""
 msgstr ""
 
-#: src/memory-management/drop.md:23
+#: src/memory-management/drop.md
 msgid "\"d\""
 msgstr ""
 
-#: src/memory-management/drop.md:24
+#: src/memory-management/drop.md
 msgid "\"Exiting block B\""
 msgstr ""
 
-#: src/memory-management/drop.md:26
+#: src/memory-management/drop.md
 msgid "\"Exiting block A\""
 msgstr ""
 
-#: src/memory-management/drop.md:29
+#: src/memory-management/drop.md
 msgid "\"Exiting main\""
 msgstr ""
 
-#: src/memory-management/drop.md:36
+#: src/memory-management/drop.md
 msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
 msgstr ""
 
-#: src/memory-management/drop.md:37
+#: src/memory-management/drop.md
 msgid "Values are automatically dropped when they go out of scope."
 msgstr ""
 
-#: src/memory-management/drop.md:38
+#: src/memory-management/drop.md
 msgid ""
 "When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
 "drop` implementation will be called."
 msgstr ""
 
-#: src/memory-management/drop.md:40
+#: src/memory-management/drop.md
 msgid ""
 "All its fields will then be dropped too, whether or not it implements `Drop`."
 msgstr ""
 
-#: src/memory-management/drop.md:41
+#: src/memory-management/drop.md
 msgid ""
 "`std::mem::drop` is just an empty function that takes any value. The "
 "significance is that it takes ownership of the value, so at the end of its "
@@ -7569,175 +7406,175 @@ msgid ""
 "values earlier than they would otherwise go out of scope."
 msgstr ""
 
-#: src/memory-management/drop.md:45
+#: src/memory-management/drop.md
 msgid ""
 "This can be useful for objects that do some work on `drop`: releasing locks, "
 "closing files, etc."
 msgstr ""
 
-#: src/memory-management/drop.md:50
+#: src/memory-management/drop.md
 msgid "Why doesn't `Drop::drop` take `self`?"
 msgstr ""
 
-#: src/memory-management/drop.md:51
+#: src/memory-management/drop.md
 msgid ""
 "Short-answer: If it did, `std::mem::drop` would be called at the end of the "
 "block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
 
-#: src/memory-management/drop.md:53
+#: src/memory-management/drop.md
 msgid "Try replacing `drop(a)` with `a.drop()`."
 msgstr ""
 
-#: src/memory-management/exercise.md:3
+#: src/memory-management/exercise.md
 msgid ""
 "In this example, we will implement a complex data type that owns all of its "
 "data. We will use the \"builder pattern\" to support building a new value "
 "piece-by-piece, using convenience functions."
 msgstr ""
 
-#: src/memory-management/exercise.md:7
+#: src/memory-management/exercise.md
 msgid "Fill in the missing pieces."
 msgstr ""
 
-#: src/memory-management/exercise.md:22 src/memory-management/solution.md:16
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// A representation of a software package.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md:34 src/memory-management/solution.md:28
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid ""
 "/// Return a representation of this package as a dependency, for use in\n"
 "    /// building other packages.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md:37
+#: src/memory-management/exercise.md
 msgid "\"1\""
 msgstr ""
 
-#: src/memory-management/exercise.md:40 src/memory-management/solution.md:37
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid ""
 "/// A builder for a Package. Use `build()` to create the `Package` itself.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md:46
+#: src/memory-management/exercise.md
 msgid "\"2\""
 msgstr ""
 
-#: src/memory-management/exercise.md:49 src/memory-management/solution.md:52
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the package version.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md:55 src/memory-management/solution.md:58
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the package authors.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md:57
+#: src/memory-management/exercise.md
 msgid "\"3\""
 msgstr ""
 
-#: src/memory-management/exercise.md:60 src/memory-management/solution.md:64
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Add an additional dependency.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md:62
+#: src/memory-management/exercise.md
 msgid "\"4\""
 msgstr ""
 
-#: src/memory-management/exercise.md:65 src/memory-management/solution.md:70
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the language. If not set, language defaults to None.\n"
 msgstr ""
 
-#: src/memory-management/exercise.md:67
+#: src/memory-management/exercise.md
 msgid "\"5\""
 msgstr ""
 
-#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"base64\""
 msgstr ""
 
-#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"0.13\""
 msgstr ""
 
-#: src/memory-management/exercise.md:77 src/memory-management/solution.md:83
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"base64: {base64:?}\""
 msgstr ""
 
-#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"log\""
 msgstr ""
 
-#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"0.4\""
 msgstr ""
 
-#: src/memory-management/exercise.md:80 src/memory-management/solution.md:86
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"log: {log:?}\""
 msgstr ""
 
-#: src/memory-management/exercise.md:81 src/memory-management/solution.md:87
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"serde\""
 msgstr ""
 
-#: src/memory-management/exercise.md:82 src/memory-management/solution.md:88
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"djmitche\""
 msgstr ""
 
-#: src/memory-management/exercise.md:83 src/memory-management/solution.md:89
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"4.0\""
 msgstr ""
 
-#: src/memory-management/exercise.md:87 src/memory-management/solution.md:93
+#: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"serde: {serde:?}\""
 msgstr ""
 
-#: src/memory-management/solution.md:45
+#: src/memory-management/solution.md
 msgid "\"0.1\""
 msgstr ""
 
-#: src/smart-pointers.md:7
+#: src/smart-pointers.md
 msgid "Box"
 msgstr ""
 
-#: src/smart-pointers.md:8
+#: src/smart-pointers.md
 msgid "Rc"
 msgstr ""
 
-#: src/smart-pointers/box.md:3
+#: src/smart-pointers/box.md
 msgid ""
 "[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
 "pointer to data on the heap:"
 msgstr ""
 
-#: src/smart-pointers/box.md:9
+#: src/smart-pointers/box.md
 msgid "\"five: {}\""
 msgstr ""
 
-#: src/smart-pointers/box.md:26
+#: src/smart-pointers/box.md
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
 "methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
 "trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 
-#: src/smart-pointers/box.md:30
+#: src/smart-pointers/box.md
 msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
-#: src/smart-pointers/box.md:35
+#: src/smart-pointers/box.md
 msgid "/// A non-empty list: first element and the rest of the list.\n"
 msgstr ""
 
-#: src/smart-pointers/box.md:37
+#: src/smart-pointers/box.md
 msgid "/// An empty list.\n"
 msgstr ""
 
-#: src/smart-pointers/box.md:44
+#: src/smart-pointers/box.md
 msgid "\"{list:?}\""
 msgstr ""
 
-#: src/smart-pointers/box.md:48
+#: src/smart-pointers/box.md
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
@@ -7759,43 +7596,43 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/smart-pointers/box.md:64
+#: src/smart-pointers/box.md
 msgid ""
 "`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
 "not null."
 msgstr ""
 
-#: src/smart-pointers/box.md:66
+#: src/smart-pointers/box.md
 msgid "A `Box` can be useful when you:"
 msgstr ""
 
-#: src/smart-pointers/box.md:67
+#: src/smart-pointers/box.md
 msgid ""
 "have a type whose size that can't be known at compile time, but the Rust "
 "compiler wants to know an exact size."
 msgstr ""
 
-#: src/smart-pointers/box.md:69
+#: src/smart-pointers/box.md
 msgid ""
 "want to transfer ownership of a large amount of data. To avoid copying large "
 "amounts of data on the stack, instead store the data on the heap in a `Box` "
 "so only the pointer is moved."
 msgstr ""
 
-#: src/smart-pointers/box.md:73
+#: src/smart-pointers/box.md
 msgid ""
 "If `Box` was not used and we attempted to embed a `List` directly into the "
 "`List`, the compiler would not be able to compute a fixed size for the "
 "struct in memory (the `List` would be of infinite size)."
 msgstr ""
 
-#: src/smart-pointers/box.md:77
+#: src/smart-pointers/box.md
 msgid ""
 "`Box` solves this problem as it has the same size as a regular pointer and "
 "just points at the next element of the `List` in the heap."
 msgstr ""
 
-#: src/smart-pointers/box.md:80
+#: src/smart-pointers/box.md
 msgid ""
 "Remove the `Box` in the List definition and show the compiler error. We get "
 "the message \"recursive without indirection\", because for data recursion, "
@@ -7803,18 +7640,18 @@ msgid ""
 "storing the value directly."
 msgstr ""
 
-#: src/smart-pointers/box.md:87
+#: src/smart-pointers/box.md
 msgid "Niche Optimization"
 msgstr ""
 
-#: src/smart-pointers/box.md:89
+#: src/smart-pointers/box.md
 msgid ""
 "Though `Box` looks like `std::unique_ptr` in C++, it cannot be empty/null. "
 "This makes `Box` one of the types that allow the compiler to optimize "
 "storage of some enums."
 msgstr ""
 
-#: src/smart-pointers/box.md:93
+#: src/smart-pointers/box.md
 msgid ""
 "For example, `Option<Box<T>>` has the same size, as just `Box<T>`, because "
 "compiler uses NULL-value to discriminate variants instead of using explicit "
@@ -7822,106 +7659,106 @@ msgid ""
 "#representation)):"
 msgstr ""
 
-#: src/smart-pointers/box.md:103
+#: src/smart-pointers/box.md
 msgid "\"Just box\""
 msgstr ""
 
-#: src/smart-pointers/box.md:105
+#: src/smart-pointers/box.md
 msgid "\"Optional box\""
 msgstr "\"Optional box\""
 
-#: src/smart-pointers/box.md:111
+#: src/smart-pointers/box.md
 msgid "\"Size of just_box: {}\""
 msgstr ""
 
-#: src/smart-pointers/box.md:112
+#: src/smart-pointers/box.md
 msgid "\"Size of optional_box: {}\""
 msgstr ""
 
-#: src/smart-pointers/box.md:113
+#: src/smart-pointers/box.md
 msgid "\"Size of none: {}\""
 msgstr ""
 
-#: src/smart-pointers/rc.md:3
+#: src/smart-pointers/rc.md
 msgid ""
 "[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
 "counted shared pointer. Use this when you need to refer to the same data "
 "from multiple places:"
 msgstr ""
 
-#: src/smart-pointers/rc.md:13
+#: src/smart-pointers/rc.md
 msgid "\"a: {a}\""
 msgstr ""
 
-#: src/smart-pointers/rc.md:14
+#: src/smart-pointers/rc.md
 msgid "\"b: {b}\""
 msgstr ""
 
-#: src/smart-pointers/rc.md:18
+#: src/smart-pointers/rc.md
 msgid ""
 "See [`Arc`](../concurrency/shared_state/arc.md) and [`Mutex`](https://doc."
 "rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
 "context."
 msgstr ""
 
-#: src/smart-pointers/rc.md:19
+#: src/smart-pointers/rc.md
 msgid ""
 "You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
 "org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
 
-#: src/smart-pointers/rc.md:30
+#: src/smart-pointers/rc.md
 msgid ""
 "`Rc`'s count ensures that its contained value is valid for as long as there "
 "are references."
 msgstr ""
 
-#: src/smart-pointers/rc.md:32
+#: src/smart-pointers/rc.md
 msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
 msgstr ""
 
-#: src/smart-pointers/rc.md:33
+#: src/smart-pointers/rc.md
 msgid ""
 "`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
 "be ignored when looking for performance issues in code."
 msgstr ""
 
-#: src/smart-pointers/rc.md:36
+#: src/smart-pointers/rc.md
 msgid ""
 "`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
 "and returns a mutable reference."
 msgstr ""
 
-#: src/smart-pointers/rc.md:38
+#: src/smart-pointers/rc.md
 msgid "Use `Rc::strong_count` to check the reference count."
 msgstr ""
 
-#: src/smart-pointers/rc.md:39
+#: src/smart-pointers/rc.md
 msgid ""
 "`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
 "cycles that will be dropped properly (likely in combination with `RefCell`)."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:3
+#: src/smart-pointers/trait-objects.md
 msgid ""
 "Trait objects allow for values of different types, for instance in a "
 "collection:"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:26
+#: src/smart-pointers/trait-objects.md
 msgid "\"Miau!\""
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:36
+#: src/smart-pointers/trait-objects.md
 msgid "\"Hello, who are you? {}\""
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:41
+#: src/smart-pointers/trait-objects.md
 msgid "Memory layout after allocating `pets`:"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:43
+#: src/smart-pointers/trait-objects.md
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -7981,25 +7818,25 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:78
+#: src/smart-pointers/trait-objects.md
 msgid ""
 "Types that implement a given trait may be of different sizes. This makes it "
 "impossible to have things like `Vec<dyn Pet>` in the example above."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:80
+#: src/smart-pointers/trait-objects.md
 msgid ""
 "`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
 "implements `Pet`."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:82
+#: src/smart-pointers/trait-objects.md
 msgid ""
 "In the example, `pets` is allocated on the stack and the vector data is on "
 "the heap. The two vector elements are _fat pointers_:"
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:84
+#: src/smart-pointers/trait-objects.md
 msgid ""
 "A fat pointer is a double-width pointer. It has two components: a pointer to "
 "the actual object and a pointer to the [virtual method table](https://en."
@@ -8007,17 +7844,17 @@ msgid ""
 "implementation of that particular object."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:87
+#: src/smart-pointers/trait-objects.md
 msgid ""
 "The data for the `Dog` named Fido is the `name` and `age` fields. The `Cat` "
 "has a `lives` field."
 msgstr ""
 
-#: src/smart-pointers/trait-objects.md:89
+#: src/smart-pointers/trait-objects.md
 msgid "Compare these outputs in the above example:"
 msgstr ""
 
-#: src/smart-pointers/exercise.md:3
+#: src/smart-pointers/exercise.md
 msgid ""
 "A binary tree is a tree-type data structure where every node has two "
 "children (left and right). We will create a tree where each node stores a "
@@ -8025,44 +7862,44 @@ msgid ""
 "values, and all nodes in N's right subtree will contain larger values."
 msgstr ""
 
-#: src/smart-pointers/exercise.md:8
+#: src/smart-pointers/exercise.md
 msgid "Implement the following types, so that the given tests pass."
 msgstr ""
 
-#: src/smart-pointers/exercise.md:10
+#: src/smart-pointers/exercise.md
 msgid ""
 "Extra Credit: implement an iterator over a binary tree that returns the "
 "values in order."
 msgstr ""
 
-#: src/smart-pointers/exercise.md:14 src/smart-pointers/solution.md:5
+#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "/// A node in the binary tree.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md:21 src/smart-pointers/solution.md:13
+#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "/// A possibly-empty subtree.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md:25 src/smart-pointers/solution.md:17
+#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid ""
 "/// A container storing a set of values, using a binary tree.\n"
 "///\n"
 "/// If the same value is added multiple times, it is only stored once.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md:51
+#: src/smart-pointers/exercise.md
 msgid "// Implement `new`, `insert`, `len`, and `has` for `Subtree`.\n"
 msgstr ""
 
-#: src/smart-pointers/exercise.md:66 src/smart-pointers/solution.md:105
+#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "// not a unique item\n"
 msgstr ""
 
-#: src/smart-pointers/solution.md:89 src/android/testing/googletest.md:11
+#: src/smart-pointers/solution.md src/android/testing/googletest.md
 msgid "\"bar\""
 msgstr ""
 
-#: src/welcome-day-3-afternoon.md:3
+#: src/welcome-day-3-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 1 hour and 55 "
 "minutes. It contains:"
@@ -8070,93 +7907,96 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 1 tiếng và 55 phút, bao gồm thời gian 10 phút "
 "nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/borrowing/shared.md:3
+#: src/borrowing/shared.md
 msgid ""
 "As we saw before, instead of transferring ownership when calling a function, "
 "you can let a function _borrow_ the value:"
 msgstr ""
 
-#: src/borrowing/shared.md:24
+#: src/borrowing/shared.md
 msgid "The `add` function _borrows_ two points and returns a new point."
 msgstr ""
 
-#: src/borrowing/shared.md:25
+#: src/borrowing/shared.md
 msgid "The caller retains ownership of the inputs."
 msgstr ""
 
-#: src/borrowing/shared.md:30
+#: src/borrowing/shared.md
 msgid ""
 "This slide is a review of the material on references from day 1, expanding "
 "slightly to include function arguments and return values."
 msgstr ""
 
-#: src/borrowing/shared.md:35
-msgid "Notes on stack returns:"
+#: src/borrowing/shared.md
+msgid "Notes on stack returns and inlining:"
 msgstr ""
 
-#: src/borrowing/shared.md:37
+#: src/borrowing/shared.md
 msgid ""
 "Demonstrate that the return from `add` is cheap because the compiler can "
-"eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground](https://play.rust-lang.org/?"
+"eliminate the copy operation, by inlining the call to add into main. Change "
+"the above code to print stack addresses and run it on the [Playground]"
+"(https://play.rust-lang.org/?"
 "version=stable&mode=release&edition=2021&gist=0cb13be1c05d7e3446686ad9947c4671) "
 "or look at the assembly in [Godbolt](https://rust.godbolt.org/). In the "
 "\"DEBUG\" optimization level, the addresses should change, while they stay "
 "the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/borrowing/shared.md:63
-msgid "The Rust compiler can do return value optimization (RVO)."
-msgstr ""
-
-#: src/borrowing/shared.md:64
+#: src/borrowing/shared.md
 msgid ""
-"In C++, copy elision has to be defined in the language specification because "
-"constructors can have side effects. In Rust, this is not an issue at all. If "
-"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
-"copy."
+"The Rust compiler can do automatic inlining, that can be disabled on a "
+"function level with `#[inline(never)]`."
 msgstr ""
 
-#: src/borrowing/borrowck.md:3
+#: src/borrowing/shared.md
+msgid ""
+"Once disabled, the printed address will change on all optimization levels. "
+"Looking at Godbolt or Playground, one can see that in this case, the return "
+"of the value depends on the ABI, e.g. on amd64 the two i32 that is making up "
+"the point will be returned in 2 registers (eax and edx)."
+msgstr ""
+
+#: src/borrowing/borrowck.md
 msgid ""
 "Rust's _borrow checker_ puts constraints on the ways you can borrow values. "
 "For a given value, at any time:"
 msgstr ""
 
-#: src/borrowing/borrowck.md:6
+#: src/borrowing/borrowck.md
 msgid "You can have one or more shared references to the value, _or_"
 msgstr ""
 
-#: src/borrowing/borrowck.md:7
+#: src/borrowing/borrowck.md
 msgid "You can have exactly one exclusive reference to the value."
 msgstr ""
 
-#: src/borrowing/borrowck.md:29
+#: src/borrowing/borrowck.md
 msgid ""
 "Note that the requirement is that conflicting references not _exist_ at the "
 "same point. It does not matter where the reference is dereferenced."
 msgstr ""
 
-#: src/borrowing/borrowck.md:31
+#: src/borrowing/borrowck.md
 msgid ""
 "The above code does not compile because `a` is borrowed as mutable (through "
 "`c`) and as immutable (through `b`) at the same time."
 msgstr ""
 
-#: src/borrowing/borrowck.md:33
+#: src/borrowing/borrowck.md
 msgid ""
 "Move the `println!` statement for `b` before the scope that introduces `c` "
 "to make the code compile."
 msgstr ""
 
-#: src/borrowing/borrowck.md:35
+#: src/borrowing/borrowck.md
 msgid ""
 "After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
 
-#: src/borrowing/borrowck.md:38
+#: src/borrowing/borrowck.md
 msgid ""
 "The exclusive reference constraint is quite strong. Rust uses it to ensure "
 "that data races do not occur. Rust also _relies_ on this constraint to "
@@ -8164,7 +8004,7 @@ msgid ""
 "cached in a register for the lifetime of that reference."
 msgstr ""
 
-#: src/borrowing/borrowck.md:42
+#: src/borrowing/borrowck.md
 msgid ""
 "The borrow checker is designed to accommodate many common patterns, such as "
 "taking exclusive references to different fields in a struct at the same "
@@ -8172,81 +8012,80 @@ msgid ""
 "this often results in \"fighting with the borrow checker.\""
 msgstr ""
 
-#: src/borrowing/examples.md:3
+#: src/borrowing/examples.md
 msgid ""
 "As a concrete example of how these borrowing rules prevent memory errors, "
 "consider the case of modifying a collection while there are references to "
 "its elements:"
 msgstr ""
 
-#: src/borrowing/examples.md:12
+#: src/borrowing/examples.md
 msgid "\"{elem}\""
 msgstr "\"{elem}\""
 
-#: src/borrowing/examples.md:16
+#: src/borrowing/examples.md
 msgid "Similarly, consider the case of iterator invalidation:"
 msgstr ""
 
-#: src/borrowing/examples.md:30
+#: src/borrowing/examples.md
 msgid ""
 "In both of these cases, modifying the collection by pushing new elements "
 "into it can potentially invalidate existing references to the collection's "
 "elements if the collection has to reallocate."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:3
+#: src/borrowing/interior-mutability.md
 msgid ""
 "In some situations, it's necessary to modify data behind a shared (read-"
 "only) reference. For example, a shared data structure might have an internal "
 "cache, and wish to update that cache from read-only methods."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:7
+#: src/borrowing/interior-mutability.md
 msgid ""
 "The \"interior mutability\" pattern allows exclusive (mutable) access behind "
 "a shared reference. The standard library provides several ways to do this, "
 "all while still ensuring safety, typically by performing a runtime check."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:11
+#: src/borrowing/interior-mutability.md
 msgid "`RefCell`"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:17
-#: src/borrowing/interior-mutability.md:43
+#: src/borrowing/interior-mutability.md
 msgid "// Note that `cell` is NOT declared as mutable.\n"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:24
+#: src/borrowing/interior-mutability.md
 msgid ""
 "// This triggers an error at runtime.\n"
 "        // let other = cell.borrow();\n"
 "        // println!(\"{}\", *other);\n"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:29
+#: src/borrowing/interior-mutability.md
 msgid "\"{cell:?}\""
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:33
+#: src/borrowing/interior-mutability.md
 msgid "`Cell`"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:35
+#: src/borrowing/interior-mutability.md
 msgid ""
 "`Cell` wraps a value and allows getting or setting the value, even with a "
 "shared reference to the `Cell`. However, it does not allow any references to "
 "the value. Since there are no references, borrowing rules cannot be broken."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:54
+#: src/borrowing/interior-mutability.md
 msgid ""
 "The main thing to take away from this slide is that Rust provides _safe_ "
 "ways to modify data behind a shared reference. There are a variety of ways "
 "to ensure that safety, and `RefCell` and `Cell` are two of them."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:58
+#: src/borrowing/interior-mutability.md
 msgid ""
 "`RefCell` enforces Rust's usual borrowing rules (either multiple shared "
 "references or a single exclusive reference) with a runtime check. In this "
@@ -8254,64 +8093,62 @@ msgid ""
 "succeed."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:63
+#: src/borrowing/interior-mutability.md
 msgid ""
 "The extra block in the `RefCell` example is to end the borrow created by the "
 "call to `borrow_mut` before we print the cell. Trying to print a borrowed "
 "`RefCell` just shows the message `\"{borrowed}\"`."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md:67
+#: src/borrowing/interior-mutability.md
 msgid ""
 "`Cell` is a simpler means to ensure safety: it has a `set` method that takes "
 "`&self`. This needs no runtime check, but requires moving values, which can "
 "have its own cost."
 msgstr ""
 
-#: src/borrowing/exercise.md:3
+#: src/borrowing/exercise.md
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
 "you need to keep track of users' health statistics."
 msgstr ""
 
-#: src/borrowing/exercise.md:6
+#: src/borrowing/exercise.md
 msgid ""
 "You'll start with a stubbed function in an `impl` block as well as a `User` "
 "struct definition. Your goal is to implement the stubbed out method on the "
 "`User` `struct` defined in the `impl` block."
 msgstr ""
 
-#: src/borrowing/exercise.md:10
+#: src/borrowing/exercise.md
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "method:"
 msgstr ""
 
-#: src/borrowing/exercise.md:45
+#: src/borrowing/exercise.md
 msgid ""
 "\"Update a user's statistics based on measurements from a visit to the "
 "doctor\""
 msgstr ""
 
-#: src/borrowing/exercise.md:50 src/borrowing/exercise.md:56
-#: src/borrowing/exercise.md:60 src/borrowing/solution.md:52
-#: src/borrowing/solution.md:58 src/borrowing/solution.md:62
-#: src/android/build-rules/library.md:44
-#: src/android/aidl/example-service/client.md:15
+#: src/borrowing/exercise.md src/borrowing/solution.md
+#: src/android/build-rules/library.md
+#: src/android/aidl/example-service/client.md
 msgid "\"Bob\""
 msgstr ""
 
-#: src/borrowing/exercise.md:51 src/borrowing/solution.md:53
+#: src/borrowing/exercise.md src/borrowing/solution.md
 msgid "\"I'm {} and my age is {}\""
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:3
+#: src/lifetimes/lifetime-annotations.md
 msgid ""
 "A reference has a _lifetime_, which must not \"outlive\" the value it refers "
 "to. This is verified by the borrow checker."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:6
+#: src/lifetimes/lifetime-annotations.md
 msgid ""
 "The lifetime can be implicit - this is what we have seen so far. Lifetimes "
 "can also be explicit: `&'a Point`, `&'document str`. Lifetimes start with "
@@ -8319,28 +8156,28 @@ msgid ""
 "`Point` which is valid for at least the lifetime `a`\"."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:11
+#: src/lifetimes/lifetime-annotations.md
 msgid ""
 "Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
 "yourself. Explicit lifetime annotations create constraints where there is "
 "ambiguity; the compiler verifies that there is a valid solution."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:15
+#: src/lifetimes/lifetime-annotations.md
 msgid ""
 "Lifetimes become more complicated when considering passing values to and "
 "returning values from functions."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:36
+#: src/lifetimes/lifetime-annotations.md
 msgid "// What is the lifetime of p3?\n"
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:37
+#: src/lifetimes/lifetime-annotations.md
 msgid "\"p3: {p3:?}\""
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:44
+#: src/lifetimes/lifetime-annotations.md
 msgid ""
 "In this example, the compiler does not know what lifetime to infer for `p3`. "
 "Looking inside the function body shows that it can only safely assume that "
@@ -8349,26 +8186,26 @@ msgid ""
 "values."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:50
+#: src/lifetimes/lifetime-annotations.md
 msgid "Add `'a` appropriately to `left_most`:"
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:56
+#: src/lifetimes/lifetime-annotations.md
 msgid ""
 "This says, \"given p1 and p2 which both outlive `'a`, the return value lives "
 "for at least `'a`."
 msgstr ""
 
-#: src/lifetimes/lifetime-annotations.md:59
+#: src/lifetimes/lifetime-annotations.md
 msgid ""
 "In common cases, lifetimes can be elided, as described on the next slide."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:1
+#: src/lifetimes/lifetime-elision.md
 msgid "Lifetimes in Function Calls"
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:3
+#: src/lifetimes/lifetime-elision.md
 msgid ""
 "Lifetimes for function arguments and return values must be fully specified, "
 "but Rust allows lifetimes to be elided in most cases with [a few simple "
@@ -8376,44 +8213,44 @@ msgid ""
 "inference -- it is just a syntactic shorthand."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:8
+#: src/lifetimes/lifetime-elision.md
 msgid "Each argument which does not have a lifetime annotation is given one."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:9
+#: src/lifetimes/lifetime-elision.md
 msgid ""
 "If there is only one argument lifetime, it is given to all un-annotated "
 "return values."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:11
+#: src/lifetimes/lifetime-elision.md
 msgid ""
 "If there are multiple argument lifetimes, but the first one is for `self`, "
 "that lifetime is given to all un-annotated return values."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:53
+#: src/lifetimes/lifetime-elision.md
 msgid "In this example, `cab_distance` is trivially elided."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:55
+#: src/lifetimes/lifetime-elision.md
 msgid ""
 "The `nearest` function provides another example of a function with multiple "
 "references in its arguments that requires explicit annotation."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:58
+#: src/lifetimes/lifetime-elision.md
 msgid "Try adjusting the signature to \"lie\" about the lifetimes returned:"
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:64
+#: src/lifetimes/lifetime-elision.md
 msgid ""
 "This won't compile, demonstrating that the annotations are checked for "
 "validity by the compiler. Note that this is not the case for raw pointers "
 "(unsafe), and this is a common source of errors with unsafe Rust."
 msgstr ""
 
-#: src/lifetimes/lifetime-elision.md:68
+#: src/lifetimes/lifetime-elision.md
 msgid ""
 "Students may ask when to use lifetimes. Rust borrows _always_ have "
 "lifetimes. Most of the time, elision and type inference mean these don't "
@@ -8422,60 +8259,60 @@ msgid ""
 "just work with owned data by cloning values where necessary."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:1
+#: src/lifetimes/struct-lifetimes.md
 msgid "Lifetimes in Data Structures"
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:3
+#: src/lifetimes/struct-lifetimes.md
 msgid ""
 "If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:10
+#: src/lifetimes/struct-lifetimes.md
 msgid "\"Bye {text}!\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:14
+#: src/lifetimes/struct-lifetimes.md
 msgid "\"The quick brown fox jumps over the lazy dog.\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:17
+#: src/lifetimes/struct-lifetimes.md
 msgid "// erase(text);\n"
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:18
+#: src/lifetimes/struct-lifetimes.md
 msgid "\"{fox:?}\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:19
+#: src/lifetimes/struct-lifetimes.md
 msgid "\"{dog:?}\""
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:26
+#: src/lifetimes/struct-lifetimes.md
 msgid ""
 "In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
 "`Highlight` that uses that data."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:29
+#: src/lifetimes/struct-lifetimes.md
 msgid ""
 "If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
 "the borrow checker throws an error."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:31
+#: src/lifetimes/struct-lifetimes.md
 msgid ""
 "Types with borrowed data force users to hold on to the original data. This "
 "can be useful for creating lightweight views, but it generally makes them "
 "somewhat harder to use."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:34
+#: src/lifetimes/struct-lifetimes.md
 msgid "When possible, make data structures own their data directly."
 msgstr ""
 
-#: src/lifetimes/struct-lifetimes.md:35
+#: src/lifetimes/struct-lifetimes.md
 msgid ""
 "Some structs with multiple references inside can have more than one lifetime "
 "annotation. This can be necessary if there is a need to describe lifetime "
@@ -8483,7 +8320,7 @@ msgid ""
 "of the struct itself. Those are very advanced use cases."
 msgstr ""
 
-#: src/lifetimes/exercise.md:3
+#: src/lifetimes/exercise.md
 msgid ""
 "In this exercise, you will build a parser for the [protobuf binary encoding]"
 "(https://protobuf.dev/programming-guides/encoding/). Don't worry, it's "
@@ -8491,7 +8328,7 @@ msgid ""
 "slices of data. The underlying data itself is never copied."
 msgstr ""
 
-#: src/lifetimes/exercise.md:8
+#: src/lifetimes/exercise.md
 msgid ""
 "Fully parsing a protobuf message requires knowing the types of the fields, "
 "indexed by their field numbers. That is typically provided in a `proto` "
@@ -8499,11 +8336,11 @@ msgid ""
 "statements in functions that get called for each field."
 msgstr ""
 
-#: src/lifetimes/exercise.md:13
+#: src/lifetimes/exercise.md
 msgid "We'll use the following proto:"
 msgstr ""
 
-#: src/lifetimes/exercise.md:28
+#: src/lifetimes/exercise.md
 msgid ""
 "A proto message is encoded as a series of fields, one after the next. Each "
 "is implemented as a \"tag\" followed by the value. The tag contains a field "
@@ -8511,7 +8348,7 @@ msgid ""
 "defining how the payload should be determined from the byte stream."
 msgstr ""
 
-#: src/lifetimes/exercise.md:33
+#: src/lifetimes/exercise.md
 msgid ""
 "Integers, including the tag, are represented with a variable-length encoding "
 "called VARINT. Luckily, `parse_varint` is defined for you below. The given "
@@ -8519,45 +8356,45 @@ msgid ""
 "to parse a message into a series of calls to those callbacks."
 msgstr ""
 
-#: src/lifetimes/exercise.md:38
+#: src/lifetimes/exercise.md
 msgid ""
 "What remains for you is to implement the `parse_field` function and the "
 "`ProtoMessage` trait for `Person` and `PhoneNumber`."
 msgstr ""
 
-#: src/lifetimes/exercise.md:49 src/lifetimes/solution.md:11
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "\"Invalid varint\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:51 src/lifetimes/solution.md:13
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "\"Invalid wire-type\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:53 src/lifetimes/solution.md:15
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "\"Unexpected EOF\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:55 src/lifetimes/solution.md:17
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "\"Invalid length\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:57 src/lifetimes/solution.md:19
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "\"Unexpected wire-type)\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:59 src/lifetimes/solution.md:21
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "\"Invalid string (not UTF-8)\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:62 src/lifetimes/solution.md:24
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "/// A wire type as seen on the wire.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:65 src/lifetimes/solution.md:27
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "/// The Varint WireType indicates the value is a single VARINT.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:67 src/lifetimes/solution.md:29
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid ""
 "//I64,  -- not needed for this exercise\n"
 "    /// The Len WireType indicates that the value is a length represented as "
@@ -8565,62 +8402,62 @@ msgid ""
 "    /// VARINT followed by exactly that number of bytes.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:71 src/lifetimes/solution.md:33
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid ""
 "/// The I32 WireType indicates that the value is precisely 4 bytes in\n"
 "    /// little-endian order containing a 32-bit signed integer.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:76 src/lifetimes/solution.md:38
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "/// A field's value, typed based on the wire type.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:80 src/lifetimes/solution.md:42
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "//I64(i64),  -- not needed for this exercise\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:85 src/lifetimes/solution.md:47
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "/// A field, containing the field number and its value.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:102 src/lifetimes/solution.md:64
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "//1 => WireType::I64,  -- not needed for this exercise\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:132 src/lifetimes/solution.md:94
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid ""
 "/// Parse a VARINT, returning the parsed value and the remaining bytes.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:140 src/lifetimes/solution.md:102
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid ""
 "// This is the last byte of the VARINT, so convert it to\n"
 "            // a u64 and return it.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:150 src/lifetimes/solution.md:112
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "// More than 7 bytes is invalid.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:153 src/lifetimes/solution.md:115
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "/// Convert a tag into a field number and a WireType.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:161 src/lifetimes/solution.md:122
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid "/// Parse a field, returning the remaining bytes\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:167
+#: src/lifetimes/exercise.md
 msgid ""
 "\"Based on the wire type, build a Field, consuming as many bytes as "
 "necessary.\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:169
+#: src/lifetimes/exercise.md
 msgid "\"Return the field, and any un-consumed bytes.\""
 msgstr ""
 
-#: src/lifetimes/exercise.md:171 src/lifetimes/solution.md:153
+#: src/lifetimes/exercise.md src/lifetimes/solution.md
 msgid ""
 "/// Parse a message in the given data, calling `T::add_field` for each field "
 "in\n"
@@ -8629,54 +8466,53 @@ msgid ""
 "/// The entire input is consumed.\n"
 msgstr ""
 
-#: src/lifetimes/exercise.md:198
+#: src/lifetimes/exercise.md
 msgid "// TODO: Implement ProtoMessage for Person and PhoneNumber.\n"
 msgstr ""
 
-#: src/lifetimes/solution.md:146
+#: src/lifetimes/solution.md
 msgid "// Unwrap error because `value` is definitely 4 bytes long.\n"
 msgstr ""
 
-#: src/lifetimes/solution.md:187 src/lifetimes/solution.md:198
+#: src/lifetimes/solution.md
 msgid "// skip everything else\n"
 msgstr ""
 
-#: src/lifetimes/solution.md:225 src/lifetimes/solution.md:232
-#: src/lifetimes/solution.md:239
+#: src/lifetimes/solution.md
 msgid "b\"hello\""
 msgstr ""
 
-#: src/welcome-day-4.md:1
+#: src/welcome-day-4.md
 msgid "Welcome to Day 4"
 msgstr ""
 
-#: src/welcome-day-4.md:3
+#: src/welcome-day-4.md
 msgid ""
 "Today we will cover topics relating to building large-scale software in Rust:"
 msgstr ""
 
-#: src/welcome-day-4.md:5
+#: src/welcome-day-4.md
 msgid "Iterators: a deep dive on the `Iterator` trait."
 msgstr ""
 
-#: src/welcome-day-4.md:6
+#: src/welcome-day-4.md
 msgid "Modules and visibility."
 msgstr ""
 
-#: src/welcome-day-4.md:7
+#: src/welcome-day-4.md
 msgid "Testing."
 msgstr ""
 
-#: src/welcome-day-4.md:8
+#: src/welcome-day-4.md
 msgid "Error handling: panics, `Result`, and the try operator `?`."
 msgstr ""
 
-#: src/welcome-day-4.md:9
+#: src/welcome-day-4.md
 msgid ""
 "Unsafe Rust: the escape hatch when you can't express yourself in safe Rust."
 msgstr ""
 
-#: src/welcome-day-4.md:13
+#: src/welcome-day-4.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 40 "
 "minutes. It contains:"
@@ -8684,23 +8520,23 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 2 tiếng và 40 phút, bao gồm thời gian 10 phút "
 "nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/iterators.md:3 src/testing.md:3
+#: src/iterators.md src/testing.md
 msgid "This segment should take about 45 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 45 phút, bao gồm:"
 
-#: src/iterators.md:7
+#: src/iterators.md
 msgid "Iterator"
 msgstr ""
 
-#: src/iterators.md:8
+#: src/iterators.md
 msgid "IntoIterator"
 msgstr ""
 
-#: src/iterators.md:9 src/iterators/fromiterator.md:1
+#: src/iterators.md src/iterators/fromiterator.md
 msgid "FromIterator"
 msgstr ""
 
-#: src/iterators/iterator.md:3
+#: src/iterators/iterator.md
 msgid ""
 "The [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
 "trait supports iterating over values in a collection. It requires a `next` "
@@ -8708,11 +8544,11 @@ msgid ""
 "`Iterator`, and you can implement it yourself, too:"
 msgstr ""
 
-#: src/iterators/iterator.md:27
+#: src/iterators/iterator.md
 msgid "\"fib({i}): {n}\""
 msgstr ""
 
-#: src/iterators/iterator.md:35
+#: src/iterators/iterator.md
 msgid ""
 "The `Iterator` trait implements many common functional programming "
 "operations over collections (e.g. `map`, `filter`, `reduce`, etc). This is "
@@ -8721,7 +8557,7 @@ msgid ""
 "implementations."
 msgstr ""
 
-#: src/iterators/iterator.md:40
+#: src/iterators/iterator.md
 msgid ""
 "`IntoIterator` is the trait that makes for loops work. It is implemented by "
 "collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
@@ -8729,7 +8565,7 @@ msgid ""
 "vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
 
-#: src/iterators/intoiterator.md:3
+#: src/iterators/intoiterator.md
 msgid ""
 "The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait [`IntoIterator`](https://doc.rust-lang.org/std/"
@@ -8737,47 +8573,47 @@ msgid ""
 "It is used automatically by the `for` loop."
 msgstr ""
 
-#: src/iterators/intoiterator.md:49
+#: src/iterators/intoiterator.md
 msgid "\"point = {x}, {y}\""
 msgstr ""
 
-#: src/iterators/intoiterator.md:57
+#: src/iterators/intoiterator.md
 msgid ""
 "Click through to the docs for `IntoIterator`. Every implementation of "
 "`IntoIterator` must declare two types:"
 msgstr ""
 
-#: src/iterators/intoiterator.md:60
+#: src/iterators/intoiterator.md
 msgid "`Item`: the type to iterate over, such as `i8`,"
 msgstr ""
 
-#: src/iterators/intoiterator.md:61
+#: src/iterators/intoiterator.md
 msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
 
-#: src/iterators/intoiterator.md:63
+#: src/iterators/intoiterator.md
 msgid ""
 "Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 
-#: src/iterators/intoiterator.md:66
+#: src/iterators/intoiterator.md
 msgid "The example iterates over all combinations of x and y coordinates."
 msgstr ""
 
-#: src/iterators/intoiterator.md:68
+#: src/iterators/intoiterator.md
 msgid ""
 "Try iterating over the grid twice in `main`. Why does this fail? Note that "
 "`IntoIterator::into_iter` takes ownership of `self`."
 msgstr ""
 
-#: src/iterators/intoiterator.md:71
+#: src/iterators/intoiterator.md
 msgid ""
 "Fix this issue by implementing `IntoIterator` for `&Grid` and storing a "
 "reference to the `Grid` in `GridIter`."
 msgstr ""
 
-#: src/iterators/intoiterator.md:74
+#: src/iterators/intoiterator.md
 msgid ""
 "The same problem can occur for standard library types: `for e in "
 "some_vector` will take ownership of `some_vector` and iterate over owned "
@@ -8785,60 +8621,60 @@ msgid ""
 "over references to elements of `some_vector`."
 msgstr ""
 
-#: src/iterators/fromiterator.md:3
+#: src/iterators/fromiterator.md
 msgid ""
 "[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
 "lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
 "std/iter/trait.Iterator.html)."
 msgstr ""
 
-#: src/iterators/fromiterator.md:9
+#: src/iterators/fromiterator.md
 msgid "\"prime_squares: {prime_squares:?}\""
 msgstr ""
 
-#: src/iterators/fromiterator.md:16
+#: src/iterators/fromiterator.md
 msgid "`Iterator` implements"
 msgstr ""
 
-#: src/iterators/fromiterator.md:25
+#: src/iterators/fromiterator.md
 msgid "There are two ways to specify `B` for this method:"
 msgstr ""
 
-#: src/iterators/fromiterator.md:27
+#: src/iterators/fromiterator.md
 msgid ""
 "With the \"turbofish\": `some_iterator.collect::<COLLECTION_TYPE>()`, as "
 "shown. The `_` shorthand used here lets Rust infer the type of the `Vec` "
 "elements."
 msgstr ""
 
-#: src/iterators/fromiterator.md:29
+#: src/iterators/fromiterator.md
 msgid ""
 "With type inference: `let prime_squares: Vec<_> = some_iterator.collect()`. "
 "Rewrite the example to use this form."
 msgstr ""
 
-#: src/iterators/fromiterator.md:32
+#: src/iterators/fromiterator.md
 msgid ""
 "There are basic implementations of `FromIterator` for `Vec`, `HashMap`, etc. "
 "There are also more specialized implementations which let you do cool things "
 "like convert an `Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 
-#: src/iterators/exercise.md:3
+#: src/iterators/exercise.md
 msgid ""
 "In this exercise, you will need to find and use some of the provided methods "
 "in the [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
 "trait to implement a complex calculation."
 msgstr ""
 
-#: src/iterators/exercise.md:6
+#: src/iterators/exercise.md
 msgid ""
 "Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Use an iterator expression and `collect` the result to construct the "
 "return value."
 msgstr ""
 
-#: src/iterators/exercise.md:11 src/iterators/solution.md:4
+#: src/iterators/exercise.md src/iterators/solution.md
 msgid ""
 "/// Calculate the differences between elements of `values` offset by "
 "`offset`,\n"
@@ -8847,239 +8683,239 @@ msgid ""
 "/// Element `n` of the result is `values[(n+offset)%len] - values[n]`.\n"
 msgstr ""
 
-#: src/modules.md:10 src/modules/paths.md:1
+#: src/modules.md src/modules/paths.md
 msgid "use, super, self"
 msgstr ""
 
-#: src/modules/modules.md:3
+#: src/modules/modules.md
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
 msgstr ""
 
-#: src/modules/modules.md:5
+#: src/modules/modules.md
 msgid "Similarly, `mod` lets us namespace types and functions:"
 msgstr ""
 
-#: src/modules/modules.md:10
+#: src/modules/modules.md
 msgid "\"In the foo module\""
 msgstr ""
 
-#: src/modules/modules.md:16
+#: src/modules/modules.md
 msgid "\"In the bar module\""
 msgstr ""
 
-#: src/modules/modules.md:29
+#: src/modules/modules.md
 msgid ""
 "Packages provide functionality and include a `Cargo.toml` file that "
 "describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/modules.md:31
+#: src/modules/modules.md
 msgid ""
 "Crates are a tree of modules, where a binary crate creates an executable and "
 "a library crate compiles to a library."
 msgstr ""
 
-#: src/modules/modules.md:33
+#: src/modules/modules.md
 msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
-#: src/modules/filesystem.md:3
+#: src/modules/filesystem.md
 msgid ""
 "Omitting the module content will tell Rust to look for it in another file:"
 msgstr ""
 
-#: src/modules/filesystem.md:9
+#: src/modules/filesystem.md
 msgid ""
 "This tells rust that the `garden` module content is found at `src/garden."
 "rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
 "vegetables.rs`."
 msgstr ""
 
-#: src/modules/filesystem.md:13
+#: src/modules/filesystem.md
 msgid "The `crate` root is in:"
 msgstr ""
 
-#: src/modules/filesystem.md:15
+#: src/modules/filesystem.md
 msgid "`src/lib.rs` (for a library crate)"
 msgstr ""
 
-#: src/modules/filesystem.md:16
+#: src/modules/filesystem.md
 msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
-#: src/modules/filesystem.md:18
+#: src/modules/filesystem.md
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
 "comments\". These document the item that contains them -- in this case, a "
 "module."
 msgstr ""
 
-#: src/modules/filesystem.md:22
+#: src/modules/filesystem.md
 msgid ""
 "//! This module implements the garden, including a highly performant "
 "germination\n"
 "//! implementation.\n"
 msgstr ""
 
-#: src/modules/filesystem.md:24
+#: src/modules/filesystem.md
 msgid "// Re-export types from this module.\n"
 msgstr ""
 
-#: src/modules/filesystem.md:28
+#: src/modules/filesystem.md
 msgid "/// Sow the given seed packets.\n"
 msgstr ""
 
-#: src/modules/filesystem.md:33
+#: src/modules/filesystem.md
 msgid "/// Harvest the produce in the garden that is ready.\n"
 msgstr ""
 
-#: src/modules/filesystem.md:43
+#: src/modules/filesystem.md
 msgid ""
 "Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
 "`module.rs`, and this is still a working alternative for editions after 2018."
 msgstr ""
 
-#: src/modules/filesystem.md:46
+#: src/modules/filesystem.md
 msgid ""
 "The main reason to introduce `filename.rs` as alternative to `filename/mod."
 "rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
 msgstr ""
 
-#: src/modules/filesystem.md:49
+#: src/modules/filesystem.md
 msgid "Deeper nesting can use folders, even if the main module is a file:"
 msgstr ""
 
-#: src/modules/filesystem.md:59
+#: src/modules/filesystem.md
 msgid ""
 "The place rust will look for modules can be changed with a compiler "
 "directive:"
 msgstr ""
 
-#: src/modules/filesystem.md:62
+#: src/modules/filesystem.md
 msgid "\"some/path.rs\""
 msgstr ""
 
-#: src/modules/filesystem.md:66
+#: src/modules/filesystem.md
 msgid ""
 "This is useful, for example, if you would like to place tests for a module "
 "in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
-#: src/modules/visibility.md:3
+#: src/modules/visibility.md
 msgid "Modules are a privacy boundary:"
 msgstr ""
 
-#: src/modules/visibility.md:5
+#: src/modules/visibility.md
 msgid "Module items are private by default (hides implementation details)."
 msgstr ""
 
-#: src/modules/visibility.md:6
+#: src/modules/visibility.md
 msgid "Parent and sibling items are always visible."
 msgstr ""
 
-#: src/modules/visibility.md:7
+#: src/modules/visibility.md
 msgid ""
 "In other words, if an item is visible in module `foo`, it's visible in all "
 "the descendants of `foo`."
 msgstr ""
 
-#: src/modules/visibility.md:13
+#: src/modules/visibility.md
 msgid "\"outer::private\""
 msgstr ""
 
-#: src/modules/visibility.md:17
+#: src/modules/visibility.md
 msgid "\"outer::public\""
 msgstr ""
 
-#: src/modules/visibility.md:22
+#: src/modules/visibility.md
 msgid "\"outer::inner::private\""
 msgstr ""
 
-#: src/modules/visibility.md:26
+#: src/modules/visibility.md
 msgid "\"outer::inner::public\""
 msgstr ""
 
-#: src/modules/visibility.md:40
+#: src/modules/visibility.md
 msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
-#: src/modules/visibility.md:42
+#: src/modules/visibility.md
 msgid ""
 "Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
 "of public visibility."
 msgstr ""
 
-#: src/modules/visibility.md:45
+#: src/modules/visibility.md
 msgid ""
 "See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
 "privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/visibility.md:47
+#: src/modules/visibility.md
 msgid "Configuring `pub(crate)` visibility is a common pattern."
 msgstr ""
 
-#: src/modules/visibility.md:48
+#: src/modules/visibility.md
 msgid "Less commonly, you can give visibility to a specific path."
 msgstr ""
 
-#: src/modules/visibility.md:49
+#: src/modules/visibility.md
 msgid ""
 "In any case, visibility must be granted to an ancestor module (and all of "
 "its descendants)."
 msgstr ""
 
-#: src/modules/paths.md:3
+#: src/modules/paths.md
 msgid ""
 "A module can bring symbols from another module into scope with `use`. You "
 "will typically see something like this at the top of each module:"
 msgstr ""
 
-#: src/modules/paths.md:11
+#: src/modules/paths.md
 msgid "Paths"
 msgstr ""
 
-#: src/modules/paths.md:13
+#: src/modules/paths.md
 msgid "Paths are resolved as follows:"
 msgstr ""
 
-#: src/modules/paths.md:15
+#: src/modules/paths.md
 msgid "As a relative path:"
 msgstr ""
 
-#: src/modules/paths.md:16
+#: src/modules/paths.md
 msgid "`foo` or `self::foo` refers to `foo` in the current module,"
 msgstr ""
 
-#: src/modules/paths.md:17
+#: src/modules/paths.md
 msgid "`super::foo` refers to `foo` in the parent module."
 msgstr ""
 
-#: src/modules/paths.md:19
+#: src/modules/paths.md
 msgid "As an absolute path:"
 msgstr ""
 
-#: src/modules/paths.md:20
+#: src/modules/paths.md
 msgid "`crate::foo` refers to `foo` in the root of the current crate,"
 msgstr ""
 
-#: src/modules/paths.md:21
+#: src/modules/paths.md
 msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
-#: src/modules/paths.md:26
+#: src/modules/paths.md
 msgid ""
 "It is common to \"re-export\" symbols at a shorter path. For example, the "
 "top-level `lib.rs` in a crate might have"
 msgstr ""
 
-#: src/modules/paths.md:36
+#: src/modules/paths.md
 msgid ""
 "making `DiskStorage` and `NetworkStorage` available to other crates with a "
 "convenient, short path."
 msgstr ""
 
-#: src/modules/paths.md:39
+#: src/modules/paths.md
 msgid ""
 "For the most part, only items that appear in a module need to be `use`'d. "
 "However, a trait must be in scope to call any methods on that trait, even if "
@@ -9088,268 +8924,262 @@ msgid ""
 "`use std::io::Read`."
 msgstr ""
 
-#: src/modules/paths.md:45
+#: src/modules/paths.md
 msgid ""
 "The `use` statement can have a wildcard: `use std::io::*`. This is "
 "discouraged because it is not clear which items are imported, and those "
 "might change over time."
 msgstr ""
 
-#: src/modules/exercise.md:3
+#: src/modules/exercise.md
 msgid ""
 "In this exercise, you will reorganize a small GUI Library implementation. "
 "This library defines a `Widget` trait and a few implementations of that "
 "trait, as well as a `main` function."
 msgstr ""
 
-#: src/modules/exercise.md:7
+#: src/modules/exercise.md
 msgid ""
 "It is typical to put each type or set of closely-related types into its own "
 "module, so each widget type should get its own module."
 msgstr ""
 
-#: src/modules/exercise.md:10
+#: src/modules/exercise.md
 msgid "Cargo Setup"
 msgstr ""
 
-#: src/modules/exercise.md:12
+#: src/modules/exercise.md
 msgid ""
 "The Rust playground only supports one file, so you will need to make a Cargo "
 "project on your local filesystem:"
 msgstr ""
 
-#: src/modules/exercise.md:21
+#: src/modules/exercise.md
 msgid ""
 "Edit the resulting `src/main.rs` to add `mod` statements, and add additional "
 "files in the `src` directory."
 msgstr ""
 
-#: src/modules/exercise.md:24
+#: src/modules/exercise.md
 msgid "Source"
 msgstr ""
 
-#: src/modules/exercise.md:26
+#: src/modules/exercise.md
 msgid "Here's the single-module implementation of the GUI library:"
 msgstr ""
 
-#: src/modules/exercise.md:30 src/modules/solution.md:36
+#: src/modules/exercise.md src/modules/solution.md
 msgid "/// Natural width of `self`.\n"
 msgstr ""
 
-#: src/modules/exercise.md:33 src/modules/solution.md:39
+#: src/modules/exercise.md src/modules/solution.md
 msgid "/// Draw the widget into a buffer.\n"
 msgstr ""
 
-#: src/modules/exercise.md:36 src/modules/solution.md:42
+#: src/modules/exercise.md src/modules/solution.md
 msgid "/// Draw the widget on standard output.\n"
 msgstr ""
 
-#: src/modules/exercise.md:40 src/modules/solution.md:46
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"{buffer}\""
 msgstr ""
 
-#: src/modules/exercise.md:88
+#: src/modules/exercise.md
 msgid "// Add 4 paddings for borders\n"
 msgstr ""
 
-#: src/modules/exercise.md:100
+#: src/modules/exercise.md
 msgid ""
 "// TODO: Change draw_into to return Result<(), std::fmt::Error>. Then use "
 "the\n"
 "        // ?-operator here instead of .unwrap().\n"
 msgstr ""
 
-#: src/modules/exercise.md:102 src/modules/exercise.md:108
-#: src/modules/solution.md:165 src/modules/solution.md:171
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"+-{:-<inner_width$}-+\""
 msgstr ""
 
-#: src/modules/exercise.md:102 src/modules/exercise.md:104
-#: src/modules/exercise.md:108 src/modules/exercise.md:122
-#: src/modules/exercise.md:126 src/modules/solution.md:110
-#: src/modules/solution.md:114 src/modules/solution.md:165
-#: src/modules/solution.md:167 src/modules/solution.md:171
-#: src/testing/unit-tests.md:27 src/testing/solution.md:89
+#: src/modules/exercise.md src/modules/solution.md src/testing/unit-tests.md
+#: src/testing/solution.md
 msgid "\"\""
 msgstr ""
 
-#: src/modules/exercise.md:103 src/modules/solution.md:166
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"| {:^inner_width$} |\""
 msgstr ""
 
-#: src/modules/exercise.md:104 src/modules/solution.md:167
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"+={:=<inner_width$}=+\""
 msgstr ""
 
-#: src/modules/exercise.md:106 src/modules/solution.md:169
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"| {:inner_width$} |\""
 msgstr ""
 
-#: src/modules/exercise.md:114 src/modules/solution.md:100
+#: src/modules/exercise.md src/modules/solution.md
 msgid "// add a bit of padding\n"
 msgstr ""
 
-#: src/modules/exercise.md:122 src/modules/exercise.md:126
-#: src/modules/solution.md:110 src/modules/solution.md:114
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"+{:-<width$}+\""
 msgstr ""
 
-#: src/modules/exercise.md:124 src/modules/solution.md:112
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"|{:^width$}|\""
 msgstr ""
 
-#: src/modules/exercise.md:141 src/modules/solution.md:183
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"Rust GUI Demo 1.23\""
 msgstr ""
 
-#: src/modules/exercise.md:142 src/modules/solution.md:185
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"This is a small text GUI demo.\""
 msgstr ""
 
-#: src/modules/exercise.md:143 src/modules/solution.md:186
+#: src/modules/exercise.md src/modules/solution.md
 msgid "\"Click me!\""
 msgstr ""
 
-#: src/modules/exercise.md:151
+#: src/modules/exercise.md
 msgid ""
 "Encourage students to divide the code in a way that feels natural for them, "
 "and get accustomed to the required `mod`, `use`, and `pub` declarations. "
 "Afterward, discuss what organizations are most idiomatic."
 msgstr ""
 
-#: src/modules/solution.md:30
+#: src/modules/solution.md
 msgid "// ---- src/widgets.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md:56
+#: src/modules/solution.md
 msgid "// ---- src/widgets/label.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md:71
+#: src/modules/solution.md
 msgid "// ANCHOR_END: Label-width\n"
 msgstr ""
 
-#: src/modules/solution.md:75
+#: src/modules/solution.md
 msgid "// ANCHOR: Label-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md:77
+#: src/modules/solution.md
 msgid "// ANCHOR_END: Label-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md:84
+#: src/modules/solution.md
 msgid "// ---- src/widgets/button.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md:99
+#: src/modules/solution.md
 msgid "// ANCHOR_END: Button-width\n"
 msgstr ""
 
-#: src/modules/solution.md:103
+#: src/modules/solution.md
 msgid "// ANCHOR: Button-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md:105
+#: src/modules/solution.md
 msgid "// ANCHOR_END: Button-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md:120
+#: src/modules/solution.md
 msgid "// ---- src/widgets/window.rs ----\n"
 msgstr ""
 
-#: src/modules/solution.md:147
+#: src/modules/solution.md
 msgid ""
 "// ANCHOR_END: Window-width\n"
 "        // Add 4 paddings for borders\n"
 msgstr ""
 
-#: src/modules/solution.md:152
+#: src/modules/solution.md
 msgid "// ANCHOR: Window-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md:154
+#: src/modules/solution.md
 msgid "// ANCHOR_END: Window-draw_into\n"
 msgstr ""
 
-#: src/modules/solution.md:162
+#: src/modules/solution.md
 msgid ""
 "// TODO: after learning about error handling, you can change\n"
 "        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
 "        // the ?-operator here instead of .unwrap().\n"
 msgstr ""
 
-#: src/modules/solution.md:177
+#: src/modules/solution.md
 msgid "// ---- src/main.rs ----\n"
 msgstr ""
 
-#: src/testing/unit-tests.md:1
+#: src/testing/unit-tests.md
 msgid "Unit Tests"
 msgstr ""
 
-#: src/testing/unit-tests.md:3
+#: src/testing/unit-tests.md
 msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr ""
 
-#: src/testing/unit-tests.md:5
+#: src/testing/unit-tests.md
 msgid "Unit tests are supported throughout your code."
 msgstr ""
 
-#: src/testing/unit-tests.md:7
+#: src/testing/unit-tests.md
 msgid "Integration tests are supported via the `tests/` directory."
 msgstr ""
 
-#: src/testing/unit-tests.md:9
+#: src/testing/unit-tests.md
 msgid ""
 "Tests are marked with `#[test]`. Unit tests are often put in a nested "
 "`tests` module, using `#[cfg(test)]` to conditionally compile them only when "
 "building tests."
 msgstr ""
 
-#: src/testing/unit-tests.md:37
+#: src/testing/unit-tests.md
 msgid "\"Hello World\""
 msgstr ""
 
-#: src/testing/unit-tests.md:42
+#: src/testing/unit-tests.md
 msgid "This lets you unit test private helpers."
 msgstr ""
 
-#: src/testing/unit-tests.md:43
+#: src/testing/unit-tests.md
 msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
 
-#: src/testing/unit-tests.md:48
+#: src/testing/unit-tests.md
 msgid "Run the tests in the playground in order to show their results."
 msgstr ""
 
-#: src/testing/other.md:3
+#: src/testing/other.md
 msgid "Integration Tests"
 msgstr ""
 
-#: src/testing/other.md:5
+#: src/testing/other.md
 msgid "If you want to test your library as a client, use an integration test."
 msgstr ""
 
-#: src/testing/other.md:7
+#: src/testing/other.md
 msgid "Create a `.rs` file under `tests/`:"
 msgstr ""
 
-#: src/testing/other.md:10
+#: src/testing/other.md
 msgid "// tests/my_library.rs\n"
 msgstr ""
 
-#: src/testing/other.md:19
+#: src/testing/other.md
 msgid "These tests only have access to the public API of your crate."
 msgstr ""
 
-#: src/testing/other.md:21
+#: src/testing/other.md
 msgid "Documentation Tests"
 msgstr ""
 
-#: src/testing/other.md:23
+#: src/testing/other.md
 msgid "Rust has built-in support for documentation tests:"
 msgstr ""
 
-#: src/testing/other.md:26
+#: src/testing/other.md
 msgid ""
 "/// Shortens a string to the given length.\n"
 "///\n"
@@ -9360,268 +9190,268 @@ msgid ""
 "/// ```\n"
 msgstr ""
 
-#: src/testing/other.md:38
+#: src/testing/other.md
 msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
 
-#: src/testing/other.md:39
+#: src/testing/other.md
 msgid "The code will be compiled and executed as part of `cargo test`."
 msgstr ""
 
-#: src/testing/other.md:40
+#: src/testing/other.md
 msgid ""
 "Adding `#` in the code will hide it from the docs, but will still compile/"
 "run it."
 msgstr ""
 
-#: src/testing/other.md:42
+#: src/testing/other.md
 msgid ""
 "Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
 
-#: src/testing/lints.md:3
+#: src/testing/lints.md
 msgid ""
 "The Rust compiler produces fantastic error messages, as well as helpful "
 "built-in lints. [Clippy](https://doc.rust-lang.org/clippy/) provides even "
 "more lints, organized into groups that can be enabled per-project."
 msgstr ""
 
-#: src/testing/lints.md:14
+#: src/testing/lints.md
 msgid "\"X probably fits in a u16, right? {}\""
 msgstr ""
 
-#: src/testing/lints.md:21
+#: src/testing/lints.md
 msgid ""
 "Run the code sample and examine the error message. There are also lints "
 "visible here, but those will not be shown once the code compiles. Switch to "
 "the Playground site to show those lints."
 msgstr ""
 
-#: src/testing/lints.md:25
+#: src/testing/lints.md
 msgid ""
 "After resolving the lints, run `clippy` on the playground site to show "
 "clippy warnings. Clippy has extensive documentation of its lints, and adds "
 "new lints (including default-deny lints) all the time."
 msgstr ""
 
-#: src/testing/lints.md:29
+#: src/testing/lints.md
 msgid ""
 "Note that errors or warnings with `help: ...` can be fixed with `cargo fix` "
 "or via your editor."
 msgstr ""
 
-#: src/testing/exercise.md:3
+#: src/testing/exercise.md
 msgid "Luhn Algorithm"
 msgstr ""
 
-#: src/testing/exercise.md:5
+#: src/testing/exercise.md
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
 "to validate credit card numbers. The algorithm takes a string as input and "
 "does the following to validate the credit card number:"
 msgstr ""
 
-#: src/testing/exercise.md:9
+#: src/testing/exercise.md
 msgid "Ignore all spaces. Reject number with fewer than two digits."
 msgstr ""
 
-#: src/testing/exercise.md:11
+#: src/testing/exercise.md
 msgid ""
 "Moving from **right to left**, double every second digit: for the number "
 "`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
 msgstr ""
 
-#: src/testing/exercise.md:14
+#: src/testing/exercise.md
 msgid ""
 "After doubling a digit, sum the digits if the result is greater than 9. So "
 "doubling `7` becomes `14` which becomes `1 + 4 = 5`."
 msgstr ""
 
-#: src/testing/exercise.md:17
+#: src/testing/exercise.md
 msgid "Sum all the undoubled and doubled digits."
 msgstr ""
 
-#: src/testing/exercise.md:19
+#: src/testing/exercise.md
 msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
-#: src/testing/exercise.md:21
+#: src/testing/exercise.md
 msgid ""
 "The provided code provides a buggy implementation of the luhn algorithm, "
 "along with two basic unit tests that confirm that most the algorithm is "
 "implemented correctly."
 msgstr ""
 
-#: src/testing/exercise.md:25
+#: src/testing/exercise.md
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and write additional "
 "tests to uncover bugs in the provided implementation, fixing any bugs you "
 "find."
 msgstr ""
 
-#: src/testing/exercise.md:57 src/testing/solution.md:69
+#: src/testing/exercise.md src/testing/solution.md
 msgid "\"4263 9826 4026 9299\""
 msgstr ""
 
-#: src/testing/exercise.md:58 src/testing/solution.md:70
+#: src/testing/exercise.md src/testing/solution.md
 msgid "\"4539 3195 0343 6467\""
 msgstr ""
 
-#: src/testing/exercise.md:59 src/testing/solution.md:71
+#: src/testing/exercise.md src/testing/solution.md
 msgid "\"7992 7398 713\""
 msgstr ""
 
-#: src/testing/exercise.md:64 src/testing/solution.md:76
+#: src/testing/exercise.md src/testing/solution.md
 msgid "\"4223 9826 4026 9299\""
 msgstr ""
 
-#: src/testing/exercise.md:65 src/testing/solution.md:77
+#: src/testing/exercise.md src/testing/solution.md
 msgid "\"4539 3195 0343 6476\""
 msgstr ""
 
-#: src/testing/exercise.md:66 src/testing/solution.md:78
+#: src/testing/exercise.md src/testing/solution.md
 msgid "\"8273 1232 7352 0569\""
 msgstr ""
 
-#: src/testing/solution.md:4
+#: src/testing/solution.md
 msgid "// This is the buggy version that appears in the problem.\n"
 msgstr ""
 
-#: src/testing/solution.md:27
+#: src/testing/solution.md
 msgid "// This is the solution and passes all of the tests below.\n"
 msgstr ""
 
-#: src/testing/solution.md:56
+#: src/testing/solution.md
 msgid "\"1234 5678 1234 5670\""
 msgstr ""
 
-#: src/testing/solution.md:58
+#: src/testing/solution.md
 msgid "\"Is {cc_number} a valid credit card number? {}\""
 msgstr ""
 
-#: src/testing/solution.md:59
+#: src/testing/solution.md
 msgid "\"yes\""
 msgstr ""
 
-#: src/testing/solution.md:59
+#: src/testing/solution.md
 msgid "\"no\""
 msgstr ""
 
-#: src/testing/solution.md:84
+#: src/testing/solution.md
 msgid "\"foo 0 0\""
 msgstr ""
 
-#: src/testing/solution.md:90
+#: src/testing/solution.md
 msgid "\" \""
 msgstr ""
 
-#: src/testing/solution.md:91
+#: src/testing/solution.md
 msgid "\"  \""
 msgstr ""
 
-#: src/testing/solution.md:92
+#: src/testing/solution.md
 msgid "\"    \""
 msgstr ""
 
-#: src/testing/solution.md:97
+#: src/testing/solution.md
 msgid "\"0\""
 msgstr ""
 
-#: src/testing/solution.md:102
+#: src/testing/solution.md
 msgid "\" 0 0 \""
 msgstr ""
 
-#: src/error-handling.md:10
+#: src/error-handling.md
 msgid "Error Trait"
 msgstr ""
 
-#: src/error-handling.md:11
+#: src/error-handling.md
 msgid "thiserror and anyhow"
 msgstr ""
 
-#: src/error-handling.md:12 src/error-handling/exercise.md:1
+#: src/error-handling.md src/error-handling/exercise.md
 msgid "Exercise: Rewriting with Result"
 msgstr ""
 
-#: src/error-handling/panics.md:3
+#: src/error-handling/panics.md
 msgid "Rust handles fatal errors with a \"panic\"."
 msgstr ""
 
-#: src/error-handling/panics.md:5
+#: src/error-handling/panics.md
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
 msgstr ""
 
-#: src/error-handling/panics.md:10
+#: src/error-handling/panics.md
 msgid "\"v[100]: {}\""
 msgstr ""
 
-#: src/error-handling/panics.md:14
+#: src/error-handling/panics.md
 msgid "Panics are for unrecoverable and unexpected errors."
 msgstr ""
 
-#: src/error-handling/panics.md:15
+#: src/error-handling/panics.md
 msgid "Panics are symptoms of bugs in the program."
 msgstr ""
 
-#: src/error-handling/panics.md:16
+#: src/error-handling/panics.md
 msgid "Runtime failures like failed bounds checks can panic"
 msgstr ""
 
-#: src/error-handling/panics.md:17
+#: src/error-handling/panics.md
 msgid "Assertions (such as `assert!`) panic on failure"
 msgstr ""
 
-#: src/error-handling/panics.md:18
+#: src/error-handling/panics.md
 msgid "Purpose-specific panics can use the `panic!` macro."
 msgstr ""
 
-#: src/error-handling/panics.md:19
+#: src/error-handling/panics.md
 msgid ""
 "A panic will \"unwind\" the stack, dropping values just as if the functions "
 "had returned."
 msgstr ""
 
-#: src/error-handling/panics.md:21
+#: src/error-handling/panics.md
 msgid ""
 "Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
 
-#: src/error-handling/panics.md:26
+#: src/error-handling/panics.md
 msgid ""
 "By default, a panic will cause the stack to unwind. The unwinding can be "
 "caught:"
 msgstr ""
 
-#: src/error-handling/panics.md:32
+#: src/error-handling/panics.md
 msgid "\"No problem here!\""
 msgstr ""
 
-#: src/error-handling/panics.md:33 src/error-handling/panics.md:38
+#: src/error-handling/panics.md
 msgid "\"{result:?}\""
 msgstr ""
 
-#: src/error-handling/panics.md:36
+#: src/error-handling/panics.md
 msgid "\"oh no!\""
 msgstr ""
 
-#: src/error-handling/panics.md:42
+#: src/error-handling/panics.md
 msgid ""
 "Catching is unusual; do not attempt to implement exceptions with "
 "`catch_unwind`!"
 msgstr ""
 
-#: src/error-handling/panics.md:44
+#: src/error-handling/panics.md
 msgid ""
 "This can be useful in servers which should keep running even if a single "
 "request crashes."
 msgstr ""
 
-#: src/error-handling/panics.md:46
+#: src/error-handling/panics.md
 msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
 msgstr ""
 
-#: src/error-handling/try.md:3
+#: src/error-handling/try.md
 msgid ""
 "Runtime errors like connection-refused or file-not-found are handled with "
 "the `Result` type, but matching this type on every call can be cumbersome. "
@@ -9629,42 +9459,42 @@ msgid ""
 "turn the common"
 msgstr ""
 
-#: src/error-handling/try.md:15
+#: src/error-handling/try.md
 msgid "into the much simpler"
 msgstr ""
 
-#: src/error-handling/try.md:21
+#: src/error-handling/try.md
 msgid "We can use this to simplify our error handling code:"
 msgstr ""
 
-#: src/error-handling/try.md:42
+#: src/error-handling/try.md
 msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
 msgstr ""
 
-#: src/error-handling/try.md:43 src/error-handling/try-conversions.md:65
-#: src/error-handling/thiserror-and-anyhow.md:36
+#: src/error-handling/try.md src/error-handling/try-conversions.md
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "\"config.dat\""
 msgstr ""
 
-#: src/error-handling/try.md:44 src/error-handling/try-conversions.md:66
+#: src/error-handling/try.md src/error-handling/try-conversions.md
 msgid "\"username or error: {username:?}\""
 msgstr ""
 
-#: src/error-handling/try.md:51
+#: src/error-handling/try.md
 msgid "Simplify the `read_username` function to use `?`."
 msgstr ""
 
-#: src/error-handling/try.md:55
+#: src/error-handling/try.md
 msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
 
-#: src/error-handling/try.md:56
+#: src/error-handling/try.md
 msgid ""
 "Use the `fs::write` call to test out the different scenarios: no file, empty "
 "file, file with username."
 msgstr ""
 
-#: src/error-handling/try.md:58
+#: src/error-handling/try.md
 msgid ""
 "Note that `main` can return a `Result<(), E>` as long as it implements `std::"
 "process::Termination`. In practice, this means that `E` implements `Debug`. "
@@ -9672,36 +9502,36 @@ msgid ""
 "on error."
 msgstr ""
 
-#: src/error-handling/try-conversions.md:3
+#: src/error-handling/try-conversions.md
 msgid ""
 "The effective expansion of `?` is a little more complicated than previously "
 "indicated:"
 msgstr ""
 
-#: src/error-handling/try-conversions.md:10
+#: src/error-handling/try-conversions.md
 msgid "works the same as"
 msgstr ""
 
-#: src/error-handling/try-conversions.md:19
+#: src/error-handling/try-conversions.md
 msgid ""
 "The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function. This makes it easy to encapsulate errors into "
 "higher-level errors."
 msgstr ""
 
-#: src/error-handling/try-conversions.md:42
+#: src/error-handling/try-conversions.md
 msgid "\"IO error: {e}\""
 msgstr ""
 
-#: src/error-handling/try-conversions.md:43
+#: src/error-handling/try-conversions.md
 msgid "\"Found no username in {path}\""
 msgstr ""
 
-#: src/error-handling/try-conversions.md:64
+#: src/error-handling/try-conversions.md
 msgid "//std::fs::write(\"config.dat\", \"\").unwrap();\n"
 msgstr ""
 
-#: src/error-handling/try-conversions.md:73
+#: src/error-handling/try-conversions.md
 msgid ""
 "The `?` operator must return a value compatible with the return type of the "
 "function. For `Result`, it means that the error types have to be compatible. "
@@ -9710,31 +9540,31 @@ msgid ""
 "same type or if `ErrorOuter` implements `From<ErrorInner>`."
 msgstr ""
 
-#: src/error-handling/try-conversions.md:79
+#: src/error-handling/try-conversions.md
 msgid ""
 "A common alternative to a `From` implementation is `Result::map_err`, "
 "especially when the conversion only happens in one place."
 msgstr ""
 
-#: src/error-handling/try-conversions.md:82
+#: src/error-handling/try-conversions.md
 msgid ""
 "There is no compatibility requirement for `Option`. A function returning "
 "`Option<T>` can use the `?` operator on `Option<U>` for arbitrary `T` and "
 "`U` types."
 msgstr ""
 
-#: src/error-handling/try-conversions.md:86
+#: src/error-handling/try-conversions.md
 msgid ""
 "A function that returns `Result` cannot use `?` on `Option` and vice versa. "
 "However, `Option::ok_or` converts `Option` to `Result` whereas `Result::ok` "
 "turns `Result` into `Option`."
 msgstr ""
 
-#: src/error-handling/error.md:1
+#: src/error-handling/error.md
 msgid "Dynamic Error Types"
 msgstr ""
 
-#: src/error-handling/error.md:3
+#: src/error-handling/error.md
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
 "our own enum covering all the different possibilities. The `std::error::"
@@ -9742,29 +9572,29 @@ msgid ""
 "error."
 msgstr ""
 
-#: src/error-handling/error.md:20 src/error-handling/error.md:21
+#: src/error-handling/error.md
 msgid "\"count.dat\""
 msgstr ""
 
-#: src/error-handling/error.md:20
+#: src/error-handling/error.md
 msgid "\"1i3\""
 msgstr ""
 
-#: src/error-handling/error.md:22
+#: src/error-handling/error.md
 msgid "\"Count: {count}\""
 msgstr ""
 
-#: src/error-handling/error.md:23
+#: src/error-handling/error.md
 msgid "\"Error: {err}\""
 msgstr ""
 
-#: src/error-handling/error.md:31
+#: src/error-handling/error.md
 msgid ""
 "The `read_count` function can return `std::io::Error` (from file operations) "
 "or `std::num::ParseIntError` (from `String::parse`)."
 msgstr ""
 
-#: src/error-handling/error.md:34
+#: src/error-handling/error.md
 msgid ""
 "Boxing errors saves on code, but gives up the ability to cleanly handle "
 "different error cases differently in the program. As such it's generally not "
@@ -9773,7 +9603,7 @@ msgid ""
 "message somewhere."
 msgstr ""
 
-#: src/error-handling/error.md:40
+#: src/error-handling/error.md
 msgid ""
 "Make sure to implement the `std::error::Error` trait when defining a custom "
 "error type so it can be boxed. But if you need to support the `no_std` "
@@ -9782,101 +9612,101 @@ msgid ""
 "issues/103765) only."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:3
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "The [`thiserror`](https://docs.rs/thiserror/) and [`anyhow`](https://docs.rs/"
 "anyhow/) crates are widely used to simplify error handling."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:7
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "`thiserror` is often used in libraries to create custom error types that "
 "implement `From<T>`."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:9
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "`anyhow` is often used by applications to help with error handling in "
 "functions, including adding contextual information to your errors."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:19
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Found no username in {0}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:25
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Failed to open {path}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:27
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Failed to read\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:35
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:37
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Username: {username}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:38
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Error: {err:?}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:46
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "`thiserror`"
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:48
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "The `Error` derive macro is provided by `thiserror`, and has lots of useful "
 "attributes to help define error types in a compact way."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:50
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "The `std::error::Error` trait is derived automatically."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:51
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "The message from `#[error]` is used to derive the `Display` trait."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:53
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "`anyhow`"
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:55
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
 "it's again generally not a good choice for the public API of a library, but "
 "is widely used in applications."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:58
+#: src/error-handling/thiserror-and-anyhow.md
 msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:59
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "Actual error type inside of it can be extracted for examination if necessary."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:60
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "Functionality provided by `anyhow::Result<T>` may be familiar to Go "
 "developers, as it provides similar usage patterns and ergonomics to `(T, "
 "error)` from Go."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md:63
+#: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "`anyhow::Context` is a trait implemented for the standard `Result` and "
 "`Option` types. `use anyhow::Context` is necessary to enable `.context()` "
 "and `.with_context()` on those types."
 msgstr ""
 
-#: src/error-handling/exercise.md:3
+#: src/error-handling/exercise.md
 msgid ""
 "The following implements a very simple parser for an expression language. "
 "However, it handles errors by panicking. Rewrite it to instead use idiomatic "
@@ -9884,156 +9714,155 @@ msgid ""
 "use `thiserror` and `anyhow`."
 msgstr ""
 
-#: src/error-handling/exercise.md:8
+#: src/error-handling/exercise.md
 msgid ""
 "HINT: start by fixing error handling in the `parse` function. Once that is "
 "working correctly, update `Tokenizer` to implement "
 "`Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser."
 msgstr ""
 
-#: src/error-handling/exercise.md:15 src/error-handling/solution.md:9
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// An arithmetic operator.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md:22 src/error-handling/solution.md:16
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A token in the expression language.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md:30 src/error-handling/solution.md:24
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// An expression in the expression language.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md:34 src/error-handling/solution.md:28
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A reference to a variable.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md:36 src/error-handling/solution.md:30
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A literal number.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md:38 src/error-handling/solution.md:32
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A binary operation.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md:60 src/error-handling/solution.md:60
-#: src/error-handling/solution.md:75
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'_'"
 msgstr ""
 
-#: src/error-handling/exercise.md:76 src/error-handling/solution.md:76
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'+'"
 msgstr ""
 
-#: src/error-handling/exercise.md:77 src/error-handling/solution.md:77
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'-'"
 msgstr ""
 
-#: src/error-handling/exercise.md:78
+#: src/error-handling/exercise.md
 msgid "\"Unexpected character {c}\""
 msgstr ""
 
-#: src/error-handling/exercise.md:88 src/error-handling/solution.md:87
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"Unexpected end of input\""
 msgstr ""
 
-#: src/error-handling/exercise.md:92
+#: src/error-handling/exercise.md
 msgid "\"Invalid 32-bit integer'\""
 msgstr ""
 
-#: src/error-handling/exercise.md:96 src/error-handling/exercise.md:106
+#: src/error-handling/exercise.md
 msgid "\"Unexpected token {tok:?}\""
 msgstr ""
 
-#: src/error-handling/exercise.md:98 src/error-handling/solution.md:110
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "// Look ahead to parse a binary operation if present.\n"
 msgstr ""
 
-#: src/error-handling/exercise.md:114 src/error-handling/solution.md:127
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"10+foo+20-30\""
 msgstr ""
 
-#: src/error-handling/exercise.md:115 src/error-handling/solution.md:128
+#: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"{expr:?}\""
 msgstr ""
 
-#: src/error-handling/solution.md:42
+#: src/error-handling/solution.md
 msgid "\"Unexpected character '{0}' in input\""
 msgstr ""
 
-#: src/error-handling/solution.md:85
+#: src/error-handling/solution.md
 msgid "\"Tokenizer error: {0}\""
 msgstr ""
 
-#: src/error-handling/solution.md:89
+#: src/error-handling/solution.md
 msgid "\"Unexpected token {0:?}\""
 msgstr ""
 
-#: src/error-handling/solution.md:91
+#: src/error-handling/solution.md
 msgid "\"Invalid number\""
 msgstr ""
 
-#: src/unsafe-rust.md:3
+#: src/unsafe-rust.md
 msgid "This segment should take about 1 hour and 5 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 5 phút, bao gồm:"
 
-#: src/unsafe-rust/unsafe.md:3
+#: src/unsafe-rust/unsafe.md
 msgid "The Rust language has two parts:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:5
+#: src/unsafe-rust/unsafe.md
 msgid "**Safe Rust:** memory safe, no undefined behavior possible."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:6
+#: src/unsafe-rust/unsafe.md
 msgid ""
 "**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:8
+#: src/unsafe-rust/unsafe.md
 msgid ""
 "We saw mostly safe Rust in this course, but it's important to know what "
 "Unsafe Rust is."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:11
+#: src/unsafe-rust/unsafe.md
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
 "carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:14
+#: src/unsafe-rust/unsafe.md
 msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:16
+#: src/unsafe-rust/unsafe.md
 msgid "Dereference raw pointers."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:17
+#: src/unsafe-rust/unsafe.md
 msgid "Access or modify mutable static variables."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:18
+#: src/unsafe-rust/unsafe.md
 msgid "Access `union` fields."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:19
+#: src/unsafe-rust/unsafe.md
 msgid "Call `unsafe` functions, including `extern` functions."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:20
+#: src/unsafe-rust/unsafe.md
 msgid "Implement `unsafe` traits."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:22
+#: src/unsafe-rust/unsafe.md
 msgid ""
 "We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
 "unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md:29
+#: src/unsafe-rust/unsafe.md
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
 "have turned off some compiler safety features and have to write correct code "
@@ -10041,15 +9870,15 @@ msgid ""
 "rules."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:3
+#: src/unsafe-rust/dereferencing.md
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:7
+#: src/unsafe-rust/dereferencing.md
 msgid "\"careful!\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:12
+#: src/unsafe-rust/dereferencing.md
 msgid ""
 "// SAFETY: r1 and r2 were obtained from references and so are guaranteed to\n"
 "    // be non-null and properly aligned, the objects underlying the "
@@ -10059,19 +9888,19 @@ msgid ""
 "    // concurrently through any other pointers.\n"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:18
+#: src/unsafe-rust/dereferencing.md
 msgid "\"r1 is: {}\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:19
+#: src/unsafe-rust/dereferencing.md
 msgid "\"uhoh\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:20
+#: src/unsafe-rust/dereferencing.md
 msgid "\"r2 is: {}\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:23
+#: src/unsafe-rust/dereferencing.md
 msgid ""
 "// NOT SAFE. DO NOT DO THIS.\n"
 "    /*\n"
@@ -10081,82 +9910,82 @@ msgid ""
 "    */"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:35
+#: src/unsafe-rust/dereferencing.md
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
 "a comment for each `unsafe` block explaining how the code inside it "
 "satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:39
+#: src/unsafe-rust/dereferencing.md
 msgid ""
 "In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:42
+#: src/unsafe-rust/dereferencing.md
 msgid "The pointer must be non-null."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:43
+#: src/unsafe-rust/dereferencing.md
 msgid ""
 "The pointer must be _dereferenceable_ (within the bounds of a single "
 "allocated object)."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:45
+#: src/unsafe-rust/dereferencing.md
 msgid "The object must not have been deallocated."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:46
+#: src/unsafe-rust/dereferencing.md
 msgid "There must not be concurrent accesses to the same location."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:47
+#: src/unsafe-rust/dereferencing.md
 msgid ""
 "If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:50
+#: src/unsafe-rust/dereferencing.md
 msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md:52
+#: src/unsafe-rust/dereferencing.md
 msgid ""
 "The \"NOT SAFE\" section gives an example of a common kind of UB bug: `*r1` "
 "has the `'static` lifetime, so `r3` has type `&'static String`, and thus "
 "outlives `s`. Creating a reference from a pointer requires _great care_."
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:3
+#: src/unsafe-rust/mutable-static.md
 msgid "It is safe to read an immutable static variable:"
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:6
+#: src/unsafe-rust/mutable-static.md
 msgid "\"Hello, world!\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:9
+#: src/unsafe-rust/mutable-static.md
 msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:13
+#: src/unsafe-rust/mutable-static.md
 msgid ""
 "However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:20 src/unsafe-rust/mutable-static.md:29
+#: src/unsafe-rust/mutable-static.md
 msgid ""
 "// SAFETY: There are no other threads which could be accessing `COUNTER`.\n"
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:31
+#: src/unsafe-rust/mutable-static.md
 msgid "\"COUNTER: {COUNTER}\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:39
+#: src/unsafe-rust/mutable-static.md
 msgid ""
 "The program here is safe because it is single-threaded. However, the Rust "
 "compiler is conservative and will assume the worst. Try removing the "
@@ -10164,36 +9993,36 @@ msgid ""
 "mutate a static from multiple threads."
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md:44
+#: src/unsafe-rust/mutable-static.md
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
 msgstr ""
 
-#: src/unsafe-rust/unions.md:3
+#: src/unsafe-rust/unions.md
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
 
-#: src/unsafe-rust/unions.md:14
+#: src/unsafe-rust/unions.md
 msgid "\"int: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unions.md:15
+#: src/unsafe-rust/unions.md
 msgid "\"bool: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unions.md:15
+#: src/unsafe-rust/unions.md
 msgid "// Undefined behavior!\n"
 msgstr ""
 
-#: src/unsafe-rust/unions.md:22
+#: src/unsafe-rust/unions.md
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
 msgstr ""
 
-#: src/unsafe-rust/unions.md:25
+#: src/unsafe-rust/unions.md
 msgid ""
 "If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
@@ -10201,62 +10030,55 @@ msgid ""
 "crates/zerocopy) crate."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:3 src/unsafe-rust/unsafe-functions.md:76
+#: src/unsafe-rust/unsafe-functions.md
 msgid "Calling Unsafe Functions"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:5
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:9 src/unsafe-rust/exercise.md:91
-#: src/unsafe-rust/solution.md:41 src/android/interoperability/with-c.md:9
-#: src/android/interoperability/with-c/rust.md:15
-#: src/android/interoperability/with-c/rust.md:30
-#: src/android/interoperability/cpp/cpp-bridge.md:29
-#: src/android/interoperability/cpp/cpp-bridge.md:38
-#: src/exercises/chromium/build-rules.md:8
-#: src/exercises/chromium/build-rules.md:21
-#: src/bare-metal/aps/inline-assembly.md:19
-#: src/bare-metal/aps/better-uart/using.md:24
-#: src/bare-metal/aps/logging/using.md:23
-#: src/exercises/bare-metal/solutions-afternoon.md:43
+#: src/unsafe-rust/unsafe-functions.md src/unsafe-rust/exercise.md
+#: src/unsafe-rust/solution.md src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/exercises/chromium/build-rules.md src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"C\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:14
+#: src/unsafe-rust/unsafe-functions.md
 msgid "\"🗻∈🌏\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:16
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "// SAFETY: The indices are in the correct order, within the bounds of the\n"
 "    // string slice, and lie on UTF-8 sequence boundaries.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:19
-#: src/unsafe-rust/unsafe-functions.md:20
-#: src/unsafe-rust/unsafe-functions.md:21
+#: src/unsafe-rust/unsafe-functions.md
 msgid "\"emoji: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:24
+#: src/unsafe-rust/unsafe-functions.md
 msgid "\"char count: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:26
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "// SAFETY: `abs` doesn't deal with pointers and doesn't have any safety\n"
 "    // requirements.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:29
+#: src/unsafe-rust/unsafe-functions.md
 msgid "\"Absolute value of -3 according to C: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:32
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
@@ -10264,18 +10086,17 @@ msgid ""
 "    // emojis.get_unchecked(0..3) }));\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:43
-#: src/unsafe-rust/unsafe-functions.md:88
+#: src/unsafe-rust/unsafe-functions.md
 msgid "Writing Unsafe Functions"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:45
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
 "conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:49
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "/// Swaps the values pointed to by the given pointers.\n"
 "///\n"
@@ -10284,15 +10105,15 @@ msgid ""
 "/// The pointers must be valid and properly aligned.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:64
+#: src/unsafe-rust/unsafe-functions.md
 msgid "// SAFETY: ...\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:69
+#: src/unsafe-rust/unsafe-functions.md
 msgid "\"a = {}, b = {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:78
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "`get_unchecked`, like most `_unchecked` functions, is unsafe, because it can "
 "create UB if the range is incorrect. `abs` is incorrect for a different "
@@ -10302,19 +10123,19 @@ msgid ""
 "undefined behaviour under any arbitrary circumstances."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:85
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "The `\"C\"` in this example is the ABI; [other ABIs are available too]"
 "(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:90
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "We wouldn't actually use pointers for a `swap` function - it can be done "
 "safely with references."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md:93
+#: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
 "`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
@@ -10322,212 +10143,207 @@ msgid ""
 "edition."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:1
+#: src/unsafe-rust/unsafe-traits.md
 msgid "Implementing Unsafe Traits"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:3
+#: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
 "must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:6
+#: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "For example, the `zerocopy` crate has an unsafe trait that looks [something "
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:12
+#: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "/// ...\n"
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:26
+#: src/unsafe-rust/unsafe-traits.md
 msgid "// SAFETY: `u32` has a defined representation and no padding.\n"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:34
+#: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:37
+#: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "The actual safety section for `AsBytes` is rather longer and more "
 "complicated."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md:39
+#: src/unsafe-rust/unsafe-traits.md
 msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:1
+#: src/unsafe-rust/exercise.md
 msgid "Safe FFI Wrapper"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:3
+#: src/unsafe-rust/exercise.md
 msgid ""
 "Rust has great support for calling functions through a _foreign function "
 "interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the names of files in a directory."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:7
+#: src/unsafe-rust/exercise.md
 msgid "You will want to consult the manual pages:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:9
+#: src/unsafe-rust/exercise.md
 msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:10
+#: src/unsafe-rust/exercise.md
 msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:11
+#: src/unsafe-rust/exercise.md
 msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:13
+#: src/unsafe-rust/exercise.md
 msgid ""
 "You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
 "ffi/) module. There you find a number of string types which you need for the "
 "exercise:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:16
+#: src/unsafe-rust/exercise.md
 msgid "Encoding"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:16
+#: src/unsafe-rust/exercise.md
 msgid "Use"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:18
+#: src/unsafe-rust/exercise.md
 msgid ""
 "[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
 "(https://doc.rust-lang.org/std/string/struct.String.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:18
+#: src/unsafe-rust/exercise.md
 msgid "UTF-8"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:18
+#: src/unsafe-rust/exercise.md
 msgid "Text processing in Rust"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:19
+#: src/unsafe-rust/exercise.md
 msgid ""
 "[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
 "(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:19
+#: src/unsafe-rust/exercise.md
 msgid "NUL-terminated"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:19
+#: src/unsafe-rust/exercise.md
 msgid "Communicating with C functions"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:20
+#: src/unsafe-rust/exercise.md
 msgid ""
 "[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
 "[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:20
+#: src/unsafe-rust/exercise.md
 msgid "OS-specific"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:20
+#: src/unsafe-rust/exercise.md
 msgid "Communicating with the OS"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:22
+#: src/unsafe-rust/exercise.md
 msgid "You will convert between all these types:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:24
+#: src/unsafe-rust/exercise.md
 msgid ""
 "`&str` to `CString`: you need to allocate space for a trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:25
+#: src/unsafe-rust/exercise.md
 msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:26
+#: src/unsafe-rust/exercise.md
 msgid ""
 "`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:28
+#: src/unsafe-rust/exercise.md
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
 "unknown data\","
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:30
+#: src/unsafe-rust/exercise.md
 msgid ""
 "`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
 "(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:33
+#: src/unsafe-rust/exercise.md
 msgid ""
 "`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
 "return it and call `readdir` again."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:36
+#: src/unsafe-rust/exercise.md
 msgid ""
 "The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
 "useful chapter about FFI."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:47
+#: src/unsafe-rust/exercise.md
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:56 src/unsafe-rust/exercise.md:69
-#: src/unsafe-rust/exercise.md:80 src/unsafe-rust/exercise.md:94
-#: src/unsafe-rust/exercise.md:102 src/unsafe-rust/solution.md:6
-#: src/unsafe-rust/solution.md:19 src/unsafe-rust/solution.md:30
-#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"macos\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:59 src/unsafe-rust/solution.md:9
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:66 src/unsafe-rust/solution.md:16
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
 "// Layout according to the Linux man page for readdir(3), where ino_t and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:79 src/unsafe-rust/solution.md:29
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Layout according to the macOS man page for dir(5).\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:94 src/unsafe-rust/exercise.md:102
-#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"x86_64\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:97 src/unsafe-rust/solution.md:47
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
 "// See https://github.com/rust-lang/libc/issues/414 and the section on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
@@ -10538,118 +10354,117 @@ msgid ""
 "PowerPC.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:103 src/unsafe-rust/solution.md:53
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"readdir$INODE64\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:121 src/unsafe-rust/solution.md:71
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
 "// Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:130
+#: src/unsafe-rust/exercise.md
 msgid "// Keep calling readdir until we get a NULL pointer back.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:137 src/unsafe-rust/solution.md:105
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Call closedir as needed.\n"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:143 src/unsafe-rust/solution.md:116
-#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
-#: src/android/interoperability/with-c/rust.md:44
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/android/interoperability/with-c/rust.md
 msgid "\".\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md:144 src/unsafe-rust/solution.md:117
+#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"files: {:#?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:74
+#: src/unsafe-rust/solution.md
 msgid "\"Invalid path: {err}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:75
+#: src/unsafe-rust/solution.md
 msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md:78
+#: src/unsafe-rust/solution.md
 msgid "\"Could not open {:?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:88
+#: src/unsafe-rust/solution.md
 msgid ""
 "// Keep calling readdir until we get a NULL pointer back.\n"
 "        // SAFETY: self.dir is never NULL.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md:92
+#: src/unsafe-rust/solution.md
 msgid "// We have reached the end of the directory.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md:95
+#: src/unsafe-rust/solution.md
 msgid ""
 "// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
 "        // terminated.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md:107
+#: src/unsafe-rust/solution.md
 msgid "// SAFETY: self.dir is not NULL.\n"
 msgstr ""
 
-#: src/unsafe-rust/solution.md:109
+#: src/unsafe-rust/solution.md
 msgid "\"Could not close {:?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:128
+#: src/unsafe-rust/solution.md
 msgid "\"no-such-directory\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:136 src/unsafe-rust/solution.md:151
+#: src/unsafe-rust/solution.md
 msgid "\"Non UTF-8 character in path\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
+#: src/unsafe-rust/solution.md
 msgid "\"..\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:147 src/unsafe-rust/solution.md:155
+#: src/unsafe-rust/solution.md
 msgid "\"foo.txt\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:147
+#: src/unsafe-rust/solution.md
 msgid "\"The Foo Diaries\\n\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:148 src/unsafe-rust/solution.md:155
+#: src/unsafe-rust/solution.md
 msgid "\"bar.png\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:148
+#: src/unsafe-rust/solution.md
 msgid "\"<PNG>\\n\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:149 src/unsafe-rust/solution.md:155
+#: src/unsafe-rust/solution.md
 msgid "\"crab.rs\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md:149
+#: src/unsafe-rust/solution.md
 msgid "\"//! Crab\\n\""
 msgstr ""
 
-#: src/android.md:1
+#: src/android.md
 msgid "Welcome to Rust in Android"
 msgstr ""
 
-#: src/android.md:3
+#: src/android.md
 msgid ""
 "Rust is supported for system software on Android. This means that you can "
 "write new services, libraries, drivers or even firmware in Rust (or improve "
 "existing code as needed)."
 msgstr ""
 
-#: src/android.md:7
+#: src/android.md
 msgid ""
 "We will attempt to call Rust from one of your own projects today. So try to "
 "find a little corner of your code base where we can move some lines of code "
@@ -10657,171 +10472,171 @@ msgid ""
 "that parses some raw bytes would be ideal."
 msgstr ""
 
-#: src/android.md:14
+#: src/android.md
 msgid ""
 "The speaker may mention any of the following given the increased use of Rust "
 "in Android:"
 msgstr ""
 
-#: src/android.md:17
+#: src/android.md
 msgid ""
 "Service example: [DNS over HTTP](https://security.googleblog.com/2022/07/dns-"
 "over-http3-in-android.html)"
 msgstr ""
 
-#: src/android.md:20
+#: src/android.md
 msgid ""
 "Libraries: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
 "appendix/rutabaga_gfx.html)"
 msgstr ""
 
-#: src/android.md:23
+#: src/android.md
 msgid ""
 "Kernel Drivers: [Binder](https://lore.kernel.org/rust-for-linux/20231101-"
 "rust-binder-v1-0-08ba9197f637@google.com/)"
 msgstr ""
 
-#: src/android.md:26
+#: src/android.md
 msgid ""
 "Firmware: [pKVM firmware](https://security.googleblog.com/2023/10/bare-metal-"
 "rust-in-android.html)"
 msgstr ""
 
-#: src/android/setup.md:3
+#: src/android/setup.md
 msgid ""
 "We will be using a Cuttlefish Android Virtual Device to test our code. Make "
 "sure you have access to one or create a new one with:"
 msgstr ""
 
-#: src/android/setup.md:12
+#: src/android/setup.md
 msgid ""
 "Please see the [Android Developer Codelab](https://source.android.com/docs/"
 "setup/start) for details."
 msgstr ""
 
-#: src/android/setup.md:20
+#: src/android/setup.md
 msgid ""
 "Cuttlefish is a reference Android device designed to work on generic Linux "
 "desktops. MacOS support is also planned."
 msgstr ""
 
-#: src/android/setup.md:23
+#: src/android/setup.md
 msgid ""
 "The Cuttlefish system image maintains high fidelity to real devices, and is "
 "the ideal emulator to run many Rust use cases."
 msgstr ""
 
-#: src/android/build-rules.md:3
+#: src/android/build-rules.md
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr ""
 
-#: src/android/build-rules.md:5
+#: src/android/build-rules.md
 msgid "Module Type"
 msgstr ""
 
-#: src/android/build-rules.md:5
+#: src/android/build-rules.md
 msgid "Description"
 msgstr ""
 
-#: src/android/build-rules.md:7
+#: src/android/build-rules.md
 msgid "`rust_binary`"
 msgstr ""
 
-#: src/android/build-rules.md:7
+#: src/android/build-rules.md
 msgid "Produces a Rust binary."
 msgstr ""
 
-#: src/android/build-rules.md:8
+#: src/android/build-rules.md
 msgid "`rust_library`"
 msgstr ""
 
-#: src/android/build-rules.md:8
+#: src/android/build-rules.md
 msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
 msgstr ""
 
-#: src/android/build-rules.md:9
+#: src/android/build-rules.md
 msgid "`rust_ffi`"
 msgstr ""
 
-#: src/android/build-rules.md:9
+#: src/android/build-rules.md
 msgid ""
 "Produces a Rust C library usable by `cc` modules, and provides both static "
 "and shared variants."
 msgstr ""
 
-#: src/android/build-rules.md:10
+#: src/android/build-rules.md
 msgid "`rust_proc_macro`"
 msgstr ""
 
-#: src/android/build-rules.md:10
+#: src/android/build-rules.md
 msgid ""
 "Produces a `proc-macro` Rust library. These are analogous to compiler "
 "plugins."
 msgstr ""
 
-#: src/android/build-rules.md:11
+#: src/android/build-rules.md
 msgid "`rust_test`"
 msgstr ""
 
-#: src/android/build-rules.md:11
+#: src/android/build-rules.md
 msgid "Produces a Rust test binary that uses the standard Rust test harness."
 msgstr ""
 
-#: src/android/build-rules.md:12
+#: src/android/build-rules.md
 msgid "`rust_fuzz`"
 msgstr ""
 
-#: src/android/build-rules.md:12
+#: src/android/build-rules.md
 msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
 msgstr ""
 
-#: src/android/build-rules.md:13
+#: src/android/build-rules.md
 msgid "`rust_protobuf`"
 msgstr ""
 
-#: src/android/build-rules.md:13
+#: src/android/build-rules.md
 msgid ""
 "Generates source and produces a Rust library that provides an interface for "
 "a particular protobuf."
 msgstr ""
 
-#: src/android/build-rules.md:14
+#: src/android/build-rules.md
 msgid "`rust_bindgen`"
 msgstr ""
 
-#: src/android/build-rules.md:14
+#: src/android/build-rules.md
 msgid ""
 "Generates source and produces a Rust library containing Rust bindings to C "
 "libraries."
 msgstr ""
 
-#: src/android/build-rules.md:16
+#: src/android/build-rules.md
 msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr ""
 
-#: src/android/build-rules.md:20
+#: src/android/build-rules.md
 msgid "Additional items speaker may mention:"
 msgstr ""
 
-#: src/android/build-rules.md:22
+#: src/android/build-rules.md
 msgid ""
 "Cargo is not optimized for multi-language repos, and also downloads packages "
 "from the internet."
 msgstr ""
 
-#: src/android/build-rules.md:25
+#: src/android/build-rules.md
 msgid ""
 "For compliance and performance, Android must have crates in-tree. It must "
 "also interop with C/C++/Java code. Soong fills that gap."
 msgstr ""
 
-#: src/android/build-rules.md:28
+#: src/android/build-rules.md
 msgid ""
 "Soong has many similarities to Bazel, which is the open-source variant of "
 "Blaze (used in google3)."
 msgstr ""
 
-#: src/android/build-rules.md:31
+#: src/android/build-rules.md
 msgid ""
 "There is a plan to transition [Android](https://source.android.com/docs/"
 "setup/build/bazel/introduction), [ChromeOS](https://chromium.googlesource."
@@ -10829,58 +10644,58 @@ msgid ""
 "build/bazel/introduction) to Bazel."
 msgstr ""
 
-#: src/android/build-rules.md:37
+#: src/android/build-rules.md
 msgid "Learning Bazel-like build rules is useful for all Rust OS developers."
 msgstr ""
 
-#: src/android/build-rules.md:39
+#: src/android/build-rules.md
 msgid "Fun fact: Data from Star Trek is a Soong-type Android."
 msgstr ""
 
-#: src/android/build-rules/binary.md:1
+#: src/android/build-rules/binary.md
 msgid "Rust Binaries"
 msgstr ""
 
-#: src/android/build-rules/binary.md:3
+#: src/android/build-rules/binary.md
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
 "create the following files:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
+#: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "_hello_rust/Android.bp_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:10 src/android/build-rules/binary.md:11
+#: src/android/build-rules/binary.md
 msgid "\"hello_rust\""
 msgstr ""
 
-#: src/android/build-rules/binary.md:12 src/android/build-rules/library.md:19
-#: src/android/logging.md:12
+#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/logging.md
 msgid "\"src/main.rs\""
 msgstr ""
 
-#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
+#: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "_hello_rust/src/main.rs_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:19 src/android/build-rules/library.md:37
+#: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "//! Rust demo.\n"
 msgstr ""
 
-#: src/android/build-rules/binary.md:20 src/android/build-rules/library.md:41
+#: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "/// Prints a greeting to standard output.\n"
 msgstr ""
 
-#: src/android/build-rules/binary.md:23 src/exercises/chromium/build-rules.md:9
+#: src/android/build-rules/binary.md src/exercises/chromium/build-rules.md
 msgid "\"Hello from Rust!\""
 msgstr ""
 
-#: src/android/build-rules/binary.md:27
+#: src/android/build-rules/binary.md
 msgid "You can now build, push, and run the binary:"
 msgstr ""
 
-#: src/android/build-rules/binary.md:29
+#: src/android/build-rules/binary.md
 msgid ""
 "```shell\n"
 "m hello_rust\n"
@@ -10889,76 +10704,76 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/build-rules/library.md:1
+#: src/android/build-rules/library.md
 msgid "Rust Libraries"
 msgstr ""
 
-#: src/android/build-rules/library.md:3
+#: src/android/build-rules/library.md
 msgid "You use `rust_library` to create a new Rust library for Android."
 msgstr ""
 
-#: src/android/build-rules/library.md:5
+#: src/android/build-rules/library.md
 msgid "Here we declare a dependency on two libraries:"
 msgstr ""
 
-#: src/android/build-rules/library.md:7
+#: src/android/build-rules/library.md
 msgid "`libgreeting`, which we define below,"
 msgstr ""
 
-#: src/android/build-rules/library.md:8
+#: src/android/build-rules/library.md
 msgid ""
 "`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
 "(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
 "crates/)."
 msgstr ""
 
-#: src/android/build-rules/library.md:17 src/android/build-rules/library.md:18
+#: src/android/build-rules/library.md
 msgid "\"hello_rust_with_dep\""
 msgstr ""
 
-#: src/android/build-rules/library.md:21 src/android/build-rules/library.md:28
+#: src/android/build-rules/library.md
 msgid "\"libgreetings\""
 msgstr ""
 
-#: src/android/build-rules/library.md:22
+#: src/android/build-rules/library.md
 msgid "\"libtextwrap\""
 msgstr ""
 
-#: src/android/build-rules/library.md:24
+#: src/android/build-rules/library.md
 msgid "// Need this to avoid dynamic link error.\n"
 msgstr ""
 
-#: src/android/build-rules/library.md:29
+#: src/android/build-rules/library.md
 msgid "\"greetings\""
 msgstr ""
 
-#: src/android/build-rules/library.md:30
-#: src/android/aidl/example-service/service.md:28 src/android/testing.md:12
-#: src/android/testing.md:18 src/android/interoperability/java.md:39
+#: src/android/build-rules/library.md
+#: src/android/aidl/example-service/service.md src/android/testing.md
+#: src/android/interoperability/java.md
 msgid "\"src/lib.rs\""
 msgstr ""
 
-#: src/android/build-rules/library.md:48
+#: src/android/build-rules/library.md
 msgid "_hello_rust/src/lib.rs_:"
 msgstr ""
 
-#: src/android/build-rules/library.md:51
+#: src/android/build-rules/library.md
 msgid "//! Greeting library.\n"
 msgstr ""
 
-#: src/android/build-rules/library.md:52
+#: src/android/build-rules/library.md
 msgid "/// Greet `name`.\n"
 msgstr ""
 
-#: src/android/build-rules/library.md:55
+#: src/android/build-rules/library.md
 msgid "\"Hello {name}, it is very nice to meet you!\""
 msgstr ""
 
-#: src/android/build-rules/library.md:59
+#: src/android/build-rules/library.md
 msgid "You build, push, and run the binary like before:"
 msgstr ""
 
-#: src/android/build-rules/library.md:61
+#: src/android/build-rules/library.md
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
@@ -10968,217 +10783,216 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md:3
+#: src/android/aidl.md
 msgid ""
 "The [Android Interface Definition Language (AIDL)](https://developer.android."
 "com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
-#: src/android/aidl.md:8
+#: src/android/aidl.md
 msgid "Rust code can call existing AIDL servers,"
 msgstr ""
 
-#: src/android/aidl.md:9
+#: src/android/aidl.md
 msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
-#: src/android/aidl/birthday-service.md:3
+#: src/android/aidl/birthday-service.md
 msgid ""
 "To illustrate how to use Rust with Binder, we're going to walk through the "
 "process of creating a Binder interface. We're then going to both implement "
 "the described service and write client code that talks to that service."
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:1
+#: src/android/aidl/example-service/interface.md
 msgid "AIDL Interfaces"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:3
+#: src/android/aidl/example-service/interface.md
 msgid "You declare the API of your service using an AIDL interface:"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:5
-#: src/android/aidl/example-service/service-bindings.md:6
+#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/service-bindings.md
 msgid ""
 "_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:8
-#: src/android/aidl/example-service/service-bindings.md:9
-#: src/android/aidl/example-service/changing-definition.md:8
+#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/changing-definition.md
 msgid "/** Birthday service interface. */"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:10
-#: src/android/aidl/example-service/service-bindings.md:11
-#: src/android/aidl/example-service/changing-definition.md:11
+#: src/android/aidl/example-service/interface.md
+#: src/android/aidl/example-service/service-bindings.md
+#: src/android/aidl/example-service/changing-definition.md
 msgid "/** Generate a Happy Birthday message. */"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:15
+#: src/android/aidl/example-service/interface.md
 msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:19
+#: src/android/aidl/example-service/interface.md
 msgid "\"com.example.birthdayservice\""
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:20
+#: src/android/aidl/example-service/interface.md
 msgid "\"com/example/birthdayservice/*.aidl\""
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:23
+#: src/android/aidl/example-service/interface.md
 msgid "// Rust is not enabled by default\n"
 msgstr ""
 
-#: src/android/aidl/example-service/interface.md:32
+#: src/android/aidl/example-service/interface.md
 msgid ""
 "Note that the directory structure under the `aidl/` directory needs to match "
 "the package name used in the AIDL file, i.e. the package is `com.example."
 "birthdayservice` and the file is at `aidl/com/example/IBirthdayService.aidl`."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md:1
+#: src/android/aidl/example-service/service-bindings.md
 msgid "Generated Service API"
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md:3
+#: src/android/aidl/example-service/service-bindings.md
 msgid ""
 "Binder generates a trait corresponding to the interface definition. trait to "
 "talk to the service."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md:16
+#: src/android/aidl/example-service/service-bindings.md
 msgid "_Generated trait_:"
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md:24
+#: src/android/aidl/example-service/service-bindings.md
 msgid ""
 "Your service will need to implement this trait, and your client will use "
 "this trait to talk to the service."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md:29
+#: src/android/aidl/example-service/service-bindings.md
 msgid ""
 "The generated bindings can be found at `out/soong/.intermediates/<path to "
 "module>/`."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md:31
+#: src/android/aidl/example-service/service-bindings.md
 msgid ""
 "Point out how the generated function signature, specifically the argument "
 "and return types, correspond the interface definition."
 msgstr ""
 
-#: src/android/aidl/example-service/service-bindings.md:33
+#: src/android/aidl/example-service/service-bindings.md
 msgid ""
 "`String` for an argument results in a different Rust type than `String` as a "
 "return type."
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:1
+#: src/android/aidl/example-service/service.md
 msgid "Service Implementation"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:3
+#: src/android/aidl/example-service/service.md
 msgid "We can now implement the AIDL service:"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:5
-#: src/android/aidl/example-service/changing-implementation.md:5
+#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/changing-implementation.md
 msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:10
+#: src/android/aidl/example-service/service.md
 msgid "/// The `IBirthdayService` implementation.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:18
-#: src/android/aidl/example-service/changing-implementation.md:16
-#: src/android/aidl/types/file-descriptor.md:57
+#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/changing-implementation.md
+#: src/android/aidl/types/file-descriptor.md
 msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:23
-#: src/android/aidl/example-service/server.md:28
-#: src/android/aidl/example-service/client.md:31
+#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/client.md
 msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:27
-#: src/android/aidl/example-service/server.md:38
+#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/server.md
 msgid "\"libbirthdayservice\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:29
-#: src/android/aidl/example-service/server.md:13
-#: src/android/aidl/example-service/client.md:11
+#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/client.md
 msgid "\"birthdayservice\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:31
-#: src/android/aidl/example-service/server.md:36
-#: src/android/aidl/example-service/client.md:39
+#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/client.md
 msgid "\"com.example.birthdayservice-rust\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:32
-#: src/android/aidl/example-service/server.md:37
-#: src/android/aidl/example-service/client.md:40
+#: src/android/aidl/example-service/service.md
+#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/client.md
 msgid "\"libbinder_rs\""
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:39
+#: src/android/aidl/example-service/service.md
 msgid ""
 "Point out the path to the generated `IBirthdayService` trait, and explain "
 "why each of the segments is necessary."
 msgstr ""
 
-#: src/android/aidl/example-service/service.md:41
+#: src/android/aidl/example-service/service.md
 msgid ""
 "TODO: What does the `binder::Interface` trait do? Are there methods to "
 "override? Where source?"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:1
+#: src/android/aidl/example-service/server.md
 msgid "AIDL Server"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:3
+#: src/android/aidl/example-service/server.md
 msgid "Finally, we can create a server which exposes the service:"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:5
+#: src/android/aidl/example-service/server.md
 msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:8
+#: src/android/aidl/example-service/server.md
 msgid "//! Birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:14
+#: src/android/aidl/example-service/server.md
 msgid "/// Entry point for birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:23
+#: src/android/aidl/example-service/server.md
 msgid "\"Failed to register service\""
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:32
-#: src/android/aidl/example-service/server.md:33
+#: src/android/aidl/example-service/server.md
 msgid "\"birthday_server\""
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:34
+#: src/android/aidl/example-service/server.md
 msgid "\"src/server.rs\""
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:40
-#: src/android/aidl/example-service/client.md:42
+#: src/android/aidl/example-service/server.md
+#: src/android/aidl/example-service/client.md
 msgid "// To avoid dynamic link error.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:46
+#: src/android/aidl/example-service/server.md
 msgid ""
 "The process for taking a user-defined service implementation (in this case "
 "the `BirthdayService` type, which implements the `IBirthdayService`) and "
@@ -11187,11 +11001,11 @@ msgid ""
 "another language. Explain to students why each step is necessary."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:52
+#: src/android/aidl/example-service/server.md
 msgid "Create an instance of your service type (`BirthdayService`)."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:53
+#: src/android/aidl/example-service/server.md
 msgid ""
 "Wrap the service object in corresponding `Bn*` type (`BnBirthdayService` in "
 "this case). This type is generated by Binder and provides the common Binder "
@@ -11200,23 +11014,23 @@ msgid ""
 "`BirthdayService` within the generated `BnBinderService`."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:58
+#: src/android/aidl/example-service/server.md
 msgid ""
 "Call `add_service`, giving it a service identifier and your service object "
 "(the `BnBirthdayService` object in the example)."
 msgstr ""
 
-#: src/android/aidl/example-service/server.md:60
+#: src/android/aidl/example-service/server.md
 msgid ""
 "Call `join_thread_pool` to add the current thread to Binder's thread pool "
 "and start listening for connections."
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md:3
+#: src/android/aidl/example-service/deploy.md
 msgid "We can now build, push, and start the service:"
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md:5
+#: src/android/aidl/example-service/deploy.md
 msgid ""
 "```shell\n"
 "m birthday_server\n"
@@ -11227,64 +11041,62 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md:12
+#: src/android/aidl/example-service/deploy.md
 msgid "In another terminal, check that the service runs:"
 msgstr ""
 
-#: src/android/aidl/example-service/deploy.md:22
+#: src/android/aidl/example-service/deploy.md
 msgid "You can also call the service with `service call`:"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:1
+#: src/android/aidl/example-service/client.md
 msgid "AIDL Client"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:3
+#: src/android/aidl/example-service/client.md
 msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:5
-#: src/android/aidl/example-service/changing-implementation.md:29
+#: src/android/aidl/example-service/client.md
+#: src/android/aidl/example-service/changing-implementation.md
 msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:12
+#: src/android/aidl/example-service/client.md
 msgid "/// Call the birthday service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:23
-#: src/android/aidl/types/objects.md:54
-#: src/android/aidl/types/parcelables.md:32
-#: src/android/aidl/types/file-descriptor.md:20
+#: src/android/aidl/example-service/client.md src/android/aidl/types/objects.md
+#: src/android/aidl/types/parcelables.md
+#: src/android/aidl/types/file-descriptor.md
 msgid "\"Failed to connect to BirthdayService\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:25
+#: src/android/aidl/example-service/client.md
 msgid "// Call the service.\n"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:27
+#: src/android/aidl/example-service/client.md
 msgid "\"{msg}\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:35
-#: src/android/aidl/example-service/client.md:36
+#: src/android/aidl/example-service/client.md
 msgid "\"birthday_client\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:37
+#: src/android/aidl/example-service/client.md
 msgid "\"src/client.rs\""
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:46
+#: src/android/aidl/example-service/client.md
 msgid "Notice that the client does not depend on `libbirthdayservice`."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:48
+#: src/android/aidl/example-service/client.md
 msgid "Build, push, and run the client on your device:"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:50
+#: src/android/aidl/example-service/client.md
 msgid ""
 "```shell\n"
 "m birthday_client\n"
@@ -11294,20 +11106,20 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:62
+#: src/android/aidl/example-service/client.md
 msgid ""
 "`Strong<dyn IBirthdayService>` is the trait object representing the service "
 "that the client has connected to."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:64
+#: src/android/aidl/example-service/client.md
 msgid ""
 "`Strong` is a custom smart pointer type for Binder. It handles both an in-"
 "process ref count for the service trait object, and the global Binder ref "
 "count that tracks how many processes have a reference to the object."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:67
+#: src/android/aidl/example-service/client.md
 msgid ""
 "Note that the trait object that the client uses to talk to the service uses "
 "the exact same trait that the server implements. For a given Binder "
@@ -11315,203 +11127,203 @@ msgid ""
 "server use."
 msgstr ""
 
-#: src/android/aidl/example-service/client.md:71
+#: src/android/aidl/example-service/client.md
 msgid ""
 "Use the same service identifier used when registering the service. This "
 "should ideally be defined in a common crate that both the client and server "
 "can depend on."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md:3
+#: src/android/aidl/example-service/changing-definition.md
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
 "specify a list of lines for the birthday card:"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md:16
+#: src/android/aidl/example-service/changing-definition.md
 msgid "This results in an updated trait definition for `IBirthdayService`:"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md:31
+#: src/android/aidl/example-service/changing-definition.md
 msgid ""
 "Note how the `String[]` in the AIDL definition is translated as a "
 "`&[String]` in Rust, i.e. that idiomatic Rust types are used in the "
 "generated bindings wherever possible:"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md:34
+#: src/android/aidl/example-service/changing-definition.md
 msgid "`in` array arguments are translated to slices."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md:35
+#: src/android/aidl/example-service/changing-definition.md
 msgid "`out` and `inout` args are translated to `&mut Vec<T>`."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-definition.md:36
+#: src/android/aidl/example-service/changing-definition.md
 msgid "Return values are translated to returning a `Vec<T>`."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md:1
+#: src/android/aidl/example-service/changing-implementation.md
 msgid "Updating Client and Service"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md:3
+#: src/android/aidl/example-service/changing-implementation.md
 msgid "Update the client and server code to account for the new API."
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md:20
+#: src/android/aidl/example-service/changing-implementation.md
 msgid "'\\n'"
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md:36
+#: src/android/aidl/example-service/changing-implementation.md
 msgid "\"Habby birfday to yuuuuu\""
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md:37
+#: src/android/aidl/example-service/changing-implementation.md
 msgid "\"And also: many more\""
 msgstr ""
 
-#: src/android/aidl/example-service/changing-implementation.md:44
+#: src/android/aidl/example-service/changing-implementation.md
 msgid ""
 "TODO: Move code snippets into project files where they'll actually be built?"
 msgstr ""
 
-#: src/android/aidl/types.md:1
+#: src/android/aidl/types.md
 msgid "Working With AIDL Types"
 msgstr ""
 
-#: src/android/aidl/types.md:3
+#: src/android/aidl/types.md
 msgid "AIDL types translate into the appropriate idiomatic Rust type:"
 msgstr ""
 
-#: src/android/aidl/types.md:5
+#: src/android/aidl/types.md
 msgid "Primitive types map (mostly) to idiomatic Rust types."
 msgstr ""
 
-#: src/android/aidl/types.md:6
+#: src/android/aidl/types.md
 msgid "Collection types like slices, `Vec`s and string types are supported."
 msgstr ""
 
-#: src/android/aidl/types.md:7
+#: src/android/aidl/types.md
 msgid ""
 "References to AIDL objects and file handles can be sent between clients and "
 "services."
 msgstr ""
 
-#: src/android/aidl/types.md:9
+#: src/android/aidl/types.md
 msgid "File handles and parcelables are fully supported."
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:3
+#: src/android/aidl/types/primitives.md
 msgid "Primitive types map (mostly) idiomatically:"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:5
+#: src/android/aidl/types/primitives.md
 msgid "AIDL Type"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:5 src/android/aidl/types/arrays.md:7
-#: src/android/interoperability/cpp/type-mapping.md:3
+#: src/android/aidl/types/primitives.md src/android/aidl/types/arrays.md
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "Rust Type"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:5
+#: src/android/aidl/types/primitives.md
 msgid "Note"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:7
+#: src/android/aidl/types/primitives.md
 msgid "`boolean`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:8
+#: src/android/aidl/types/primitives.md
 msgid "`byte`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:8
+#: src/android/aidl/types/primitives.md
 msgid "`i8`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:8
+#: src/android/aidl/types/primitives.md
 msgid "Note that bytes are signed."
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:9
+#: src/android/aidl/types/primitives.md
 msgid "`u16`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:9
+#: src/android/aidl/types/primitives.md
 msgid "Note the usage of `u16`, NOT `u32`."
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:10
+#: src/android/aidl/types/primitives.md
 msgid "`int`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:10
+#: src/android/aidl/types/primitives.md
 msgid "`i32`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:11
+#: src/android/aidl/types/primitives.md
 msgid "`long`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:11
+#: src/android/aidl/types/primitives.md
 msgid "`i64`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:12
+#: src/android/aidl/types/primitives.md
 msgid "`float`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:12
+#: src/android/aidl/types/primitives.md
 msgid "`f32`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:13
+#: src/android/aidl/types/primitives.md
 msgid "`double`"
 msgstr ""
 
-#: src/android/aidl/types/primitives.md:13
+#: src/android/aidl/types/primitives.md
 msgid "`f64`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:3
+#: src/android/aidl/types/arrays.md
 msgid ""
 "The array types (`T[]`, `byte[]`, and `List<T>`) get translated to the "
 "appropriate Rust array type depending on how they are used in the function "
 "signature:"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:7
+#: src/android/aidl/types/arrays.md
 msgid "Position"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:9
+#: src/android/aidl/types/arrays.md
 msgid "`in` argument"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:9
+#: src/android/aidl/types/arrays.md
 msgid "`&[T]`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:10
+#: src/android/aidl/types/arrays.md
 msgid "`out`/`inout` argument"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:10
+#: src/android/aidl/types/arrays.md
 msgid "`&mut Vec<T>`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:11
+#: src/android/aidl/types/arrays.md
 msgid "Return"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:11
-#: src/android/interoperability/cpp/type-mapping.md:11
+#: src/android/aidl/types/arrays.md
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`Vec<T>`"
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:15
+#: src/android/aidl/types/arrays.md
 msgid ""
 "In Android 13 or higher, fixed-size arrays are supported, i.e. `T[N]` "
 "becomes `[T; N]`. Fixed-size arrays can have multiple dimensions (e.g. "
@@ -11519,114 +11331,112 @@ msgid ""
 "as array types."
 msgstr ""
 
-#: src/android/aidl/types/arrays.md:18
+#: src/android/aidl/types/arrays.md
 msgid "Arrays in parcelable fields always get translated to `Vec<T>`."
 msgstr ""
 
-#: src/android/aidl/types/objects.md:3
+#: src/android/aidl/types/objects.md
 msgid ""
 "AIDL objects can be sent either as a concrete AIDL type or as the type-"
 "erased `IBinder` interface:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:6
+#: src/android/aidl/types/objects.md
 msgid ""
 "**birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider."
 "aidl**:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:17
-#: src/android/aidl/types/parcelables.md:16
-#: src/android/aidl/types/file-descriptor.md:6
+#: src/android/aidl/types/objects.md src/android/aidl/types/parcelables.md
+#: src/android/aidl/types/file-descriptor.md
 msgid ""
 "**birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl**:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:23
+#: src/android/aidl/types/objects.md
 msgid "/** The same thing, but using a binder object. */"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:26
+#: src/android/aidl/types/objects.md
 msgid "/** The same thing, but using `IBinder`. */"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:31
-#: src/android/aidl/types/parcelables.md:27
-#: src/android/aidl/types/file-descriptor.md:15
+#: src/android/aidl/types/objects.md src/android/aidl/types/parcelables.md
+#: src/android/aidl/types/file-descriptor.md
 msgid "**birthday_service/src/client.rs**:"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:34
+#: src/android/aidl/types/objects.md
 msgid "/// Rust struct implementing the `IBirthdayInfoProvider` interface.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:56
+#: src/android/aidl/types/objects.md
 msgid "// Create a binder object for the `IBirthdayInfoProvider` interface.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:62
+#: src/android/aidl/types/objects.md
 msgid "// Send the binder object to the service.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:65
+#: src/android/aidl/types/objects.md
 msgid ""
 "// Perform the same operation but passing the provider as an `SpIBinder`.\n"
 msgstr ""
 
-#: src/android/aidl/types/objects.md:72
+#: src/android/aidl/types/objects.md
 msgid ""
 "Note the usage of `BnBirthdayInfoProvider`. This serves the same purpose as "
 "`BnBirthdayService` that we saw previously."
 msgstr ""
 
-#: src/android/aidl/types/parcelables.md:3
+#: src/android/aidl/types/parcelables.md
 msgid "Binder for Rust supports sending parcelables directly:"
 msgstr ""
 
-#: src/android/aidl/types/parcelables.md:5
+#: src/android/aidl/types/parcelables.md
 msgid ""
 "**birthday_service/aidl/com/example/birthdayservice/BirthdayInfo.aidl**:"
 msgstr ""
 
-#: src/android/aidl/types/parcelables.md:22
+#: src/android/aidl/types/parcelables.md
 msgid "/** The same thing, but with a parcelable. */"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:3
+#: src/android/aidl/types/file-descriptor.md
 msgid ""
 "Files can be sent between Binder clients/servers using the "
 "`ParcelFileDescriptor` type:"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:10
+#: src/android/aidl/types/file-descriptor.md
 msgid "/** The same thing, but loads info from a file. */"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:22
+#: src/android/aidl/types/file-descriptor.md
 msgid "// Open a file and put the birthday info in it.\n"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:23
+#: src/android/aidl/types/file-descriptor.md
 msgid "\"/data/local/tmp/birthday.info\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:24
+#: src/android/aidl/types/file-descriptor.md
 msgid "\"{name}\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:25
+#: src/android/aidl/types/file-descriptor.md
 msgid "\"{years}\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:27
+#: src/android/aidl/types/file-descriptor.md
 msgid "// Create a `ParcelFileDescriptor` from the file and send it.\n"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:33
+#: src/android/aidl/types/file-descriptor.md
 msgid "**birthday_service/src/lib.rs**:"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:41
+#: src/android/aidl/types/file-descriptor.md
 msgid ""
 "// Convert the file descriptor to a `File`. `ParcelFileDescriptor` wraps\n"
 "        // an `OwnedFd`, which can be cloned and then used to create a "
@@ -11634,90 +11444,90 @@ msgid ""
 "        // object.\n"
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:48
+#: src/android/aidl/types/file-descriptor.md
 msgid "\"Invalid file handle\""
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:64
+#: src/android/aidl/types/file-descriptor.md
 msgid ""
 "`ParcelFileDescriptor` wraps an `OwnedFd`, and so can be created from a "
 "`File` (or any other type that wraps an `OwnedFd`), and can be used to "
 "create a new `File` handle on the other side."
 msgstr ""
 
-#: src/android/aidl/types/file-descriptor.md:67
+#: src/android/aidl/types/file-descriptor.md
 msgid ""
 "Other types of file descriptors can be wrapped and sent, e.g. TCP, UDP, and "
 "UNIX sockets."
 msgstr ""
 
-#: src/android/testing.md:1
+#: src/android/testing.md
 msgid "Testing in Android"
 msgstr ""
 
-#: src/android/testing.md:3
+#: src/android/testing.md
 msgid ""
 "Building on [Testing](../testing.md), we will now look at how unit tests "
 "work in AOSP. Use the `rust_test` module for your unit tests:"
 msgstr ""
 
-#: src/android/testing.md:6
+#: src/android/testing.md
 msgid "_testing/Android.bp_:"
 msgstr ""
 
-#: src/android/testing.md:10
+#: src/android/testing.md
 msgid "\"libleftpad\""
 msgstr ""
 
-#: src/android/testing.md:11
+#: src/android/testing.md
 msgid "\"leftpad\""
 msgstr ""
 
-#: src/android/testing.md:16
+#: src/android/testing.md
 msgid "\"libleftpad_test\""
 msgstr ""
 
-#: src/android/testing.md:17
+#: src/android/testing.md
 msgid "\"leftpad_test\""
 msgstr ""
 
-#: src/android/testing.md:20 src/android/interoperability/with-c/bindgen.md:116
+#: src/android/testing.md src/android/interoperability/with-c/bindgen.md
 msgid "\"general-tests\""
 msgstr ""
 
-#: src/android/testing.md:24
+#: src/android/testing.md
 msgid "_testing/src/lib.rs_:"
 msgstr ""
 
-#: src/android/testing.md:27
+#: src/android/testing.md
 msgid "//! Left-padding library.\n"
 msgstr ""
 
-#: src/android/testing.md:28
+#: src/android/testing.md
 msgid "/// Left-pad `s` to `width`.\n"
 msgstr ""
 
-#: src/android/testing.md:31
+#: src/android/testing.md
 msgid "\"{s:>width$}\""
 msgstr ""
 
-#: src/android/testing.md:40
+#: src/android/testing.md
 msgid "\"  foo\""
 msgstr ""
 
-#: src/android/testing.md:45
+#: src/android/testing.md
 msgid "\"foobar\""
 msgstr ""
 
-#: src/android/testing.md:50
+#: src/android/testing.md
 msgid "You can now run the test with"
 msgstr ""
 
-#: src/android/testing.md:56
+#: src/android/testing.md
 msgid "The output looks like this:"
 msgstr ""
 
-#: src/android/testing.md:58
+#: src/android/testing.md
 msgid ""
 "```text\n"
 "INFO: Elapsed time: 2.666s, Critical Path: 2.40s\n"
@@ -11731,47 +11541,47 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/testing.md:68
+#: src/android/testing.md
 msgid ""
 "Notice how you only mention the root of the library crate. Tests are found "
 "recursively in nested modules."
 msgstr ""
 
-#: src/android/testing/googletest.md:3
+#: src/android/testing/googletest.md
 msgid ""
 "The [GoogleTest](https://docs.rs/googletest/) crate allows for flexible test "
 "assertions using _matchers_:"
 msgstr ""
 
-#: src/android/testing/googletest.md:11
+#: src/android/testing/googletest.md
 msgid "\"baz\""
 msgstr ""
 
-#: src/android/testing/googletest.md:12
+#: src/android/testing/googletest.md
 msgid "\"xyz\""
 msgstr ""
 
-#: src/android/testing/googletest.md:16
+#: src/android/testing/googletest.md
 msgid ""
 "If we change the last element to `\"!\"`, the test fails with a structured "
 "error message pin-pointing the error:"
 msgstr ""
 
-#: src/android/testing/googletest.md:37
+#: src/android/testing/googletest.md
 msgid ""
 "GoogleTest is not part of the Rust Playground, so you need to run this "
 "example in a local environment. Use `cargo add googletest` to quickly add it "
 "to an existing Cargo project."
 msgstr ""
 
-#: src/android/testing/googletest.md:41
+#: src/android/testing/googletest.md
 msgid ""
 "The `use googletest::prelude::*;` line imports a number of [commonly used "
 "macros and types](https://docs.rs/googletest/latest/googletest/prelude/index."
 "html)."
 msgstr ""
 
-#: src/android/testing/googletest.md:44
+#: src/android/testing/googletest.md
 msgid ""
 "This just scratches the surface, there are many builtin matchers. Consider "
 "going through the first chapter of [\"Advanced testing for Rust "
@@ -11781,44 +11591,44 @@ msgid ""
 "macros, its matchers and its overall philosophy."
 msgstr ""
 
-#: src/android/testing/googletest.md:51
+#: src/android/testing/googletest.md
 msgid ""
 "A particularly nice feature is that mismatches in multi-line strings are "
 "shown as a diff:"
 msgstr ""
 
-#: src/android/testing/googletest.md:57
+#: src/android/testing/googletest.md
 msgid ""
 "\"Memory safety found,\\n\\\n"
 "                 Rust's strong typing guides the way,\\n\\\n"
 "                 Secure code you'll write.\""
 msgstr ""
 
-#: src/android/testing/googletest.md:62
+#: src/android/testing/googletest.md
 msgid ""
 "\"Memory safety found,\\n\\\n"
 "            Rust's silly humor guides the way,\\n\\\n"
 "            Secure code you'll write.\""
 msgstr ""
 
-#: src/android/testing/googletest.md:69
+#: src/android/testing/googletest.md
 msgid "shows a color-coded diff (colors not shown here):"
 msgstr ""
 
-#: src/android/testing/googletest.md:86
+#: src/android/testing/googletest.md
 msgid ""
 "The crate is a Rust port of [GoogleTest for C++](https://google.github.io/"
 "googletest/)."
 msgstr ""
 
-#: src/android/testing/mocking.md:3
+#: src/android/testing/mocking.md
 msgid ""
 "For mocking, [Mockall](https://docs.rs/mockall/) is a widely used library. "
 "You need to refactor your code to use traits, which you can then quickly "
 "mock:"
 msgstr ""
 
-#: src/android/testing/mocking.md:27
+#: src/android/testing/mocking.md
 msgid ""
 "Mockall is the recommended mocking library in Android (AOSP). There are "
 "other [mocking libraries available on crates.io](https://crates.io/keywords/"
@@ -11827,7 +11637,7 @@ msgid ""
 "easy to get a mock implementation of a given trait."
 msgstr ""
 
-#: src/android/testing/mocking.md:33
+#: src/android/testing/mocking.md
 msgid ""
 "Note that mocking is somewhat _controversial_: mocks allow you to completely "
 "isolate a test from its dependencies. The immediate result is faster and "
@@ -11835,7 +11645,7 @@ msgid ""
 "wrongly and return output different from what the real dependencies would do."
 msgstr ""
 
-#: src/android/testing/mocking.md:38
+#: src/android/testing/mocking.md
 msgid ""
 "If at all possible, it is recommended that you use the real dependencies. As "
 "an example, many databases allow you to configure an in-memory backend. This "
@@ -11843,90 +11653,90 @@ msgid ""
 "and will automatically clean up after themselves."
 msgstr ""
 
-#: src/android/testing/mocking.md:43
+#: src/android/testing/mocking.md
 msgid ""
 "Similarly, many web frameworks allow you to start an in-process server which "
 "binds to a random port on `localhost`. Always prefer this over mocking away "
 "the framework since it helps you test your code in the real environment."
 msgstr ""
 
-#: src/android/testing/mocking.md:47
+#: src/android/testing/mocking.md
 msgid ""
 "Mockall is not part of the Rust Playground, so you need to run this example "
 "in a local environment. Use `cargo add mockall` to quickly add Mockall to an "
 "existing Cargo project."
 msgstr ""
 
-#: src/android/testing/mocking.md:51
+#: src/android/testing/mocking.md
 msgid ""
 "Mockall has a lot more functionality. In particular, you can set up "
 "expectations which depend on the arguments passed. Here we use this to mock "
 "a cat which becomes hungry 3 hours after the last time it was fed:"
 msgstr ""
 
-#: src/android/testing/mocking.md:69
+#: src/android/testing/mocking.md
 msgid ""
 "You can use `.times(n)` to limit the number of times a mock method can be "
 "called to `n` --- the mock will automatically panic when dropped if this "
 "isn't satisfied."
 msgstr ""
 
-#: src/android/logging.md:3
+#: src/android/logging.md
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
 "or `stdout` (on-host):"
 msgstr ""
 
-#: src/android/logging.md:6
+#: src/android/logging.md
 msgid "_hello_rust_logs/Android.bp_:"
 msgstr ""
 
-#: src/android/logging.md:10 src/android/logging.md:11
+#: src/android/logging.md
 msgid "\"hello_rust_logs\""
 msgstr ""
 
-#: src/android/logging.md:14
+#: src/android/logging.md
 msgid "\"liblog_rust\""
 msgstr ""
 
-#: src/android/logging.md:15
+#: src/android/logging.md
 msgid "\"liblogger\""
 msgstr ""
 
-#: src/android/logging.md:21
+#: src/android/logging.md
 msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
-#: src/android/logging.md:24
+#: src/android/logging.md
 msgid "//! Rust logging demo.\n"
 msgstr ""
 
-#: src/android/logging.md:27
+#: src/android/logging.md
 msgid "/// Logs a greeting.\n"
 msgstr ""
 
-#: src/android/logging.md:32
+#: src/android/logging.md
 msgid "\"rust\""
 msgstr ""
 
-#: src/android/logging.md:35
+#: src/android/logging.md
 msgid "\"Starting program.\""
 msgstr ""
 
-#: src/android/logging.md:36
+#: src/android/logging.md
 msgid "\"Things are going fine.\""
 msgstr ""
 
-#: src/android/logging.md:37
+#: src/android/logging.md
 msgid "\"Something went wrong!\""
 msgstr ""
 
-#: src/android/logging.md:41 src/android/interoperability/with-c/bindgen.md:99
-#: src/android/interoperability/with-c/rust.md:72
+#: src/android/logging.md src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/rust.md
 msgid "Build, push, and run the binary on your device:"
 msgstr ""
 
-#: src/android/logging.md:43
+#: src/android/logging.md
 msgid ""
 "```shell\n"
 "m hello_rust_logs\n"
@@ -11936,184 +11746,177 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:49
+#: src/android/logging.md
 msgid "The logs show up in `adb logcat`:"
 msgstr ""
 
-#: src/android/interoperability.md:3
+#: src/android/interoperability.md
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
 "means that you can:"
 msgstr ""
 
-#: src/android/interoperability.md:6
+#: src/android/interoperability.md
 msgid "Call Rust functions from other languages."
 msgstr ""
 
-#: src/android/interoperability.md:7
+#: src/android/interoperability.md
 msgid "Call functions written in other languages from Rust."
 msgstr ""
 
-#: src/android/interoperability.md:9
+#: src/android/interoperability.md
 msgid ""
 "When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
-#: src/android/interoperability/with-c.md:1
+#: src/android/interoperability/with-c.md
 msgid "Interoperability with C"
 msgstr ""
 
-#: src/android/interoperability/with-c.md:3
+#: src/android/interoperability/with-c.md
 msgid ""
 "Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
-#: src/android/interoperability/with-c.md:6
+#: src/android/interoperability/with-c.md
 msgid "You can do it by hand if you want:"
 msgstr ""
 
-#: src/android/interoperability/with-c.md:15
+#: src/android/interoperability/with-c.md
 msgid "// SAFETY: `abs` doesn't have any safety requirements.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c.md:17
+#: src/android/interoperability/with-c.md
 msgid "\"{x}, {abs_x}\""
 msgstr ""
 
-#: src/android/interoperability/with-c.md:21
+#: src/android/interoperability/with-c.md
 msgid ""
 "We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
 "safe-ffi-wrapper.md)."
 msgstr ""
 
-#: src/android/interoperability/with-c.md:24
+#: src/android/interoperability/with-c.md
 msgid ""
 "This assumes full knowledge of the target platform. Not recommended for "
 "production."
 msgstr ""
 
-#: src/android/interoperability/with-c.md:27
+#: src/android/interoperability/with-c.md
 msgid "We will look at better options next."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:1
+#: src/android/interoperability/with-c/bindgen.md
 msgid "Using Bindgen"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:3
+#: src/android/interoperability/with-c/bindgen.md
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
 "tool can auto-generate bindings from a C header file."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:6
+#: src/android/interoperability/with-c/bindgen.md
 msgid "First create a small C library:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:8
+#: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/libbirthday.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:19
+#: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/libbirthday.c_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:22
+#: src/android/interoperability/with-c/bindgen.md
 msgid "<stdio.h>"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:23
-#: src/android/interoperability/with-c/bindgen.md:50
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:26
-#: src/android/interoperability/with-c/bindgen.md:29
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"+--------------\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:27
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"| Happy Birthday %s!\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:28
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"| Congratulations with the %i years!\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:33
+#: src/android/interoperability/with-c/bindgen.md
 msgid "Add this to your `Android.bp` file:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:35
-#: src/android/interoperability/with-c/bindgen.md:55
-#: src/android/interoperability/with-c/bindgen.md:69
-#: src/android/interoperability/with-c/bindgen.md:109
+#: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:39
-#: src/android/interoperability/with-c/bindgen.md:63
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:40
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday.c\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:44
+#: src/android/interoperability/with-c/bindgen.md
 msgid ""
 "Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:47
+#: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:53
+#: src/android/interoperability/with-c/bindgen.md
 msgid "You can now auto-generate the bindings:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:59
-#: src/android/interoperability/with-c/bindgen.md:75
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:60
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"birthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:61
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_wrapper.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:62
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"bindings\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:67
+#: src/android/interoperability/with-c/bindgen.md
 msgid "Finally, we can use the bindings in our Rust program:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:73
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"print_birthday_card\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:74
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"main.rs\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:79
+#: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/main.rs_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:82
+#: src/android/interoperability/with-c/bindgen.md
 msgid "//! Bindgen demo.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:89
+#: src/android/interoperability/with-c/bindgen.md
 msgid ""
 "// SAFETY: The pointer we pass is valid because it came from a Rust\n"
 "    // reference, and the `name` it contains refers to `name` above which "
@@ -12123,7 +11926,7 @@ msgid ""
 "    // after it returns.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:101
+#: src/android/interoperability/with-c/bindgen.md
 msgid ""
 "```shell\n"
 "m print_birthday_card\n"
@@ -12133,102 +11936,99 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:107
+#: src/android/interoperability/with-c/bindgen.md
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:113
-#: src/android/interoperability/with-c/bindgen.md:115
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_bindgen_test\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:114
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\":libbirthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:118
-#: src/android/interoperability/with-c/bindgen.md:119
+#: src/android/interoperability/with-c/bindgen.md
 msgid "\"none\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md:118
+#: src/android/interoperability/with-c/bindgen.md
 msgid "// Generated file, skip linting\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:1
+#: src/android/interoperability/with-c/rust.md
 msgid "Calling Rust"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:3
+#: src/android/interoperability/with-c/rust.md
 msgid "Exporting Rust functions and types to C is easy:"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:5
+#: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/libanalyze/analyze.rs_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:8
+#: src/android/interoperability/with-c/rust.md
 msgid "//! Rust FFI demo.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:12
+#: src/android/interoperability/with-c/rust.md
 msgid "/// Analyze the numbers.\n"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:17
+#: src/android/interoperability/with-c/rust.md
 msgid "\"x ({x}) is smallest!\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:19
+#: src/android/interoperability/with-c/rust.md
 msgid "\"y ({y}) is probably larger than x ({x})\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:24
+#: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/libanalyze/analyze.h_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:37
+#: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/libanalyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:41
-#: src/android/interoperability/with-c/rust.md:68
+#: src/android/interoperability/with-c/rust.md
 msgid "\"libanalyze_ffi\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:42
+#: src/android/interoperability/with-c/rust.md
 msgid "\"analyze_ffi\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:43
+#: src/android/interoperability/with-c/rust.md
 msgid "\"analyze.rs\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:48
+#: src/android/interoperability/with-c/rust.md
 msgid "We can now call this from a C binary:"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:50
+#: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/analyze/main.c_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:53
+#: src/android/interoperability/with-c/rust.md
 msgid "\"analyze.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:62
+#: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/analyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:66
+#: src/android/interoperability/with-c/rust.md
 msgid "\"analyze_numbers\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:67
+#: src/android/interoperability/with-c/rust.md
 msgid "\"main.c\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:74
+#: src/android/interoperability/with-c/rust.md
 msgid ""
 "```shell\n"
 "m analyze_numbers\n"
@@ -12238,82 +12038,82 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md:82
+#: src/android/interoperability/with-c/rust.md
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
 "will just be the name of the function. You can also use `#[export_name = "
 "\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:3
+#: src/android/interoperability/cpp.md
 msgid ""
 "The [CXX crate](https://cxx.rs/) makes it possible to do safe "
 "interoperability between Rust and C++."
 msgstr ""
 
-#: src/android/interoperability/cpp.md:6
+#: src/android/interoperability/cpp.md
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:3
+#: src/android/interoperability/cpp/bridge.md
 msgid ""
 "CXX relies on a description of the function signatures that will be exposed "
 "from each language to the other. You provide this description using extern "
 "blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:9
+#: src/android/interoperability/cpp/bridge.md
 msgid "\"org::blobstore\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:11
+#: src/android/interoperability/cpp/bridge.md
 msgid "// Shared structs with fields visible to both languages.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:17
-#: src/android/interoperability/cpp/generated-cpp.md:6
+#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/generated-cpp.md
 msgid "// Rust types and signatures exposed to C++.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:18
-#: src/android/interoperability/cpp/rust-bridge.md:6
-#: src/android/interoperability/cpp/generated-cpp.md:7
-#: src/android/interoperability/cpp/rust-result.md:6
-#: src/chromium/interoperability-with-cpp/example-bindings.md:9
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md:10
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:9
+#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/generated-cpp.md
+#: src/android/interoperability/cpp/rust-result.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "\"Rust\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:24
-#: src/android/interoperability/cpp/cpp-bridge.md:6
+#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid "// C++ types and signatures exposed to Rust.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:25
-#: src/android/interoperability/cpp/cpp-bridge.md:7
-#: src/android/interoperability/cpp/cpp-exception.md:6
-#: src/chromium/interoperability-with-cpp/example-bindings.md:15
+#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-exception.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "\"C++\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:26
-#: src/android/interoperability/cpp/cpp-bridge.md:8
+#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"include/blobstore.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:40
+#: src/android/interoperability/cpp/bridge.md
 msgid "The bridge is generally declared in an `ffi` module within your crate."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:41
+#: src/android/interoperability/cpp/bridge.md
 msgid ""
 "From the declarations made in the bridge module, CXX will generate matching "
 "Rust and C++ type/function definitions in order to expose those items to "
 "both languages."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:44
+#: src/android/interoperability/cpp/bridge.md
 msgid ""
 "To view the generated Rust code, use [cargo-expand](https://github.com/"
 "dtolnay/cargo-expand) to view the expanded proc macro. For most of the "
@@ -12321,33 +12121,33 @@ msgid ""
 "(though this doesn't apply for Android projects)."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md:47
+#: src/android/interoperability/cpp/bridge.md
 msgid "To view the generated C++ code, look in `target/cxxbridge`."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:1
+#: src/android/interoperability/cpp/rust-bridge.md
 msgid "Rust Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:7
+#: src/android/interoperability/cpp/rust-bridge.md
 msgid "// Opaque type\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:8
+#: src/android/interoperability/cpp/rust-bridge.md
 msgid "// Method on `MyType`\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:9
+#: src/android/interoperability/cpp/rust-bridge.md
 msgid "// Free function\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:28
+#: src/android/interoperability/cpp/rust-bridge.md
 msgid ""
 "Items declared in the `extern \"Rust\"` reference items that are in scope in "
 "the parent module."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md:30
+#: src/android/interoperability/cpp/rust-bridge.md
 msgid ""
 "The CXX code generator uses your `extern \"Rust\"` section(s) to produce a C+"
 "+ header file containing the corresponding C++ declarations. The generated "
@@ -12355,48 +12155,48 @@ msgid ""
 "except with a .rs.h file extension."
 msgstr ""
 
-#: src/android/interoperability/cpp/generated-cpp.md:15
+#: src/android/interoperability/cpp/generated-cpp.md
 msgid "Results in (roughly) the following C++:"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:1
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid "C++ Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:20
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid "Results in (roughly) the following Rust:"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:30
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:39
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:56
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid ""
 "The programmer does not need to promise that the signatures they have typed "
 "in are accurate. CXX performs static assertions that the signatures exactly "
 "correspond with what is declared in C++."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md:59
+#: src/android/interoperability/cpp/cpp-bridge.md
 msgid ""
 "`unsafe extern` blocks allow you to declare C++ functions that are safe to "
 "call from Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md:9
+#: src/android/interoperability/cpp/shared-types.md
 msgid "// A=1, J=11, Q=12, K=13\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md:23
+#: src/android/interoperability/cpp/shared-types.md
 msgid "Only C-like (unit) enums are supported."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md:24
+#: src/android/interoperability/cpp/shared-types.md
 msgid ""
 "A limited number of traits are supported for `#[derive()]` on shared types. "
 "Corresponding functionality is also generated for the C++ code, e.g. if you "
@@ -12404,15 +12204,15 @@ msgid ""
 "corresponding C++ type."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md:15
+#: src/android/interoperability/cpp/shared-enums.md
 msgid "Generated Rust:"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md:33
+#: src/android/interoperability/cpp/shared-enums.md
 msgid "Generated C++:"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md:46
+#: src/android/interoperability/cpp/shared-enums.md
 msgid ""
 "On the Rust side, the code generated for shared enums is actually a struct "
 "wrapping a numeric value. This is because it is not UB in C++ for an enum "
@@ -12420,48 +12220,48 @@ msgid ""
 "Rust representation needs to have the same behavior."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md:13
+#: src/android/interoperability/cpp/rust-result.md
 msgid "\"fallible1 requires depth > 0\""
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md:16
+#: src/android/interoperability/cpp/rust-result.md
 msgid "\"Success!\""
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md:22
+#: src/android/interoperability/cpp/rust-result.md
 msgid ""
 "Rust functions that return `Result` are translated to exceptions on the C++ "
 "side."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md:24
+#: src/android/interoperability/cpp/rust-result.md
 msgid ""
 "The exception thrown will always be of type `rust::Error`, which primarily "
 "exposes a way to get the error message string. The error message will come "
 "from the error type's `Display` impl."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md:27
+#: src/android/interoperability/cpp/rust-result.md
 msgid ""
 "A panic unwinding from Rust to C++ will always cause the process to "
 "immediately terminate."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md:7
+#: src/android/interoperability/cpp/cpp-exception.md
 msgid "\"example/include/example.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md:14
+#: src/android/interoperability/cpp/cpp-exception.md
 msgid "\"Error: {}\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md:22
+#: src/android/interoperability/cpp/cpp-exception.md
 msgid ""
 "C++ functions declared to return a `Result` will catch any thrown exception "
 "on the C++ side and return it as an `Err` value to the calling Rust function."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md:24
+#: src/android/interoperability/cpp/cpp-exception.md
 msgid ""
 "If an exception is thrown from an extern \"C++\" function that is not "
 "declared by the CXX bridge to return `Result`, the program calls C++'s `std::"
@@ -12469,140 +12269,140 @@ msgid ""
 "through a `noexcept` C++ function."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:3
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "C++ Type"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:5
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::String`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:6
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`&str`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:6
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Str`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:7
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`CxxString`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:7
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`std::string`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:8
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`&[T]`/`&mut [T]`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:8
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Slice`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:9
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Box<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:10
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`UniquePtr<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:10
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`std::unique_ptr<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:11
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Vec<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:12
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`CxxVector<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:12
+#: src/android/interoperability/cpp/type-mapping.md
 msgid "`std::vector<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:16
+#: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "These types can be used in the fields of shared structs and the arguments "
 "and returns of extern functions."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:18
+#: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "Note that Rust's `String` does not map directly to `std::string`. There are "
 "a few reasons for this:"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:20
+#: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "`std::string` does not uphold the UTF-8 invariant that `String` requires."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:21
+#: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "The two types have different layouts in memory and so can't be passed "
 "directly between languages."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md:23
+#: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "`std::string` requires move constructors that don't match Rust's move "
 "semantics, so a `std::string` can't be passed by value to Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:1
-#: src/android/interoperability/cpp/android-cpp-genrules.md:1
-#: src/android/interoperability/cpp/android-build-rust.md:1
+#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-build-rust.md
 msgid "Building in Android"
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:3
+#: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
 "Create a `cc_library_static` to build the C++ library, including the CXX "
 "generated header and source file."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:8
-#: src/android/interoperability/cpp/android-build-rust.md:10
+#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"libcxx_test_cpp\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:9
+#: src/android/interoperability/cpp/android-build-cpp.md
 msgid "\"cxx_test.cpp\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:11
+#: src/android/interoperability/cpp/android-build-cpp.md
 msgid "\"cxx-bridge-header\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:12
-#: src/android/interoperability/cpp/android-cpp-genrules.md:10
+#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"libcxx_test_bridge_header\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:14
-#: src/android/interoperability/cpp/android-cpp-genrules.md:19
+#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"libcxx_test_bridge_code\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:20
+#: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
 "Point out that `libcxx_test_bridge_header` and `libcxx_test_bridge_code` are "
 "the dependencies for the CXX-generated C++ bindings. We'll show how these "
 "are setup on the next slide."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:23
+#: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
 "Note that you also need to depend on the `cxx-bridge-header` library in "
 "order to pull in common CXX definitions."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md:25
+#: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
 "Full docs for using CXX in Android can be found in [the Android docs]"
 "(https://source.android.com/docs/setup/build/rust/building-rust-modules/"
@@ -12611,184 +12411,179 @@ msgid ""
 "instructions again in the future."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:3
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "Create two genrules: One to generate the CXX header, and one to generate the "
 "CXX source file. These are then used as inputs to the `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:7
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "// Generate a C++ header containing the C++ bindings\n"
 "// to the Rust exported functions in lib.rs.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:11
-#: src/android/interoperability/cpp/android-cpp-genrules.md:20
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"cxxbridge\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:12
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:13
-#: src/android/interoperability/cpp/android-cpp-genrules.md:22
-#: src/android/interoperability/cpp/android-build-rust.md:8
+#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"lib.rs\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:14
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"lib.rs.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:16
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "// Generate the C++ code that Rust calls into.\n"
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:21
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"$(location cxxbridge) $(in) > $(out)\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:23
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"lib.rs.cc\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:29
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
 "bridge module. It is included in Android and available as a Soong tool."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md:31
+#: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "By convention, if your Rust source file is `lib.rs` your header file will be "
 "named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
 "convention isn't enforced, though."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md:3
+#: src/android/interoperability/cpp/android-build-rust.md
 msgid ""
 "Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md:7
+#: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"cxx_test\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md:9
+#: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"libcxx\""
 msgstr ""
 
-#: src/android/interoperability/java.md:1
+#: src/android/interoperability/java.md
 msgid "Interoperability with Java"
 msgstr ""
 
-#: src/android/interoperability/java.md:3
+#: src/android/interoperability/java.md
 msgid ""
 "Java can load shared objects via [Java Native Interface (JNI)](https://en."
 "wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
 "jni/) allows you to create a compatible library."
 msgstr ""
 
-#: src/android/interoperability/java.md:8
+#: src/android/interoperability/java.md
 msgid "First, we create a Rust function to export to Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md:10
+#: src/android/interoperability/java.md
 msgid "_interoperability/java/src/lib.rs_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:13
+#: src/android/interoperability/java.md
 msgid "//! Rust <-> Java FFI demo.\n"
 msgstr ""
 
-#: src/android/interoperability/java.md:18
+#: src/android/interoperability/java.md
 msgid "/// HelloWorld::hello method implementation.\n"
 msgstr ""
 
-#: src/android/interoperability/java.md:21
+#: src/android/interoperability/java.md
 msgid "\"system\""
 msgstr ""
 
-#: src/android/interoperability/java.md:27
+#: src/android/interoperability/java.md
 msgid "\"Hello, {input}!\""
 msgstr ""
 
-#: src/android/interoperability/java.md:33
-#: src/android/interoperability/java.md:63
+#: src/android/interoperability/java.md
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:37
-#: src/android/interoperability/java.md:70
+#: src/android/interoperability/java.md
 msgid "\"libhello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:38
-#: src/android/interoperability/java.md:53
+#: src/android/interoperability/java.md
 msgid "\"hello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:40
+#: src/android/interoperability/java.md
 msgid "\"libjni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:44
+#: src/android/interoperability/java.md
 msgid "We then call this function from Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md:46
+#: src/android/interoperability/java.md
 msgid "_interoperability/java/HelloWorld.java_:"
 msgstr ""
 
-#: src/android/interoperability/java.md:67
+#: src/android/interoperability/java.md
 msgid "\"helloworld_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md:68
+#: src/android/interoperability/java.md
 msgid "\"HelloWorld.java\""
 msgstr ""
 
-#: src/android/interoperability/java.md:69
+#: src/android/interoperability/java.md
 msgid "\"HelloWorld\""
 msgstr ""
 
-#: src/android/interoperability/java.md:74
+#: src/android/interoperability/java.md
 msgid "Finally, you can build, sync, and run the binary:"
 msgstr ""
 
-#: src/exercises/android/morning.md:3
+#: src/exercises/android/morning.md
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
 "and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 
-#: src/exercises/android/morning.md:6
+#: src/exercises/android/morning.md
 msgid "Call your AIDL service with a client written in Rust."
 msgstr ""
 
-#: src/exercises/android/morning.md:8
+#: src/exercises/android/morning.md
 msgid "Move a function from your project to Rust and call it."
 msgstr ""
 
-#: src/exercises/android/morning.md:12
+#: src/exercises/android/morning.md
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
 "in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
-#: src/chromium.md:1
+#: src/chromium.md
 msgid "Welcome to Rust in Chromium"
 msgstr ""
 
-#: src/chromium.md:3
+#: src/chromium.md
 msgid ""
 "Rust is supported for third-party libraries in Chromium, with first-party "
 "glue code to connect between Rust and existing Chromium C++ code."
 msgstr ""
 
-#: src/chromium.md:6
+#: src/chromium.md
 msgid ""
 "Today, we'll call into Rust to do something silly with strings. If you've "
 "got a corner of the code where you're displaying a UTF8 string to the user, "
@@ -12796,35 +12591,35 @@ msgid ""
 "exact part we talk about."
 msgstr ""
 
-#: src/chromium/setup.md:3
+#: src/chromium/setup.md
 msgid ""
 "Make sure you can build and run Chromium. Any platform and set of build "
 "flags is OK, so long as your code is relatively recent (commit position "
 "1223636 onwards, corresponding to November 2023):"
 msgstr ""
 
-#: src/chromium/setup.md:13
+#: src/chromium/setup.md
 msgid ""
 "(A component, debug build is recommended for quickest iteration time. This "
 "is the default!)"
 msgstr ""
 
-#: src/chromium/setup.md:16
+#: src/chromium/setup.md
 msgid ""
 "See [How to build Chromium](https://www.chromium.org/developers/how-tos/get-"
 "the-code/) if you aren't already at that point. Be warned: setting up to "
 "build Chromium takes time."
 msgstr ""
 
-#: src/chromium/setup.md:21
+#: src/chromium/setup.md
 msgid "It's also recommended that you have Visual Studio code installed."
 msgstr ""
 
-#: src/chromium/setup.md:23
+#: src/chromium/setup.md
 msgid "About the exercises"
 msgstr ""
 
-#: src/chromium/setup.md:25
+#: src/chromium/setup.md
 msgid ""
 "This part of the course has a series of exercises which build on each other. "
 "We'll be doing them spread throughout the course instead of just at the end. "
@@ -12832,78 +12627,78 @@ msgid ""
 "catch up in the next slot."
 msgstr ""
 
-#: src/chromium/cargo.md:3
+#: src/chromium/cargo.md
 msgid ""
 "The Rust community typically uses `cargo` and libraries from [crates.io]"
 "(https://crates.io/). Chromium is built using `gn` and `ninja` and a curated "
 "set of dependencies."
 msgstr ""
 
-#: src/chromium/cargo.md:6
+#: src/chromium/cargo.md
 msgid "When writing code in Rust, your choices are:"
 msgstr ""
 
-#: src/chromium/cargo.md:8
+#: src/chromium/cargo.md
 msgid ""
 "Use `gn` and `ninja` with the help of the templates from `//build/rust/*."
 "gni` (e.g. `rust_static_library` that we'll meet later). This uses "
 "Chromium's audited toolchain and crates."
 msgstr ""
 
-#: src/chromium/cargo.md:11
+#: src/chromium/cargo.md
 msgid ""
 "Use `cargo`, but [restrict yourself to Chromium's audited toolchain and "
 "crates](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/"
 "docs/rust.md#Using-cargo)"
 msgstr ""
 
-#: src/chromium/cargo.md:13
+#: src/chromium/cargo.md
 msgid ""
 "Use `cargo`, trusting a [toolchain](https://rustup.rs/) and/or [crates "
 "downloaded from the internet](https://crates.io/)"
 msgstr ""
 
-#: src/chromium/cargo.md:16
+#: src/chromium/cargo.md
 msgid ""
 "From here on we'll be focusing on `gn` and `ninja`, because this is how Rust "
 "code can be built into the Chromium browser. At the same time, Cargo is an "
 "important part of the Rust ecosystem and you should keep it in your toolbox."
 msgstr ""
 
-#: src/chromium/cargo.md:20
+#: src/chromium/cargo.md
 msgid "Mini exercise"
 msgstr ""
 
-#: src/chromium/cargo.md:22
+#: src/chromium/cargo.md
 msgid "Split into small groups and:"
 msgstr ""
 
-#: src/chromium/cargo.md:24
+#: src/chromium/cargo.md
 msgid ""
 "Brainstorm scenarios where `cargo` may offer an advantage and assess the "
 "risk profile of these scenarios."
 msgstr ""
 
-#: src/chromium/cargo.md:26
+#: src/chromium/cargo.md
 msgid ""
 "Discuss which tools, libraries, and groups of people need to be trusted when "
 "using `gn` and `ninja`, offline `cargo`, etc."
 msgstr ""
 
-#: src/chromium/cargo.md:31
+#: src/chromium/cargo.md
 msgid ""
 "Ask students to avoid peeking at the speaker notes before completing the "
 "exercise. Assuming folks taking the course are physically together, ask them "
 "to discuss in small groups of 3-4 people."
 msgstr ""
 
-#: src/chromium/cargo.md:35
+#: src/chromium/cargo.md
 msgid ""
 "Notes/hints related to the first part of the exercise (\"scenarios where "
 "Cargo may offer an advantage\"):"
 msgstr ""
 
-#: src/chromium/cargo.md:38
+#: src/chromium/cargo.md
 msgid ""
 "It's fantastic that when writing a tool, or prototyping a part of Chromium, "
 "one has access to the rich ecosystem of crates.io libraries. There is a "
@@ -12912,19 +12707,19 @@ msgid ""
 "from various formats, `itertools` for working with iterators, etc.)."
 msgstr ""
 
-#: src/chromium/cargo.md:44
+#: src/chromium/cargo.md
 msgid ""
 "`cargo` makes it easy to try a library (just add a single line to `Cargo."
 "toml` and start writing code)"
 msgstr ""
 
-#: src/chromium/cargo.md:46
+#: src/chromium/cargo.md
 msgid ""
 "It may be worth comparing how CPAN helped make `perl` a popular choice. Or "
 "comparing with `python` + `pip`."
 msgstr ""
 
-#: src/chromium/cargo.md:49
+#: src/chromium/cargo.md
 msgid ""
 "Development experience is made really nice not only by core Rust tools (e.g. "
 "using `rustup` to switch to a different `rustc` version when testing a crate "
@@ -12934,21 +12729,21 @@ msgid ""
 "streamlined way to run benchmarks)."
 msgstr ""
 
-#: src/chromium/cargo.md:56
+#: src/chromium/cargo.md
 msgid ""
 "`cargo` makes it easy to add a tool via `cargo install --locked cargo-vet`."
 msgstr ""
 
-#: src/chromium/cargo.md:57
+#: src/chromium/cargo.md
 msgid "It may be worth comparing with Chrome Extensions or VScode extensions."
 msgstr ""
 
-#: src/chromium/cargo.md:59
+#: src/chromium/cargo.md
 msgid ""
 "Broad, generic examples of projects where `cargo` may be the right choice:"
 msgstr ""
 
-#: src/chromium/cargo.md:61
+#: src/chromium/cargo.md
 msgid ""
 "Perhaps surprisingly, Rust is becoming increasingly popular in the industry "
 "for writing command line tools. The breadth and ergonomics of libraries is "
@@ -12957,7 +12752,7 @@ msgid ""
 "language)."
 msgstr ""
 
-#: src/chromium/cargo.md:66
+#: src/chromium/cargo.md
 msgid ""
 "Participating in the Rust ecosystem requires using standard Rust tools like "
 "Cargo. Libraries that want to get external contributions, and want to be "
@@ -12965,95 +12760,95 @@ msgid ""
 "should probably use Cargo."
 msgstr ""
 
-#: src/chromium/cargo.md:71
+#: src/chromium/cargo.md
 msgid "Examples of Chromium-related projects that are `cargo`\\-based:"
 msgstr ""
 
-#: src/chromium/cargo.md:72
+#: src/chromium/cargo.md
 msgid ""
 "`serde_json_lenient` (experimented with in other parts of Google which "
 "resulted in PRs with performance improvements)"
 msgstr ""
 
-#: src/chromium/cargo.md:74
+#: src/chromium/cargo.md
 msgid "Fontations libraries like `font-types`"
 msgstr ""
 
-#: src/chromium/cargo.md:75
+#: src/chromium/cargo.md
 msgid ""
 "`gnrt` tool (we will meet it later in the course) which depends on `clap` "
 "for command-line parsing and on `toml` for configuration files."
 msgstr ""
 
-#: src/chromium/cargo.md:77
+#: src/chromium/cargo.md
 msgid ""
 "Disclaimer: a unique reason for using `cargo` was unavailability of `gn` "
 "when building and bootstrapping Rust standard library when building Rust "
 "toolchain."
 msgstr ""
 
-#: src/chromium/cargo.md:80
+#: src/chromium/cargo.md
 msgid ""
 "`run_gnrt.py` uses Chromium's copy of `cargo` and `rustc`. `gnrt` depends on "
 "third-party libraries downloaded from the internet, but `run_gnrt.py` asks "
 "`cargo` that only `--locked` content is allowed via `Cargo.lock`.)"
 msgstr ""
 
-#: src/chromium/cargo.md:84
+#: src/chromium/cargo.md
 msgid ""
 "Students may identify the following items as being implicitly or explicitly "
 "trusted:"
 msgstr ""
 
-#: src/chromium/cargo.md:87
+#: src/chromium/cargo.md
 msgid ""
 "`rustc` (the Rust compiler) which in turn depends on the LLVM libraries, the "
 "Clang compiler, the `rustc` sources (fetched from GitHub, reviewed by Rust "
 "compiler team), binary Rust compiler downloaded for bootstrapping"
 msgstr ""
 
-#: src/chromium/cargo.md:90
+#: src/chromium/cargo.md
 msgid ""
 "`rustup` (it may be worth pointing out that `rustup` is developed under the "
 "umbrella of the https://github.com/rust-lang/ organization - same as `rustc`)"
 msgstr ""
 
-#: src/chromium/cargo.md:92
+#: src/chromium/cargo.md
 msgid "`cargo`, `rustfmt`, etc."
 msgstr ""
 
-#: src/chromium/cargo.md:93
+#: src/chromium/cargo.md
 msgid ""
 "Various internal infrastructure (bots that build `rustc`, system for "
 "distributing the prebuilt toolchain to Chromium engineers, etc.)"
 msgstr ""
 
-#: src/chromium/cargo.md:95
+#: src/chromium/cargo.md
 msgid "Cargo tools like `cargo audit`, `cargo vet`, etc."
 msgstr ""
 
-#: src/chromium/cargo.md:96
+#: src/chromium/cargo.md
 msgid ""
 "Rust libraries vendored into `//third_party/rust` (audited by "
 "security@chromium.org)"
 msgstr ""
 
-#: src/chromium/cargo.md:98
+#: src/chromium/cargo.md
 msgid "Other Rust libraries (some niche, some quite popular and commonly used)"
 msgstr ""
 
-#: src/chromium/policy.md:1
+#: src/chromium/policy.md
 msgid "Chromium Rust policy"
 msgstr ""
 
-#: src/chromium/policy.md:3
+#: src/chromium/policy.md
 msgid ""
 "Chromium does not yet allow first-party Rust except in rare cases as "
 "approved by Chromium's [Area Tech Leads](https://source.chromium.org/"
 "chromium/chromium/src/+/main:ATL_OWNERS)."
 msgstr ""
 
-#: src/chromium/policy.md:7
+#: src/chromium/policy.md
 msgid ""
 "Chromium's policy on third party libraries is outlined [here](https://"
 "chromium.googlesource.com/chromium/src/+/main/docs/adding_to_third_party."
@@ -13062,14 +12857,14 @@ msgid ""
 "security."
 msgstr ""
 
-#: src/chromium/policy.md:12
+#: src/chromium/policy.md
 msgid ""
 "Very few Rust libraries directly expose a C/C++ API, so that means that "
 "nearly all such libraries will require a small amount of first-party glue "
 "code."
 msgstr ""
 
-#: src/chromium/policy.md:15
+#: src/chromium/policy.md
 msgid ""
 "```bob\n"
 "\"C++\"                           Rust\n"
@@ -13096,49 +12891,49 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/policy.md:30
+#: src/chromium/policy.md
 msgid ""
 "First-party Rust glue code for a particular third-party crate should "
 "normally be kept in `third_party/rust/<crate>/<version>/wrapper`."
 msgstr ""
 
-#: src/chromium/policy.md:33
+#: src/chromium/policy.md
 msgid "Because of this, today's course will be heavily focused on:"
 msgstr ""
 
-#: src/chromium/policy.md:35
+#: src/chromium/policy.md
 msgid "Bringing in third-party Rust libraries (\"crates\")"
 msgstr ""
 
-#: src/chromium/policy.md:36
+#: src/chromium/policy.md
 msgid "Writing glue code to be able to use those crates from Chromium C++."
 msgstr ""
 
-#: src/chromium/policy.md:38
+#: src/chromium/policy.md
 msgid "If this policy changes over time, the course will evolve to keep up."
 msgstr ""
 
-#: src/chromium/build-rules.md:1
+#: src/chromium/build-rules.md
 msgid "Build rules"
 msgstr ""
 
-#: src/chromium/build-rules.md:3
+#: src/chromium/build-rules.md
 msgid ""
 "Rust code is usually built using `cargo`. Chromium builds with `gn` and "
 "`ninja` for efficiency --- its static rules allow maximum parallelism. Rust "
 "is no exception."
 msgstr ""
 
-#: src/chromium/build-rules.md:7
+#: src/chromium/build-rules.md
 msgid "Adding Rust code to Chromium"
 msgstr ""
 
-#: src/chromium/build-rules.md:9
+#: src/chromium/build-rules.md
 msgid ""
 "In some existing Chromium `BUILD.gn` file, declare a `rust_static_library`:"
 msgstr ""
 
-#: src/chromium/build-rules.md:11
+#: src/chromium/build-rules.md
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13150,13 +12945,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules.md:20
+#: src/chromium/build-rules.md
 msgid ""
 "You can also add `deps` on other Rust targets. Later we'll use this to "
 "depend upon third party code."
 msgstr ""
 
-#: src/chromium/build-rules.md:25
+#: src/chromium/build-rules.md
 msgid ""
 "You must specify _both_ the crate root, _and_ a full list of sources. The "
 "`crate_root` is the file given to the Rust compiler representing the root "
@@ -13165,13 +12960,13 @@ msgid ""
 "rebuilds are necessary."
 msgstr ""
 
-#: src/chromium/build-rules.md:31
+#: src/chromium/build-rules.md
 msgid ""
 "(There's no such thing as a Rust `source_set`, because in Rust, an entire "
 "crate is a compilation unit. A `static_library` is the smallest unit.)"
 msgstr ""
 
-#: src/chromium/build-rules.md:34
+#: src/chromium/build-rules.md
 msgid ""
 "Students might be wondering why we need a gn template, rather than using "
 "[gn's built-in support for Rust static libraries](https://gn.googlesource."
@@ -13180,11 +12975,11 @@ msgid ""
 "tests, some of which we'll use later."
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md:1
+#: src/chromium/build-rules/unsafe.md
 msgid "Including `unsafe` Rust Code"
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md:3
+#: src/chromium/build-rules/unsafe.md
 msgid ""
 "Unsafe Rust code is forbidden in `rust_static_library` by default --- it "
 "won't compile. If you need unsafe Rust code, add `allow_unsafe = true` to "
@@ -13192,7 +12987,7 @@ msgid ""
 "necessary.)"
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md:7
+#: src/chromium/build-rules/unsafe.md
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13208,11 +13003,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules/depending.md:3
+#: src/chromium/build-rules/depending.md
 msgid "Simply add the above target to the `deps` of some Chromium C++ target."
 msgstr ""
 
-#: src/chromium/build-rules/depending.md:5
+#: src/chromium/build-rules/depending.md
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13229,107 +13024,107 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:3
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "Types are elided in Rust code, which makes a good IDE even more useful than "
 "for C++. Visual Studio code works well for Rust in Chromium. To use it,"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:6
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "Ensure your VSCode has the `rust-analyzer` extension, not earlier forms of "
 "Rust support"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:8
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "`gn gen out/Debug --export-rust-project` (or equivalent for your output "
 "directory)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:10
+#: src/chromium/build-rules/vscode.md
 msgid "`ln -s out/Debug/rust-project.json rust-project.json`"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:16
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "A demo of some of the code annotation and exploration features of rust-"
 "analyzer might be beneficial if the audience are naturally skeptical of IDEs."
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:19
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "The following steps may help with the demo (but feel free to instead use a "
 "piece of Chromium-related Rust that you are most familiar with):"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:22
+#: src/chromium/build-rules/vscode.md
 msgid "Open `components/qr_code_generator/qr_code_generator_ffi_glue.rs`"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:23
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "Place the cursor over the `QrCode::new` call (around line 26) in "
 "\\`qr_code_generator_ffi_glue.rs"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:25
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "Demo **show documentation** (typical bindings: vscode = ctrl k i; vim/CoC = "
 "K)."
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:27
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "Demo **go to definition** (typical bindings: vscode = F12; vim/CoC = g d). "
 "(This will take you to `//third_party/rust/.../qr_code-.../src/lib.rs`.)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:29
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "Demo **outline** and navigate to the `QrCode::with_bits` method (around line "
 "164; the outline is in the file explorer pane in vscode; typical vim/CoC "
 "bindings = space o)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:32
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "Demo **type annotations** (there are quote a few nice examples in the "
 "`QrCode::with_bits` method)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md:35
+#: src/chromium/build-rules/vscode.md
 msgid ""
 "It may be worth pointing out that `gn gen ... --export-rust-project` will "
 "need to be rerun after editing `BUILD.gn` files (which we will do a few "
 "times throughout the exercises in this session)."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:1
+#: src/exercises/chromium/build-rules.md
 msgid "Build rules exercise"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:3
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "In your Chromium build, add a new Rust target to `//ui/base/BUILD.gn` "
 "containing:"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:13
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "**Important**: note that `no_mangle` here is considered a type of unsafety "
 "by the Rust compiler, so you'll need to allow unsafe code in your `gn` "
 "target."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:16
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "Add this new Rust target as a dependency of `//ui/base:base`. Declare this "
 "function at the top of `ui/base/resource/resource_bundle.cc` (later, we'll "
 "see how this can be automated by bindings generation tools):"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:24
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "Call this function from somewhere in `ui/base/resource/resource_bundle.cc` - "
 "we suggest the top of `ResourceBundle::MaybeMangleLocalizedString`. Build "
@@ -13337,50 +13132,50 @@ msgid ""
 "times."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:28
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "If you use VSCode, now set up Rust to work well in VSCode. It will be useful "
 "in subsequent exercises. If you've succeeded, you will be able to use right-"
 "click \"Go to definition\" on `println!`."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:32
-#: src/exercises/chromium/interoperability-with-cpp.md:48
+#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Where to find help"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:34
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "The options available to the [`rust_static_library` gn template](https://"
 "source.chromium.org/chromium/chromium/src/+/main:build/rust/"
 "rust_static_library.gni;l=16)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:35
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "Information about [`#[no_mangle]`](https://doc.rust-lang.org/beta/reference/"
 "abi.html#the-no_mangle-attribute)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:36
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "Information about [`extern \"C\"`](https://doc.rust-lang.org/std/keyword."
 "extern.html)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:37
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "Information about gn's [`--export-rust-project`](https://gn.googlesource.com/"
 "gn/+/main/docs/reference.md#compilation-database) switch"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:38
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "[How to install rust-analyzer in VSCode](https://code.visualstudio.com/docs/"
 "languages/rust)"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:44
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "This example is unusual because it boils down to the lowest-common-"
 "denominator interop language, C. Both C++ and Rust can natively declare and "
@@ -13388,27 +13183,27 @@ msgid ""
 "Rust."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:48
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "`allow_unsafe = true` is required here because `#[no_mangle]` might allow "
 "Rust to generate two functions with the same name, and Rust can no longer "
 "guarantee that the right one is called."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md:52
+#: src/exercises/chromium/build-rules.md
 msgid ""
 "If you need a pure Rust executable, you can also do that using the "
 "`rust_executable` gn template."
 msgstr ""
 
-#: src/chromium/testing.md:3
+#: src/chromium/testing.md
 msgid ""
 "Rust community typically authors unit tests in a module placed in the same "
 "source file as the code being tested. This was covered [earlier](../testing."
 "md) in the course and looks like this:"
 msgstr ""
 
-#: src/chromium/testing.md:17
+#: src/chromium/testing.md
 msgid ""
 "In Chromium we place unit tests in a separate source file and we continue to "
 "follow this practice for Rust --- this makes tests consistently discoverable "
@@ -13416,45 +13211,45 @@ msgid ""
 "configuration)."
 msgstr ""
 
-#: src/chromium/testing.md:22
+#: src/chromium/testing.md
 msgid ""
 "This results in the following options for testing Rust code in Chromium:"
 msgstr ""
 
-#: src/chromium/testing.md:24
+#: src/chromium/testing.md
 msgid ""
 "Native Rust tests (i.e. `#[test]`). Discouraged outside of `//third_party/"
 "rust`."
 msgstr ""
 
-#: src/chromium/testing.md:26
+#: src/chromium/testing.md
 msgid ""
 "`gtest` tests authored in C++ and exercising Rust via FFI calls. Sufficient "
 "when Rust code is just a thin FFI layer and the existing unit tests provide "
 "sufficient coverage for the feature."
 msgstr ""
 
-#: src/chromium/testing.md:29
+#: src/chromium/testing.md
 msgid ""
 "`gtest` tests authored in Rust and using the crate under test through its "
 "public API (using `pub mod for_testing { ... }` if needed). This is the "
 "subject of the next few slides."
 msgstr ""
 
-#: src/chromium/testing.md:35
+#: src/chromium/testing.md
 msgid ""
 "Mention that native Rust tests of third-party crates should eventually be "
 "exercised by Chromium bots. (Such testing is needed rarely --- only after "
 "adding or updating third-party crates.)"
 msgstr ""
 
-#: src/chromium/testing.md:39
+#: src/chromium/testing.md
 msgid ""
 "Some examples may help illustrate when C++ `gtest` vs Rust `gtest` should be "
 "used:"
 msgstr ""
 
-#: src/chromium/testing.md:42
+#: src/chromium/testing.md
 msgid ""
 "QR has very little functionality in the first-party Rust layer (it's just a "
 "thin FFI glue) and therefore uses the existing C++ unit tests for testing "
@@ -13462,7 +13257,7 @@ msgid ""
 "enable or disable Rust using a `ScopedFeatureList`)."
 msgstr ""
 
-#: src/chromium/testing.md:47
+#: src/chromium/testing.md
 msgid ""
 "Hypothetical/WIP PNG integration may need to implement memory-safe "
 "implementation of pixel transformations that are provided by `libpng` but "
@@ -13470,35 +13265,35 @@ msgid ""
 "functionality may benefit from separate tests authored in Rust."
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md:3
+#: src/chromium/testing/rust-gtest-interop.md
 msgid ""
 "The [`rust_gtest_interop`](https://chromium.googlesource.com/chromium/src/+/"
 "main/testing/rust_gtest_interop/README.md) library provides a way to:"
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md:5
+#: src/chromium/testing/rust-gtest-interop.md
 msgid ""
 "Use a Rust function as a `gtest` testcase (using the `#[gtest(...)]` "
 "attribute)"
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md:7
+#: src/chromium/testing/rust-gtest-interop.md
 msgid ""
 "Use `expect_eq!` and similar macros (similar to `assert_eq!` but not "
 "panicking and not terminating the test when the assertion fails)."
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md:10
+#: src/chromium/testing/rust-gtest-interop.md
 msgid "Example:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md:3
+#: src/chromium/testing/build-gn.md
 msgid ""
 "The simplest way to build Rust `gtest` tests is to add them to an existing "
 "test binary that already contains tests authored in C++. For example:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md:6
+#: src/chromium/testing/build-gn.md
 msgid ""
 "```gn\n"
 "test(\"ui_base_unittests\") {\n"
@@ -13509,13 +13304,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md:14
+#: src/chromium/testing/build-gn.md
 msgid ""
 "Authoring Rust tests in a separate `static_library` also works, but requires "
 "manually declaring the dependency on the support libraries:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md:17
+#: src/chromium/testing/build-gn.md
 msgid ""
 "```gn\n"
 "rust_static_library(\"my_rust_lib_unittests\") {\n"
@@ -13536,7 +13331,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md:3
+#: src/chromium/testing/chromium-import-macro.md
 msgid ""
 "After adding `:my_rust_lib` to GN `deps`, we still need to learn how to "
 "import and use `my_rust_lib` from `my_rust_lib_unittest.rs`. We haven't "
@@ -13546,15 +13341,15 @@ msgid ""
 "from the automatically-imported `chromium` crate:"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md:12
+#: src/chromium/testing/chromium-import-macro.md
 msgid "\"//ui/base:my_rust_lib\""
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md:18
+#: src/chromium/testing/chromium-import-macro.md
 msgid "Under the covers the macro expands to something similar to:"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md:26
+#: src/chromium/testing/chromium-import-macro.md
 msgid ""
 "More information can be found in [the doc comment](https://source.chromium."
 "org/chromium/chromium/src/+/main:build/rust/chromium_prelude/"
@@ -13562,7 +13357,7 @@ msgid ""
 "third_party&ss=chromium%2Fchromium%2Fsrc) of the `chromium::import` macro."
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md:31
+#: src/chromium/testing/chromium-import-macro.md
 msgid ""
 "`rust_static_library` supports specifying an explicit name via `crate_name` "
 "property, but doing this is discouraged. And it is discouraged because the "
@@ -13571,65 +13366,65 @@ msgid ""
 "covered in a later section) use short crate names."
 msgstr ""
 
-#: src/exercises/chromium/testing.md:1
+#: src/exercises/chromium/testing.md
 msgid "Testing exercise"
 msgstr ""
 
-#: src/exercises/chromium/testing.md:3
+#: src/exercises/chromium/testing.md
 msgid "Time for another exercise!"
 msgstr ""
 
-#: src/exercises/chromium/testing.md:5
+#: src/exercises/chromium/testing.md
 msgid "In your Chromium build:"
 msgstr ""
 
-#: src/exercises/chromium/testing.md:7
+#: src/exercises/chromium/testing.md
 msgid ""
 "Add a testable function next to `hello_from_rust`. Some suggestions: adding "
 "two integers received as arguments, computing the nth Fibonacci number, "
 "summing integers in a slice, etc."
 msgstr ""
 
-#: src/exercises/chromium/testing.md:10
+#: src/exercises/chromium/testing.md
 msgid "Add a separate `..._unittest.rs` file with a test for the new function."
 msgstr ""
 
-#: src/exercises/chromium/testing.md:11
+#: src/exercises/chromium/testing.md
 msgid "Add the new tests to `BUILD.gn`."
 msgstr ""
 
-#: src/exercises/chromium/testing.md:12
+#: src/exercises/chromium/testing.md
 msgid "Build the tests, run them, and verify that the new test works."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:3
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "The Rust community offers multiple options for C++/Rust interop, with new "
 "tools being developed all the time. At the moment, Chromium uses a tool "
 "called CXX."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:6
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "You describe your whole language boundary in an interface definition "
 "language (which looks a lot like Rust) and then CXX tools generate "
 "declarations for functions and types in both Rust and C++."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:12
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "See the [CXX tutorial](https://cxx.rs/tutorial.html) for a full example of "
 "using this."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:19
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "Talk through the diagram. Explain that behind the scenes, this is doing just "
 "the same as you previously did. Point out that automating the process has "
 "the following benefits:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:23
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "The tool guarantees that the C++ and Rust sides match (e.g. you get compile "
 "errors if the `#[cxx::bridge]` doesn't match the actual C++ or Rust "
@@ -13637,7 +13432,7 @@ msgid ""
 "Behavior)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:27
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "The tool automates generation of FFI thunks (small, C-ABI-compatible, free "
 "functions) for non-C features (e.g. enabling FFI calls into Rust or C++ "
@@ -13645,11 +13440,11 @@ msgid ""
 "functions manually)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:31
+#: src/chromium/interoperability-with-cpp.md
 msgid "The tool and the library can handle a set of core types - for example:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:32
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "`&[T]` can be passed across the FFI boundary, even though it doesn't "
 "guarantee any particular ABI or memory layout. With manual bindings `std::"
@@ -13658,7 +13453,7 @@ msgid ""
 "empty slices slightly differently)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:37
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "Smart pointers like `std::unique_ptr<T>`, `std::shared_ptr<T>`, and/or `Box` "
 "are natively supported. With manual bindings, one would have to pass C-ABI-"
@@ -13666,7 +13461,7 @@ msgid ""
 "risks."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp.md:41
+#: src/chromium/interoperability-with-cpp.md
 msgid ""
 "`rust::String` and `CxxString` types understand and maintain differences in "
 "string representation across the languages (e.g. `rust::String::lossy` can "
@@ -13674,25 +13469,25 @@ msgid ""
 "terminate a string)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:3
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid ""
 "CXX requires that the whole C++/Rust boundary is declared in `cxx::bridge` "
 "modules inside `.rs` source code."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:16
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "\"example/include/blobstore.h\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:24
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "// Definitions of Rust types and functions go here\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:30
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Point out:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:32
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid ""
 "Although this looks like a regular Rust `mod`, the `#[cxx::bridge]` "
 "procedural macro does complex things to it. The generated code is quite a "
@@ -13700,23 +13495,23 @@ msgid ""
 "`ffi` in your code."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:36
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Native support for C++'s `std::unique_ptr` in Rust"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:37
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Native support for Rust slices in C++"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:38
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Calls from C++ to Rust, and Rust types (in the top part)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:39
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Calls from Rust to C++, and C++ types (in the bottom part)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md:41
+#: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid ""
 "**Common misconception**: It _looks_ like a C++ header is being parsed by "
 "Rust, but this is misleading. This header is never interpreted by Rust, but "
@@ -13724,35 +13519,35 @@ msgid ""
 "compilers."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:3
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "By far the most useful page when using CXX is the [type reference](https://"
 "cxx.rs/bindings.html)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:5
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "CXX fundamentally suits cases where:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:7
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "Your Rust-C++ interface is sufficiently simple that you can declare all of "
 "it."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:8
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "You're using only the types natively supported by CXX already, for example "
 "`std::unique_ptr`, `std::string`, `&[u8]` etc."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:11
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "It has many limitations --- for example lack of support for Rust's `Option` "
 "type."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:14
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "These limitations constrain us to using Rust in Chromium only for well "
 "isolated \"leaf nodes\" rather than for arbitrary Rust-C++ interop. When "
@@ -13761,75 +13556,75 @@ msgid ""
 "enough."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:26
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "You should also discuss some of the other sticky points with CXX, for "
 "example:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:28
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid ""
 "Its error handling is based around C++ exceptions (given on the next slide)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:29
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "Function pointers are awkward to use."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:3
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "CXX's [support for `Result<T,E>`](https://cxx.rs/binding/result.html) relies "
 "on C++ exceptions, so we can't use that in Chromium. Alternatives:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:6
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid "The `T` part of `Result<T, E>` can be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:7
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "Returned via out parameters (e.g. via `&mut T`). This requires that `T` can "
 "be passed across the FFI boundary - for example `T` has to be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:9
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid "A primitive type (like `u32` or `usize`)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:10
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "A type natively supported by `cxx` (like `UniquePtr<T>`) that has a suitable "
 "default value to use in a failure case (_unlike_ `Box<T>`)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:12
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "Retained on the Rust side, and exposed via reference. This may be needed "
 "when `T` is a Rust type, which cannot be passed across the FFI boundary, and "
 "cannot be stored in `UniquePtr<T>`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:16
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid "The `E` part of `Result<T, E>` can be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:17
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "Returned as a boolean (e.g. `true` representing success, and `false` "
 "representing failure)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md:19
+#: src/chromium/interoperability-with-cpp/error-handling.md
 msgid ""
 "Preserving error details is in theory possible, but so far hasn't been "
 "needed in practice."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md:1
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid "CXX Error Handling: QR Example"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md:3
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
 "The QR code generator is [an example](https://source.chromium.org/chromium/"
 "chromium/src/+/main:components/qr_code_generator/qr_code_generator_ffi_glue."
@@ -13838,11 +13633,11 @@ msgid ""
 "be passed across the FFI boundary:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md:8
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid "\"qr_code_generator\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md:23
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
 "Students may be curious about the semantics of the `out_qr_size` output. "
 "This is not the size of the vector, but the size of the QR code (and "
@@ -13850,7 +13645,7 @@ msgid ""
 "the vector)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md:27
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
 "It may be worth pointing out the importance of initializing `out_qr_size` "
 "before calling into the Rust function. Creation of a Rust reference that "
@@ -13858,42 +13653,42 @@ msgid ""
 "when only the act of dereferencing such memory results in UB)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md:32
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md
 msgid ""
 "If students ask about `Pin`, then explain why CXX needs it for mutable "
 "references to C++ data: the answer is that C++ data can’t be moved around "
 "like Rust data, because it may contain self-referential pointers."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:1
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "CXX Error Handling: PNG Example"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:3
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid ""
 "A prototype of a PNG decoder illustrates what can be done when the "
 "successful result cannot be passed across the FFI boundary:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:7
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "\"gfx::rust_bindings\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:10
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid ""
 "/// This returns an FFI-friendly equivalent of `Result<PngReader<'a>,\n"
 "        /// ()>`.\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:14
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "/// C++ bindings for the `crate::png::ResultOfPngReader` type.\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:21
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid "/// C++ bindings for the `crate::png::PngReader` type.\n"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:32
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid ""
 "`PngReader` and `ResultOfPngReader` are Rust types --- objects of these "
 "types cannot cross the FFI boundary without indirection of a `Box<T>`. We "
@@ -13901,7 +13696,7 @@ msgid ""
 "to store Rust objects by value."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md:37
+#: src/chromium/interoperability-with-cpp/error-handling-png.md
 msgid ""
 "This example illustrates that even though CXX doesn't support arbitrary "
 "generics nor templates, we can still pass them across the FFI boundary by "
@@ -13911,18 +13706,18 @@ msgid ""
 "`as_mut`)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:1
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "Using cxx in Chromium"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:3
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
 "In Chromium, we define an independent `#[cxx::bridge] mod` for each leaf-"
 "node where we want to use Rust. You'd typically have one for each "
 "`rust_static_library`. Just add"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:7
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
 "```gn\n"
 "cxx_bindings = [ \"my_rust_file.rs\" ]\n"
@@ -13931,21 +13726,21 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:13
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
 "to your existing `rust_static_library` target alongside `crate_root` and "
 "`sources`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:16
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "C++ headers will be generated at a sensible location, so you can just"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:19
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "\"ui/base/my_rust_file.rs.h\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:22
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
 "You will find some utility functions in `//base` to convert to/from Chromium "
 "C++ types to CXX Rust types --- for example [`SpanToRustSlice`](https://"
@@ -13953,11 +13748,11 @@ msgid ""
 "l=21)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:27
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid "Students may ask --- why do we still need `allow_unsafe = true`?"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:29
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
 "The broad answer is that no C/C++ code is \"safe\" by the normal Rust "
 "standards. Calling back and forth to C/C++ from Rust may do arbitrary things "
@@ -13968,7 +13763,7 @@ msgid ""
 "binary can cause unexpected behavior from Rust's perspective."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:36
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
 msgid ""
 "The narrow answer lies in the diagram at the top of [this page](../"
 "interoperability-with-cpp.md) --- behind the scenes, CXX generates Rust "
@@ -13976,151 +13771,151 @@ msgid ""
 "previous section."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:1
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Exercise: Interoperability with C++"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:3
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Part one"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:5
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "In the Rust file you previously created, add a `#[cxx::bridge]` which "
 "specifies a single function, to be called from C++, called "
 "`hello_from_rust`, taking no parameters and returning no value."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:8
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Modify your previous `hello_from_rust` function to remove `extern \"C\"` and "
 "`#[no_mangle]`. This is now just a standard Rust function."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:10
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Modify your `gn` target to build these bindings."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:11
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "In your C++ code, remove the forward-declaration of `hello_from_rust`. "
 "Instead, include the generated header file."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:13
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Build and run!"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:15
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Part two"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:17
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "It's a good idea to play with CXX a little. It helps you think about how "
 "flexible Rust in Chromium actually is."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:20
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Some things to try:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:22
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Call back into C++ from Rust. You will need:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:23
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "An additional header file which you can `include!` from your `cxx::bridge`. "
 "You'll need to declare your C++ function in that new header file."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:25
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "An `unsafe` block to call such a function, or alternatively specify the "
 "`unsafe` keyword in your `#[cxx::bridge]` [as described here](https://cxx.rs/"
 "extern-c++.html#functions-and-member-functions)."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:27
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "You may also need to `#include \"third_party/rust/cxx/v1/crate/include/cxx."
 "h\"`"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:29
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Pass a C++ string from C++ into Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:30
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Pass a reference to a C++ object into Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:31
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Intentionally get the Rust function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:33
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Intentionally get the C++ function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:35
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Pass a `std::unique_ptr` of some type from C++ into Rust, so that Rust can "
 "own some C++ object."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:37
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Create a Rust object and pass it into C++, so that C++ owns it. (Hint: you "
 "need a `Box`)."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:39
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Declare some methods on a C++ type. Call them from Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:40
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Declare some methods on a Rust type. Call them from C++."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:42
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Part three"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:44
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "Now you understand the strengths and limitations of CXX interop, think of a "
 "couple of use-cases for Rust in Chromium where the interface would be "
 "sufficiently simple. Sketch how you might define that interface."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:50
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "The [`cxx` binding reference](https://cxx.rs/bindings.html)"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:51
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "The [`rust_static_library` gn template](https://source.chromium.org/chromium/"
 "chromium/src/+/main:build/rust/rust_static_library.gni;l=16)"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:57
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Some of the questions you may encounter:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:59
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "I'm seeing a problem initializing a variable of type X with type Y, where X "
 "and Y are both function types. This is because your C++ function doesn't "
 "quite match the declaration in your `cxx::bridge`."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md:62
+#: src/exercises/chromium/interoperability-with-cpp.md
 msgid ""
 "I seem to be able to freely convert C++ references into Rust references. "
 "Doesn't that risk UB? For CXX's _opaque_ types, no, because they are zero-"
@@ -14128,95 +13923,94 @@ msgid ""
 "CXX's design makes it quite difficult to craft such an example."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:3
+#: src/chromium/adding-third-party-crates.md
 msgid ""
 "Rust libraries are called \"crates\" and are found at [crates.io](https://"
 "crates.io). It's _very easy_ for Rust crates to depend upon one another. So "
 "they do!"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:6
+#: src/chromium/adding-third-party-crates.md
 msgid "Property"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:6
+#: src/chromium/adding-third-party-crates.md
 msgid "C++ library"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:6
+#: src/chromium/adding-third-party-crates.md
 msgid "Rust crate"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:8
+#: src/chromium/adding-third-party-crates.md
 msgid "Build system"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:8
-#: src/chromium/adding-third-party-crates.md:10
+#: src/chromium/adding-third-party-crates.md
 msgid "Lots"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:8
+#: src/chromium/adding-third-party-crates.md
 msgid "Consistent: `Cargo.toml`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:9
+#: src/chromium/adding-third-party-crates.md
 msgid "Typical library size"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:9
+#: src/chromium/adding-third-party-crates.md
 msgid "Large-ish"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:9
+#: src/chromium/adding-third-party-crates.md
 msgid "Small"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:10
+#: src/chromium/adding-third-party-crates.md
 msgid "Transitive dependencies"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:10
+#: src/chromium/adding-third-party-crates.md
 msgid "Few"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:12
+#: src/chromium/adding-third-party-crates.md
 msgid "For a Chromium engineer, this has pros and cons:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:14
+#: src/chromium/adding-third-party-crates.md
 msgid ""
 "All crates use a common build system so we can automate their inclusion into "
 "Chromium..."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:16
+#: src/chromium/adding-third-party-crates.md
 msgid ""
 "... but, crates typically have transitive dependencies, so you will likely "
 "have to bring in multiple libraries."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:19
+#: src/chromium/adding-third-party-crates.md
 msgid "We'll discuss:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:21
+#: src/chromium/adding-third-party-crates.md
 msgid "How to put a crate in the Chromium source code tree"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:22
+#: src/chromium/adding-third-party-crates.md
 msgid "How to make `gn` build rules for it"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates.md:23
+#: src/chromium/adding-third-party-crates.md
 msgid "How to audit its source code for sufficient safety."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:1
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid "Configuring the `Cargo.toml` file to add crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:3
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
 "Chromium has a single set of centrally-managed direct crate dependencies. "
 "These are managed through a single [`Cargo.toml`](https://source.chromium."
@@ -14224,7 +14018,7 @@ msgid ""
 "toml):"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:6
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
 "```toml\n"
 "[dependencies]\n"
@@ -14235,7 +14029,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:14
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
 "As with any other `Cargo.toml`, you can specify [more details about the "
 "dependencies](https://doc.rust-lang.org/cargo/reference/specifying-"
@@ -14243,53 +14037,53 @@ msgid ""
 "that you wish to enable in the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:18
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
 msgid ""
 "When adding a crate to Chromium, you'll often need to provide some extra "
 "information in an additional file, `gnrt_config.toml`, which we'll meet next."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:3
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
 "Alongside `Cargo.toml` is [`gnrt_config.toml`](https://source.chromium.org/"
 "chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/gnrt_config."
 "toml). This contains Chromium-specific extensions to crate handling."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:6
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
 "If you add a new crate, you should specify at least the `group`. This is one "
 "of:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:15
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:15
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid "For instance,"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:22
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
 "Depending on the crate source code layout, you may also need to use this "
 "file to specify where its `LICENSE` file(s) can be found."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:25
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid ""
 "Later, we'll see some other things you will need to configure in this file "
 "to resolve problems."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:3
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
 "A tool called `gnrt` knows how to download crates and how to generate `BUILD."
 "gn` rules."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:6
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "To start, download the crate you want like this:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:13
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
 "Although the `gnrt` tool is part of the Chromium source code, by running "
 "this command you will be downloading and running its dependencies from "
@@ -14297,75 +14091,75 @@ msgid ""
 "decision."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:17
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "This `vendor` command may download:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:19
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "Your crate"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:20
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "Direct and transitive dependencies"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:21
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
 "New versions of other crates, as required by `cargo` to resolve the complete "
 "set of crates required by Chromium."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md:24
+#: src/chromium/adding-third-party-crates/downloading-crates.md
 msgid ""
 "Chromium maintains patches for some crates, kept in `//third_party/rust/"
 "chromium_crates_io/patches`. These will be reapplied automatically, but if "
 "patching fails you may need to take manual action."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:3
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "Once you've downloaded the crate, generate the `BUILD.gn` files like this:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:9
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid "Now run `git status`. You should find:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:11
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "At least one new crate source code in `third_party/rust/chromium_crates_io/"
 "vendor`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:13
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "At least one new `BUILD.gn` in `third_party/rust/<crate name>/v<major semver "
 "version>`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:15
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid "An appropriate `README.chromium`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:17
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "The \"major semver version\" is a [Rust \"semver\" version number](https://"
 "doc.rust-lang.org/cargo/reference/semver.html)."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:19
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "Take a close look, especially at the things generated in `third_party/rust`."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:23
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid ""
 "Talk a little about semver --- and specifically the way that in Chromium "
 "it's to allow multiple incompatible versions of a crate, which is "
 "discouraged but sometimes necessary in the Cargo ecosystem."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:3
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid ""
 "If your build fails, it may be because of a `build.rs`: programs which do "
 "arbitrary things at build time. This is fundamentally at odds with the "
@@ -14373,81 +14167,76 @@ msgid ""
 "to maximize parallelism and repeatability of builds."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:8
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid ""
 "Some `build.rs` actions are automatically supported; others require action:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:10
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "build script effect"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:10
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Supported by our gn templates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:10
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Work required by you"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Checking rustc version to configure features on and off"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:12
-#: src/chromium/adding-third-party-crates/resolving-problems.md:13
-#: src/chromium/adding-third-party-crates/resolving-problems.md:14
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Yes"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:12
-#: src/chromium/adding-third-party-crates/resolving-problems.md:13
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "None"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:13
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Checking platform or CPU to configure features on and off"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:14
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Generating code"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:14
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Yes - specify in `gnrt_config.toml`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Building C/C++"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:15
-#: src/chromium/adding-third-party-crates/resolving-problems.md:16
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "No"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:15
-#: src/chromium/adding-third-party-crates/resolving-problems.md:16
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Patch around it"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:16
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Arbitrary other actions"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md:18
+#: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid ""
 "Fortunately, most crates don't contain a build script, and fortunately, most "
 "build scripts only do the top two actions."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:3
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
 "If `ninja` complains about missing files, check the `build.rs` to see if it "
 "writes source code files."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:6
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
 "If so, modify [`gnrt_config.toml`](../configuring-gnrt-config-toml.md) to "
 "add `build-script-outputs` to the crate. If this is a transitive dependency, "
@@ -14456,7 +14245,7 @@ msgid ""
 "file:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:11
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
 "```toml\n"
 "[crate.unicode-linebreak]\n"
@@ -14465,14 +14254,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:17
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid ""
 "Now rerun [`gnrt.py -- gen`](../generating-gn-build-rules.md) to regenerate "
 "`BUILD.gn` files to inform ninja that this particular output file is input "
 "to subsequent build steps."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:3
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid ""
 "Some crates use the [`cc`](https://crates.io/crates/cc) crate to build and "
 "link C/C++ libraries. Other crates parse C/C++ using [`bindgen`](https://"
@@ -14481,19 +14270,19 @@ msgid ""
 "very specific in expressing relationships between build actions."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:8
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "So, your options are:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:10
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "Avoid these crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:11
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "Apply a patch to the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:13
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid ""
 "Patches should be kept in `third_party/rust/chromium_crates_io/patches/"
 "<crate>` - see for example the [patches against the `cxx` crate](https://"
@@ -14502,18 +14291,18 @@ msgid ""
 "`gnrt` each time it upgrades the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:3
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid ""
 "Once you've added a third-party crate and generated build rules, depending "
 "on a crate is simple. Find your `rust_static_library` target, and add a "
 "`dep` on the `:lib` target within your crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:7
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid "Specifically,"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:9
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid ""
 "```bob\n"
 "                     +------------+      +----------------------+\n"
@@ -14523,7 +14312,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:17
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid ""
 "```gn\n"
 "rust_static_library(\"my_rust_lib\") {\n"
@@ -14534,11 +14323,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:1
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid "Auditing Third Party Crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:3
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Adding new libraries is subject to Chromium's standard [policies](https://"
 "chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/rust."
@@ -14548,18 +14337,18 @@ msgid ""
 "Rust code can have limited negative side effects. How should you review it?"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:9
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Over time Chromium aims to move to a process based around [cargo vet]"
 "(https://mozilla.github.io/cargo-vet/)."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:11
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Meanwhile, for each new crate addition, we are checking for the following:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:13
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Understand why each crate is used. What's the relationship between crates? "
 "If the build system for each crate contains a `build.rs` or procedural "
@@ -14567,11 +14356,11 @@ msgid ""
 "is normally built?"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:17
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid "Check each crate seems to be reasonably well maintained"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:18
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Use `cd third-party/rust/chromium_crates_io; cargo audit` to check for known "
 "vulnerabilities (first you'll need to `cargo install cargo-audit`, which "
@@ -14579,65 +14368,65 @@ msgid ""
 "cargo.md))"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:21
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Ensure any `unsafe` code is good enough for the [Rule of Two](https://"
 "chromium.googlesource.com/chromium/src/+/main/docs/security/rule-of-2."
 "md#unsafe-code-in-safe-languages)"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:22
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid "Check for any use of `fs` or `net` APIs"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:23
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "Read all the code at a sufficient level to look for anything out of place "
 "that might have been maliciously inserted. (You can't realistically aim for "
 "100% perfection here: there's often just too much code.)"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md:27
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md
 msgid ""
 "These are just guidelines --- work with reviewers from `security@chromium."
 "org` to work out the right way to become confident of the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:1
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid "Checking Crates into Chromium Source Code"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:3
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid "`git status` should reveal:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:5
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid "Crate code in `//third_party/rust/chromium_crates_io`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:6
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
 "Metadata (`BUILD.gn` and `README.chromium`) in `//third_party/rust/<crate>/"
 "<version>`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:9
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid "Please also add an `OWNERS` file in the latter location."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:11
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
 "You should land all this, along with your `Cargo.toml` and `gnrt_config."
 "toml` changes, into the Chromium repo."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:14
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
 "**Important**: you need to use `git add -f` because otherwise `.gitignore` "
 "files may result in some files being skipped."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md:17
+#: src/chromium/adding-third-party-crates/checking-in.md
 msgid ""
 "As you do so, you might find presubmit checks fail because of non-inclusive "
 "language. This is because Rust crate data tends to include names of git "
@@ -14645,7 +14434,7 @@ msgid ""
 "you may need to run:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:3
+#: src/chromium/adding-third-party-crates/keeping-up-to-date.md
 msgid ""
 "As the OWNER of any third party Chromium dependency, you are [expected to "
 "keep it up to date with any security fixes](https://chromium.googlesource."
@@ -14654,7 +14443,7 @@ msgid ""
 "still your responsibility just as it is for any other third party dependency."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:3
+#: src/exercises/chromium/third-party.md
 msgid ""
 "Add [uwuify](https://crates.io/crates/uwuify) to Chromium, turning off the "
 "crate's [default features](https://doc.rust-lang.org/cargo/reference/"
@@ -14662,7 +14451,7 @@ msgid ""
 "shipping Chromium, but won't be used to handle untrustworthy input."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:7
+#: src/exercises/chromium/third-party.md
 msgid ""
 "(In the next exercise we'll use uwuify from Chromium, but feel free to skip "
 "ahead and do that now if you like. Or, you could create a new "
@@ -14670,128 +14459,128 @@ msgid ""
 "+/main:build/rust/rust_executable.gni) which uses `uwuify`)."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:13
+#: src/exercises/chromium/third-party.md
 msgid "Students will need to download lots of transitive dependencies."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:15
+#: src/exercises/chromium/third-party.md
 msgid "The total crates needed are:"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:17
+#: src/exercises/chromium/third-party.md
 msgid "`instant`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:18
+#: src/exercises/chromium/third-party.md
 msgid "`lock_api`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:19
+#: src/exercises/chromium/third-party.md
 msgid "`parking_lot`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:20
+#: src/exercises/chromium/third-party.md
 msgid "`parking_lot_core`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:21
+#: src/exercises/chromium/third-party.md
 msgid "`redox_syscall`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:22
+#: src/exercises/chromium/third-party.md
 msgid "`scopeguard`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:23
+#: src/exercises/chromium/third-party.md
 msgid "`smallvec`, and"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:24
+#: src/exercises/chromium/third-party.md
 msgid "`uwuify`."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:26
+#: src/exercises/chromium/third-party.md
 msgid ""
 "If students are downloading even more than that, they probably forgot to "
 "turn off the default features."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md:29
+#: src/exercises/chromium/third-party.md
 msgid ""
 "Thanks to [Daniel Liu](https://github.com/Daniel-Liu-c0deb0t) for this crate!"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:1
+#: src/exercises/chromium/bringing-it-together.md
 msgid "Bringing It Together --- Exercise"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:3
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "In this exercise, you're going to add a whole new Chromium feature, bringing "
 "together everything you already learned."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:6
+#: src/exercises/chromium/bringing-it-together.md
 msgid "The Brief from Product Management"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:8
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "A community of pixies has been discovered living in a remote rainforest. "
 "It's important that we get Chromium for Pixies delivered to them as soon as "
 "possible."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:11
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "The requirement is to translate all Chromium's UI strings into Pixie "
 "language."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:13
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "There's not time to wait for proper translations, but fortunately pixie "
 "language is very close to English, and it turns out there's a Rust crate "
 "which does the translation."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:17
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "In fact, you already [imported that crate in the previous exercise](https://"
 "crates.io/crates/uwuify)."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:19
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "(Obviously, real translations of Chrome require incredible care and "
 "diligence. Don't ship this!)"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:22
+#: src/exercises/chromium/bringing-it-together.md
 msgid "Steps"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:24
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "Modify `ResourceBundle::MaybeMangleLocalizedString` so that it uwuifies all "
 "strings before display. In this special build of Chromium, it should always "
 "do this irrespective of the setting of `mangle_localized_strings_`."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:28
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "If you've done everything right across all these exercises, congratulations, "
 "you should have created Chrome for pixies!"
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:36
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "UTF16 vs UTF8. Students should be aware that Rust strings are always UTF8, "
 "and will probably decide that it's better to do the conversion on the C++ "
 "side using `base::UTF16ToUTF8` and back again."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:39
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "If students decide to do the conversion on the Rust side, they'll need to "
 "consider [`String::from_utf16`](https://doc.rust-lang.org/std/string/struct."
@@ -14800,7 +14589,7 @@ msgid ""
 "slice.html)."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:42
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "Students may design the C++/Rust boundary in several different ways, e.g. "
 "taking and returning strings by value, or taking a mutable reference to a "
@@ -14811,30 +14600,30 @@ msgid ""
 "around like Rust data, because it may contain self-referential pointers."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:49
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "The C++ target containing `ResourceBundle::MaybeMangleLocalizedString` will "
 "need to depend on a `rust_static_library` target. The student probably "
 "already did this."
 msgstr ""
 
-#: src/exercises/chromium/bringing-it-together.md:52
+#: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "The `rust_static_library` target will need to depend on `//third_party/rust/"
 "uwuify/v0_2:lib`."
 msgstr ""
 
-#: src/exercises/chromium/solutions.md:3
+#: src/exercises/chromium/solutions.md
 msgid ""
 "Solutions to the Chromium exercises can be found in [this series of CLs]"
 "(https://chromium-review.googlesource.com/c/chromium/src/+/5096560)."
 msgstr ""
 
-#: src/bare-metal.md:1
+#: src/bare-metal.md
 msgid "Welcome to Bare Metal Rust"
 msgstr ""
 
-#: src/bare-metal.md:3
+#: src/bare-metal.md
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
 "who are familiar with the basics of Rust (perhaps from completing the "
@@ -14842,29 +14631,29 @@ msgid ""
 "metal programming in some other language such as C."
 msgstr ""
 
-#: src/bare-metal.md:8
+#: src/bare-metal.md
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
 "underneath us. This will be divided into several parts:"
 msgstr ""
 
-#: src/bare-metal.md:11
+#: src/bare-metal.md
 msgid "What is `no_std` Rust?"
 msgstr ""
 
-#: src/bare-metal.md:12
+#: src/bare-metal.md
 msgid "Writing firmware for microcontrollers."
 msgstr ""
 
-#: src/bare-metal.md:13
+#: src/bare-metal.md
 msgid "Writing bootloader / kernel code for application processors."
 msgstr ""
 
-#: src/bare-metal.md:14
+#: src/bare-metal.md
 msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
-#: src/bare-metal.md:16
+#: src/bare-metal.md
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
 "(https://microbit.org/) v2 as an example. It's a [development board](https://"
@@ -14873,318 +14662,317 @@ msgid ""
 "an on-board SWD debugger."
 msgstr ""
 
-#: src/bare-metal.md:22
+#: src/bare-metal.md
 msgid ""
 "To get started, install some tools we'll need later. On gLinux or Debian:"
 msgstr ""
 
-#: src/bare-metal.md:34
+#: src/bare-metal.md
 msgid ""
 "And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
 
-#: src/bare-metal.md:44 src/bare-metal/microcontrollers/debugging.md:33
+#: src/bare-metal.md src/bare-metal/microcontrollers/debugging.md
 msgid "On MacOS:"
 msgstr ""
 
-#: src/bare-metal/no_std.md:7
+#: src/bare-metal/no_std.md
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:17
+#: src/bare-metal/no_std.md
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:24
+#: src/bare-metal/no_std.md
 msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:25
+#: src/bare-metal/no_std.md
 msgid "`NonZeroU8`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md:26
+#: src/bare-metal/no_std.md
 msgid "`Option`, `Result`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:27
+#: src/bare-metal/no_std.md
 msgid "`Display`, `Debug`, `write!`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md:29
+#: src/bare-metal/no_std.md
 msgid "`panic!`, `assert_eq!`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md:30
+#: src/bare-metal/no_std.md
 msgid "`NonNull` and all the usual pointer-related functions"
 msgstr ""
 
-#: src/bare-metal/no_std.md:31
+#: src/bare-metal/no_std.md
 msgid "`Future` and `async`/`await`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:32
+#: src/bare-metal/no_std.md
 msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
 msgstr ""
 
-#: src/bare-metal/no_std.md:33
+#: src/bare-metal/no_std.md
 msgid "`Duration`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:38
+#: src/bare-metal/no_std.md
 msgid "`Box`, `Cow`, `Arc`, `Rc`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:39
+#: src/bare-metal/no_std.md
 msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:40
+#: src/bare-metal/no_std.md
 msgid "`String`, `CString`, `format!`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:45
+#: src/bare-metal/no_std.md
 msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:47
+#: src/bare-metal/no_std.md
 msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:48
+#: src/bare-metal/no_std.md
 msgid "`File` and the rest of `fs`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:49
+#: src/bare-metal/no_std.md
 msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:50
+#: src/bare-metal/no_std.md
 msgid "`Path`, `OsString`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:51
+#: src/bare-metal/no_std.md
 msgid "`net`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:52
+#: src/bare-metal/no_std.md
 msgid "`Command`, `Child`, `ExitCode`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:53
+#: src/bare-metal/no_std.md
 msgid "`spawn`, `sleep` and the rest of `thread`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:54
+#: src/bare-metal/no_std.md
 msgid "`SystemTime`, `Instant`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:62
+#: src/bare-metal/no_std.md
 msgid "`HashMap` depends on RNG."
 msgstr ""
 
-#: src/bare-metal/no_std.md:63
+#: src/bare-metal/no_std.md
 msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
-#: src/bare-metal/minimal.md:1
+#: src/bare-metal/minimal.md
 msgid "A minimal `no_std` program"
 msgstr ""
 
-#: src/bare-metal/minimal.md:19
+#: src/bare-metal/minimal.md
 msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/minimal.md:20
+#: src/bare-metal/minimal.md
 msgid "`std` provides a panic handler; without it we must provide our own."
 msgstr ""
 
-#: src/bare-metal/minimal.md:21
+#: src/bare-metal/minimal.md
 msgid "It can also be provided by another crate, such as `panic-halt`."
 msgstr ""
 
-#: src/bare-metal/minimal.md:22
+#: src/bare-metal/minimal.md
 msgid ""
 "Depending on the target, you may need to compile with `panic = \"abort\"` to "
 "avoid an error about `eh_personality`."
 msgstr ""
 
-#: src/bare-metal/minimal.md:24
+#: src/bare-metal/minimal.md
 msgid ""
 "Note that there is no `main` or any other entry point; it's up to you to "
 "define your own entry point. This will typically involve a linker script and "
 "some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
-#: src/bare-metal/alloc.md:3
+#: src/bare-metal/alloc.md
 msgid ""
 "To use `alloc` you must implement a [global (heap) allocator](https://doc."
 "rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
-#: src/bare-metal/alloc.md:23
+#: src/bare-metal/alloc.md
 msgid "// SAFETY: `HEAP` is only used here and `entry` is only called once.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md:25
+#: src/bare-metal/alloc.md
 msgid "// Give the allocator some memory to allocate.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md:29
+#: src/bare-metal/alloc.md
 msgid "// Now we can do things that require heap allocation.\n"
 msgstr ""
 
-#: src/bare-metal/alloc.md:31
+#: src/bare-metal/alloc.md
 msgid "\"A string\""
 msgstr ""
 
-#: src/bare-metal/alloc.md:37
+#: src/bare-metal/alloc.md
 msgid ""
 "`buddy_system_allocator` is a third-party crate implementing a basic buddy "
 "system allocator. Other crates are available, or you can write your own or "
 "hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/alloc.md:40
+#: src/bare-metal/alloc.md
 msgid ""
 "The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
 "in this case it can allocate regions of up to 2\\*\\*32 bytes."
 msgstr ""
 
-#: src/bare-metal/alloc.md:42
+#: src/bare-metal/alloc.md
 msgid ""
 "If any crate in your dependency tree depends on `alloc` then you must have "
 "exactly one global allocator defined in your binary. Usually this is done in "
 "the top-level binary crate."
 msgstr ""
 
-#: src/bare-metal/alloc.md:45
+#: src/bare-metal/alloc.md
 msgid ""
 "`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
 "crate is linked in so we get its panic handler."
 msgstr ""
 
-#: src/bare-metal/alloc.md:47
+#: src/bare-metal/alloc.md
 msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:3
+#: src/bare-metal/microcontrollers.md
 msgid ""
 "The `cortex_m_rt` crate provides (among other things) a reset handler for "
 "Cortex M microcontrollers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:24
+#: src/bare-metal/microcontrollers.md
 msgid ""
 "Next we'll look at how to access peripherals, with increasing levels of "
 "abstraction."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:29
+#: src/bare-metal/microcontrollers.md
 msgid ""
 "The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
 "> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:31
+#: src/bare-metal/microcontrollers.md
 msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:3
+#: src/bare-metal/microcontrollers/mmio.md
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
 "turning on an LED on our micro:bit:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:16
+#: src/bare-metal/microcontrollers/mmio.md
 msgid "/// GPIO port 0 peripheral address\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:19
+#: src/bare-metal/microcontrollers/mmio.md
 msgid "// GPIO peripheral offsets\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:24
+#: src/bare-metal/microcontrollers/mmio.md
 msgid "// PIN_CNF fields\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:34
-#: src/bare-metal/microcontrollers/pacs.md:21
-#: src/bare-metal/microcontrollers/hals.md:26
+#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/hals.md
 msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:37
-#: src/bare-metal/microcontrollers/mmio.md:59
+#: src/bare-metal/microcontrollers/mmio.md
 msgid ""
 "// SAFETY: The pointers are to valid peripheral control registers, and no\n"
 "    // aliases exist.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:56
-#: src/bare-metal/microcontrollers/pacs.md:39
-#: src/bare-metal/microcontrollers/hals.md:30
+#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/hals.md
 msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:72
+#: src/bare-metal/microcontrollers/mmio.md
 msgid ""
 "GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
 "to the first row."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:75
-#: src/bare-metal/microcontrollers/pacs.md:61
-#: src/bare-metal/microcontrollers/hals.md:44
-#: src/bare-metal/microcontrollers/board-support.md:37
+#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/board-support.md
 msgid "Run the example with:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md:1
+#: src/bare-metal/microcontrollers/pacs.md
 msgid "Peripheral Access Crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md:3
+#: src/bare-metal/microcontrollers/pacs.md
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
 "wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
 "pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md:49
+#: src/bare-metal/microcontrollers/pacs.md
 msgid ""
 "SVD (System View Description) files are XML files typically provided by "
 "silicon vendors which describe the memory map of the device."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md:51
+#: src/bare-metal/microcontrollers/pacs.md
 msgid ""
 "They are organised by peripheral, register, field and value, with names, "
 "descriptions, addresses and so on."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md:53
+#: src/bare-metal/microcontrollers/pacs.md
 msgid ""
 "SVD files are often buggy and incomplete, so there are various projects "
 "which patch the mistakes, add missing details, and publish the generated "
 "crates."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md:56
+#: src/bare-metal/microcontrollers/pacs.md
 msgid "`cortex-m-rt` provides the vector table, among other things."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md:57
+#: src/bare-metal/microcontrollers/pacs.md
 msgid ""
 "If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
 "pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md:1
+#: src/bare-metal/microcontrollers/hals.md
 msgid "HAL crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md:3
+#: src/bare-metal/microcontrollers/hals.md
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
 "implementation-crates) for many microcontrollers provide wrappers around "
@@ -15192,72 +14980,72 @@ msgid ""
 "(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md:23
+#: src/bare-metal/microcontrollers/hals.md
 msgid "// Create HAL wrapper for GPIO port 0.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md:40
+#: src/bare-metal/microcontrollers/hals.md
 msgid ""
 "`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md:41
+#: src/bare-metal/microcontrollers/hals.md
 msgid ""
 "HAL crates exist for many Cortex-M and RISC-V devices, including various "
 "STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md:1
+#: src/bare-metal/microcontrollers/board-support.md
 msgid "Board support crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md:3
+#: src/bare-metal/microcontrollers/board-support.md
 msgid ""
 "Board support crates provide a further level of wrapping for a specific "
 "board for convenience."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md:31
+#: src/bare-metal/microcontrollers/board-support.md
 msgid ""
 "In this case the board support crate is just providing more useful names, "
 "and a bit of initialisation."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md:33
+#: src/bare-metal/microcontrollers/board-support.md
 msgid ""
 "The crate may also include drivers for some on-board devices outside of the "
 "microcontroller itself."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md:35
+#: src/bare-metal/microcontrollers/board-support.md
 msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:1
+#: src/bare-metal/microcontrollers/type-state.md
 msgid "The type state pattern"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:11
+#: src/bare-metal/microcontrollers/type-state.md
 msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:19
+#: src/bare-metal/microcontrollers/type-state.md
 msgid "// pin_input.is_high(); // Error, moved.\n"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:33
+#: src/bare-metal/microcontrollers/type-state.md
 msgid ""
 "Pins don't implement `Copy` or `Clone`, so only one instance of each can "
 "exist. Once a pin is moved out of the port struct nobody else can take it."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:35
+#: src/bare-metal/microcontrollers/type-state.md
 msgid ""
 "Changing the configuration of a pin consumes the old pin instance, so you "
 "can’t keep use the old instance afterwards."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:37
+#: src/bare-metal/microcontrollers/type-state.md
 msgid ""
 "The type of a value indicates the state that it is in: e.g. in this case, "
 "the configuration state of a GPIO pin. This encodes the state machine into "
@@ -15266,39 +15054,39 @@ msgid ""
 "caught at compile time."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:42
+#: src/bare-metal/microcontrollers/type-state.md
 msgid ""
 "You can call `is_high` on an input pin and `set_high` on an output pin, but "
 "not vice-versa."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md:44
+#: src/bare-metal/microcontrollers/type-state.md
 msgid "Many HAL crates follow this pattern."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:3
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
 "number of traits covering common microcontroller peripherals:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:6
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid "GPIO"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:7
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid "PWM"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:8
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid "Delay timers"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:9
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid "I2C and SPI buses and devices"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:11
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid ""
 "Similar traits for byte streams (e.g. UARTs), CAN buses and RNGs and broken "
 "out into [`embedded-io`](https://crates.io/crates/embedded-io), [`embedded-"
@@ -15306,66 +15094,66 @@ msgid ""
 "crates.io/crates/rand_core) respectively."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:14
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid ""
 "Other crates then implement [drivers](https://github.com/rust-embedded/"
 "awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
 "accelerometer driver might need an I2C or SPI device instance."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:19
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid ""
 "The traits cover using the peripherals but not initialising or configuring "
 "them, as initialisation and configuration is usually highly platform-"
 "specific."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:21
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid ""
 "There are implementations for many microcontrollers, as well as other "
 "platforms such as Linux on Raspberry Pi."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid ""
 "[`embedded-hal-async`](https://crates.io/crates/embedded-hal-async) provides "
 "async versions of the traits."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md:24
+#: src/bare-metal/microcontrollers/embedded-hal.md
 msgid ""
 "[`embedded-hal-nb`](https://crates.io/crates/embedded-hal-nb) provides "
 "another approach to non-blocking I/O, based on the [`nb`](https://crates.io/"
 "crates/nb) crate."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:3
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
 "like OpenOCD but better integrated."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:6
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "SWD (Serial Wire Debug) and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:7
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid "GDB stub and Microsoft DAP (Debug Adapter Protocol) server"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:8
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid "Cargo integration"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:10
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "`cargo-embed` is a cargo subcommand to build and flash binaries, log RTT "
 "(Real Time Transfers) output and connect GDB. It's configured by an `Embed."
 "toml` file in your project directory."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:16
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
 "an Arm standard protocol over USB for an in-circuit debugger to access the "
@@ -15373,170 +15161,170 @@ msgid ""
 "on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:20
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
 "is a range from SEGGER."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:22
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
 "Serial Wire Debug."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:24
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "probe-rs is a library which you can integrate into your own tools if you "
 "want to."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:26
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
 "adapter-protocol/) lets VSCode and other IDEs debug code running on any "
 "supported microcontroller."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:30
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid "cargo-embed is a binary built using the probe-rs library."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md:31
+#: src/bare-metal/microcontrollers/probe-rs.md
 msgid ""
 "RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
 "host and the target through a number of ringbuffers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:3
+#: src/bare-metal/microcontrollers/debugging.md
 msgid "_Embed.toml_:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:15
+#: src/bare-metal/microcontrollers/debugging.md
 msgid "In one terminal under `src/bare-metal/microcontrollers/examples/`:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:23
+#: src/bare-metal/microcontrollers/debugging.md
 msgid "In another terminal in the same directory:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:25
+#: src/bare-metal/microcontrollers/debugging.md
 msgid "On gLinux or Debian:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:43
+#: src/bare-metal/microcontrollers/debugging.md
 msgid "In GDB, try running:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:1
-#: src/bare-metal/aps/other-projects.md:1
+#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/aps/other-projects.md
 msgid "Other projects"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:3
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "[RTIC](https://rtic.rs/)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:4
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "\"Real-Time Interrupt-driven Concurrency\""
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:5
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid ""
 "Shared resource management, message passing, task scheduling, timer queue"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:6
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "[Embassy](https://embassy.dev/)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:7
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "`async` executors with priorities, timers, networking, USB"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:8
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:9
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid ""
 "Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
 "support"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:11
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "[Hubris](https://hubris.oxide.computer/)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:12
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid ""
 "Microkernel RTOS from Oxide Computer Company with memory protection, "
 "unprivileged drivers, IPC"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:14
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:15
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid ""
 "Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
 "github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:20
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "RTIC can be considered either an RTOS or a concurrency framework."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:21
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "It doesn't include any HALs."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:22
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid ""
 "It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
 "scheduling rather than a proper kernel."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:24
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid "Cortex-M only."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:25
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid ""
 "Google uses TockOS on the Haven microcontroller for Titan security keys."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md:26
+#: src/bare-metal/microcontrollers/other-projects.md
 msgid ""
 "FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
 
-#: src/exercises/bare-metal/morning.md:3
+#: src/exercises/bare-metal/morning.md
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/morning.md:8
+#: src/exercises/bare-metal/morning.md
 msgid ""
 "After looking at the exercises, you can look at the [solutions](solutions-"
 "morning.md) provided."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:3
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
 "serial port. If you have time, try displaying it on the LEDs somehow too, or "
 "use the buttons somehow."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:7
+#: src/exercises/bare-metal/compass.md
 msgid "Hints:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:9
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
 "latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
@@ -15544,123 +15332,123 @@ msgid ""
 "org/hardware/)."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:13
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:14
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "TWI is another name for I2C, so the I2C master peripheral is called TWIM."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:15
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "The LSM303AGR driver needs something implementing the `embedded_hal::"
 "blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
 "microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:19
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
 "struct.Board.html) struct with fields for the various pins and peripherals."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:22
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
 "com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
 "this exercise."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:26
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
 "look in the `compass` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:29 src/exercises/bare-metal/rtc.md:22
+#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
 msgid "_src/main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:71 src/exercises/bare-metal/rtc.md:393
+#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
 msgid "_Cargo.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:93
+#: src/exercises/bare-metal/compass.md
 msgid "_Embed.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:109 src/exercises/bare-metal/rtc.md:1000
+#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
 msgid "_.cargo/config.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:122
+#: src/exercises/bare-metal/compass.md
 msgid "See the serial output on Linux with:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:130
+#: src/exercises/bare-metal/compass.md
 msgid ""
 "Or on Mac OS something like (the device name may be slightly different):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:138
+#: src/exercises/bare-metal/compass.md
 msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:1
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "Bare Metal Rust Morning Exercise"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:5
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "([back to exercise](compass.md))"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:34
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "// Configure serial port.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:42
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "// Use the system timer as a delay provider.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:45
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:46
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "\"Setting up IMU...\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:64
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "// Set up display and timer.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:71
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "\"Ready.\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:74
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "// Read compass data and log it to the serial port.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:82
+#: src/exercises/bare-metal/solutions-morning.md
 msgid "\"{},{},{}\\t{},{},{}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md:120
+#: src/exercises/bare-metal/solutions-morning.md
 msgid ""
 "// If button A is pressed, switch to the next mode and briefly blink all "
 "LEDs\n"
 "        // on.\n"
 msgstr ""
 
-#: src/bare-metal/aps.md:1
+#: src/bare-metal/aps.md
 msgid "Application processors"
 msgstr ""
 
-#: src/bare-metal/aps.md:3
+#: src/bare-metal/aps.md
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
 "Now let's try writing something for Cortex-A. For simplicity we'll just work "
@@ -15668,26 +15456,26 @@ msgid ""
 "virt.html) board."
 msgstr ""
 
-#: src/bare-metal/aps.md:10
+#: src/bare-metal/aps.md
 msgid ""
 "Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
 "privilege (exception levels on Arm CPUs, rings on x86), while application "
 "processors do."
 msgstr ""
 
-#: src/bare-metal/aps.md:13
+#: src/bare-metal/aps.md
 msgid ""
 "QEMU supports emulating various different machines or board models for each "
 "architecture. The 'virt' board doesn't correspond to any particular real "
 "hardware, but is designed purely for virtual machines."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:3
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "Before we can start running Rust code, we need to do some initialisation."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:5
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "```armasm\n"
 ".section .init.entry, \"ax\"\n"
@@ -15763,13 +15551,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:77
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "This is the same as it would be for C: initialising the processor state, "
 "zeroing the BSS, and setting up the stack pointer."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:79
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "The BSS (block starting symbol, for historical reasons) is the part of the "
 "object file which containing statically allocated variables which are "
@@ -15778,19 +15566,19 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:84
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "The BSS may already be zeroed, depending on how memory is initialised and "
 "the image is loaded, but we zero it to be sure."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:86
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "We need to enable the MMU and cache before reading or writing any memory. If "
 "we don't:"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:88
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "Unaligned accesses will fault. We build the Rust code for the `aarch64-"
 "unknown-none` target which sets `+strict-align` to prevent the compiler "
@@ -15798,7 +15586,7 @@ msgid ""
 "is not necessarily the case in general."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:92
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -15809,7 +15597,7 @@ msgid ""
 "not VA or IPA.)"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:99
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
 "identity maps the first 1 GiB of address space for devices, the next 1 GiB "
@@ -15817,86 +15605,86 @@ msgid ""
 "memory layout that QEMU uses."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:103
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "We also set up the exception vector (`vbar_el1`), which we'll see more about "
 "later."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:105
+#: src/bare-metal/aps/entry-point.md
 msgid ""
 "All examples this afternoon assume we will be running at exception level 1 "
 "(EL1). If you need to run at a different exception level you'll need to "
 "modify `entry.S` accordingly."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:1
+#: src/bare-metal/aps/inline-assembly.md
 msgid "Inline assembly"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:3
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
 "Rust code. For example, to make an HVC (hypervisor call) to tell the "
 "firmware to power off the system:"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:20
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "// SAFETY: this only uses the declared registers and doesn't do anything\n"
 "    // with memory.\n"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:23
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"hvc #0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:24
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:25
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w1\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:26
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w2\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:27
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w3\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:28
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w4\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:29
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w5\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:30
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w6\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:31
+#: src/bare-metal/aps/inline-assembly.md
 msgid "\"w7\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:40
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
 "smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:45
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "PSCI is the Arm Power State Coordination Interface, a standard set of "
 "functions to manage system and CPU power states, among other things. It is "
 "implemented by EL3 firmware and hypervisors on many systems."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:48
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "The `0 => _` syntax means initialise the register to 0 before running the "
 "inline assembly code, and ignore its contents afterwards. We need to use "
@@ -15904,13 +15692,13 @@ msgid ""
 "contents of the registers."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:52
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
 "it is called from our entry point in `entry.S`."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:54
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
 "used by the bootloader to pass things like a pointer to the device tree. "
@@ -15920,71 +15708,71 @@ msgid ""
 "special except make sure it doesn't change these registers."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md:60
+#: src/bare-metal/aps/inline-assembly.md
 msgid ""
 "Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:1
+#: src/bare-metal/aps/mmio.md
 msgid "Volatile memory access for MMIO"
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:3
+#: src/bare-metal/aps/mmio.md
 msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:4
+#: src/bare-metal/aps/mmio.md
 msgid "Never hold a reference."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:5
+#: src/bare-metal/aps/mmio.md
 msgid ""
 "`addr_of!` lets you get fields of structs without creating an intermediate "
 "reference."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:10
+#: src/bare-metal/aps/mmio.md
 msgid ""
 "Volatile access: read or write operations may have side-effects, so prevent "
 "the compiler or hardware from reordering, duplicating or eliding them."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:12
+#: src/bare-metal/aps/mmio.md
 msgid ""
 "Usually if you write and then read, e.g. via a mutable reference, the "
 "compiler may assume that the value read is the same as the value just "
 "written, and not bother actually reading memory."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:15
+#: src/bare-metal/aps/mmio.md
 msgid ""
 "Some existing crates for volatile access to hardware do hold references, but "
 "this is unsound. Whenever a reference exist, the compiler may choose to "
 "dereference it."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md:18
+#: src/bare-metal/aps/mmio.md
 msgid ""
 "Use the `addr_of!` macro to get struct field pointers from a pointer to the "
 "struct."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:1
+#: src/bare-metal/aps/uart.md
 msgid "Let's write a UART driver"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:3
+#: src/bare-metal/aps/uart.md
 msgid ""
 "The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
 "documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:9
+#: src/bare-metal/aps/uart.md
 msgid "/// Minimal driver for a PL011 UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:17 src/bare-metal/aps/better-uart/driver.md:13
+#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 msgid ""
 "/// Constructs a new instance of the UART driver for a PL011 device at the\n"
 "    /// given base address.\n"
@@ -15998,29 +15786,29 @@ msgid ""
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:25
+#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 msgid "/// Writes a single byte to the UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:27
+#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 msgid "// Wait until there is room in the TX buffer.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:34 src/bare-metal/aps/uart.md:46
+#: src/bare-metal/aps/uart.md
 msgid ""
 "// SAFETY: We know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:33
+#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 msgid "// Write to the TX buffer.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:37
+#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
 msgid "// Wait until the UART is no longer busy.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:55
+#: src/bare-metal/aps/uart.md
 msgid ""
 "Note that `Uart::new` is unsafe while the other methods are safe. This is "
 "because as long as the caller of `Uart::new` guarantees that its safety "
@@ -16030,53 +15818,53 @@ msgid ""
 "necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:61
+#: src/bare-metal/aps/uart.md
 msgid ""
 "We could have done it the other way around (making `new` safe but "
 "`write_byte` unsafe), but that would be much less convenient to use as every "
 "place that calls `write_byte` would need to reason about the safety"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:64
+#: src/bare-metal/aps/uart.md
 msgid ""
 "This is a common pattern for writing safe wrappers of unsafe code: moving "
 "the burden of proof for soundness from a large number of places to a smaller "
 "number of places."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:1
+#: src/bare-metal/aps/uart/traits.md
 msgid "More traits"
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:3
+#: src/bare-metal/aps/uart/traits.md
 msgid ""
 "We derived the `Debug` trait. It would be useful to implement a few more "
 "traits too."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:17
+#: src/bare-metal/aps/uart/traits.md
 msgid ""
 "// SAFETY: `Uart` just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:25
+#: src/bare-metal/aps/uart/traits.md
 msgid ""
 "Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
 "`Uart` type."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md:27
+#: src/bare-metal/aps/uart/traits.md
 msgid ""
 "Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:1
+#: src/bare-metal/aps/better-uart.md
 msgid "A better UART driver"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:3
+#: src/bare-metal/aps/better-uart.md
 msgid ""
 "The PL011 actually has [a bunch more registers](https://developer.arm.com/"
 "documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
@@ -16085,213 +15873,212 @@ msgid ""
 "structured way."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:7
+#: src/bare-metal/aps/better-uart.md
 msgid "Offset"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:7
+#: src/bare-metal/aps/better-uart.md
 msgid "Register name"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:7
+#: src/bare-metal/aps/better-uart.md
 msgid "Width"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:9
+#: src/bare-metal/aps/better-uart.md
 msgid "0x00"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:9
+#: src/bare-metal/aps/better-uart.md
 msgid "DR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:9
+#: src/bare-metal/aps/better-uart.md
 msgid "12"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:10
+#: src/bare-metal/aps/better-uart.md
 msgid "0x04"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:10
+#: src/bare-metal/aps/better-uart.md
 msgid "RSR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:11
+#: src/bare-metal/aps/better-uart.md
 msgid "0x18"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:11
+#: src/bare-metal/aps/better-uart.md
 msgid "FR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:11
+#: src/bare-metal/aps/better-uart.md
 msgid "9"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:12
+#: src/bare-metal/aps/better-uart.md
 msgid "0x20"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:12
+#: src/bare-metal/aps/better-uart.md
 msgid "ILPR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:13
+#: src/bare-metal/aps/better-uart.md
 msgid "0x24"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:13
+#: src/bare-metal/aps/better-uart.md
 msgid "IBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+#: src/bare-metal/aps/better-uart.md
 msgid "16"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:14
+#: src/bare-metal/aps/better-uart.md
 msgid "0x28"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:14
+#: src/bare-metal/aps/better-uart.md
 msgid "FBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:15
+#: src/bare-metal/aps/better-uart.md
 msgid "0x2c"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:15
+#: src/bare-metal/aps/better-uart.md
 msgid "LCR_H"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:16
+#: src/bare-metal/aps/better-uart.md
 msgid "0x30"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:16
+#: src/bare-metal/aps/better-uart.md
 msgid "CR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:17
+#: src/bare-metal/aps/better-uart.md
 msgid "0x34"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:17
+#: src/bare-metal/aps/better-uart.md
 msgid "IFLS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:18
+#: src/bare-metal/aps/better-uart.md
 msgid "0x38"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:18
+#: src/bare-metal/aps/better-uart.md
 msgid "IMSC"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
-#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+#: src/bare-metal/aps/better-uart.md
 msgid "11"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md
 msgid "0x3c"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md
 msgid "RIS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:20
+#: src/bare-metal/aps/better-uart.md
 msgid "0x40"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:20
+#: src/bare-metal/aps/better-uart.md
 msgid "MIS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:21
+#: src/bare-metal/aps/better-uart.md
 msgid "0x44"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:21
+#: src/bare-metal/aps/better-uart.md
 msgid "ICR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:22
+#: src/bare-metal/aps/better-uart.md
 msgid "0x48"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:22
+#: src/bare-metal/aps/better-uart.md
 msgid "DMACR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md:26
+#: src/bare-metal/aps/better-uart.md
 msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:3
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid ""
 "The [`bitflags`](https://crates.io/crates/bitflags) crate is useful for "
 "working with bitflags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:10
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Flags from the UART flag register.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:14
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Clear to send.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:16
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Data set ready.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:18
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Data carrier detect.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:20
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// UART busy transmitting data.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:22
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Receive FIFO is empty.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:24
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Transmit FIFO is full.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:26
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Receive FIFO is full.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:28
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Transmit FIFO is empty.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:30
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid "/// Ring indicator.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md:38
+#: src/bare-metal/aps/better-uart/bitflags.md
 msgid ""
 "The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
 "with a bunch of method implementations to get and set flags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md:1
+#: src/bare-metal/aps/better-uart/registers.md
 msgid "Multiple registers"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md:3
+#: src/bare-metal/aps/better-uart/registers.md
 msgid ""
 "We can use a struct to represent the memory layout of the UART's registers."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md:43
+#: src/bare-metal/aps/better-uart/registers.md
 msgid ""
 "[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
 "representation) tells the compiler to lay the struct fields out in order, "
@@ -16300,143 +16087,138 @@ msgid ""
 "(among other things) reorder fields however it sees fit."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:3
+#: src/bare-metal/aps/better-uart/driver.md
 msgid "Now let's use the new `Registers` struct in our driver."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:6
+#: src/bare-metal/aps/better-uart/driver.md
 msgid "/// Driver for a PL011 UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:30
-#: src/bare-metal/aps/better-uart/driver.md:56
+#: src/bare-metal/aps/better-uart/driver.md
 msgid ""
 "// SAFETY: We know that self.registers points to the control registers\n"
 "        // of a PL011 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:41
+#: src/bare-metal/aps/better-uart/driver.md
 msgid ""
 "/// Reads and returns a pending byte, or `None` if nothing has been\n"
 "    /// received.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:47
+#: src/bare-metal/aps/better-uart/driver.md
 msgid ""
 "// SAFETY: We know that self.registers points to the control\n"
 "            // registers of a PL011 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:50
+#: src/bare-metal/aps/better-uart/driver.md
 msgid "// TODO: Check for error conditions in bits 8-11.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md:65
+#: src/bare-metal/aps/better-uart/driver.md
 msgid ""
 "Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
 "fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:1
-#: src/bare-metal/aps/logging/using.md:1
+#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
 msgid "Using it"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:3
+#: src/bare-metal/aps/better-uart/using.md
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
 "and echo incoming bytes."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:19
-#: src/bare-metal/aps/logging/using.md:18
-#: src/exercises/bare-metal/solutions-afternoon.md:33
+#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Base address of the primary PL011 UART.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:25
-#: src/bare-metal/aps/logging/using.md:24
-#: src/exercises/bare-metal/solutions-afternoon.md:44
+#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "// SAFETY: `PL011_BASE_ADDRESS` is the base address of a PL011 device, and\n"
 "    // nothing else accesses that address range.\n"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:29
-#: src/bare-metal/aps/logging/using.md:29
+#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
 msgid "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:35
+#: src/bare-metal/aps/better-uart/using.md
 msgid "b'\\r'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:36
-#: src/concurrency/async-pitfalls/cancellation.md:27
+#: src/bare-metal/aps/better-uart/using.md
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "b'\\n'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:38
+#: src/bare-metal/aps/better-uart/using.md
 msgid "b'q'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:44
+#: src/bare-metal/aps/better-uart/using.md
 msgid "\"Bye!\""
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:51
+#: src/bare-metal/aps/better-uart/using.md
 msgid ""
 "As in the [inline assembly](../inline-assembly.md) example, this `main` "
 "function is called from our entry point code in `entry.S`. See the speaker "
 "notes there for details."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md:54
+#: src/bare-metal/aps/better-uart/using.md
 msgid ""
 "Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:3
+#: src/bare-metal/aps/logging.md
 msgid ""
 "It would be nice to be able to use the logging macros from the [`log`]"
 "(https://crates.io/crates/log) crate. We can do this by implementing the "
 "`Log` trait."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:26
+#: src/bare-metal/aps/logging.md
 msgid "\"[{}] {}\""
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:35
+#: src/bare-metal/aps/logging.md
 msgid "/// Initialises UART logger.\n"
 msgstr ""
 
-#: src/bare-metal/aps/logging.md:48
+#: src/bare-metal/aps/logging.md
 msgid ""
 "The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md:3
+#: src/bare-metal/aps/logging/using.md
 msgid "We need to initialise the logger before we use it."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md:38
-#: src/exercises/bare-metal/solutions-afternoon.md:115
+#: src/bare-metal/aps/logging/using.md
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"{info}\""
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md:46
+#: src/bare-metal/aps/logging/using.md
 msgid "Note that our panic handler can now log details of panics."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md:47
+#: src/bare-metal/aps/logging/using.md
 msgid ""
 "Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md:3
+#: src/bare-metal/aps/exceptions.md
 msgid ""
 "AArch64 defines an exception vector table with 16 entries, for 4 types of "
 "exceptions (synchronous, IRQ, FIQ, SError) from 4 states (current EL with "
@@ -16445,23 +16227,23 @@ msgid ""
 "calling into Rust code:"
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md:67
+#: src/bare-metal/aps/exceptions.md
 msgid "EL is exception level; all our examples this afternoon run in EL1."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md:68
+#: src/bare-metal/aps/exceptions.md
 msgid ""
 "For simplicity we aren't distinguishing between SP0 and SPx for the current "
 "EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md:70
+#: src/bare-metal/aps/exceptions.md
 msgid ""
 "For this example we just log the exception and power down, as we don't "
 "expect any of them to actually happen."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md:72
+#: src/bare-metal/aps/exceptions.md
 msgid ""
 "We can think of exception handlers and our main execution context more or "
 "less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
@@ -16471,55 +16253,55 @@ msgid ""
 "it in something like a `Mutex` and put it in a static."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:3
+#: src/bare-metal/aps/other-projects.md
 msgid "[oreboot](https://github.com/oreboot/oreboot)"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:4
+#: src/bare-metal/aps/other-projects.md
 msgid "\"coreboot without the C\""
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:5
+#: src/bare-metal/aps/other-projects.md
 msgid "Supports x86, aarch64 and RISC-V."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:6
+#: src/bare-metal/aps/other-projects.md
 msgid "Relies on LinuxBoot rather than having many drivers itself."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:7
+#: src/bare-metal/aps/other-projects.md
 msgid ""
 "[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
 "raspberrypi-OS-tutorials)"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:8
+#: src/bare-metal/aps/other-projects.md
 msgid ""
 "Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
 "exception handling, page tables"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:10
+#: src/bare-metal/aps/other-projects.md
 msgid ""
 "Some dodginess around cache maintenance and initialisation in Rust, not "
 "necessarily a good example to copy for production code."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:12
+#: src/bare-metal/aps/other-projects.md
 msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:13
+#: src/bare-metal/aps/other-projects.md
 msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:17
+#: src/bare-metal/aps/other-projects.md
 msgid ""
 "The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
 "enabled. This will read and write memory (e.g. the stack). However:"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:19
+#: src/bare-metal/aps/other-projects.md
 msgid ""
 "Without the MMU and cache, unaligned accesses will fault. It builds with "
 "`aarch64-unknown-none` which sets `+strict-align` to prevent the compiler "
@@ -16527,7 +16309,7 @@ msgid ""
 "necessarily the case in general."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md:23
+#: src/bare-metal/aps/other-projects.md
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -16538,94 +16320,94 @@ msgid ""
 "hypervisor), but isn't a good pattern in general."
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
+#: src/bare-metal/useful-crates.md
 msgid "Useful crates"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:3
+#: src/bare-metal/useful-crates.md
 msgid ""
 "We'll go over a few crates which solve some common problems in bare-metal "
 "programming."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md:3
+#: src/bare-metal/useful-crates/zerocopy.md
 msgid ""
 "The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
 "traits and macros for safely converting between byte sequences and other "
 "types."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md:42
+#: src/bare-metal/useful-crates/zerocopy.md
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
 "but can be useful for working with structures shared with hardware e.g. by "
 "DMA, or sent over some external interface."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md:48
+#: src/bare-metal/useful-crates/zerocopy.md
 msgid ""
 "`FromBytes` can be implemented for types for which any byte pattern is "
 "valid, and so can safely be converted from an untrusted sequence of bytes."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md:50
+#: src/bare-metal/useful-crates/zerocopy.md
 msgid ""
 "Attempting to derive `FromBytes` for these types would fail, because "
 "`RequestType` doesn't use all possible u32 values as discriminants, so not "
 "all byte patterns are valid."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md:53
+#: src/bare-metal/useful-crates/zerocopy.md
 msgid ""
 "`zerocopy::byteorder` has types for byte-order aware numeric primitives."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md:54
+#: src/bare-metal/useful-crates/zerocopy.md
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "zerocopy-example/`. (It won't run in the Playground because of the crate "
 "dependency.)"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:3
+#: src/bare-metal/useful-crates/aarch64-paging.md
 msgid ""
 "The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
 "you create page tables according to the AArch64 Virtual Memory System "
 "Architecture."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:14
+#: src/bare-metal/useful-crates/aarch64-paging.md
 msgid "// Create a new page table with identity mapping.\n"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:16
+#: src/bare-metal/useful-crates/aarch64-paging.md
 msgid "// Map a 2 MiB region of memory as read-only.\n"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:21
+#: src/bare-metal/useful-crates/aarch64-paging.md
 msgid "// Set `TTBR0_EL1` to activate the page table.\n"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:28
+#: src/bare-metal/useful-crates/aarch64-paging.md
 msgid ""
 "For now it only supports EL1, but support for other exception levels should "
 "be straightforward to add."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:30
+#: src/bare-metal/useful-crates/aarch64-paging.md
 msgid ""
 "This is used in Android for the [Protected VM Firmware](https://cs.android."
 "com/android/platform/superproject/+/master:packages/modules/Virtualization/"
 "pvmfw/)."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md:31
+#: src/bare-metal/useful-crates/aarch64-paging.md
 msgid ""
 "There's no easy way to run this example, as it needs to run on real hardware "
 "or under QEMU."
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:3
+#: src/bare-metal/useful-crates/buddy_system_allocator.md
 msgid ""
 "[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
 "is a third-party crate implementing a basic buddy system allocator. It can "
@@ -16637,18 +16419,18 @@ msgid ""
 "space for PCI BARs:"
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:29
+#: src/bare-metal/useful-crates/buddy_system_allocator.md
 msgid "PCI BARs always have alignment equal to their size."
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
+#: src/bare-metal/useful-crates/buddy_system_allocator.md
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "allocator-example/`. (It won't run in the Playground because of the crate "
 "dependency.)"
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md:3
+#: src/bare-metal/useful-crates/tinyvec.md
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
 "heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
@@ -16657,53 +16439,53 @@ msgid ""
 "and panics if you try to use more than are allocated."
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md:25
+#: src/bare-metal/useful-crates/tinyvec.md
 msgid ""
 "`tinyvec` requires that the element type implement `Default` for "
 "initialisation."
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md:27
+#: src/bare-metal/useful-crates/tinyvec.md
 msgid ""
 "The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md:3
+#: src/bare-metal/useful-crates/spin.md
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
 "are not available in `core` or `alloc`. How can we manage synchronisation or "
 "interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md:7
+#: src/bare-metal/useful-crates/spin.md
 msgid ""
 "The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
 "equivalents of many of these primitives."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md:26
+#: src/bare-metal/useful-crates/spin.md
 msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md:27
+#: src/bare-metal/useful-crates/spin.md
 msgid ""
 "`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
 "`Barrier` and `Once` from `std::sync`; and `Lazy` for lazy initialisation."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md:29
+#: src/bare-metal/useful-crates/spin.md
 msgid ""
 "The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
 "useful types for late initialisation with a slightly different approach to "
 "`spin::once::Once`."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md:31
+#: src/bare-metal/useful-crates/spin.md
 msgid ""
 "The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
 
-#: src/bare-metal/android.md:3
+#: src/bare-metal/android.md
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
 "`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
@@ -16711,11 +16493,11 @@ msgid ""
 "to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
+#: src/bare-metal/android/vmbase.md
 msgid "vmbase"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:3
+#: src/bare-metal/android/vmbase.md
 msgid ""
 "For VMs running under crosvm on aarch64, the [vmbase](https://android."
 "googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
@@ -16723,229 +16505,224 @@ msgid ""
 "build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:24
+#: src/bare-metal/android/vmbase.md
 msgid ""
 "The `main!` macro marks your main function, to be called from the `vmbase` "
 "entry point."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:26
+#: src/bare-metal/android/vmbase.md
 msgid ""
 "The `vmbase` entry point handles console initialisation, and issues a "
 "PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
-#: src/exercises/bare-metal/afternoon.md:3
+#: src/exercises/bare-metal/afternoon.md
 msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
-#: src/exercises/bare-metal/afternoon.md:7
+#: src/exercises/bare-metal/afternoon.md
 msgid ""
 "After looking at the exercises, you can look at the [solutions](solutions-"
 "afternoon.md) provided."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:1
-#: src/exercises/bare-metal/solutions-afternoon.md:3
+#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "RTC driver"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:3
+#: src/exercises/bare-metal/rtc.md
 msgid ""
 "The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
 "documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
 "you should write a driver for it."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:6
+#: src/exercises/bare-metal/rtc.md
 msgid ""
 "Use it to print the current time to the serial console. You can use the "
 "[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:8
+#: src/exercises/bare-metal/rtc.md
 msgid ""
 "Use the match register and raw interrupt status to busy-wait until a given "
 "time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
 "doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:11
+#: src/exercises/bare-metal/rtc.md
 msgid ""
 "_Extension if you have time:_ Enable and handle the interrupt generated by "
 "the RTC match. You can use the driver provided in the [`arm-gic`](https://"
 "docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:14
+#: src/exercises/bare-metal/rtc.md
 msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:15
+#: src/exercises/bare-metal/rtc.md
 msgid ""
 "Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
 "wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:19
+#: src/exercises/bare-metal/rtc.md
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
 "look in the `rtc` directory for the following files."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:79
+#: src/exercises/bare-metal/rtc.md
 msgid ""
 "_src/exceptions.rs_ (you should only need to change this for the 3rd part of "
 "the exercise):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:156
+#: src/exercises/bare-metal/rtc.md
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:216
+#: src/exercises/bare-metal/rtc.md
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:419
+#: src/exercises/bare-metal/rtc.md
 msgid "_build.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:456
+#: src/exercises/bare-metal/rtc.md
 msgid "_entry.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:606
+#: src/exercises/bare-metal/rtc.md
 msgid "_exceptions.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:792
+#: src/exercises/bare-metal/rtc.md
 msgid "_idmap.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:842
+#: src/exercises/bare-metal/rtc.md
 msgid "_image.ld_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:954
+#: src/exercises/bare-metal/rtc.md
 msgid "_Makefile_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:1011
+#: src/exercises/bare-metal/rtc.md
 msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:1
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "Bare Metal Rust Afternoon"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:5
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "([back to exercise](rtc.md))"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:7
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "_main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:29
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Base addresses of the GICv3.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:36
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Base address of the PL031 RTC.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:38
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// The IRQ used by the PL031 RTC.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:49
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:51
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "// SAFETY: `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:57
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "// SAFETY: `PL031_BASE_ADDRESS` is the base address of a PL031 device, and\n"
 "    // nothing else accesses that address range.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:62
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"RTC: {time}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:70
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "// Wait for 3 seconds, without interrupts.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:73
-#: src/exercises/bare-metal/solutions-afternoon.md:91
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"Waiting for {}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:75
-#: src/exercises/bare-metal/solutions-afternoon.md:83
-#: src/exercises/bare-metal/solutions-afternoon.md:96
-#: src/exercises/bare-metal/solutions-afternoon.md:104
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"matched={}, interrupt_pending={}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:87
-#: src/exercises/bare-metal/solutions-afternoon.md:108
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"Finished waiting\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:89
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "// Wait another 3 seconds for an interrupt.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:121
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "_pl031.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:128
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Data register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:130
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Match register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:132
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Load register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:134
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Control register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:137
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Interrupt Mask Set or Clear register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:140
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Raw Interrupt Status\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:143
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Masked Interrupt Status\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:146
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Interrupt Clear Register\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:150
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Driver for a PL031 real-time clock.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:158
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
 "    /// given base address.\n"
@@ -16959,35 +16736,30 @@ msgid ""
 "    /// as device memory and not have any other aliases.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:170
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Reads the current RTC value.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:172
-#: src/exercises/bare-metal/solutions-afternoon.md:180
-#: src/exercises/bare-metal/solutions-afternoon.md:188
-#: src/exercises/bare-metal/solutions-afternoon.md:199
-#: src/exercises/bare-metal/solutions-afternoon.md:211
-#: src/exercises/bare-metal/solutions-afternoon.md:218
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "// SAFETY: We know that self.registers points to the control registers\n"
 "        // of a PL031 device which is appropriately mapped.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:177
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "/// Writes a match value. When the RTC value matches this then an interrupt\n"
 "    /// will be generated (if it is enabled).\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:185
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "/// Returns whether the match register matches the RTC value, whether or "
 "not\n"
 "    /// the interrupt is enabled.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:194
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "/// Returns whether there is currently an interrupt pending.\n"
 "    ///\n"
@@ -16995,7 +16767,7 @@ msgid ""
 "    /// interrupt is masked.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:205
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "/// Sets or clears the interrupt mask.\n"
 "    ///\n"
@@ -17004,34 +16776,34 @@ msgid ""
 "    /// interrupt is disabled.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:216
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid "/// Clears a pending interrupt, if any.\n"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:223
+#: src/exercises/bare-metal/solutions-afternoon.md
 msgid ""
 "// SAFETY: `Rtc` just contains a pointer to device memory, which can be\n"
 "// accessed from any context.\n"
 msgstr ""
 
-#: src/concurrency/welcome.md:1
+#: src/concurrency/welcome.md
 msgid "Welcome to Concurrency in Rust"
 msgstr ""
 
-#: src/concurrency/welcome.md:3
+#: src/concurrency/welcome.md
 msgid ""
 "Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 
-#: src/concurrency/welcome.md:6
+#: src/concurrency/welcome.md
 msgid ""
 "The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
 "you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 
-#: src/concurrency/welcome.md:12 src/concurrency/welcome-async.md:29
+#: src/concurrency/welcome.md src/concurrency/welcome-async.md
 msgid ""
 "Including 10 minute breaks, this session should take about 3 hours and 20 "
 "minutes. It contains:"
@@ -17039,302 +16811,296 @@ msgstr ""
 "Buổi học nên kéo dài khoảng 3 tiếng và 20 phút, bao gồm thời gian 10 phút "
 "nghỉ trưa. Nội dung buổi học bao gồm:"
 
-#: src/concurrency/welcome.md:25
+#: src/concurrency/welcome.md
 msgid ""
 "Rust lets us access OS concurrency toolkit: threads, sync. primitives, etc."
 msgstr ""
 
-#: src/concurrency/welcome.md:26
+#: src/concurrency/welcome.md
 msgid ""
 "The type system gives us safety for concurrency without any special features."
 msgstr ""
 
-#: src/concurrency/welcome.md:27
+#: src/concurrency/welcome.md
 msgid ""
 "The same tools that help with \"concurrent\" access in a single thread (e."
 "g., a called function that might mutate an argument or save references to it "
 "to read later) save us from multi-threading issues."
 msgstr ""
 
-#: src/concurrency/threads.md:3 src/concurrency/shared-state.md:3
-#: src/concurrency/async.md:3
+#: src/concurrency/threads.md src/concurrency/shared-state.md
+#: src/concurrency/async.md
 msgid "This segment should take about 30 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 30 phút, bao gồm:"
 
-#: src/concurrency/threads/plain.md:3
+#: src/concurrency/threads/plain.md
 msgid "Rust threads work similarly to threads in other languages:"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:12
+#: src/concurrency/threads/plain.md
 msgid "\"Count in thread: {i}!\""
 msgstr ""
 
-#: src/concurrency/threads/plain.md:18
+#: src/concurrency/threads/plain.md
 msgid "\"Main thread: {i}\""
 msgstr ""
 
-#: src/concurrency/threads/plain.md:24
+#: src/concurrency/threads/plain.md
 msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:25
+#: src/concurrency/threads/plain.md
 msgid "Thread panics are independent of each other."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:26
+#: src/concurrency/threads/plain.md
 msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:31
+#: src/concurrency/threads/plain.md
 msgid "Rust thread APIs look not too different from e.g. C++ ones."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:33
+#: src/concurrency/threads/plain.md
 msgid "Run the example."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:34
+#: src/concurrency/threads/plain.md
 msgid ""
 "5ms timing is loose enough that main and spawned threads stay mostly in "
 "lockstep."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:36
+#: src/concurrency/threads/plain.md
 msgid "Notice that the program ends before the spawned thread reaches 10!"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:37
+#: src/concurrency/threads/plain.md
 msgid ""
 "This is because main ends the program and spawned threads do not make it "
 "persist."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:39
+#: src/concurrency/threads/plain.md
 msgid "Compare to pthreads/C++ std::thread/boost::thread if desired."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:41
+#: src/concurrency/threads/plain.md
 msgid "How do we wait around for the spawned thread to complete?"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:42
+#: src/concurrency/threads/plain.md
 msgid ""
 "[`thread::spawn`](https://doc.rust-lang.org/std/thread/fn.spawn.html) "
 "returns a `JoinHandle`. Look at the docs."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:43
+#: src/concurrency/threads/plain.md
 msgid ""
 "`JoinHandle` has a [`.join()`](https://doc.rust-lang.org/std/thread/struct."
 "JoinHandle.html#method.join) method that blocks."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:45
+#: src/concurrency/threads/plain.md
 msgid ""
 "Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
 "the thread to finish and have the program count all the way to 10."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:48
+#: src/concurrency/threads/plain.md
 msgid "Now what if we want to return a value?"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:49
+#: src/concurrency/threads/plain.md
 msgid "Look at docs again:"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:50
+#: src/concurrency/threads/plain.md
 msgid ""
 "[`thread::spawn`](https://doc.rust-lang.org/std/thread/fn.spawn.html)'s "
 "closure returns `T`"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:51
+#: src/concurrency/threads/plain.md
 msgid ""
 "`JoinHandle` [`.join()`](https://doc.rust-lang.org/std/thread/struct."
 "JoinHandle.html#method.join) returns `thread::Result<T>`"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:53
+#: src/concurrency/threads/plain.md
 msgid ""
 "Use the `Result` return value from `handle.join()` to get access to the "
 "returned value."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:56
+#: src/concurrency/threads/plain.md
 msgid "Ok, what about the other case?"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:57
+#: src/concurrency/threads/plain.md
 msgid "Trigger a panic in the thread. Note that this doesn't panic `main`."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:58
+#: src/concurrency/threads/plain.md
 msgid ""
 "Access the panic payload. This is a good time to talk about [`Any`](https://"
 "doc.rust-lang.org/std/any/index.html)."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:60
+#: src/concurrency/threads/plain.md
 msgid "Now we can return values from threads! What about taking inputs?"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:61
+#: src/concurrency/threads/plain.md
 msgid "Capture something by reference in the thread closure."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:62
+#: src/concurrency/threads/plain.md
 msgid "An error message indicates we must move it."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:63
+#: src/concurrency/threads/plain.md
 msgid "Move it in, see we can compute and then return a derived value."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:65
+#: src/concurrency/threads/plain.md
 msgid "If we want to borrow?"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:66
+#: src/concurrency/threads/plain.md
 msgid ""
 "Main kills child threads when it returns, but another function would just "
 "return and leave them running."
 msgstr ""
 
-#: src/concurrency/threads/plain.md:68
+#: src/concurrency/threads/plain.md
 msgid "That would be stack use-after-return, which violates memory safety!"
 msgstr ""
 
-#: src/concurrency/threads/plain.md:69
+#: src/concurrency/threads/plain.md
 msgid "How do we avoid this? see next slide."
 msgstr ""
 
-#: src/concurrency/threads/scoped.md:3
+#: src/concurrency/threads/scoped.md
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/threads/scoped.md:20
+#: src/concurrency/threads/scoped.md
 msgid ""
 "However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
 "fn.scope.html) for this:"
 msgstr ""
 
-#: src/concurrency/threads/scoped.md:41
+#: src/concurrency/threads/scoped.md
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/threads/scoped.md:43
+#: src/concurrency/threads/scoped.md
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."
 msgstr ""
 
-#: src/concurrency/channels.md:3 src/concurrency/async-control-flow.md:3
+#: src/concurrency/channels.md src/concurrency/async-control-flow.md
 msgid "This segment should take about 20 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 20 phút, bao gồm:"
 
-#: src/concurrency/channels/senders-receivers.md:3
+#: src/concurrency/channels/senders-receivers.md
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
 "parts are connected via the channel, but you only see the end-points."
 msgstr ""
 
-#: src/concurrency/channels/senders-receivers.md:15
-#: src/concurrency/channels/senders-receivers.md:16
-#: src/concurrency/channels/senders-receivers.md:20
+#: src/concurrency/channels/senders-receivers.md
 msgid "\"Received: {:?}\""
 msgstr ""
 
-#: src/concurrency/channels/senders-receivers.md:27
+#: src/concurrency/channels/senders-receivers.md
 msgid ""
 "`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
 "implement `Clone` (so you can make multiple producers) but `Receiver` does "
 "not."
 msgstr ""
 
-#: src/concurrency/channels/senders-receivers.md:30
+#: src/concurrency/channels/senders-receivers.md
 msgid ""
 "`send()` and `recv()` return `Result`. If they return `Err`, it means the "
 "counterpart `Sender` or `Receiver` is dropped and the channel is closed."
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:3
+#: src/concurrency/channels/unbounded.md
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:16
-#: src/concurrency/channels/bounded.md:16
+#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"Message {i}\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:17
-#: src/concurrency/channels/bounded.md:17
+#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"{thread_id:?}: sent Message {i}\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:19
-#: src/concurrency/channels/bounded.md:19
+#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"{thread_id:?}: done\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:24
-#: src/concurrency/channels/bounded.md:24
+#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"Main: got {msg}\""
 msgstr ""
 
-#: src/concurrency/channels/bounded.md:3
+#: src/concurrency/channels/bounded.md
 msgid ""
 "With bounded (synchronous) channels, `send` can block the current thread:"
 msgstr ""
 
-#: src/concurrency/channels/bounded.md:32
+#: src/concurrency/channels/bounded.md
 msgid ""
 "Calling `send` will block the current thread until there is space in the "
 "channel for the new message. The thread can be blocked indefinitely if there "
 "is nobody who reads from the channel."
 msgstr ""
 
-#: src/concurrency/channels/bounded.md:35
+#: src/concurrency/channels/bounded.md
 msgid ""
 "A call to `send` will abort with an error (that is why it returns `Result`) "
 "if the channel is closed. A channel is closed when the receiver is dropped."
 msgstr ""
 
-#: src/concurrency/channels/bounded.md:37
+#: src/concurrency/channels/bounded.md
 msgid ""
 "A bounded channel with a size of zero is called a \"rendezvous channel\". "
 "Every send will block the current thread until another thread calls `recv`."
 msgstr ""
 
-#: src/concurrency/send-sync.md:8
+#: src/concurrency/send-sync.md
 msgid "Send"
 msgstr ""
 
-#: src/concurrency/send-sync.md:9
+#: src/concurrency/send-sync.md
 msgid "Sync"
 msgstr ""
 
-#: src/concurrency/send-sync/marker-traits.md:3
+#: src/concurrency/send-sync/marker-traits.md
 msgid ""
 "How does Rust know to forbid shared access across threads? The answer is in "
 "two traits:"
 msgstr ""
 
-#: src/concurrency/send-sync/marker-traits.md:6
+#: src/concurrency/send-sync/marker-traits.md
 msgid ""
 "[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
 "is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
 
-#: src/concurrency/send-sync/marker-traits.md:8
+#: src/concurrency/send-sync/marker-traits.md
 msgid ""
 "[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
 "is `Sync` if it is safe to move a `&T` across a thread boundary."
 msgstr ""
 
-#: src/concurrency/send-sync/marker-traits.md:11
+#: src/concurrency/send-sync/marker-traits.md
 msgid ""
 "`Send` and `Sync` are [unsafe traits](../../unsafe-rust/unsafe-traits.md). "
 "The compiler will automatically derive them for your types as long as they "
@@ -17342,57 +17108,57 @@ msgid ""
 "when you know it is valid."
 msgstr ""
 
-#: src/concurrency/send-sync/marker-traits.md:22
+#: src/concurrency/send-sync/marker-traits.md
 msgid ""
 "One can think of these traits as markers that the type has certain thread-"
 "safety properties."
 msgstr ""
 
-#: src/concurrency/send-sync/marker-traits.md:24
+#: src/concurrency/send-sync/marker-traits.md
 msgid "They can be used in the generic constraints as normal traits."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md:3
+#: src/concurrency/send-sync/send.md
 msgid ""
 "A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
 "if it is safe to move a `T` value to another thread."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md:5
+#: src/concurrency/send-sync/send.md
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
 "run in that thread. So the question is when you can allocate a value in one "
 "thread and deallocate it in another."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md:14
+#: src/concurrency/send-sync/send.md
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
 "a single thread."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md:3
+#: src/concurrency/send-sync/sync.md
 msgid ""
 "A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
 "if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md:6
+#: src/concurrency/send-sync/sync.md
 msgid "More precisely, the definition is:"
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md:8
+#: src/concurrency/send-sync/sync.md
 msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md:15
+#: src/concurrency/send-sync/sync.md
 msgid ""
 "This statement is essentially a shorthand way of saying that if a type is "
 "thread-safe for shared use, it is also thread-safe to pass references of it "
 "across threads."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md:19
+#: src/concurrency/send-sync/sync.md
 msgid ""
 "This is because if a type is Sync it means that it can be shared across "
 "multiple threads without the risk of data races or other synchronization "
@@ -17401,158 +17167,156 @@ msgid ""
 "be accessed from any thread safely."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:3
+#: src/concurrency/send-sync/examples.md
 msgid "`Send + Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:5
+#: src/concurrency/send-sync/examples.md
 msgid "Most types you come across are `Send + Sync`:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:7
+#: src/concurrency/send-sync/examples.md
 msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:8
+#: src/concurrency/send-sync/examples.md
 msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:9
+#: src/concurrency/send-sync/examples.md
 msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:10
+#: src/concurrency/send-sync/examples.md
 msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:11
+#: src/concurrency/send-sync/examples.md
 msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:12
+#: src/concurrency/send-sync/examples.md
 msgid "`mpsc::Sender<T>`: As of 1.72.0."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:13
+#: src/concurrency/send-sync/examples.md
 msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:15
+#: src/concurrency/send-sync/examples.md
 msgid ""
 "The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:18
+#: src/concurrency/send-sync/examples.md
 msgid "`Send + !Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:20
+#: src/concurrency/send-sync/examples.md
 msgid ""
 "These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:23
+#: src/concurrency/send-sync/examples.md
 msgid "`mpsc::Receiver<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:24
+#: src/concurrency/send-sync/examples.md
 msgid "`Cell<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:25
+#: src/concurrency/send-sync/examples.md
 msgid "`RefCell<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:27
+#: src/concurrency/send-sync/examples.md
 msgid "`!Send + Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:29
+#: src/concurrency/send-sync/examples.md
 msgid ""
 "These types are thread-safe, but they cannot be moved to another thread:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:31
+#: src/concurrency/send-sync/examples.md
 msgid ""
 "`MutexGuard<T: Sync>`: Uses OS level primitives which must be deallocated on "
 "the thread which created them."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:34
+#: src/concurrency/send-sync/examples.md
 msgid "`!Send + !Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:36
+#: src/concurrency/send-sync/examples.md
 msgid "These types are not thread-safe and cannot be moved to other threads:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:38
+#: src/concurrency/send-sync/examples.md
 msgid ""
 "`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
 "atomic reference count."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:40
+#: src/concurrency/send-sync/examples.md
 msgid ""
 "`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
 "considerations."
 msgstr ""
 
-#: src/concurrency/shared-state.md:7
+#: src/concurrency/shared-state.md
 msgid "Arc"
 msgstr ""
 
-#: src/concurrency/shared-state.md:8
+#: src/concurrency/shared-state.md
 msgid "Mutex"
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:3
+#: src/concurrency/shared-state/arc.md
 msgid ""
 "[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
 "read-only access via `Arc::clone`:"
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:16
+#: src/concurrency/shared-state/arc.md
 msgid "\"{thread_id:?}: {v:?}\""
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:21
-#: src/concurrency/shared-state/example.md:17
-#: src/concurrency/shared-state/example.md:46
+#: src/concurrency/shared-state/arc.md src/concurrency/shared-state/example.md
 msgid "\"v: {v:?}\""
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:30
+#: src/concurrency/shared-state/arc.md
 msgid ""
 "`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
 "that uses atomic operations."
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:32
+#: src/concurrency/shared-state/arc.md
 msgid ""
 "`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
 "and `Sync` if and only if `T` implements them both."
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:34
+#: src/concurrency/shared-state/arc.md
 msgid ""
 "`Arc::clone()` has the cost of atomic operations that get executed, but "
 "after that the use of the `T` is free."
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:36
+#: src/concurrency/shared-state/arc.md
 msgid ""
 "Beware of reference cycles, `Arc` does not use a garbage collector to detect "
 "them."
 msgstr ""
 
-#: src/concurrency/shared-state/arc.md:38
+#: src/concurrency/shared-state/arc.md
 msgid "`std::sync::Weak` can help."
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:3
+#: src/concurrency/shared-state/mutex.md
 msgid ""
 "[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
 "mutual exclusion _and_ allows mutable access to `T` behind a read-only "
@@ -17560,51 +17324,50 @@ msgid ""
 "mutability)):"
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:12
-#: src/concurrency/shared-state/mutex.md:19
+#: src/concurrency/shared-state/mutex.md
 msgid "\"v: {:?}\""
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:23
+#: src/concurrency/shared-state/mutex.md
 msgid ""
 "Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
 "lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:33
+#: src/concurrency/shared-state/mutex.md
 msgid ""
 "`Mutex` in Rust looks like a collection with just one element --- the "
 "protected data."
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:35
+#: src/concurrency/shared-state/mutex.md
 msgid ""
 "It is not possible to forget to acquire the mutex before accessing the "
 "protected data."
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:37
+#: src/concurrency/shared-state/mutex.md
 msgid ""
 "You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
 "`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:39
+#: src/concurrency/shared-state/mutex.md
 msgid ""
 "`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
 "implements `Send`."
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:41
+#: src/concurrency/shared-state/mutex.md
 msgid "A read-write lock counterpart: `RwLock`."
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:42
+#: src/concurrency/shared-state/mutex.md
 msgid "Why does `lock()` return a `Result`?"
 msgstr ""
 
-#: src/concurrency/shared-state/mutex.md:43
+#: src/concurrency/shared-state/mutex.md
 msgid ""
 "If the thread that held the `Mutex` panicked, the `Mutex` becomes "
 "\"poisoned\" to signal that the data it protected might be in an "
@@ -17613,55 +17376,55 @@ msgid ""
 "You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:3
+#: src/concurrency/shared-state/example.md
 msgid "Let us see `Arc` and `Mutex` in action:"
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:6
+#: src/concurrency/shared-state/example.md
 msgid "// use std::sync::{Arc, Mutex};\n"
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:24
+#: src/concurrency/shared-state/example.md
 msgid "Possible solution:"
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:50
+#: src/concurrency/shared-state/example.md
 msgid "Notable parts:"
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:52
+#: src/concurrency/shared-state/example.md
 msgid ""
 "`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
 "orthogonal."
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:54
+#: src/concurrency/shared-state/example.md
 msgid ""
 "Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
 "between threads."
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:56
+#: src/concurrency/shared-state/example.md
 msgid ""
 "`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
 "thread. Note `move` was added to the lambda signature."
 msgstr ""
 
-#: src/concurrency/shared-state/example.md:58
+#: src/concurrency/shared-state/example.md
 msgid ""
 "Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
 
-#: src/concurrency/sync-exercises.md:3 src/concurrency/async-exercises.md:3
+#: src/concurrency/sync-exercises.md src/concurrency/async-exercises.md
 msgid "This segment should take about 1 hour and 10 minutes. It contains:"
 msgstr "Phần này sẽ kéo dài khoảng 1 giờ và 10 phút, bao gồm:"
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:3
+#: src/concurrency/sync-exercises/dining-philosophers.md
 msgid "The dining philosophers problem is a classic problem in concurrency:"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:5
+#: src/concurrency/sync-exercises/dining-philosophers.md
 msgid ""
 "Five philosophers dine together at the same table. Each philosopher has "
 "their own place at the table. There is a fork between each plate. The dish "
@@ -17673,102 +17436,102 @@ msgid ""
 "down both forks."
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:13
+#: src/concurrency/sync-exercises/dining-philosophers.md
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
 "for this exercise. Copy the code below to a file called `src/main.rs`, fill "
 "out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:28
-#: src/concurrency/async-exercises/dining-philosophers.md:23
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/dining-philosophers.md
 msgid ""
 "// left_fork: ...\n"
 "    // right_fork: ...\n"
 "    // thoughts: ...\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:36
-#: src/concurrency/sync-exercises/solutions.md:22
-#: src/concurrency/async-exercises/dining-philosophers.md:31
-#: src/concurrency/async-exercises/solutions.md:23
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Eureka! {} has a new idea!\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:41
-#: src/concurrency/async-exercises/solutions.md:31
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Pick up forks...\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:42
-#: src/concurrency/sync-exercises/solutions.md:31
-#: src/concurrency/async-exercises/dining-philosophers.md:38
-#: src/concurrency/async-exercises/solutions.md:51
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"{} is eating...\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:48
-#: src/concurrency/sync-exercises/solutions.md:37
-#: src/concurrency/async-exercises/dining-philosophers.md:44
-#: src/concurrency/async-exercises/solutions.md:59
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Socrates\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:48
-#: src/concurrency/sync-exercises/solutions.md:37
-#: src/concurrency/async-exercises/dining-philosophers.md:44
-#: src/concurrency/async-exercises/solutions.md:59
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Hypatia\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:48
-#: src/concurrency/sync-exercises/solutions.md:37
-#: src/concurrency/async-exercises/dining-philosophers.md:44
-#: src/concurrency/async-exercises/solutions.md:59
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Plato\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:48
-#: src/concurrency/sync-exercises/solutions.md:37
-#: src/concurrency/async-exercises/dining-philosophers.md:44
-#: src/concurrency/async-exercises/solutions.md:59
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Aristotle\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:48
-#: src/concurrency/sync-exercises/solutions.md:37
-#: src/concurrency/async-exercises/dining-philosophers.md:44
-#: src/concurrency/async-exercises/solutions.md:59
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/sync-exercises/solutions.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Pythagoras\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:51
-#: src/concurrency/async-exercises/dining-philosophers.md:48
-#: src/concurrency/async-exercises/solutions.md:63
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Create forks\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:53
-#: src/concurrency/async-exercises/dining-philosophers.md:50
-#: src/concurrency/async-exercises/solutions.md:67
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Create philosophers\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:55
+#: src/concurrency/sync-exercises/dining-philosophers.md
 msgid "// Make each of them think and eat 100 times\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:57
-#: src/concurrency/async-exercises/dining-philosophers.md:54
-#: src/concurrency/async-exercises/solutions.md:95
+#: src/concurrency/sync-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Output their thoughts\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:61
+#: src/concurrency/sync-exercises/dining-philosophers.md
 msgid "You can use the following `Cargo.toml`:"
 msgstr ""
 
-#: src/concurrency/sync-exercises/dining-philosophers.md:65
+#: src/concurrency/sync-exercises/dining-philosophers.md
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -17778,7 +17541,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:3
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
 "should start at a webpage and check that links on the page are valid. It "
@@ -17786,7 +17549,7 @@ msgid ""
 "until all pages have been validated."
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:8
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
 "reqwest/). You will also need a way to find links, we can use [`scraper`]"
@@ -17794,22 +17557,22 @@ msgid ""
 "we will use [`thiserror`](https://docs.rs/thiserror/)."
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:12
+#: src/concurrency/sync-exercises/link-checker.md
 msgid "Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:22
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "If `cargo add` fails with `error: no such subcommand`, then please edit the "
 "`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:25
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:29
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -17826,114 +17589,114 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:42
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "You can now download the start page. Try with a small site such as `https://"
 "www.google.org/`."
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:45
+#: src/concurrency/sync-exercises/link-checker.md
 msgid "Your `src/main.rs` file should look something like this:"
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:57
-#: src/concurrency/sync-exercises/solutions.md:93
+#: src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"request error: {0}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:59
-#: src/concurrency/sync-exercises/solutions.md:95
+#: src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"bad http response: {0}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:70
-#: src/concurrency/sync-exercises/solutions.md:106
+#: src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"Checking {:#}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:88
-#: src/concurrency/sync-exercises/solutions.md:124
+#: src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"href\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:95
-#: src/concurrency/sync-exercises/solutions.md:131
+#: src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:104
-#: src/concurrency/sync-exercises/solutions.md:241
+#: src/concurrency/sync-exercises/link-checker.md
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"https://www.google.org\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:107
+#: src/concurrency/sync-exercises/link-checker.md
 msgid "\"Links: {links:#?}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:108
+#: src/concurrency/sync-exercises/link-checker.md
 msgid "\"Could not extract links: {err:#}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:113
+#: src/concurrency/sync-exercises/link-checker.md
 msgid "Run the code in `src/main.rs` with"
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:121
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "Use threads to check the links in parallel: send the URLs to be checked to a "
 "channel and let a few threads check the URLs in parallel."
 msgstr ""
 
-#: src/concurrency/sync-exercises/link-checker.md:123
+#: src/concurrency/sync-exercises/link-checker.md
 msgid ""
 "Extend this to recursively extract links from all pages on the `www.google."
 "org` domain. Put an upper limit of 100 pages or so so that you don't end up "
 "being blocked by the site."
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:27
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"{} is trying to eat\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:51
+#: src/concurrency/sync-exercises/solutions.md
 msgid ""
 "// To avoid a deadlock, we have to break the symmetry\n"
 "        // somewhere. This will swap the forks without deinitializing\n"
 "        // either of them.\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:75
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"{thought}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:80
+#: src/concurrency/sync-exercises/solutions.md
 msgid "Link Checker"
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:150
+#: src/concurrency/sync-exercises/solutions.md
 msgid ""
 "/// Determine whether links within the given page should be extracted.\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:158
+#: src/concurrency/sync-exercises/solutions.md
 msgid ""
 "/// Mark the given page as visited, returning false if it had already\n"
 "    /// been visited.\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:184
+#: src/concurrency/sync-exercises/solutions.md
 msgid "// The sender got dropped. No more commands coming in.\n"
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:225
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"Got crawling error: {:#}\""
 msgstr ""
 
-#: src/concurrency/sync-exercises/solutions.md:243
+#: src/concurrency/sync-exercises/solutions.md
 msgid "\"Bad URLs: {:#?}\""
 msgstr ""
 
-#: src/concurrency/welcome-async.md:3
+#: src/concurrency/welcome-async.md
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
 "concurrently by executing each task until it would block, then switching to "
@@ -17943,92 +17706,92 @@ msgid ""
 "primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 
-#: src/concurrency/welcome-async.md:10
+#: src/concurrency/welcome-async.md
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
 "that may be completed in the future. Futures are \"polled\" until they "
 "signal that they are complete."
 msgstr ""
 
-#: src/concurrency/welcome-async.md:14
+#: src/concurrency/welcome-async.md
 msgid ""
 "Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 
-#: src/concurrency/welcome-async.md:19
+#: src/concurrency/welcome-async.md
 msgid ""
 "Python has a similar model in its `asyncio`. However, its `Future` type is "
 "callback-based, and not polled. Async Python programs require a \"loop\", "
 "similar to a runtime in Rust."
 msgstr ""
 
-#: src/concurrency/welcome-async.md:23
+#: src/concurrency/welcome-async.md
 msgid ""
 "JavaScript's `Promise` is similar, but again callback-based. The language "
 "runtime implements the event loop, so many of the details of Promise "
 "resolution are hidden."
 msgstr ""
 
-#: src/concurrency/async.md:7
+#: src/concurrency/async.md
 msgid "async/await"
 msgstr ""
 
-#: src/concurrency/async/async-await.md:3
+#: src/concurrency/async/async-await.md
 msgid ""
 "At a high level, async Rust code looks very much like \"normal\" sequential "
 "code:"
 msgstr ""
 
-#: src/concurrency/async/async-await.md:10
+#: src/concurrency/async/async-await.md
 msgid "\"Count is: {i}!\""
 msgstr ""
 
-#: src/concurrency/async/async-await.md:28
+#: src/concurrency/async/async-await.md
 msgid ""
 "Note that this is a simplified example to show the syntax. There is no long "
 "running operation or any real concurrency in it!"
 msgstr ""
 
-#: src/concurrency/async/async-await.md:31
+#: src/concurrency/async/async-await.md
 msgid "What is the return type of an async call?"
 msgstr ""
 
-#: src/concurrency/async/async-await.md:32
+#: src/concurrency/async/async-await.md
 msgid "Use `let future: () = async_main(10);` in `main` to see the type."
 msgstr ""
 
-#: src/concurrency/async/async-await.md:34
+#: src/concurrency/async/async-await.md
 msgid ""
 "The \"async\" keyword is syntactic sugar. The compiler replaces the return "
 "type with a future."
 msgstr ""
 
-#: src/concurrency/async/async-await.md:37
+#: src/concurrency/async/async-await.md
 msgid ""
 "You cannot make `main` async, without additional instructions to the "
 "compiler on how to use the returned future."
 msgstr ""
 
-#: src/concurrency/async/async-await.md:40
+#: src/concurrency/async/async-await.md
 msgid ""
 "You need an executor to run async code. `block_on` blocks the current thread "
 "until the provided future has run to completion."
 msgstr ""
 
-#: src/concurrency/async/async-await.md:43
+#: src/concurrency/async/async-await.md
 msgid ""
 "`.await` asynchronously waits for the completion of another operation. "
 "Unlike `block_on`, `.await` doesn't block the current thread."
 msgstr ""
 
-#: src/concurrency/async/async-await.md:46
+#: src/concurrency/async/async-await.md
 msgid ""
 "`.await` can only be used inside an `async` function (or block; these are "
 "introduced later)."
 msgstr ""
 
-#: src/concurrency/async/futures.md:3
+#: src/concurrency/async/futures.md
 msgid ""
 "[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
 "trait, implemented by objects that represent an operation that may not be "
@@ -18036,7 +17799,7 @@ msgid ""
 "doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
-#: src/concurrency/async/futures.md:23
+#: src/concurrency/async/futures.md
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
 "uncommon) to implement `Future` for your own types. For example, the "
@@ -18044,76 +17807,76 @@ msgid ""
 "joining to it."
 msgstr ""
 
-#: src/concurrency/async/futures.md:27
+#: src/concurrency/async/futures.md
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
 "to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
-#: src/concurrency/async/futures.md:33
+#: src/concurrency/async/futures.md
 msgid ""
 "The `Future` and `Poll` types are implemented exactly as shown; click the "
 "links to show the implementations in the docs."
 msgstr ""
 
-#: src/concurrency/async/futures.md:36
+#: src/concurrency/async/futures.md
 msgid ""
 "We will not get to `Pin` and `Context`, as we will focus on writing async "
 "code, rather than building new async primitives. Briefly:"
 msgstr ""
 
-#: src/concurrency/async/futures.md:39
+#: src/concurrency/async/futures.md
 msgid ""
 "`Context` allows a Future to schedule itself to be polled again when an "
 "event occurs."
 msgstr ""
 
-#: src/concurrency/async/futures.md:42
+#: src/concurrency/async/futures.md
 msgid ""
 "`Pin` ensures that the Future isn't moved in memory, so that pointers into "
 "that future remain valid. This is required to allow references to remain "
 "valid after an `.await`."
 msgstr ""
 
-#: src/concurrency/async/runtimes.md:3
+#: src/concurrency/async/runtimes.md
 msgid ""
 "A _runtime_ provides support for performing operations asynchronously (a "
 "_reactor_) and is responsible for executing futures (an _executor_). Rust "
 "does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
-#: src/concurrency/async/runtimes.md:7
+#: src/concurrency/async/runtimes.md
 msgid ""
 "[Tokio](https://tokio.rs/): performant, with a well-developed ecosystem of "
 "functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
 "github.com/hyperium/tonic) for gRPC."
 msgstr ""
 
-#: src/concurrency/async/runtimes.md:10
+#: src/concurrency/async/runtimes.md
 msgid ""
 "[async-std](https://async.rs/): aims to be a \"std for async\", and includes "
 "a basic runtime in `async::task`."
 msgstr ""
 
-#: src/concurrency/async/runtimes.md:12
+#: src/concurrency/async/runtimes.md
 msgid "[smol](https://docs.rs/smol/latest/smol/): simple and lightweight"
 msgstr ""
 
-#: src/concurrency/async/runtimes.md:14
+#: src/concurrency/async/runtimes.md
 msgid ""
 "Several larger applications have their own runtimes. For example, [Fuchsia]"
 "(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
 "async/src/lib.rs) already has one."
 msgstr ""
 
-#: src/concurrency/async/runtimes.md:21
+#: src/concurrency/async/runtimes.md
 msgid ""
 "Note that of the listed runtimes, only Tokio is supported in the Rust "
 "playground. The playground also does not permit any I/O, so most interesting "
 "async things can't run in the playground."
 msgstr ""
 
-#: src/concurrency/async/runtimes.md:25
+#: src/concurrency/async/runtimes.md
 msgid ""
 "Futures are \"inert\" in that they do not do anything (not even start an I/O "
 "operation) unless there is an executor polling them. This differs from JS "
@@ -18121,66 +17884,66 @@ msgid ""
 "used."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:3
+#: src/concurrency/async/runtimes/tokio.md
 msgid "Tokio provides:"
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:5
+#: src/concurrency/async/runtimes/tokio.md
 msgid "A multi-threaded runtime for executing asynchronous code."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:6
+#: src/concurrency/async/runtimes/tokio.md
 msgid "An asynchronous version of the standard library."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:7
+#: src/concurrency/async/runtimes/tokio.md
 msgid "A large ecosystem of libraries."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:14
+#: src/concurrency/async/runtimes/tokio.md
 msgid "\"Count in task: {i}!\""
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:24
+#: src/concurrency/async/runtimes/tokio.md
 msgid "\"Main task: {i}\""
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:32
+#: src/concurrency/async/runtimes/tokio.md
 msgid "With the `tokio::main` macro we can now make `main` async."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:34
+#: src/concurrency/async/runtimes/tokio.md
 msgid "The `spawn` function creates a new, concurrent \"task\"."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:36
+#: src/concurrency/async/runtimes/tokio.md
 msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:38
+#: src/concurrency/async/runtimes/tokio.md
 msgid "**Further exploration:**"
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:40
+#: src/concurrency/async/runtimes/tokio.md
 msgid ""
 "Why does `count_to` not (usually) get to 10? This is an example of async "
 "cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
 "until it finishes."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:44
+#: src/concurrency/async/runtimes/tokio.md
 msgid "Try `count_to(10).await` instead of spawning."
 msgstr ""
 
-#: src/concurrency/async/runtimes/tokio.md:46
+#: src/concurrency/async/runtimes/tokio.md
 msgid "Try awaiting the task returned from `tokio::spawn`."
 msgstr ""
 
-#: src/concurrency/async/tasks.md:3
+#: src/concurrency/async/tasks.md
 msgid "Rust has a task system, which is a form of lightweight threading."
 msgstr ""
 
-#: src/concurrency/async/tasks.md:5
+#: src/concurrency/async/tasks.md
 msgid ""
 "A task has a single top-level future which the executor polls to make "
 "progress. That future may have one or more nested futures that its `poll` "
@@ -18189,153 +17952,151 @@ msgid ""
 "and an I/O operation."
 msgstr ""
 
-#: src/concurrency/async/tasks.md:16
+#: src/concurrency/async/tasks.md
 msgid "\"127.0.0.1:0\""
 msgstr ""
 
-#: src/concurrency/async/tasks.md:17
+#: src/concurrency/async/tasks.md
 msgid "\"listening on port {}\""
 msgstr ""
 
-#: src/concurrency/async/tasks.md:22
+#: src/concurrency/async/tasks.md
 msgid "\"connection from {addr:?}\""
 msgstr ""
 
-#: src/concurrency/async/tasks.md:25
+#: src/concurrency/async/tasks.md
 msgid "b\"Who are you?\\n\""
 msgstr ""
 
-#: src/concurrency/async/tasks.md:25 src/concurrency/async/tasks.md:28
-#: src/concurrency/async/tasks.md:31
+#: src/concurrency/async/tasks.md
 msgid "\"socket error\""
 msgstr ""
 
-#: src/concurrency/async/tasks.md:30
+#: src/concurrency/async/tasks.md
 msgid "\"Thanks for dialing in, {name}!\\n\""
 msgstr ""
 
-#: src/concurrency/async/tasks.md:40
-#: src/concurrency/async-control-flow/join.md:37
+#: src/concurrency/async/tasks.md src/concurrency/async-control-flow/join.md
 msgid ""
 "Copy this example into your prepared `src/main.rs` and run it from there."
 msgstr ""
 
-#: src/concurrency/async/tasks.md:42
+#: src/concurrency/async/tasks.md
 msgid ""
 "Try connecting to it with a TCP connection tool like [nc](https://www.unix."
 "com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
 "telnet/)."
 msgstr ""
 
-#: src/concurrency/async/tasks.md:46
+#: src/concurrency/async/tasks.md
 msgid ""
 "Ask students to visualize what the state of the example server would be with "
 "a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/concurrency/async/tasks.md:49
+#: src/concurrency/async/tasks.md
 msgid ""
 "This is the first time we've seen an `async` block. This is similar to a "
 "closure, but does not take any arguments. Its return value is a Future, "
 "similar to an `async fn`."
 msgstr ""
 
-#: src/concurrency/async/tasks.md:53
+#: src/concurrency/async/tasks.md
 msgid ""
 "Refactor the async block into a function, and improve the error handling "
 "using `?`."
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:3
+#: src/concurrency/async-control-flow/channels.md
 msgid ""
 "Several crates have support for asynchronous channels. For instance `tokio`:"
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:13
+#: src/concurrency/async-control-flow/channels.md
 msgid "\"Received {count} pings so far.\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:16
+#: src/concurrency/async-control-flow/channels.md
 msgid "\"ping_handler complete\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:24
+#: src/concurrency/async-control-flow/channels.md
 msgid "\"Failed to send ping.\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:25
+#: src/concurrency/async-control-flow/channels.md
 msgid "\"Sent {} pings so far.\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:29
+#: src/concurrency/async-control-flow/channels.md
 msgid "\"Something went wrong in ping handler task.\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:36
+#: src/concurrency/async-control-flow/channels.md
 msgid "Change the channel size to `3` and see how it affects the execution."
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:38
+#: src/concurrency/async-control-flow/channels.md
 msgid ""
 "Overall, the interface is similar to the `sync` channels as seen in the "
 "[morning class](concurrency/channels.md)."
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:41
+#: src/concurrency/async-control-flow/channels.md
 msgid "Try removing the `std::mem::drop` call. What happens? Why?"
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:43
+#: src/concurrency/async-control-flow/channels.md
 msgid ""
 "The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
 "implement both `sync` and `async` `send` and `recv`. This can be convenient "
 "for complex applications with both IO and heavy CPU processing tasks."
 msgstr ""
 
-#: src/concurrency/async-control-flow/channels.md:47
+#: src/concurrency/async-control-flow/channels.md
 msgid ""
 "What makes working with `async` channels preferable is the ability to "
 "combine them with other `future`s to combine them and create complex control "
 "flow."
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:3
+#: src/concurrency/async-control-flow/join.md
 msgid ""
 "A join operation waits until all of a set of futures are ready, and returns "
 "a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:21
+#: src/concurrency/async-control-flow/join.md
 msgid "\"https://google.com\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:22
+#: src/concurrency/async-control-flow/join.md
 msgid "\"https://httpbin.org/ip\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:23
+#: src/concurrency/async-control-flow/join.md
 msgid "\"https://play.rust-lang.org/\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:24
+#: src/concurrency/async-control-flow/join.md
 msgid "\"BAD_URL\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:39
+#: src/concurrency/async-control-flow/join.md
 msgid ""
 "For multiple futures of disjoint types, you can use `std::future::join!` but "
 "you must know how many futures you will have at compile time. This is "
 "currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:43
+#: src/concurrency/async-control-flow/join.md
 msgid ""
 "The risk of `join` is that one of the futures may never resolve, this would "
 "cause your program to stall."
 msgstr ""
 
-#: src/concurrency/async-control-flow/join.md:46
+#: src/concurrency/async-control-flow/join.md
 msgid ""
 "You can also combine `join_all` with `join!` for instance to join all "
 "requests to an http service as well as a database query. Try adding a "
@@ -18344,7 +18105,7 @@ msgid ""
 "demonstrates `join!`."
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:3
+#: src/concurrency/async-control-flow/select.md
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
 "responds to that future's result. In JavaScript, this is similar to `Promise."
@@ -18352,7 +18113,7 @@ msgid ""
 "FIRST_COMPLETED)`."
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:8
+#: src/concurrency/async-control-flow/select.md
 msgid ""
 "Similar to a match statement, the body of `select!` has a number of arms, "
 "each of the form `pattern = future => statement`. When a `future` is ready, "
@@ -18361,27 +18122,27 @@ msgid ""
 "of the `select!` macro."
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:40
+#: src/concurrency/async-control-flow/select.md
 msgid "\"Felix\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:40
+#: src/concurrency/async-control-flow/select.md
 msgid "\"Failed to send cat.\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:44
+#: src/concurrency/async-control-flow/select.md
 msgid "\"Failed to send dog.\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:49
+#: src/concurrency/async-control-flow/select.md
 msgid "\"Failed to receive winner\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:51
+#: src/concurrency/async-control-flow/select.md
 msgid "\"Winner is {winner:?}\""
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:58
+#: src/concurrency/async-control-flow/select.md
 msgid ""
 "In this example, we have a race between a cat and a dog. "
 "`first_animal_to_finish_race` listens to both channels and will pick "
@@ -18389,31 +18150,31 @@ msgid ""
 "that take 500ms."
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:63
+#: src/concurrency/async-control-flow/select.md
 msgid ""
 "You can use `oneshot` channels in this example as the channels are supposed "
 "to receive only one `send`."
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:66
+#: src/concurrency/async-control-flow/select.md
 msgid ""
 "Try adding a deadline to the race, demonstrating selecting different sorts "
 "of futures."
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:69
+#: src/concurrency/async-control-flow/select.md
 msgid ""
 "Note that `select!` drops unmatched branches, which cancels their futures. "
 "It is easiest to use when every execution of `select!` creates new futures."
 msgstr ""
 
-#: src/concurrency/async-control-flow/select.md:72
+#: src/concurrency/async-control-flow/select.md
 msgid ""
 "An alternative is to pass `&mut future` instead of the future itself, but "
 "this can lead to issues, further discussed in the pinning slide."
 msgstr ""
 
-#: src/concurrency/async-pitfalls.md:3
+#: src/concurrency/async-pitfalls.md
 msgid ""
 "Async / await provides convenient and efficient abstraction for concurrent "
 "asynchronous programming. However, the async/await model in Rust also comes "
@@ -18421,15 +18182,15 @@ msgid ""
 "chapter."
 msgstr ""
 
-#: src/concurrency/async-pitfalls.md:12
+#: src/concurrency/async-pitfalls.md
 msgid "Pin"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:1
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid "Blocking the executor"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:3
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid ""
 "Most async runtimes only allow IO tasks to run concurrently. This means that "
 "CPU blocking tasks will block the executor and prevent other tasks from "
@@ -18437,39 +18198,39 @@ msgid ""
 "possible."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:14
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:19
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid "\"current_thread\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:30
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid ""
 "Run the code and see that the sleeps happen consecutively rather than "
 "concurrently."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:33
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid ""
 "The `\"current_thread\"` flavor puts all tasks on a single thread. This "
 "makes the effect more obvious, but the bug is still present in the multi-"
 "threaded flavor."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:37
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid ""
 "Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:39
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid ""
 "Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
 "thread and transforms its handle into a future without blocking the executor."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:42
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid ""
 "You should not think of tasks as OS threads. They do not map 1 to 1 and most "
 "executors will allow many tasks to run on a single OS thread. This is "
@@ -18479,27 +18240,27 @@ msgid ""
 "situations."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/blocking-executor.md:48
+#: src/concurrency/async-pitfalls/blocking-executor.md
 msgid ""
 "Use sync mutexes with care. Holding a mutex over an `.await` may cause "
 "another task to block, and that task may be running on the same thread."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:3
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "Async blocks and functions return types implementing the `Future` trait. The "
 "type returned is the result of a compiler transformation which turns local "
 "variables into data stored inside the future."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:7
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "Some of those variables can hold pointers to other local variables. Because "
 "of that, the future should never be moved to a different memory location, as "
 "it would invalidate those pointers."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:11
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "To prevent moving the future type in memory, it can only be polled through a "
 "pinned pointer. `Pin` is a wrapper around a reference that disallows all "
@@ -18507,95 +18268,95 @@ msgid ""
 "location."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:20
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "// A work item. In this case, just sleep for the given time and respond\n"
 "// with a message on the `respond_on` channel.\n"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:28
+#: src/concurrency/async-pitfalls/pin.md
 msgid "// A worker which listens for work on a queue and performs it.\n"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:35
+#: src/concurrency/async-pitfalls/pin.md
 msgid "// Pretend to work.\n"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:38
+#: src/concurrency/async-pitfalls/pin.md
 msgid "\"failed to send response\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:41
+#: src/concurrency/async-pitfalls/pin.md
 msgid "// TODO: report number of iterations every 100ms\n"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:45
+#: src/concurrency/async-pitfalls/pin.md
 msgid "// A requester which requests work and waits for it to complete.\n"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:52
+#: src/concurrency/async-pitfalls/pin.md
 msgid "\"failed to send on work queue\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:53
+#: src/concurrency/async-pitfalls/pin.md
 msgid "\"failed waiting for response\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:62
+#: src/concurrency/async-pitfalls/pin.md
 msgid "\"work result for iteration {i}: {resp}\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:70
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "You may recognize this as an example of the actor pattern. Actors typically "
 "call `select!` in a loop."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:73
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "This serves as a summation of a few of the previous lessons, so take your "
 "time with it."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:76
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
 "the `select!`. This will never execute. Why?"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:79
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "Instead, add a `timeout_fut` containing that future outside of the `loop`:"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:90
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "This still doesn't work. Follow the compiler errors, adding `&mut` to the "
 "`timeout_fut` in the `select!` to work around the move, then using `Box::"
 "pin`:"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:104
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "This compiles, but once the timeout expires it is `Poll::Ready` on every "
 "iteration (a fused future would help with this). Update to reset "
 "`timeout_fut` every time it expires."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:108
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
 "stabilized, with older code often using `tokio::pin!`) is also an option, "
 "but that is difficult to use for a future that is reassigned."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:112
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "Another alternative is to not use `pin` at all but spawn another task that "
 "will send to a `oneshot` channel every 100ms."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:115
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "Data that contains pointers to itself is called self-referential. Normally, "
 "the Rust borrow checker would prevent self-referential data from being "
@@ -18604,21 +18365,21 @@ msgid ""
 "borrow checker."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:121
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "`Pin` is a wrapper around a reference. An object cannot be moved from its "
 "place using a pinned pointer. However, it can still be moved through an "
 "unpinned pointer."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/pin.md:125
+#: src/concurrency/async-pitfalls/pin.md
 msgid ""
 "The `poll` method of the `Future` trait uses `Pin<&mut Self>` instead of "
 "`&mut Self` to refer to the instance. That's why it can only be called on a "
 "pinned pointer."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:3
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "Async methods in traits are were stabilized only recently, in the 1.75 "
 "release. This required support for using return-position `impl Trait` (RPIT) "
@@ -18626,46 +18387,46 @@ msgid ""
 "= ...>`."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:7
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "However, even with the native support today there are some pitfalls around "
 "`async fn` and RPIT in traits:"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:10
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "Return-position impl Trait captures all in-scope lifetimes (so some patterns "
 "of borrowing cannot be expressed)"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:13
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "Traits whose methods use return-position `impl trait` or `async` are not "
 "`dyn` compatible."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:16
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "If we do need `dyn` support, the crate [async_trait](https://docs.rs/async-"
 "trait/latest/async_trait/) provides a workaround through a macro, with some "
 "caveats:"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:46
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid "\"running all sleepers..\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:50
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid "\"slept for {}ms\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:68
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "`async_trait` is easy to use, but note that it's using heap allocations to "
 "achieve this. This heap allocation has performance overhead."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:71
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "The challenges in language support for `async trait` are deep Rust and "
 "probably not worth describing in-depth. Niko Matsakis did a good job of "
@@ -18674,13 +18435,13 @@ msgid ""
 "digging deeper."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/async-traits.md:77
+#: src/concurrency/async-pitfalls/async-traits.md
 msgid ""
 "Try creating a new sleeper struct that will sleep for a random amount of "
 "time and adding it to the Vec."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:3
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "Dropping a future implies it can never be polled again. This is called "
 "_cancellation_ and it can occur at any `await` point. Care is needed to "
@@ -18688,106 +18449,106 @@ msgid ""
 "example, it shouldn't deadlock or lose data."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:35
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "\"not UTF-8\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:51
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "\"hi\\nthere\\n\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:57
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "\"tick!\""
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:73
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "The compiler doesn't help with cancellation-safety. You need to read API "
 "documentation and consider what state your `async fn` holds."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:76
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
 "error-handling)."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:79
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "The example loses parts of the string."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:81
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
 "dropped."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:84
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "`LinesReader` can be made cancellation-safe by making `buf` part of the "
 "struct:"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:98
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid "// prefix buf and bytes with self.\n"
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:107
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
 "html#method.tick) is cancellation-safe because it keeps track of whether a "
 "tick has been 'delivered'."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:111
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
 "AsyncReadExt.html#method.read) is cancellation-safe because it either "
 "returns or doesn't read data."
 msgstr ""
 
-#: src/concurrency/async-pitfalls/cancellation.md:114
+#: src/concurrency/async-pitfalls/cancellation.md
 msgid ""
 "[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
 "AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
 "cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:1
-#: src/concurrency/async-exercises/solutions.md:3
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "Dining Philosophers --- Async"
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:3
+#: src/concurrency/async-exercises/dining-philosophers.md
 msgid ""
 "See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:6
+#: src/concurrency/async-exercises/dining-philosophers.md
 msgid ""
 "As before, you will need a local [Cargo installation](../../cargo/running-"
 "locally.md) for this exercise. Copy the code below to a file called `src/"
 "main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:37
-#: src/concurrency/async-exercises/solutions.md:29
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Keep trying until we have both forks\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:52
-#: src/concurrency/async-exercises/solutions.md:85
+#: src/concurrency/async-exercises/dining-philosophers.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Make them think and eat\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:58
+#: src/concurrency/async-exercises/dining-philosophers.md
 msgid ""
 "Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:63
+#: src/concurrency/async-exercises/dining-philosophers.md
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -18801,17 +18562,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:73
+#: src/concurrency/async-exercises/dining-philosophers.md
 msgid ""
 "Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
-#: src/concurrency/async-exercises/dining-philosophers.md:79
+#: src/concurrency/async-exercises/dining-philosophers.md
 msgid "Can you make your implementation single-threaded?"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:3
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
@@ -18820,7 +18581,7 @@ msgid ""
 "that it receives to all the clients."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:9
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
 "sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
@@ -18828,15 +18589,15 @@ msgid ""
 "and the server."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:12
+#: src/concurrency/async-exercises/chat-app.md
 msgid "Create a new Cargo project and add the following dependencies:"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:14
+#: src/concurrency/async-exercises/chat-app.md
 msgid "_Cargo.toml_:"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:18
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -18853,49 +18614,49 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:31
+#: src/concurrency/async-exercises/chat-app.md
 msgid "The required APIs"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:33
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "You are going to need the following functions from `tokio` and "
 "[`tokio_websockets`](https://docs.rs/tokio-websockets/). Spend a few minutes "
 "to familiarize yourself with the API."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:37
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
 "trait.StreamExt.html#method.next) implemented by `WebSocketStream`: for "
 "asynchronously reading messages from a Websocket Stream."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:39
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
 "trait.SinkExt.html#method.send) implemented by `WebSocketStream`: for "
 "asynchronously sending messages on a Websocket Stream."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:41
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
 "html#method.next_line): for asynchronously reading user messages from the "
 "standard input."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:43
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
 "struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:45
+#: src/concurrency/async-exercises/chat-app.md
 msgid "Two binaries"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:47
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "Normally in a Cargo project, you can have only one binary, and one `src/main."
 "rs` file. In this project, we need two binaries. One for the client, and one "
@@ -18906,81 +18667,80 @@ msgid ""
 "targets.html#binaries))."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:54
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "Copy the following server and client code into `src/bin/server.rs` and `src/"
 "bin/client.rs`, respectively. Your task is to complete these files as "
 "described below."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:58
-#: src/concurrency/async-exercises/solutions.md:104
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "_src/bin/server.rs_:"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:77
-#: src/concurrency/async-exercises/chat-app.md:124
+#: src/concurrency/async-exercises/chat-app.md
 msgid "// TODO: For a hint, see the description of the task below.\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:85
-#: src/concurrency/async-exercises/solutions.md:154
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"127.0.0.1:2000\""
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:86
-#: src/concurrency/async-exercises/solutions.md:155
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"listening on port 2000\""
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:90
-#: src/concurrency/async-exercises/solutions.md:159
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"New connection from {addr:?}\""
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:93
-#: src/concurrency/async-exercises/solutions.md:162
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Wrap the raw TCP stream into a websocket.\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:102
-#: src/concurrency/async-exercises/solutions.md:171
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "_src/bin/client.rs_:"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:116
-#: src/concurrency/async-exercises/solutions.md:183
+#: src/concurrency/async-exercises/chat-app.md
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"ws://127.0.0.1:2000\""
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:129
+#: src/concurrency/async-exercises/chat-app.md
 msgid "Running the binaries"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:131
+#: src/concurrency/async-exercises/chat-app.md
 msgid "Run the server with:"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:137
+#: src/concurrency/async-exercises/chat-app.md
 msgid "and the client with:"
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:145
+#: src/concurrency/async-exercises/chat-app.md
 msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:146
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "Hint: Use `tokio::select!` for concurrently performing two tasks in a "
 "continuous loop. One task receives messages from the client and broadcasts "
 "them. The other sends messages received by the server to the client."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:149
+#: src/concurrency/async-exercises/chat-app.md
 msgid "Complete the main function in `src/bin/client.rs`."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:150
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
 "performing two tasks: (1) reading user messages from standard input and "
@@ -18988,66 +18748,66 @@ msgid ""
 "displaying them for the user."
 msgstr ""
 
-#: src/concurrency/async-exercises/chat-app.md:154
+#: src/concurrency/async-exercises/chat-app.md
 msgid ""
 "Optional: Once you are done, change the code to broadcast messages to all "
 "clients, but the sender of the message."
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:35
+#: src/concurrency/async-exercises/solutions.md
 msgid ""
 "// If we didn't get the left fork, drop the right fork if we\n"
 "                // have it and let other tasks make progress.\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:42
+#: src/concurrency/async-exercises/solutions.md
 msgid ""
 "// If we didn't get the right fork, drop the left fork and let\n"
 "                // other tasks make progress.\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:54
+#: src/concurrency/async-exercises/solutions.md
 msgid "// The locks are dropped here\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:82
+#: src/concurrency/async-exercises/solutions.md
 msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:97
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Here is a thought: {thought}\""
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:122
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"Welcome to chat! Type a message\""
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:126
+#: src/concurrency/async-exercises/solutions.md
 msgid ""
 "// A continuous loop for concurrently performing two tasks: (1) receiving\n"
 "    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
 "    // messages on `bcast_rx` and sending them to the client.\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:135
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"From client {addr:?} {text:?}\""
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:190
+#: src/concurrency/async-exercises/solutions.md
 msgid "// Continuous loop for concurrently sending and receiving messages.\n"
 msgstr ""
 
-#: src/concurrency/async-exercises/solutions.md:197
+#: src/concurrency/async-exercises/solutions.md
 msgid "\"From server: {}\""
 msgstr ""
 
-#: src/thanks.md:3
+#: src/thanks.md
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
 "that it was useful."
 msgstr ""
 
-#: src/thanks.md:6
+#: src/thanks.md
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
 "perfect, so if you spotted any mistakes or have ideas for improvements, "
@@ -19056,7 +18816,7 @@ msgid ""
 msgstr ""
 
 # this is a translation, so the second part of the sentence need not be translated
-#: src/glossary.md:5
+#: src/glossary.md
 msgid ""
 "The following is a glossary which aims to give a short definition of many "
 "Rust terms. For translations, this also serves to connect the term back to "
@@ -19064,7 +18824,7 @@ msgid ""
 msgstr ""
 "Bảng từ vựng dưới đây cung cấp định nghĩa ngắn gọn của nhiều thuật ngữ Rust. "
 
-#: src/glossary.md:31
+#: src/glossary.md
 msgid ""
 "allocate:  \n"
 "Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md)."
@@ -19072,7 +18832,7 @@ msgstr ""
 "allocate:  \n"
 "Cấp phát bộ nhớ động trên [bộ nhớ heap](memory-management/stack-vs-heap.md)."
 
-#: src/glossary.md:33
+#: src/glossary.md
 msgid ""
 "argument:  \n"
 "Information that is passed into a function or method."
@@ -19080,7 +18840,7 @@ msgstr ""
 "argument:  \n"
 "Giá trị được truyền vào một hàm. Có thể được gọi là tham số."
 
-#: src/glossary.md:35
+#: src/glossary.md
 msgid ""
 "Bare-metal Rust:  \n"
 "Low-level Rust development, often deployed to a system without an operating "
@@ -19090,7 +18850,7 @@ msgstr ""
 "Việc phát triển chương trình Rust ở cấp thấp, thường để triển khai trên hệ "
 "thống không cần hệ điều hành. Xem [Bare-metal Rust](bare-metal.md)."
 
-#: src/glossary.md:38
+#: src/glossary.md
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
@@ -19098,7 +18858,7 @@ msgstr ""
 "block:  \n"
 "Xem [Blocks](control-flow/blocks.md) và _scope_."
 
-#: src/glossary.md:40
+#: src/glossary.md
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
@@ -19106,7 +18866,7 @@ msgstr ""
 "borrow:  \n"
 "Xem [Borrowing](ownership/borrowing.md)."
 
-#: src/glossary.md:42
+#: src/glossary.md
 msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
@@ -19115,7 +18875,7 @@ msgstr ""
 "Một bộ phận của Rust compiler kiểm tra xem tất cả các _borrow_ có hợp lệ hay "
 "không."
 
-#: src/glossary.md:44
+#: src/glossary.md
 msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
@@ -19123,7 +18883,7 @@ msgstr ""
 "brace:  \n"
 "`{` và `}`. Được gọi là dấu _ngoặc nhọn_, phân chia các _block_."
 
-#: src/glossary.md:46
+#: src/glossary.md
 msgid ""
 "build:  \n"
 "The process of converting source code into executable code or a usable "
@@ -19132,7 +18892,7 @@ msgstr ""
 "build:  \n"
 "Quá trình chuyển đổi mã nguồn thành một chương trình executable."
 
-#: src/glossary.md:49
+#: src/glossary.md
 msgid ""
 "call:  \n"
 "To invoke or execute a function or method."
@@ -19140,7 +18900,7 @@ msgstr ""
 "call:  \n"
 "Gọi hoặc thực thi hàm."
 
-#: src/glossary.md:51
+#: src/glossary.md
 msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
@@ -19149,7 +18909,7 @@ msgstr ""
 "Dùng để truyền thông điệp một cách an toàn [giữa các _thread_](concurrency/"
 "channels.md)."
 
-#: src/glossary.md:53
+#: src/glossary.md
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
@@ -19157,7 +18917,7 @@ msgstr ""
 "Comprehensive Rust 🦀:  \n"
 "Các khóa học ở đây được gọi chung là Comprehensive Rust 🦀."
 
-#: src/glossary.md:55
+#: src/glossary.md
 msgid ""
 "concurrency:  \n"
 "The execution of multiple tasks or processes at the same time."
@@ -19165,7 +18925,7 @@ msgstr ""
 "concurrency:  \n"
 "Quá trình thực thi nhiều tác vụ hoặc process cùng một lúc."
 
-#: src/glossary.md:57
+#: src/glossary.md
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
@@ -19173,7 +18933,7 @@ msgstr ""
 "Concurrency in Rust:  \n"
 "Xem [Concurrency trong Rust](concurrency.md)."
 
-#: src/glossary.md:59
+#: src/glossary.md
 msgid ""
 "constant:  \n"
 "A value that does not change during the execution of a program."
@@ -19182,7 +18942,7 @@ msgstr ""
 "Một giá trị không thay đổi trong quá trình thực thi của chương trình. Còn "
 "được gọi là _hằng số_."
 
-#: src/glossary.md:61
+#: src/glossary.md
 msgid ""
 "control flow:  \n"
 "The order in which the individual statements or instructions are executed in "
@@ -19192,7 +18952,7 @@ msgstr ""
 "Thứ tự thực thi của các câu lệnh trong một chương trình. Một vài sách gọi từ "
 "này là _luồng điều khiển_."
 
-#: src/glossary.md:64
+#: src/glossary.md
 msgid ""
 "crash:  \n"
 "An unexpected and unhandled failure or termination of a program."
@@ -19200,7 +18960,7 @@ msgstr ""
 "crash:  \n"
 "Khi chương trình gặp lỗi không xử lý được và bị dừng đột ngột."
 
-#: src/glossary.md:66
+#: src/glossary.md
 msgid ""
 "enumeration:  \n"
 "A data type that holds one of several named constants, possibly with an "
@@ -19210,7 +18970,7 @@ msgstr ""
 "Môt kiểu dữ liệu chứa một hoặc nhiều hằng số, có thể kèm theo một _tuple_ "
 "hoặc một _struct_."
 
-#: src/glossary.md:69
+#: src/glossary.md
 msgid ""
 "error:  \n"
 "An unexpected condition or result that deviates from the expected behavior."
@@ -19218,7 +18978,7 @@ msgstr ""
 "error:  \n"
 "Khi gặp phải một hành vi hoặc kết quả không như dự kiến."
 
-#: src/glossary.md:71
+#: src/glossary.md
 msgid ""
 "error handling:  \n"
 "The process of managing and responding to errors that occur during program "
@@ -19227,7 +18987,7 @@ msgstr ""
 "error handling:  \n"
 "Quá trình quản lý và xử lý lỗi xảy ra trong quá trình thực thi chương trình."
 
-#: src/glossary.md:74
+#: src/glossary.md
 msgid ""
 "exercise:  \n"
 "A task or problem designed to practice and test programming skills."
@@ -19236,7 +18996,7 @@ msgstr ""
 "Bài tập được thiết kế giúp học viên luyện tập và kiểm tra năng lực lập "
 "trình. "
 
-#: src/glossary.md:76
+#: src/glossary.md
 msgid ""
 "function:  \n"
 "A reusable block of code that performs a specific task."
@@ -19245,7 +19005,7 @@ msgstr ""
 "Một đoạn code có thể được tái sử dụng, nhằm thực hiện một nhiệm vụ cụ thể."
 "Còn được gọi là _hàm_."
 
-#: src/glossary.md:78
+#: src/glossary.md
 msgid ""
 "garbage collector:  \n"
 "A mechanism that automatically frees up memory occupied by objects that are "
@@ -19255,7 +19015,7 @@ msgstr ""
 "Một cơ chế tự động giải phóng bộ nhớ bị chiếm bởi các biến không còn được sử "
 "dụng nữa."
 
-#: src/glossary.md:81
+#: src/glossary.md
 msgid ""
 "generics:  \n"
 "A feature that allows writing code with placeholders for types, enabling "
@@ -19266,7 +19026,7 @@ msgstr ""
 "cần phải định rõ kiểu dữ liệu, giúp tái sử dụng code với nhiều kiểu dữ liệu "
 "khác nhau."
 
-#: src/glossary.md:84
+#: src/glossary.md
 msgid ""
 "immutable:  \n"
 "Unable to be changed after creation."
@@ -19274,7 +19034,7 @@ msgstr ""
 "immutable:  \n"
 "Không thể thay đổi sau khi tạo. Có thể được dịch là _bất biến_."
 
-#: src/glossary.md:86
+#: src/glossary.md
 msgid ""
 "integration test:  \n"
 "A type of test that verifies the interactions between different parts or "
@@ -19284,7 +19044,7 @@ msgstr ""
 "Một quy trình _test_ code để kiểm tra sự tương tác giữa các thành phần của "
 "hệ thống."
 
-#: src/glossary.md:89
+#: src/glossary.md
 msgid ""
 "keyword:  \n"
 "A reserved word in a programming language that has a specific meaning and "
@@ -19294,7 +19054,7 @@ msgstr ""
 "Một từ khóa trong ngôn ngữ lập trình, có ý nghĩa cụ thể và không thể sử dụng "
 "như một _identifier_ (tên biến)."
 
-#: src/glossary.md:92
+#: src/glossary.md
 msgid ""
 "library:  \n"
 "A collection of precompiled routines or code that can be used by programs."
@@ -19303,7 +19063,7 @@ msgstr ""
 "Một bộ sưu tập các hàm hoặc code đã được biên dịch trước, có thể được sử "
 "dụng trong chương trình. Thường được gọi là _thư viện_."
 
-#: src/glossary.md:94
+#: src/glossary.md
 msgid ""
 "macro:  \n"
 "Rust macros can be recognized by a `!` in the name. Macros are used when "
@@ -19317,7 +19077,7 @@ msgstr ""
 "tham số không cố định (có thể 1 tham số, 2 tham số, hay thậm chí là không có "
 "tham số nào). Hàm thông thường trong Rust không làm được điều này."
 
-#: src/glossary.md:98
+#: src/glossary.md
 msgid ""
 "`main` function:  \n"
 "Rust programs start executing with the `main` function."
@@ -19325,7 +19085,7 @@ msgstr ""
 "`main` function:  \n"
 "Điểm bắt đầu của mọi chương trình Rust là hàm `main`."
 
-#: src/glossary.md:100
+#: src/glossary.md
 msgid ""
 "match:  \n"
 "A control flow construct in Rust that allows for pattern matching on the "
@@ -19335,7 +19095,7 @@ msgstr ""
 "Một _control flow_ trong Rust cho phép so sánh một giá trị với một số "
 "_pattern_ cho trước."
 
-#: src/glossary.md:103
+#: src/glossary.md
 msgid ""
 "memory leak:  \n"
 "A situation where a program fails to release memory that is no longer "
@@ -19345,7 +19105,7 @@ msgstr ""
 "Khi chương trình không giải phóng bộ nhớ của biến không còn cần thiết, dẫn "
 "đến việc bộ nhớ sử dụng tăng dần trong quá trình thực thi."
 
-#: src/glossary.md:106
+#: src/glossary.md
 msgid ""
 "method:  \n"
 "A function associated with an object or a type in Rust."
@@ -19353,7 +19113,7 @@ msgstr ""
 "method:  \n"
 "Một hàm liên kết với một đối tượng hoặc một kiểu dữ liệu trong Rust."
 
-#: src/glossary.md:108
+#: src/glossary.md
 msgid ""
 "module:  \n"
 "A namespace that contains definitions, such as functions, types, or traits, "
@@ -19363,7 +19123,7 @@ msgstr ""
 "Một phương pháp đẻ nhóm các định nghĩa, như hàm, kiểu dữ liệu, hoặc traits, "
 "trong Rust."
 
-#: src/glossary.md:111
+#: src/glossary.md
 msgid ""
 "move:  \n"
 "The transfer of ownership of a value from one variable to another in Rust."
@@ -19372,7 +19132,7 @@ msgstr ""
 "Chuyển quyền sở hữu của một giá trị từ một biến sang một biến khác trong "
 "Rust."
 
-#: src/glossary.md:113
+#: src/glossary.md
 msgid ""
 "mutable:  \n"
 "A property in Rust that allows variables to be modified after they have been "
@@ -19382,7 +19142,7 @@ msgstr ""
 "Một thuộc tính trong Rust cho phép biến có thể được thay đổi sau khi đã được "
 "khai báo."
 
-#: src/glossary.md:116
+#: src/glossary.md
 msgid ""
 "ownership:  \n"
 "The concept in Rust that defines which part of the code is responsible for "
@@ -19392,7 +19152,7 @@ msgstr ""
 "Một khái niệm trong Rust xác định phần nào của code chịu trách nhiệm quản lý "
 "bộ nhớ liên quan đến một giá trị."
 
-#: src/glossary.md:119
+#: src/glossary.md
 msgid ""
 "panic:  \n"
 "An unrecoverable error condition in Rust that results in the termination of "
@@ -19402,7 +19162,7 @@ msgstr ""
 "Khi chương trình gặp phải một lỗi không thể phục hồi được, dẫn đến việc dừng "
 "chương trình."
 
-#: src/glossary.md:122
+#: src/glossary.md
 msgid ""
 "parameter:  \n"
 "A value that is passed into a function or method when it is called."
@@ -19410,7 +19170,7 @@ msgstr ""
 "parameter:  \n"
 "Giá trị được truyền vào một hàm khi hàm đó được gọi. Còn được gọi là tham số."
 
-#: src/glossary.md:124
+#: src/glossary.md
 msgid ""
 "pattern:  \n"
 "A combination of values, literals, or structures that can be matched against "
@@ -19420,7 +19180,7 @@ msgstr ""
 "Cách sử dụng giá trị, hằng số, hoặc cấu trúc để so sánh với một biểu thức "
 "trong Rust."
 
-#: src/glossary.md:127
+#: src/glossary.md
 msgid ""
 "payload:  \n"
 "The data or information carried by a message, event, or data structure."
@@ -19429,7 +19189,7 @@ msgstr ""
 "Dữ liệu hoặc thông tin được chuyển đi, thường sử dụng khi nhắc đến việc "
 "chuyển dữ liệu qua mạng."
 
-#: src/glossary.md:129
+#: src/glossary.md
 msgid ""
 "program:  \n"
 "A set of instructions that a computer can execute to perform a specific task "
@@ -19439,7 +19199,7 @@ msgstr ""
 "Một tập hợp các dòng lệnh máy tính có thể thực thi để thực hiện một nhiệm vụ "
 "hoặc giải quyết một vấn đề cụ thể. Còn được gọi là _chương trình_."
 
-#: src/glossary.md:132
+#: src/glossary.md
 msgid ""
 "programming language:  \n"
 "A formal system used to communicate instructions to a computer, such as Rust."
@@ -19448,7 +19208,7 @@ msgstr ""
 "Một hệ thống ngôn ngữ được sử dụng để truyền thông điệp cho máy tính, như "
 "Rust."
 
-#: src/glossary.md:134
+#: src/glossary.md
 msgid ""
 "receiver:  \n"
 "The first parameter in a Rust method that represents the instance on which "
@@ -19458,7 +19218,7 @@ msgstr ""
 "Tham số đầu tiên trong một _method_ của Rust, đại diện cho biến mà _method_ "
 "đó gọi lên."
 
-#: src/glossary.md:137
+#: src/glossary.md
 msgid ""
 "reference counting:  \n"
 "A memory management technique in which the number of references to an object "
@@ -19469,7 +19229,7 @@ msgstr ""
 "được theo dõi, và đối tượng được giải phóng khi số lượng tham chiếu giảm về "
 "0."
 
-#: src/glossary.md:140
+#: src/glossary.md
 msgid ""
 "return:  \n"
 "A keyword in Rust used to indicate the value to be returned from a function."
@@ -19477,7 +19237,7 @@ msgstr ""
 "return:  \n"
 "Một từ khóa trong Rust dùng để chỉ ra giá trị trả về của một hàm."
 
-#: src/glossary.md:142
+#: src/glossary.md
 msgid ""
 "Rust:  \n"
 "A systems programming language that focuses on safety, performance, and "
@@ -19486,7 +19246,7 @@ msgstr ""
 "Rust:  \n"
 "Ngôn ngữ lập trình hệ thống chú trọng vào an toàn và hiệu suất."
 
-#: src/glossary.md:145
+#: src/glossary.md
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 4 of this course."
@@ -19494,7 +19254,7 @@ msgstr ""
 "Rust Fundamentals:  \n"
 "Ngày 1 đến ngày 4 của khóa học này."
 
-#: src/glossary.md:147
+#: src/glossary.md
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
@@ -19502,7 +19262,7 @@ msgstr ""
 "Rust in Android:  \n"
 "Xem [Sử dụng Rust trong Android](android.md)."
 
-#: src/glossary.md:149
+#: src/glossary.md
 msgid ""
 "Rust in Chromium:  \n"
 "See [Rust in Chromium](chromium.md)."
@@ -19510,7 +19270,7 @@ msgstr ""
 "Rust in Chromium:  \n"
 "Xem [Sử dụng Rust trong Chromium](chromium.md)."
 
-#: src/glossary.md:151
+#: src/glossary.md
 msgid ""
 "safe:  \n"
 "Refers to code that adheres to Rust's ownership and borrowing rules, "
@@ -19520,7 +19280,7 @@ msgstr ""
 "Đoạn code tuân thủ các quy tắc về _ownership_ và _borrowing_ của Rust, ngăn "
 "chặn lỗi liên quan đến bộ nhớ."
 
-#: src/glossary.md:154
+#: src/glossary.md
 msgid ""
 "scope:  \n"
 "The region of a program where a variable is valid and can be used."
@@ -19528,7 +19288,7 @@ msgstr ""
 "scope:  \n"
 "Một phạm vi trong chương trình mà một biến có thể được sử dụng."
 
-#: src/glossary.md:156
+#: src/glossary.md
 msgid ""
 "standard library:  \n"
 "A collection of modules providing essential functionality in Rust."
@@ -19537,7 +19297,7 @@ msgstr ""
 "Một bộ sưu tập các _module_ cung cấp các chức năng cần thiết trong Rust. Một "
 "số sách gọi là _thư viện chuẩn_."
 
-#: src/glossary.md:158
+#: src/glossary.md
 msgid ""
 "static:  \n"
 "A keyword in Rust used to define static variables or items with a `'static` "
@@ -19547,7 +19307,7 @@ msgstr ""
 "Một từ khóa trong Rust dùng để định nghĩa biến tĩnh hoặc các phần tử với "
 "_lifetime_ là `'static`."
 
-#: src/glossary.md:161
+#: src/glossary.md
 msgid ""
 "string:  \n"
 "A data type storing textual data. See [`String` vs `str`](basic-syntax/"
@@ -19557,7 +19317,7 @@ msgstr ""
 "Một kiểu dữ liệu lưu trữ dữ liệu văn bản. Xem [`String` vs `str`](basic-"
 "syntax/string-slices.html) để biết thêm chi tiết. Còn được gọi là _chuỗi_."
 
-#: src/glossary.md:164
+#: src/glossary.md
 msgid ""
 "struct:  \n"
 "A composite data type in Rust that groups together variables of different "
@@ -19567,7 +19327,7 @@ msgstr ""
 "Một kiểu dữ liệu trong Rust, dùng để nhóm các biến khác nhau với nhau thành "
 "một kiểu dữ liệu mới."
 
-#: src/glossary.md:167
+#: src/glossary.md
 msgid ""
 "test:  \n"
 "A Rust module containing functions that test the correctness of other "
@@ -19576,7 +19336,7 @@ msgstr ""
 "test:  \n"
 "Một _module_ trong Rust chứa các hàm kiểm tra sự chính xác của các hàm khác."
 
-#: src/glossary.md:170
+#: src/glossary.md
 msgid ""
 "thread:  \n"
 "A separate sequence of execution in a program, allowing concurrent execution."
@@ -19585,7 +19345,7 @@ msgstr ""
 "Một cơ chế cho phép thực thi nhiều tác vụ cùng một lúc trong chương trình. "
 "Còn được gọi là _luồng_."
 
-#: src/glossary.md:172
+#: src/glossary.md
 msgid ""
 "thread safety:  \n"
 "The property of a program that ensures correct behavior in a multithreaded "
@@ -19595,7 +19355,7 @@ msgstr ""
 "Thuộc tính của chương trình đảm bảo chương trình hoạt động chuẩn xác trong "
 "môi trường đa luồng."
 
-#: src/glossary.md:175
+#: src/glossary.md
 msgid ""
 "trait:  \n"
 "A collection of methods defined for an unknown type, providing a way to "
@@ -19604,7 +19364,7 @@ msgstr ""
 "trait:  \n"
 "Một tập hợp các hành vi mà ta muốn một kiểu dữ liệu cụ thể phải có."
 
-#: src/glossary.md:178
+#: src/glossary.md
 msgid ""
 "trait bound:  \n"
 "An abstraction where you can require types to implement some traits of your "
@@ -19613,7 +19373,7 @@ msgstr ""
 "trait bound:  \n"
 "Một cách để yêu cầu một kiểu dữ liệu phải _implement_ một số _trait_ cụ thể."
 
-#: src/glossary.md:181
+#: src/glossary.md
 msgid ""
 "tuple:  \n"
 "A composite data type that contains variables of different types. Tuple "
@@ -19623,7 +19383,7 @@ msgstr ""
 "Một kiểu dữ liệu trong Rust chứa các biến khác nhau. Các trường của _tuple_ "
 "không có tên, và được truy cập bằng số thứ tự."
 
-#: src/glossary.md:184
+#: src/glossary.md
 msgid ""
 "type:  \n"
 "A classification that specifies which operations can be performed on values "
@@ -19633,7 +19393,7 @@ msgstr ""
 "Một cơ chế giúp xác định các thao tác có thể thực hiện trên giá trị của một "
 "kiểu dữ liệu cụ thể trong Rust."
 
-#: src/glossary.md:187
+#: src/glossary.md
 msgid ""
 "type inference:  \n"
 "The ability of the Rust compiler to deduce the type of a variable or "
@@ -19643,7 +19403,7 @@ msgstr ""
 "Một chức năng của Rust compiler giúp suy luận kiểu dữ liệu của biến hoặc "
 "biểu thức, thay vì phải khai báo kiểu dữ liệu cho từng biến."
 
-#: src/glossary.md:190
+#: src/glossary.md
 msgid ""
 "undefined behavior:  \n"
 "Actions or conditions in Rust that have no specified result, often leading "
@@ -19653,7 +19413,7 @@ msgstr ""
 "Một số hành vi và điều kiện trong Rust không có kết quả cụ thể, thường dẫn "
 "đến việc chương trình hoạt động bất thường."
 
-#: src/glossary.md:193
+#: src/glossary.md
 msgid ""
 "union:  \n"
 "A data type that can hold values of different types but only one at a time."
@@ -19662,7 +19422,7 @@ msgstr ""
 "Một kiểu dữ liệu có thể chứa giá trị của nhiều kiểu dữ liệu khác nhau, nhưng "
 "chỉ một giá trị một lúc."
 
-#: src/glossary.md:195
+#: src/glossary.md
 msgid ""
 "unit test:  \n"
 "Rust comes with built-in support for running small unit tests and larger "
@@ -19672,7 +19432,7 @@ msgstr ""
 "Một loại _test_ trong Rust, giúp kiểm tra từng phần nhỏ của chương trình. "
 "Xem [Unit Tests](testing/unit-tests.html)."
 
-#: src/glossary.md:198
+#: src/glossary.md
 msgid ""
 "unit type:  \n"
 "Type that holds no data, written as a tuple with no members."
@@ -19680,7 +19440,7 @@ msgstr ""
 "unit type:  \n"
 "Kiểu dữ liệu không chứa dữ liệu, ký hiệu bằng `()`."
 
-#: src/glossary.md:200
+#: src/glossary.md
 msgid ""
 "unsafe:  \n"
 "The subset of Rust which allows you to trigger _undefined behavior_. See "
@@ -19690,7 +19450,7 @@ msgstr ""
 "Một phần của Rust cho phép người lập trình gây ra _undefined behavior_. Xem "
 "[Unsafe Rust](unsafe.html)."
 
-#: src/glossary.md:203
+#: src/glossary.md
 msgid ""
 "variable:  \n"
 "A memory location storing data. Variables are valid in a _scope_."
@@ -19699,32 +19459,32 @@ msgstr ""
 "Một vùng bộ nhớ lưu trữ dữ liệu. Có thể được sử dụng trong một _scope_. Còn "
 "được gọi là _biến_."
 
-#: src/other-resources.md:1
+#: src/other-resources.md
 msgid "Other Rust Resources"
 msgstr ""
 
-#: src/other-resources.md:3
+#: src/other-resources.md
 msgid ""
 "The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 
-#: src/other-resources.md:6
+#: src/other-resources.md
 msgid "Official Documentation"
 msgstr ""
 
-#: src/other-resources.md:8
+#: src/other-resources.md
 msgid "The Rust project hosts many resources. These cover Rust in general:"
 msgstr ""
 
-#: src/other-resources.md:10
+#: src/other-resources.md
 msgid ""
 "[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
 "canonical free book about Rust. Covers the language in detail and includes a "
 "few projects for people to build."
 msgstr ""
 
-#: src/other-resources.md:13
+#: src/other-resources.md
 msgid ""
 "[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
 "Rust syntax via a series of examples which showcase different constructs. "
@@ -19732,78 +19492,78 @@ msgid ""
 "in the examples."
 msgstr ""
 
-#: src/other-resources.md:17
+#: src/other-resources.md
 msgid ""
 "[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
 "of the standard library for Rust."
 msgstr ""
 
-#: src/other-resources.md:19
+#: src/other-resources.md
 msgid ""
 "[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
 "book which describes the Rust grammar and memory model."
 msgstr ""
 
-#: src/other-resources.md:22
+#: src/other-resources.md
 msgid "More specialized guides hosted on the official Rust site:"
 msgstr ""
 
-#: src/other-resources.md:24
+#: src/other-resources.md
 msgid ""
 "[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
 "including working with raw pointers and interfacing with other languages "
 "(FFI)."
 msgstr ""
 
-#: src/other-resources.md:27
+#: src/other-resources.md
 msgid ""
 "[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
 "covers the new asynchronous programming model which was introduced after the "
 "Rust Book was written."
 msgstr ""
 
-#: src/other-resources.md:30
+#: src/other-resources.md
 msgid ""
 "[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
 "an introduction to using Rust on embedded devices without an operating "
 "system."
 msgstr ""
 
-#: src/other-resources.md:33
+#: src/other-resources.md
 msgid "Unofficial Learning Material"
 msgstr ""
 
-#: src/other-resources.md:35
+#: src/other-resources.md
 msgid "A small selection of other guides and tutorial for Rust:"
 msgstr ""
 
-#: src/other-resources.md:37
+#: src/other-resources.md
 msgid ""
 "[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
 "from the perspective of low-level C programmers."
 msgstr ""
 
-#: src/other-resources.md:39
+#: src/other-resources.md
 msgid ""
 "[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
 "rust_for_c/): covers Rust from the perspective of developers who write "
 "firmware in C."
 msgstr ""
 
-#: src/other-resources.md:41
+#: src/other-resources.md
 msgid ""
 "[Rust for professionals](https://overexact.com/rust-for-professionals/): "
 "covers the syntax of Rust using side-by-side comparisons with other "
 "languages such as C, C++, Java, JavaScript, and Python."
 msgstr ""
 
-#: src/other-resources.md:44
+#: src/other-resources.md
 msgid ""
 "[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
 "you learn Rust."
 msgstr ""
 
-#: src/other-resources.md:46
+#: src/other-resources.md
 msgid ""
 "[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
 "material/index.html): a series of small presentations covering both basic "
@@ -19811,7 +19571,7 @@ msgid ""
 "and async/await are also covered."
 msgstr ""
 
-#: src/other-resources.md:50
+#: src/other-resources.md
 msgid ""
 "[Advanced testing for Rust applications](https://github.com/mainmatter/rust-"
 "advanced-testing-workshop): a self-paced workshop that goes beyond Rust's "
@@ -19819,7 +19579,7 @@ msgid ""
 "mocking as well as how to write your own custom test harness."
 msgstr ""
 
-#: src/other-resources.md:54
+#: src/other-resources.md
 msgid ""
 "[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
 "series-to-rust/) and [Take your first steps with Rust](https://docs."
@@ -19828,38 +19588,38 @@ msgid ""
 "11 modules which covers Rust syntax and basic constructs."
 msgstr ""
 
-#: src/other-resources.md:60
+#: src/other-resources.md
 msgid ""
 "[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
 "github.io/too-many-lists/): in-depth exploration of Rust's memory management "
 "rules, through implementing a few different types of list structures."
 msgstr ""
 
-#: src/other-resources.md:65
+#: src/other-resources.md
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
 "for even more Rust books."
 msgstr ""
 
-#: src/credits.md:3
+#: src/credits.md
 msgid ""
 "The material here builds on top of the many great sources of Rust "
 "documentation. See the page on [other resources](other-resources.md) for a "
 "full list of useful resources."
 msgstr ""
 
-#: src/credits.md:7
+#: src/credits.md
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
 "2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
 "rust/blob/main/LICENSE) for details."
 msgstr ""
 
-#: src/credits.md:12
+#: src/credits.md
 msgid "Rust by Example"
 msgstr ""
 
-#: src/credits.md:14
+#: src/credits.md
 msgid ""
 "Some examples and exercises have been copied and adapted from [Rust by "
 "Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
@@ -19867,22 +19627,22 @@ msgid ""
 "terms."
 msgstr ""
 
-#: src/credits.md:19
+#: src/credits.md
 msgid "Rust on Exercism"
 msgstr ""
 
-#: src/credits.md:21
+#: src/credits.md
 msgid ""
 "Some exercises have been copied and adapted from [Rust on Exercism](https://"
 "exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
 "directory for details, including the license terms."
 msgstr ""
 
-#: src/credits.md:26
+#: src/credits.md
 msgid "CXX"
 msgstr ""
 
-#: src/credits.md:28
+#: src/credits.md
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
 "uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "


### PR DESCRIPTION
The English contents has changed, leading to untranslated session outline and schedule because the msgid no longer match the original contents. Additionally, incorrect file names are listed in the comment.
This PR follow the steps outlined in [Refreshing an Existing Translation](https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md#refreshing-an-existing-translation) to refresh the Vietnamese translation file. After the update, some translated session outlines were no longer appropriated, so this PR also updates all of them