### PR TITLE
Fix broken link to unsafe-traits.md

### DIFF
--- a/src/concurrency/send-sync/marker-traits.md
+++ b/src/concurrency/send-sync/marker-traits.md
@@ -18,7 +18,7 @@ can also implement them manually when you know it is valid.
 
 [1]: https://doc.rust-lang.org/std/marker/trait.Send.html
 [2]: https://doc.rust-lang.org/std/marker/trait.Sync.html
-[3]: ../unsafe/unsafe-traits.md
+[3]: ../../unsafe-rust/unsafe-traits.md
 
 <details>
 


### PR DESCRIPTION
I came upon a broken link which takes you to (Document Not Found): https://google.github.io/comprehensive-rust/concurrency/unsafe/unsafe-traits.html

Verified locally with `mdbook serve` and now it links correctly