### PR TITLE
Fix missing lifetime error in dangling reference example

### DIFF
--- a/src/references/shared.md
+++ b/src/references/shared.md
@@ -30,8 +30,8 @@ Rust will statically forbid dangling references:
 <!-- mdbook-xgettext: skip -->
 
 ```rust,editable,compile_fail
-fn x_axis(x: i32) -> &(i32, i32) {
-    let point = (x, 0);
+fn x_axis(x: &i32) -> &(i32, i32) {
+    let point = (*x, 0);
     return &point;
 }
 ```


### PR DESCRIPTION
The example of returning a reference to a local variable doesn't compile due to a missing lifetime specifier, which isn't what we're trying to demonstrate with that example. I usually add the lifetime in manually in order to demonstrate the compiler error, but it occurs to me that if we make the argument a reference we can sneakily get the correct compiler error without having to introduce the lifetime syntax.