### PR TITLE
Adding crowdin.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ count.dat
 node_modules/
 package.json
 pnpm-lock.yaml
+
+# Crowdin Config (Contains API Keys)
+crowdin.yml


### PR DESCRIPTION
 To remove the risk of committing API keys while testing the Crowdin integration.