### PR TITLE
ja: Merge CR v.2 Japanese translation back into main

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -9881,22 +9881,23 @@ msgid "b\"hello\""
 msgstr "b\"hello\""
 
 #: src/welcome-day-4.md
-#, fuzzy
 msgid "Welcome to Day 4"
-msgstr "Day 1へようこそ"
+msgstr "4 日目のトレーニングにようこそ"
 
 #: src/welcome-day-4.md
 msgid ""
 "Today we will cover topics relating to building large-scale software in Rust:"
 msgstr ""
+"本日は、Rust での大規模なソフトウェアのビルドに関連するトピックを取り上げま"
+"す。"
 
 #: src/welcome-day-4.md
 msgid "Iterators: a deep dive on the `Iterator` trait."
-msgstr ""
+msgstr "イテレータ: `Iterator` トレイトの詳細。"
 
 #: src/welcome-day-4.md
 msgid "Modules and visibility."
-msgstr ""
+msgstr "モジュールと可視性。"
 
 #: src/welcome-day-4.md
 #, fuzzy
@@ -9905,45 +9906,46 @@ msgstr "テスト"
 
 #: src/welcome-day-4.md
 msgid "Error handling: panics, `Result`, and the try operator `?`."
-msgstr ""
+msgstr "エラー処理: パニック、`Result`、try 演算子 `?`。"
 
 #: src/welcome-day-4.md
 msgid ""
 "Unsafe Rust: the escape hatch when you can't express yourself in safe Rust."
-msgstr ""
+msgstr "アンセーフRust: 安全な Rust では記述できない場合の回避策。"
 
 #: src/welcome-day-4.md
 msgid "[Welcome](./welcome-day-4.md) (3 minutes)"
-msgstr ""
+msgstr "[ようこそ](./welcome-day-4.md)（3 分）"
 
 #: src/welcome-day-4.md
 msgid "[Iterators](./iterators.md) (45 minutes)"
-msgstr ""
+msgstr "[イテレータ](./iterators.md)（45 分）"
 
 #: src/welcome-day-4.md
 msgid "[Modules](./modules.md) (40 minutes)"
-msgstr ""
+msgstr "[モジュール](./modules.md)（40 分）"
 
 #: src/welcome-day-4.md
 msgid "[Testing](./testing.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[テスト](./testing.md)（1 時間 5 分）"
 
 #: src/iterators.md
 msgid "[Iterator](./iterators/iterator.md) (5 minutes)"
-msgstr ""
+msgstr "[Iterator](./iterators/iterator.md)（5 分）"
 
 #: src/iterators.md
 msgid "[IntoIterator](./iterators/intoiterator.md) (5 minutes)"
-msgstr ""
+msgstr "[IntoIterator](./iterators/intoiterator.md)（5 分）"
 
 #: src/iterators.md
 msgid "[FromIterator](./iterators/fromiterator.md) (5 minutes)"
-msgstr ""
+msgstr "[FromIterator](./iterators/fromiterator.md)（5 分）"
 
 #: src/iterators.md
 msgid ""
 "[Exercise: Iterator Method Chaining](./iterators/exercise.md) (30 minutes)"
 msgstr ""
+"[演習: イテレータ メソッドのチェーン化](./iterators/exercise.md)（30 分）"
 
 #: src/iterators/iterator.md
 msgid ""
@@ -9952,10 +9954,15 @@ msgid ""
 "method and provides lots of methods. Many standard library types implement "
 "`Iterator`, and you can implement it yourself, too:"
 msgstr ""
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) トレイト"
+"は、コレクション内の一連の要素に対して順番に処理を適用することを可能にしま"
+"す。このトレイトはnextメソッドを必要とし、それにより多くのメソッドを提供しま"
+"す。多くの標準ライブラリ型で `Iterator` が実装されていますが、自分で実装する"
+"こともできます。"
 
 #: src/iterators/iterator.md
 msgid "\"fib({i}): {n}\""
-msgstr ""
+msgstr "\"fib({i}): {n}\""
 
 #: src/iterators/iterator.md
 msgid ""
@@ -9965,6 +9972,11 @@ msgid ""
 "functions should produce the code as efficient as equivalent imperative "
 "implementations."
 msgstr ""
+"`Iterator` トレイトは、コレクションに対する多くの一般的な関数型プログラミン"
+"グ オペレーション（例: `map`、`filter`、`reduce` など）を実装します。このトレ"
+"イトのドキュメントにおいて、これらのすべてのオペレーションに関する説明を確認"
+"できます。Rust では、これらの関数により、同等の命令型実装と同じくらい効率的な"
+"コードが生成されます。"
 
 #: src/iterators/iterator.md
 msgid ""
@@ -9973,6 +9985,11 @@ msgid ""
 "and `&[T]`. Ranges also implement it. This is why you can iterate over a "
 "vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
+"`IntoIterator` は、forループを実現するためのトレイトです。コレクション型"
+"（`Vec<T>` など）と、それらに対する参照（`&Vec<T>`、`&[T]` など）において実装"
+"されています。また、範囲を表す型においても実装されています。`for i in "
+"some_vec { .. }` を使用してベクターを反復処理できるのに、`some_vec.next()` が"
+"存在しないのはこのためです。"
 
 #: src/iterators/intoiterator.md
 msgid ""
@@ -9981,46 +9998,59 @@ msgid ""
 "iter/trait.IntoIterator.html) defines how to create an iterator for a type. "
 "It is used automatically by the `for` loop."
 msgstr ""
+"`Iterator` トレイトは、イテレータを作成した後に反復処理を行う方法を示します。"
+"関連するトレイト [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait."
+"IntoIterator.html) は、ある型に対するイテレータを作成する方法を定義します。こ"
+"れは `for` ループによって自動的に使用されます。"
 
 #: src/iterators/intoiterator.md
 msgid "\"point = {x}, {y}\""
-msgstr ""
+msgstr "\"point = {x}, {y}\""
 
 #: src/iterators/intoiterator.md
 msgid ""
 "Click through to the docs for `IntoIterator`. Every implementation of "
 "`IntoIterator` must declare two types:"
 msgstr ""
+"`IntoIterator`のドキュメントをクリックしてご覧ください。`IntoIterator` のすべ"
+"ての実装で、次の 2 つの型を宣言する必要があります。"
 
 #: src/iterators/intoiterator.md
 msgid "`Item`: the type to iterate over, such as `i8`,"
-msgstr ""
+msgstr "`Item`: 反復処理する型（`i8` など）。"
 
 #: src/iterators/intoiterator.md
 msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
-msgstr ""
+msgstr "`IntoIter`: `into_iter` メソッドによって返される `Iterator` 型。"
 
 #: src/iterators/intoiterator.md
 msgid ""
 "Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
+"`IntoIter`と`Item`は関連があり、イテレータは`Item`と同じ型を持つ必要がありま"
+"す。すなわち、`Option<Item>`を返します。"
 
 #: src/iterators/intoiterator.md
 msgid "The example iterates over all combinations of x and y coordinates."
-msgstr ""
+msgstr "この例は、x 座標と y 座標のすべての組み合わせを反復処理しています。"
 
 #: src/iterators/intoiterator.md
 msgid ""
 "Try iterating over the grid twice in `main`. Why does this fail? Note that "
 "`IntoIterator::into_iter` takes ownership of `self`."
 msgstr ""
+"`main` でグリッドを 2 回反復処理してみましょう。これはなぜ失敗するのでしょう"
+"か。`IntoIterator::into_iter` は `self` の所有権を取得することに着目してくだ"
+"さい。"
 
 #: src/iterators/intoiterator.md
 msgid ""
 "Fix this issue by implementing `IntoIterator` for `&Grid` and storing a "
 "reference to the `Grid` in `GridIter`."
 msgstr ""
+"この問題を修正するには、`&Grid` に `IntoIterator` を実装し、`Grid` への参照"
+"を `GridIter` に保存します。"
 
 #: src/iterators/intoiterator.md
 msgid ""
@@ -10029,6 +10059,10 @@ msgid ""
 "elements from that vector. Use `for e in &some_vector` instead, to iterate "
 "over references to elements of `some_vector`."
 msgstr ""
+"標準ライブラリ型でも同じ問題が発生する可能性があります。`for e in "
+"some_vector` は、`some_vector` の所有権を取得し、そのベクターの所有要素を反復"
+"処理します。`some_vector` の要素への参照を反復処理するには、代わりに `for e "
+"in &some_vector` を使用します。"
 
 #: src/iterators/fromiterator.md
 msgid "FromIterator"
@@ -10040,18 +10074,21 @@ msgid ""
 "lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
 "std/iter/trait.Iterator.html)."
 msgstr ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"を使用すると、[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator."
+"html) からコレクションを作成できます。"
 
 #: src/iterators/fromiterator.md
 msgid "\"prime_squares: {prime_squares:?}\""
-msgstr ""
+msgstr "\"prime_squares: {prime_squares:?}\""
 
 #: src/iterators/fromiterator.md
 msgid "`Iterator` implements"
-msgstr ""
+msgstr "`Iterator` の実装"
 
 #: src/iterators/fromiterator.md
 msgid "There are two ways to specify `B` for this method:"
-msgstr ""
+msgstr "このメソッドで `B` を指定するには、次の 2 つの方法があります。"
 
 #: src/iterators/fromiterator.md
 msgid ""
@@ -10059,12 +10096,17 @@ msgid ""
 "shown. The `_` shorthand used here lets Rust infer the type of the `Vec` "
 "elements."
 msgstr ""
+"「turbofish」を使用する場合: 例えば、上記における、`some_iterator.collect::"
+"<COLLECTION_TYPE>()`。ここで使用されている_ はRustに`Vecの`要素の方を推測させ"
+"るためのものです。"
 
 #: src/iterators/fromiterator.md
 msgid ""
 "With type inference: `let prime_squares: Vec<_> = some_iterator.collect()`. "
 "Rewrite the example to use this form."
 msgstr ""
+"型推論を使用する場合: `let prime_squares: Vec<_> = some_iterator.collect()`。"
+"この形式を使用するように例を書き換えてください。"
 
 #: src/iterators/fromiterator.md
 msgid ""
@@ -10072,6 +10114,9 @@ msgid ""
 "There are also more specialized implementations which let you do cool things "
 "like convert an `Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
+"`Vec` や `HashMap` などに `FromIterator` の基本的な実装が用意されています。ま"
+"た、`Iterator<Item = Result<V, E>>` を `Result<Vec<V>, E>` に変換できるものな"
+"ど、より特化した実装もあります。"
 
 #: src/iterators/exercise.md
 msgid ""
@@ -10079,6 +10124,9 @@ msgid ""
 "in the [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
 "trait to implement a complex calculation."
 msgstr ""
+"この演習では、複雑な計算を実装するために[`Iterator`](https://doc.rust-lang."
+"org/std/iter/trait.Iterator.html) トレイトで提供されているメソッドをいくつか"
+"を探して使用する必要があります。"
 
 #: src/iterators/exercise.md
 msgid ""
@@ -10086,6 +10134,9 @@ msgid ""
 "pass. Use an iterator expression and `collect` the result to construct the "
 "return value."
 msgstr ""
+"次のコードを <https://play.rust-lang.org/> にコピーし、テストが通るようにして"
+"ください。イテレータ式を使用し、その結果を`collect`することで戻り値を生成しま"
+"す。"
 
 #: src/iterators/exercise.md src/iterators/solution.md
 msgid ""
@@ -10095,68 +10146,80 @@ msgid ""
 "///\n"
 "/// Element `n` of the result is `values[(n+offset)%len] - values[n]`.\n"
 msgstr ""
+"/// `values`において、`offset`だけ離れた要素間の差を計算します。\n"
+"/// なお、`values`の末尾要素の次は先頭へ戻ることとします。\n"
+"///\n"
+"/// 結果の要素 `n` は `values[(n+offset)%len] - values[n]` です。\n"
 
 #: src/modules.md
 msgid "[Modules](./modules/modules.md) (5 minutes)"
-msgstr ""
+msgstr "[モジュール](./modules/modules.md)（5 分）"
 
 #: src/modules.md
 msgid "[Filesystem Hierarchy](./modules/filesystem.md) (5 minutes)"
-msgstr ""
+msgstr "[ファイル システム階層](./modules/filesystem.md)（5 分）"
 
 #: src/modules.md
 msgid "[Visibility](./modules/visibility.md) (5 minutes)"
-msgstr ""
+msgstr "[可視性](./modules/visibility.md)（5 分）"
 
 #: src/modules.md
 msgid "[use, super, self](./modules/paths.md) (10 minutes)"
-msgstr ""
+msgstr "[use、super、self](./modules/paths.md)（10 分）"
 
 #: src/modules.md
 msgid ""
 "[Exercise: Modules for a GUI Library](./modules/exercise.md) (15 minutes)"
-msgstr ""
+msgstr "[演習: GUI ライブラリのモジュール](./modules/exercise.md)（15 分）"
 
 #: src/modules.md
 msgid "This segment should take about 40 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 40 分です"
 
 #: src/modules/modules.md
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
 msgstr ""
+"`impl` ブロックで関数を型の名前空間に所属させる方法はすでに見てきました。"
 
 #: src/modules/modules.md
 msgid "Similarly, `mod` lets us namespace types and functions:"
-msgstr ""
+msgstr "同様に、`mod` を使用して型と関数の名前空間を指定できます。"
 
 #: src/modules/modules.md
 msgid "\"In the foo module\""
-msgstr ""
+msgstr "\"In the foo module\""
 
 #: src/modules/modules.md
 msgid "\"In the bar module\""
-msgstr ""
+msgstr "\"In the bar module\""
 
 #: src/modules/modules.md
 msgid ""
 "Packages provide functionality and include a `Cargo.toml` file that "
 "describes how to build a bundle of 1+ crates."
 msgstr ""
+"パッケージ(package)は機能を提供するものであり、一つ以上のクレートをビルドする"
+"方法を記述した`Cargo.toml` ファイルを含むものです。"
 
 #: src/modules/modules.md
 msgid ""
 "Crates are a tree of modules, where a binary crate creates an executable and "
 "a library crate compiles to a library."
 msgstr ""
+"バイナリクレートの場合は実行可能ファイルを生成し、ライブラリクレートの場合は"
+"ライブラリを生成します。"
 
 #: src/modules/modules.md
 msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
+"モジュールによって構成とスコープが定義されます。このセクションではモジュール"
+"に焦点を当てます。"
 
 #: src/modules/filesystem.md
 msgid ""
 "Omitting the module content will tell Rust to look for it in another file:"
 msgstr ""
+"モジュールの定義内容を省略すると、Rust はそれを別のファイルで探します。"
 
 #: src/modules/filesystem.md
 msgid ""
@@ -10164,18 +10227,21 @@ msgid ""
 "rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
 "vegetables.rs`."
 msgstr ""
+"これにより、`garden` モジュールの定義内容が `src/garden.rs` にあることを "
+"Rust に伝えます。同様に、`garden::vegetables` モジュールは `src/garden/"
+"vegetables.rs` にあります。"
 
 #: src/modules/filesystem.md
 msgid "The `crate` root is in:"
-msgstr ""
+msgstr "`crate` ルートは以下の場所にあります。"
 
 #: src/modules/filesystem.md
 msgid "`src/lib.rs` (for a library crate)"
-msgstr ""
+msgstr "`src/lib.rs`（ライブラリ クレートの場合）"
 
 #: src/modules/filesystem.md
 msgid "`src/main.rs` (for a binary crate)"
-msgstr ""
+msgstr "`src/main.rs`（バイナリ クレートの場合）"
 
 #: src/modules/filesystem.md
 msgid ""
@@ -10183,6 +10249,9 @@ msgid ""
 "comments\". These document the item that contains them -- in this case, a "
 "module."
 msgstr ""
+"ファイルで定義されたモジュールに対して、「内部ドキュメント用コメント」を使用"
+"して説明を加えることもできます。これらのコメントは、それが含まれるアイテム"
+"（この場合はモジュール）に対する説明になります。"
 
 #: src/modules/filesystem.md
 msgid ""
@@ -10190,124 +10259,150 @@ msgid ""
 "germination\n"
 "//! implementation.\n"
 msgstr ""
+"//! このモジュールは畑を実装します（パフォーマンスの高い発芽の\n"
+"//! 実装を含む）。\n"
 
 #: src/modules/filesystem.md
 msgid "// Re-export types from this module.\n"
-msgstr ""
+msgstr "// このモジュールから型を再エクスポートします。\n"
 
 #: src/modules/filesystem.md
 msgid "/// Sow the given seed packets.\n"
-msgstr ""
+msgstr "/// 指定された種をまきます。\n"
 
 #: src/modules/filesystem.md
 msgid "/// Harvest the produce in the garden that is ready.\n"
-msgstr ""
+msgstr "/// 十分に実っている畑で作物を収穫します。\n"
 
 #: src/modules/filesystem.md
 msgid ""
 "Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
 "`module.rs`, and this is still a working alternative for editions after 2018."
 msgstr ""
+"Rust 2018 より前では、モジュールを `module.rs` ではなく `module/mod.rs` に配"
+"置する必要がありました。これは 2018 以降のエディションでも依然としてサポート"
+"されています。"
 
 #: src/modules/filesystem.md
 msgid ""
 "The main reason to introduce `filename.rs` as alternative to `filename/mod."
 "rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
 msgstr ""
+"`filename/mod.rs` の代わりに `filename.rs` が導入された主な理由は、`mod.rs` "
+"という名前のファイルが多くあると、それらをIDEで区別するのが難しい場合があるか"
+"らです。"
 
 #: src/modules/filesystem.md
 msgid "Deeper nesting can use folders, even if the main module is a file:"
 msgstr ""
+"より深いネストでは、メイン モジュールがファイルであっても、フォルダを使用でき"
+"ます。"
 
 #: src/modules/filesystem.md
 msgid ""
 "The place rust will look for modules can be changed with a compiler "
 "directive:"
 msgstr ""
+"Rust がモジュールを検索する場所は、コンパイラ ディレクティブで変更できます。"
 
 #: src/modules/filesystem.md
 msgid "\"some/path.rs\""
-msgstr ""
+msgstr "\"some/path.rs\""
 
 #: src/modules/filesystem.md
 msgid ""
 "This is useful, for example, if you would like to place tests for a module "
 "in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
+"これは、たとえば Go でよく行われているように、`some_module_test.rs` という名"
+"前のファイルにモジュールのテストを配置する場合に便利です。"
 
 #: src/modules/visibility.md
 msgid "Modules are a privacy boundary:"
-msgstr ""
+msgstr "モジュールはプライバシーの境界です。"
 
 #: src/modules/visibility.md
 msgid "Module items are private by default (hides implementation details)."
 msgstr ""
+"モジュール アイテムはデフォルトでプライベートです（実装の詳細は表示されませ"
+"ん）。"
 
 #: src/modules/visibility.md
 msgid "Parent and sibling items are always visible."
-msgstr ""
+msgstr "親アイテムと兄弟アイテムは常に見えます。"
 
 #: src/modules/visibility.md
 msgid ""
 "In other words, if an item is visible in module `foo`, it's visible in all "
 "the descendants of `foo`."
 msgstr ""
+"言い換えれば、あるアイテムがモジュール `foo` から見える場合、そのアイテムは "
+"`foo` のすべての子孫から見えます。"
 
 #: src/modules/visibility.md
 msgid "\"outer::private\""
-msgstr ""
+msgstr "\"outer::private\""
 
 #: src/modules/visibility.md
 msgid "\"outer::public\""
-msgstr ""
+msgstr "\"outer::public\""
 
 #: src/modules/visibility.md
 msgid "\"outer::inner::private\""
-msgstr ""
+msgstr "\"outer::inner::private\""
 
 #: src/modules/visibility.md
 msgid "\"outer::inner::public\""
-msgstr ""
+msgstr "\"outer::inner::public\""
 
 #: src/modules/visibility.md
 msgid "Use the `pub` keyword to make modules public."
-msgstr ""
+msgstr "モジュールを公開するには `pub` キーワードを使用します。"
 
 #: src/modules/visibility.md
 msgid ""
 "Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
 "of public visibility."
 msgstr ""
+"また、高度な `pub(...)` 指定子を使用して、公開範囲を制限することもできます。"
 
 #: src/modules/visibility.md
 msgid ""
 "See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
 "privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
+"[Rust リファレンス](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself) をご覧ください。"
 
 #: src/modules/visibility.md
 msgid "Configuring `pub(crate)` visibility is a common pattern."
-msgstr ""
+msgstr "`pub(crate)` の可視性を設定するのは一般的なパターンです。"
 
 #: src/modules/visibility.md
 msgid "Less commonly, you can give visibility to a specific path."
 msgstr ""
+"それほど一般的ではありませんが、特定のパスに対して可視性を指定することが出来"
+"ます。"
 
 #: src/modules/visibility.md
 msgid ""
 "In any case, visibility must be granted to an ancestor module (and all of "
 "its descendants)."
 msgstr ""
+"どのような場合も、祖先モジュール（およびそのすべての子孫）に可視性を与える必"
+"要があります。"
 
 #: src/modules/paths.md
 msgid "use, super, self"
-msgstr ""
+msgstr "use、super、self"
 
 #: src/modules/paths.md
 msgid ""
 "A module can bring symbols from another module into scope with `use`. You "
 "will typically see something like this at the top of each module:"
 msgstr ""
+"モジュールは、`use` を使用して別のモジュールのシンボルをスコープに取り込むこ"
+"とができます。次のような記述はモジュールの先頭においてよく見られます。"
 
 #: src/modules/paths.md
 msgid "Paths"
@@ -10315,43 +10410,47 @@ msgstr "パス"
 
 #: src/modules/paths.md
 msgid "Paths are resolved as follows:"
-msgstr ""
+msgstr "パスは次のように解決されます。"
 
 #: src/modules/paths.md
 msgid "As a relative path:"
-msgstr ""
+msgstr "相対パスの場合:"
 
 #: src/modules/paths.md
 msgid "`foo` or `self::foo` refers to `foo` in the current module,"
-msgstr ""
+msgstr "`foo` または `self::foo` は、現在のモジュール内の `foo` を参照します。"
 
 #: src/modules/paths.md
 msgid "`super::foo` refers to `foo` in the parent module."
-msgstr ""
+msgstr "`super::foo` は、親モジュール内の `foo` を参照します。"
 
 #: src/modules/paths.md
 msgid "As an absolute path:"
-msgstr ""
+msgstr "絶対パスの場合:"
 
 #: src/modules/paths.md
 msgid "`crate::foo` refers to `foo` in the root of the current crate,"
-msgstr ""
+msgstr "`crate::foo` は、現在のクレートのルート内の `foo` を参照します。"
 
 #: src/modules/paths.md
 msgid "`bar::foo` refers to `foo` in the `bar` crate."
-msgstr ""
+msgstr "`bar::foo` は、`bar` クレート内の `foo` を参照します。"
 
 #: src/modules/paths.md
 msgid ""
 "It is common to \"re-export\" symbols at a shorter path. For example, the "
 "top-level `lib.rs` in a crate might have"
 msgstr ""
+"シンボルは、より短いパスで「再エクスポート」するのが一般的です。たとえば、ク"
+"レート内の最上位の `lib.rs` に、以下のように記述します。"
 
 #: src/modules/paths.md
 msgid ""
 "making `DiskStorage` and `NetworkStorage` available to other crates with a "
 "convenient, short path."
 msgstr ""
+"これにより、短く使いやすいパスを使用して、`DiskStorage` と `NetworkStorage` "
+"を他のクレートで使用できるようになります。"
 
 #: src/modules/paths.md
 msgid ""
@@ -10361,6 +10460,12 @@ msgid ""
 "`read_to_string` method on a type implementing the `Read` trait, you need to "
 "`use std::io::Read`."
 msgstr ""
+"ほとんどの場合、`use` を指定する必要があるのはモジュール内で実際に直接使用さ"
+"れるアイテムのみです。ただし、あるトレイトを実装する型がすでにスコープに含ま"
+"れている場合でも、そのトレイトのメソッドを呼び出すには、そのトレイトがスコー"
+"プに含まれている必要があります。たとえば、`Read` トレイトを実装する型で "
+"`read_to_string` メソッドを使用するには、`use std::io::Read` という記述が必要"
+"になります。"
 
 #: src/modules/paths.md
 msgid ""
@@ -10368,6 +10473,9 @@ msgid ""
 "discouraged because it is not clear which items are imported, and those "
 "might change over time."
 msgstr ""
+"`use` ステートメントには `use std::io::*` というようにワイルドカードを含める"
+"ことができます。この方法は、どのアイテムがインポートされるのかが明確ではな"
+"く、時間の経過とともに変化する可能性があるため、おすすめしません。"
 
 #: src/modules/exercise.md
 msgid ""
@@ -10375,12 +10483,17 @@ msgid ""
 "This library defines a `Widget` trait and a few implementations of that "
 "trait, as well as a `main` function."
 msgstr ""
+"この演習では、小規模な GUI ライブラリ実装を再編成します。このライブラリでは、"
+"`Widget` トレイト、そのトレイトのいくつかの実装、`main` 関数を定義していま"
+"す。"
 
 #: src/modules/exercise.md
 msgid ""
 "It is typical to put each type or set of closely-related types into its own "
 "module, so each widget type should get its own module."
 msgstr ""
+"通常は、各型または密接に関連する型のセットを個別のモジュールに配置するので、"
+"ウィジェット タイプごとに独自のモジュールを用意する必要があります。"
 
 #: src/modules/exercise.md
 #, fuzzy
@@ -10392,40 +10505,44 @@ msgid ""
 "The Rust playground only supports one file, so you will need to make a Cargo "
 "project on your local filesystem:"
 msgstr ""
+"Rust プレイグラウンドは 1 つのファイルしかサポートしていないため、ローカル "
+"ファイル システムで Cargo プロジェクトを作成する必要があります。"
 
 #: src/modules/exercise.md
 msgid ""
 "Edit the resulting `src/main.rs` to add `mod` statements, and add additional "
 "files in the `src` directory."
 msgstr ""
+"生成された `src/main.rs` を編集して `mod` ステートメントを追加し、`src` ディ"
+"レクトリにファイルを追加します。"
 
 #: src/modules/exercise.md
 msgid "Source"
-msgstr ""
+msgstr "ソース"
 
 #: src/modules/exercise.md
 msgid "Here's the single-module implementation of the GUI library:"
-msgstr ""
+msgstr "GUI ライブラリの単一モジュール実装は次のとおりです。"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "/// Natural width of `self`.\n"
-msgstr ""
+msgstr "/// `self` の自然な幅。\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "/// Draw the widget into a buffer.\n"
-msgstr ""
+msgstr "/// ウィジェットをバッファに描画します。\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "/// Draw the widget on standard output.\n"
-msgstr ""
+msgstr "/// ウィジェットを標準出力に描画します。\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"{buffer}\""
-msgstr ""
+msgstr "\"{buffer}\""
 
 #: src/modules/exercise.md
 msgid "// Add 4 paddings for borders\n"
-msgstr ""
+msgstr "// 枠線用に 4 つのパディングを追加します。\n"
 
 #: src/modules/exercise.md
 msgid ""
@@ -10433,51 +10550,54 @@ msgid ""
 "the\n"
 "        // ?-operator here instead of .unwrap().\n"
 msgstr ""
+"// TODO: Result<(), std::fmt::Error> を返すように draw_into を変更します。次"
+"に、.unwrap() の代わりに\n"
+"        // ? 演算子を使用します。\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"+-{:-<inner_width$}-+\""
-msgstr ""
+msgstr "\"+-{:-<inner_width$}-+\""
 
 #: src/modules/exercise.md src/modules/solution.md src/testing/unit-tests.md
 #: src/testing/solution.md
 msgid "\"\""
-msgstr ""
+msgstr "\"\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"| {:^inner_width$} |\""
-msgstr ""
+msgstr "\"| {:^inner_width$} |\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"+={:=<inner_width$}=+\""
-msgstr ""
+msgstr "\"+={:=<inner_width$}=+\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"| {:inner_width$} |\""
-msgstr ""
+msgstr "\"| {:inner_width$} |\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "// add a bit of padding\n"
-msgstr ""
+msgstr "// パディングを少し追加します。\n"
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"+{:-<width$}+\""
-msgstr ""
+msgstr "\"+{:-<width$}+\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"|{:^width$}|\""
-msgstr ""
+msgstr "\"|{:^width$}|\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"Rust GUI Demo 1.23\""
-msgstr ""
+msgstr "\"Rust GUI Demo 1.23\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"This is a small text GUI demo.\""
-msgstr ""
+msgstr "\"This is a small text GUI demo.\""
 
 #: src/modules/exercise.md src/modules/solution.md
 msgid "\"Click me!\""
-msgstr ""
+msgstr "\"Click me!\""
 
 #: src/modules/exercise.md
 msgid ""
@@ -10485,60 +10605,65 @@ msgid ""
 "and get accustomed to the required `mod`, `use`, and `pub` declarations. "
 "Afterward, discuss what organizations are most idiomatic."
 msgstr ""
+"自分にとって自然な方法でコードを分割し、必要な `mod`、`use`、`pub` 宣言に慣れ"
+"るよう受講者に促します。その後、どの構成が最も慣用的であるかについて話し合い"
+"ます。"
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets.rs ----\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets/label.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets/label.rs ----\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Label-width\n"
-msgstr ""
+msgstr "// ANCHOR_END: Label-width\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR: Label-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR: Label-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Label-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR_END: Label-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets/button.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets/button.rs ----\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Button-width\n"
-msgstr ""
+msgstr "// ANCHOR_END: Button-width\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR: Button-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR: Button-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Button-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR_END: Button-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/widgets/window.rs ----\n"
-msgstr ""
+msgstr "// ---- src/widgets/window.rs ----\n"
 
 #: src/modules/solution.md
 msgid ""
 "// ANCHOR_END: Window-width\n"
 "        // Add 4 paddings for borders\n"
 msgstr ""
+"// ANCHOR_END: Window-width\n"
+"        // 枠線に 4 つのパディングを追加します。\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR: Window-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR: Window-draw_into\n"
 
 #: src/modules/solution.md
 msgid "// ANCHOR_END: Window-draw_into\n"
-msgstr ""
+msgstr "// ANCHOR_END: Window-draw_into\n"
 
 #: src/modules/solution.md
 msgid ""
@@ -10546,38 +10671,42 @@ msgid ""
 "        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
 "        // the ?-operator here instead of .unwrap().\n"
 msgstr ""
+"// TODO: エラー処理について学習した後で、\n"
+"        // Result<(), std::fmt::Error> を返すように draw_into を変更できま"
+"す。次に、ここで\n"
+"        // .unwrap() の代わりに ? 演算子を使用します。\n"
 
 #: src/modules/solution.md
 msgid "// ---- src/main.rs ----\n"
-msgstr ""
+msgstr "// ---- src/main.rs ----\n"
 
 #: src/testing.md
 msgid "[Test Modules](./testing/unit-tests.md) (5 minutes)"
-msgstr ""
+msgstr "[テスト] モジュール(./testing/unit-tests.md)（5 分）"
 
 #: src/testing.md
 msgid "[Other Types of Tests](./testing/other.md) (10 minutes)"
-msgstr ""
+msgstr "[その他の種類のテスト](./testing/other.md)（10 分）"
 
 #: src/testing.md
 msgid "[Useful Crates](./testing/useful-crates.md) (3 minutes)"
-msgstr ""
+msgstr "[便利なクレート](./testing/useful-crates.md)（3 分）"
 
 #: src/testing.md
 msgid "[GoogleTest](./testing/googletest.md) (5 minutes)"
-msgstr ""
+msgstr "[GoogleTest](./testing/googletest.md)（5 分）"
 
 #: src/testing.md
 msgid "[Mocking](./testing/mocking.md) (5 minutes)"
-msgstr ""
+msgstr "[モック](./testing/mocking.md)（5 分）"
 
 #: src/testing.md
 msgid "[Compiler Lints and Clippy](./testing/lints.md) (5 minutes)"
-msgstr ""
+msgstr "[コンパイラの リント と Clippy](./testing/lints.md)（5 分）"
 
 #: src/testing.md
 msgid "[Exercise: Luhn Algorithm](./testing/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: Luhn アルゴリズム](./testing/exercise.md)（30 分）"
 
 #: src/testing/unit-tests.md
 msgid "Unit Tests"
@@ -10586,14 +10715,15 @@ msgstr "ユニットテスト"
 #: src/testing/unit-tests.md
 msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr ""
+"Rust と Cargo には、シンプルな単体テスト フレームワークが付属しています。"
 
 #: src/testing/unit-tests.md
 msgid "Unit tests are supported throughout your code."
-msgstr ""
+msgstr "単体テストはコードのあらゆる場所に記述可能です。"
 
 #: src/testing/unit-tests.md
 msgid "Integration tests are supported via the `tests/` directory."
-msgstr ""
+msgstr "統合テストは`tests/`ディレクトリ内に記述します。"
 
 #: src/testing/unit-tests.md
 msgid ""
@@ -10601,22 +10731,27 @@ msgid ""
 "`tests` module, using `#[cfg(test)]` to conditionally compile them only when "
 "building tests."
 msgstr ""
+"テストには `#[test]` のマークが付きます。多くの場合、単体テストは通常ネストさ"
+"れた`tests`モジュールに配置され、`#[cfg(test)]`によりテストのビルド時にのみコ"
+"ンパイルされるようになります。"
 
 #: src/testing/unit-tests.md
 msgid "\"Hello World\""
-msgstr ""
+msgstr "\"Hello World\""
 
 #: src/testing/unit-tests.md
 msgid "This lets you unit test private helpers."
-msgstr ""
+msgstr "これにより、プライベート ヘルパーの単体テストを行えます。"
 
 #: src/testing/unit-tests.md
 msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
+"`#[cfg(test)]` 属性が付与されたコードは `cargo test` の実行時にのみ有効になり"
+"ます。"
 
 #: src/testing/unit-tests.md
 msgid "Run the tests in the playground in order to show their results."
-msgstr ""
+msgstr "結果を表示するには、プレイグラウンドでテストを実行します。"
 
 #: src/testing/other.md
 msgid "Integration Tests"
@@ -10625,18 +10760,19 @@ msgstr "インテグレーションテスト"
 #: src/testing/other.md
 msgid "If you want to test your library as a client, use an integration test."
 msgstr ""
+"ライブラリをクライアントとしてテストする場合は、統合テストを使用します。"
 
 #: src/testing/other.md
 msgid "Create a `.rs` file under `tests/`:"
-msgstr ""
+msgstr "`tests/` の下に `.rs` ファイルを作成します。"
 
 #: src/testing/other.md
 msgid "// tests/my_library.rs\n"
-msgstr ""
+msgstr "// tests/my_library.rs\n"
 
 #: src/testing/other.md
 msgid "These tests only have access to the public API of your crate."
-msgstr ""
+msgstr "これらのテストでは、クレートの公開 API にのみアクセスできます。"
 
 #: src/testing/other.md
 msgid "Documentation Tests"
@@ -10644,7 +10780,7 @@ msgstr "ドキュメンテーションテスト"
 
 #: src/testing/other.md
 msgid "Rust has built-in support for documentation tests:"
-msgstr ""
+msgstr "Rust には、ドキュメントのテストに関する機能が組み込まれています。"
 
 #: src/testing/other.md
 msgid ""
@@ -10656,70 +10792,92 @@ msgid ""
 "/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
 "/// ```\n"
 msgstr ""
+"/// 指定した長さに文字列を短縮します。\n"
+"///\n"
+"/// ```\n"
+"/// # use playground::shorten_string;\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
+"/// ```\n"
 
 #: src/testing/other.md
 msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
+"`///` コメント内のコードブロックは、自動的に Rust コードとみなされます。"
 
 #: src/testing/other.md
 msgid "The code will be compiled and executed as part of `cargo test`."
-msgstr ""
+msgstr "コードは `cargo test` の一環としてコンパイルされ、実行されます。"
 
 #: src/testing/other.md
 msgid ""
 "Adding `#` in the code will hide it from the docs, but will still compile/"
 "run it."
 msgstr ""
+"コードに `#` を追加すると、ドキュメントには表示されなくなりますが、コンパイル"
+"と実行は引き続き行われます。"
 
 #: src/testing/other.md
 msgid ""
 "Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
+"[Rust プレイグラウンド](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
+"で上記のコードをテストします。"
 
 #: src/testing/useful-crates.md
 msgid "Rust comes with only basic support for writing tests."
-msgstr ""
+msgstr "Rust は、テストを作成するための基本的なサポートのみを提供します。"
 
 #: src/testing/useful-crates.md
 msgid "Here are some additional crates which we recommend for writing tests:"
-msgstr ""
+msgstr "テストを作成する際に推奨されるその他のクレートを以下に示します。"
 
 #: src/testing/useful-crates.md
 msgid ""
 "[googletest](https://docs.rs/googletest): Comprehensive test assertion "
 "library in the tradition of GoogleTest for C++."
 msgstr ""
+"[googletest](https://docs.rs/googletest): 従来の C++ 向け GoogleTestのような"
+"包括的なテスト アサーション ライブラリです。"
 
 #: src/testing/useful-crates.md
 msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
 msgstr ""
+"[proptest](https://docs.rs/proptest): Rust のプロパティ ベースのテストです。"
 
 #: src/testing/useful-crates.md
 msgid ""
 "[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
 "tests."
 msgstr ""
+"[rstest](https://docs.rs/rstest): フィクスチャとパラメータ化されたテストをサ"
+"ポートします。"
 
 #: src/testing/googletest.md
 msgid ""
 "The [GoogleTest](https://docs.rs/googletest/) crate allows for flexible test "
 "assertions using _matchers_:"
 msgstr ""
+"[GoogleTest](https://docs.rs/googletest/) クレートにより、マッチャーを使用し"
+"た柔軟なテスト アサーションが可能になります。"
 
 #: src/testing/googletest.md
 msgid "\"baz\""
-msgstr ""
+msgstr "\"baz\""
 
 #: src/testing/googletest.md
 msgid "\"xyz\""
-msgstr ""
+msgstr "\"xyz\""
 
 #: src/testing/googletest.md
 msgid ""
 "If we change the last element to `\"!\"`, the test fails with a structured "
 "error message pin-pointing the error:"
 msgstr ""
+"最後の要素を `\"!\"` に変更すると、テストは失敗し、エラー箇所を示す構造化され"
+"たエラー メッセージが表示されます。"
 
 #: src/testing/googletest.md
 msgid ""
@@ -10727,6 +10885,9 @@ msgid ""
 "example in a local environment. Use `cargo add googletest` to quickly add it "
 "to an existing Cargo project."
 msgstr ""
+"GoogleTest は Rust プレイグラウンドの一部ではないため、この例はローカル環境で"
+"実行する必要があります。`cargo add googletest` を使用して、既存の Cargo プロ"
+"ジェクトにすばやく追加します。"
 
 #: src/testing/googletest.md
 msgid ""
@@ -10734,16 +10895,20 @@ msgid ""
 "macros and types](https://docs.rs/googletest/latest/googletest/prelude/index."
 "html)."
 msgstr ""
+"`use googletest::prelude::*;` 行は、[一般的に使用されるマクロと型](https://"
+"docs.rs/googletest/latest/googletest/prelude/index.html)をインポートします。"
 
 #: src/testing/googletest.md
 msgid "This just scratches the surface, there are many builtin matchers."
 msgstr ""
+"ここで扱っているものはごく一部であり、他にも多くの組み込みマッチャーがありま"
+"す。"
 
 #: src/testing/googletest.md
 msgid ""
 "A particularly nice feature is that mismatches in multi-line strings strings "
 "are shown as a diff:"
-msgstr ""
+msgstr "特に便利なのは、複数行の文字列の不一致が差分として表示される機能です。"
 
 #: src/testing/googletest.md
 msgid ""
@@ -10751,6 +10916,9 @@ msgid ""
 "                 Rust's strong typing guides the way,\\n\\\n"
 "                 Secure code you'll write.\""
 msgstr ""
+"\"Memory safety found,\\n\\\n"
+"                 Rust's strong typing guides the way,\\n\\\n"
+"                 Secure code you'll write.\""
 
 #: src/testing/googletest.md
 msgid ""
@@ -10758,20 +10926,25 @@ msgid ""
 "            Rust's silly humor guides the way,\\n\\\n"
 "            Secure code you'll write.\""
 msgstr ""
+"\"Memory safety found,\\n\\\n"
+"            Rust's silly humor guides the way,\\n\\\n"
+"            Secure code you'll write.\""
 
 #: src/testing/googletest.md
 msgid "shows a color-coded diff (colors not shown here):"
-msgstr ""
+msgstr "これにより、差分が色分けされます（ここでは色分けされていません）。"
 
 #: src/testing/googletest.md
 msgid ""
 "The crate is a Rust port of [GoogleTest for C++](https://google.github.io/"
 "googletest/)."
 msgstr ""
+"このクレートは [GoogleTest for C++](https://google.github.io/googletest/) を"
+"Rustに移植したものです。"
 
 #: src/testing/googletest.md
 msgid "GoogleTest is available for use in AOSP."
-msgstr ""
+msgstr "GoogleTest は AOSP で使用できます。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10779,6 +10952,9 @@ msgid ""
 "You need to refactor your code to use traits, which you can then quickly "
 "mock:"
 msgstr ""
+"モックには、[Mockall](https://docs.rs/mockall/) というライブラリが広く使用さ"
+"れています。トレイトを使用するようにコードをリファクタリングする必要がありま"
+"す。これにより、すぐにモックできるようになります。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10788,6 +10964,11 @@ msgid ""
 "services. The other mocking libraries work in a similar fashion as Mockall, "
 "meaning that they make it easy to get a mock implementation of a given trait."
 msgstr ""
+"ここでは、Mockall が推奨モック ライブラリである Android（AOSP）向けのアドバイ"
+"スを行います。特に HTTP サービスのモックに関しては、[crates.io で他のモック "
+"ライブラリが公開されています](https://crates.io/keywords/mock)。他のモック ラ"
+"イブラリも Mockall と 同様で、特定のトレイトのモック実装を簡単に得ることがで"
+"きます。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10796,6 +10977,10 @@ msgid ""
 "more stable test execution. On the other hand, the mocks can be configured "
 "wrongly and return output different from what the real dependencies would do."
 msgstr ""
+"モックを使用する際は少し注意が必要です。モックを使用すると、テストを依存関係"
+"から完全に分離できます。その結果、より高速で安定したテスト実行が可能になりま"
+"す。一方、モックが誤って構成され、実際の依存関係の動作とは異なる出力が返され"
+"る可能性があります。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10804,6 +10989,9 @@ msgid ""
 "means that you get the correct behavior in your tests, plus they are fast "
 "and will automatically clean up after themselves."
 msgstr ""
+"可能な限り、実際の依存関係を使用することをおすすめします。たとえば、多くの"
+"データベースではインメモリ バックエンドを構成できます。つまり、テストで正しい"
+"動作が得られ、しかも高速で、テスト後は自動的にクリーンアップされます。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10811,6 +10999,10 @@ msgid ""
 "binds to a random port on `localhost`. Always prefer this over mocking away "
 "the framework since it helps you test your code in the real environment."
 msgstr ""
+"同様に、多くのウェブ フレームワークでは、`localhost` 上のランダムなポートにバ"
+"インドするプロセス内サーバーを起動できます。このような構成は実際の環境でコー"
+"ドをテストすることを可能にするので、フレームワークをモックすることよりも常に"
+"優先して利用しましょう。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10818,6 +11010,9 @@ msgid ""
 "in a local environment. Use `cargo add mockall` to quickly add Mockall to an "
 "existing Cargo project."
 msgstr ""
+"Mockall は Rust プレイグラウンドの一部ではないため、この例はローカル環境で実"
+"行する必要があります。`cargo add mockall` を使用して、Mockall を既存の Cargo "
+"プロジェクトにすばやく追加します。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10825,6 +11020,9 @@ msgid ""
 "expectations which depend on the arguments passed. Here we use this to mock "
 "a cat which becomes hungry 3 hours after the last time it was fed:"
 msgstr ""
+"Mockall にはさらに多くの機能があります。特に、渡される引数に応じて期待値を設"
+"定できます。ここでは、最後に餌を与えてらえてから 3 時間後に空腹になる猫をモッ"
+"クするためにこれを使用します。"
 
 #: src/testing/mocking.md
 msgid ""
@@ -10832,6 +11030,8 @@ msgid ""
 "called to `n` --- the mock will automatically panic when dropped if this "
 "isn't satisfied."
 msgstr ""
+"`.times(n)` を使用すると、モックメソッドが呼び出される回数を`n` に制限できま"
+"す。これが満たされない場合、モックはドロップ時に自動的にパニックになります。"
 
 #: src/testing/lints.md
 msgid ""
@@ -10839,10 +11039,13 @@ msgid ""
 "built-in lints. [Clippy](https://doc.rust-lang.org/clippy/) provides even "
 "more lints, organized into groups that can be enabled per-project."
 msgstr ""
+"Rust コンパイラは、読みやすいエラーおよびlintメッセージを生成します。[Clippy]"
+"(https://doc.rust-lang.org/clippy/) では、さらに多くの lint がグループにまと"
+"められており、プロジェクトごとに有効にできます。"
 
 #: src/testing/lints.md
 msgid "\"X probably fits in a u16, right? {}\""
-msgstr ""
+msgstr "\"X probably fits in a u16, right? {}\""
 
 #: src/testing/lints.md
 msgid ""
@@ -10850,6 +11053,9 @@ msgid ""
 "visible here, but those will not be shown once the code compiles. Switch to "
 "the Playground site to show those lints."
 msgstr ""
+"コードサンプルを実行してエラー メッセージを確認します。ここにも lint が表示さ"
+"れていますが、コードのコンパイルが一度コンパイル出来ると表示されなくなりま"
+"す。これらの lint を表示するには、プレイグラウンド サイトに切り替えます。"
 
 #: src/testing/lints.md
 msgid ""
@@ -10857,12 +11063,17 @@ msgid ""
 "clippy warnings. Clippy has extensive documentation of its lints, and adds "
 "new lints (including default-deny lints) all the time."
 msgstr ""
+"lint を解決した後、プレイグラウンド サイトで `clippy` を実行して、Clippy の警"
+"告を表示します。Clippy には、lint に関する広範なドキュメントがあり、新しい "
+"lint（デフォルトでエラーになるリント を含む）が常に追加されています。"
 
 #: src/testing/lints.md
 msgid ""
 "Note that errors or warnings with `help: ...` can be fixed with `cargo fix` "
 "or via your editor."
 msgstr ""
+"`help: ...` が付くエラーや警告は、`cargo fix` またはエディタを使用して修正で"
+"きます。"
 
 #: src/testing/exercise.md
 msgid "Luhn Algorithm"
@@ -10874,30 +11085,38 @@ msgid ""
 "to validate credit card numbers. The algorithm takes a string as input and "
 "does the following to validate the credit card number:"
 msgstr ""
+"[Luhn アルゴリズム](https://en.wikipedia.org/wiki/Luhn_algorithm) は、クレ"
+"ジット カード番号の検証に使用されます。このアルゴリズムは文字列を入力として受"
+"け取り、以下の処理を行ってクレジット カード番号を検証します。"
 
 #: src/testing/exercise.md
 msgid "Ignore all spaces. Reject number with less than two digits."
-msgstr ""
+msgstr "すべてのスペースを無視し、2 桁未満の番号を拒否します。"
 
 #: src/testing/exercise.md
 msgid ""
 "Moving from **right to left**, double every second digit: for the number "
 "`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
 msgstr ""
+"**右から左に**見ていきながら、それぞれ2桁目の数字を 2 倍にします。数値 "
+"`1234` の場合、`3` と `1` を 2 倍にします。数値 `98765` の場合、`6` と `8` "
+"を 2 倍にします。"
 
 #: src/testing/exercise.md
 msgid ""
 "After doubling a digit, sum the digits if the result is greater than 9. So "
 "doubling `7` becomes `14` which becomes `1 + 4 = 5`."
 msgstr ""
+"桁を 2 倍にした後、結果が 9 より大きい場合はその桁を合計します。したがって、"
+"`7` を 2 倍すると `14` になり、`1 + 4 = 5` になります。"
 
 #: src/testing/exercise.md
 msgid "Sum all the undoubled and doubled digits."
-msgstr ""
+msgstr "2 倍にしていない数字と 2 倍にした数字をすべて合計します。"
 
 #: src/testing/exercise.md
 msgid "The credit card number is valid if the sum ends with `0`."
-msgstr ""
+msgstr "クレジット カード番号は、合計が `0` で終わる場合に有効です。"
 
 #: src/testing/exercise.md
 msgid ""
@@ -10905,6 +11124,9 @@ msgid ""
 "along with two basic unit tests that confirm that most the algorithm is "
 "implemented correctly."
 msgstr ""
+"提供されているコードでは、luhn アルゴリズムのバグのある実装と、ほとんどのアル"
+"ゴリズムが正しく実装されていることを確認する 2 つの基本的な単体テストを提供し"
+"ています。"
 
 #: src/testing/exercise.md
 msgid ""
@@ -10912,193 +11134,212 @@ msgid ""
 "tests to uncover bugs in the provided implementation, fixing any bugs you "
 "find."
 msgstr ""
+"以下のコードを <https://play.rust-lang.org/> にコピーし、提供された実装のバグ"
+"を発見するための追加のテストを記述し、見つけたバグを修正してください。"
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4263 9826 4026 9299\""
-msgstr ""
+msgstr "\"4263 9826 4026 9299\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4539 3195 0343 6467\""
-msgstr ""
+msgstr "\"4539 3195 0343 6467\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"7992 7398 713\""
-msgstr ""
+msgstr "\"7992 7398 713\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4223 9826 4026 9299\""
-msgstr ""
+msgstr "\"4223 9826 4026 9299\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"4539 3195 0343 6476\""
-msgstr ""
+msgstr "\"4539 3195 0343 6476\""
 
 #: src/testing/exercise.md src/testing/solution.md
 msgid "\"8273 1232 7352 0569\""
-msgstr ""
+msgstr "\"8273 1232 7352 0569\""
 
 #: src/testing/solution.md
 msgid "// This is the buggy version that appears in the problem.\n"
-msgstr ""
+msgstr "// これは問題に記述されているバグのあるバージョンです。\n"
 
 #: src/testing/solution.md
 msgid "// This is the solution and passes all of the tests below.\n"
-msgstr ""
+msgstr "// これは解答で、以下のすべてのテストに合格します。\n"
 
 #: src/testing/solution.md
 msgid "\"1234 5678 1234 5670\""
-msgstr ""
+msgstr "\"1234 5678 1234 5670\""
 
 #: src/testing/solution.md
 msgid "\"Is {cc_number} a valid credit card number? {}\""
-msgstr ""
+msgstr "\"Is {cc_number} a valid credit card number? {}\""
 
 #: src/testing/solution.md
 msgid "\"yes\""
-msgstr ""
+msgstr "\"yes\""
 
 #: src/testing/solution.md
 msgid "\"no\""
-msgstr ""
+msgstr "\"no\""
 
 #: src/testing/solution.md
 msgid "\"foo 0 0\""
-msgstr ""
+msgstr "\"foo 0 0\""
 
 #: src/testing/solution.md
 msgid "\" \""
-msgstr ""
+msgstr "\" \""
 
 #: src/testing/solution.md
 msgid "\"  \""
-msgstr ""
+msgstr "\"  \""
 
 #: src/testing/solution.md
 msgid "\"    \""
-msgstr ""
+msgstr "\"    \""
 
 #: src/testing/solution.md
 msgid "\"0\""
-msgstr ""
+msgstr "\"0\""
 
 #: src/testing/solution.md
 msgid "\" 0 0 \""
-msgstr ""
+msgstr "\" 0 0 \""
 
 #: src/welcome-day-4-afternoon.md
 msgid "[Error Handling](./error-handling.md) (45 minutes)"
-msgstr ""
+msgstr "[エラー処理](./error-handling.md)（45 分）"
 
 #: src/welcome-day-4-afternoon.md
 msgid "[Unsafe Rust](./unsafe-rust.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[アンセーフRust](./unsafe-rust.md)（1 時間 5 分）"
 
 #: src/welcome-day-4-afternoon.md
 msgid "Including 10 minute breaks, this session should take about 2 hours"
-msgstr ""
+msgstr "このセッションの所要時間は、10 分間の休憩を入れて約 2 時間です。"
 
 #: src/error-handling.md
 msgid "[Panics](./error-handling/panics.md) (3 minutes)"
-msgstr ""
+msgstr "[パニック](./error-handling/panics.md)（3 分）"
 
 #: src/error-handling.md
 msgid "[Try Operator](./error-handling/try.md) (5 minutes)"
-msgstr ""
+msgstr "[try 演算子](./error-handling/try.md)（5 分）"
 
 #: src/error-handling.md
 msgid "[Try Conversions](./error-handling/try-conversions.md) (5 minutes)"
-msgstr ""
+msgstr "[try 変換](./error-handling/try-conversions.md)（5 分）"
 
 #: src/error-handling.md
 msgid "[Error Trait](./error-handling/error.md) (5 minutes)"
-msgstr ""
+msgstr "[エラートレイト](./error-handling/error.md)（5 分）"
 
 #: src/error-handling.md
 msgid ""
 "[thiserror and anyhow](./error-handling/thiserror-and-anyhow.md) (5 minutes)"
 msgstr ""
+"[thiserror と anyhow](./error-handling/thiserror-and-anyhow.md)（5 分）"
 
 #: src/error-handling.md
 msgid ""
 "[Exercise: Rewriting with Result](./error-handling/exercise.md) (20 minutes)"
 msgstr ""
+"[演習: Result を使用した書き換え](./error-handling/exercise.md)（20 分）"
 
 #: src/error-handling/panics.md
 msgid "Rust handles fatal errors with a \"panic\"."
-msgstr ""
+msgstr "Rust は「パニック」を使用して致命的なエラーを処理します。"
 
 #: src/error-handling/panics.md
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
-msgstr ""
+msgstr "実行時に致命的なエラーが発生すると、Rust はパニックをトリガーします。"
 
 #: src/error-handling/panics.md
 msgid "\"v[100]: {}\""
-msgstr ""
+msgstr "\"v[100]: {}\""
 
 #: src/error-handling/panics.md
 msgid "Panics are for unrecoverable and unexpected errors."
 msgstr ""
+"パニックは、回復不能なエラーや予期しないエラーに使用するためのものです。"
 
 #: src/error-handling/panics.md
 msgid "Panics are symptoms of bugs in the program."
-msgstr ""
+msgstr "パニックはプログラムにバグがあることの兆候です。"
 
 #: src/error-handling/panics.md
 msgid "Runtime failures like failed bounds checks can panic"
 msgstr ""
+"ランタイム エラー（境界チェックの失敗など）は、パニックになる場合があります。"
 
 #: src/error-handling/panics.md
 msgid "Assertions (such as `assert!`) panic on failure"
-msgstr ""
+msgstr "アサーション（`assert!` など）は失敗時にパニックになります。"
 
 #: src/error-handling/panics.md
 msgid "Purpose-specific panics can use the `panic!` macro."
 msgstr ""
+"特定の目的でパニックさせてあい場合には、`panic!` マクロを使用できます。"
 
 #: src/error-handling/panics.md
 msgid ""
 "A panic will \"unwind\" the stack, dropping values just as if the functions "
 "had returned."
 msgstr ""
+"パニックが発生すると、スタックが「アンワインド」され、関数がリターンされたか"
+"のように値がドロップされます。"
 
 #: src/error-handling/panics.md
 msgid ""
 "Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
+"クラッシュが許容されない場合は、パニックが発生しない API（`Vec::get` など）を"
+"使用します。"
 
 #: src/error-handling/panics.md
 msgid ""
 "By default, a panic will cause the stack to unwind. The unwinding can be "
 "caught:"
 msgstr ""
+"デフォルトでは、パニックが発生するとスタックはアンワインドされます。アンワイ"
+"ンドは以下のようにキャッチできます。"
 
 #: src/error-handling/panics.md
 msgid "\"No problem here!\""
-msgstr ""
+msgstr "\"No problem here!\""
 
 #: src/error-handling/panics.md
 msgid "\"{result:?}\""
-msgstr ""
+msgstr "\"{result:?}\""
 
 #: src/error-handling/panics.md
 msgid "\"oh no!\""
-msgstr ""
+msgstr "\"oh no!\""
 
 #: src/error-handling/panics.md
 msgid ""
 "Catching is unusual; do not attempt to implement exceptions with "
 "`catch_unwind`!"
 msgstr ""
+"キャッチは一般的ではないため、`catch_unwind` を使用して例外処理を実装しようと"
+"しないでください。"
 
 #: src/error-handling/panics.md
 msgid ""
 "This can be useful in servers which should keep running even if a single "
 "request crashes."
 msgstr ""
+"これは、1 つのリクエストがクラッシュした場合でも実行し続ける必要があるサー"
+"バーで有用です。"
 
 #: src/error-handling/panics.md
 msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
 msgstr ""
+"これは、`Cargo.toml` で `panic = 'abort'` が設定されている場合は機能しませ"
+"ん。"
 
 #: src/error-handling/try.md
 msgid ""
@@ -11107,41 +11348,48 @@ msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
 "turn the common"
 msgstr ""
+"connection-refused や file-not-found などのランタイム エラーは `Result` 型で"
+"処理されますが、すべての呼び出しでこの型を照合するのは面倒な場合があります。"
+"try 演算子 `?` は、呼び出し元にエラーを返すのに使用されます。これにより、一般"
+"的な以下のコードを、はるかにシンプルなコードに変換できます。"
 
 #: src/error-handling/try.md
 msgid "into the much simpler"
-msgstr ""
+msgstr "変換後のコード:"
 
 #: src/error-handling/try.md
 msgid "We can use this to simplify our error handling code:"
-msgstr ""
+msgstr "この演算子を使用することで、エラー処理コードを簡素化できます。"
 
 #: src/error-handling/try.md
 msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
-msgstr ""
+msgstr "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
 
 #: src/error-handling/try.md src/error-handling/try-conversions.md
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"config.dat\""
-msgstr ""
+msgstr "\"config.dat\""
 
 #: src/error-handling/try.md src/error-handling/try-conversions.md
 msgid "\"username or error: {username:?}\""
-msgstr ""
+msgstr "\"username or error: {username:?}\""
 
 #: src/error-handling/try.md
 msgid "Simplify the `read_username` function to use `?`."
-msgstr ""
+msgstr "? を使用して `read_username` 関数を簡素化します。"
 
 #: src/error-handling/try.md
 msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
+"`username` 変数は、`Ok(string)` または `Err(error)` のいずれかになります。"
 
 #: src/error-handling/try.md
 msgid ""
 "Use the `fs::write` call to test out the different scenarios: no file, empty "
 "file, file with username."
 msgstr ""
+"`fs::write` 呼び出しを使用して、さまざまなシナリオ（ファイルがない、空のファ"
+"イル、ユーザー名のあるファイルなど）をテストします。"
 
 #: src/error-handling/try.md
 msgid ""
@@ -11150,16 +11398,20 @@ msgid ""
 "The executable will print the `Err` variant and return a nonzero exit status "
 "on error."
 msgstr ""
+"なお、`main` は `std::process:Termination` を実装している限り、Result<(), "
+"E>` を返すことができます。つまり、実際には `E` が`Debug` を実装していることを"
+"意味します。この実行可能ファイルはエラー発生時にErrバリアントを出力し、ゼロ以"
+"外の終了ステータスを返します。"
 
 #: src/error-handling/try-conversions.md
 msgid ""
 "The effective expansion of `?` is a little more complicated than previously "
 "indicated:"
-msgstr ""
+msgstr "`?` を実際に展開すると、前述のコードよりも少し複雑なコードになります。"
 
 #: src/error-handling/try-conversions.md
 msgid "works the same as"
-msgstr ""
+msgstr "上のコードは、以下と同じように動作します。"
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11167,19 +11419,22 @@ msgid ""
 "type returned by the function. This makes it easy to encapsulate errors into "
 "higher-level errors."
 msgstr ""
+"ここでの `From::from` 呼び出しは、エラー型を関数が返す型に変換しようとしてい"
+"ることを意味します。これにより、エラーを上位レベルのエラーに簡単にカプセル化"
+"できます。"
 
 #: src/error-handling/try-conversions.md
 msgid "\"IO error: {e}\""
-msgstr ""
+msgstr "\"IO error: {e}\""
 
 #: src/error-handling/try-conversions.md
 msgid "\"Found no username in {path}\""
-msgstr ""
+msgstr "\"Found no username in {path}\""
 
 #: src/error-handling/try-conversions.md
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
-msgstr ""
+msgstr "//fs::write(\"config.dat\", \"\").unwrap();\n"
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11189,12 +11444,19 @@ msgid ""
 "of type `Result<U, ErrorInner>` if `ErrorOuter` and `ErrorInner` are the "
 "same type or if `ErrorOuter` implements `From<ErrorInner>`."
 msgstr ""
+"`?` 演算子は、関数の戻り値の型と互換性のある値を返す必要があります。つまり、"
+"`Result` の場合、エラー型に互換性がなければなりません。`Result<T, "
+"ErrorOuter>` を返す関数は、`ErrorOuter` と `ErrorInner` が同じ型であるか、"
+"`ErrorOuter` が `From<ErrorInner>` を実装している場合にのみ、型 `Result<U, "
+"ErrorInner>` の値に `?` を使用できます。"
 
 #: src/error-handling/try-conversions.md
 msgid ""
 "A common alternative to a `From` implementation is `Result::map_err`, "
 "especially when the conversion only happens in one place."
 msgstr ""
+"特に変換が 1 か所でのみ発生する場合は、`From` を実装する代わりに Result::"
+"map_err を使用するのが一般的です。"
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11202,6 +11464,8 @@ msgid ""
 "`Option<T>` can use the `?` operator on `Option<U>` for arbitrary `T` and "
 "`U` types."
 msgstr ""
+"`Option`には互換性の要件はありません。`Option<T>`を返す関数は、任意のT型とU型"
+"に対して、?演算子をOption<T>に適用できます。"
 
 #: src/error-handling/try-conversions.md
 msgid ""
@@ -11209,6 +11473,9 @@ msgid ""
 "However, `Option::ok_or` converts `Option` to `Result` whereas `Result::ok` "
 "turns `Result` into `Option`."
 msgstr ""
+"`Result` を返す関数では `Option` に `?` を使用できません。その逆も同様です。"
+"ただし、`Option::ok_or` は `Option` を `Result` に変換でき、`Result::ok` は "
+"`Result` を `Option` に変換できます。"
 
 #: src/error-handling/error.md
 msgid "Dynamic Error Types"
@@ -11221,28 +11488,34 @@ msgid ""
 "Error` trait makes it easy to create a trait object that can contain any "
 "error."
 msgstr ""
+"さまざまな可能性をカバーする独自の列挙型を記述することなく、あらゆる種類のエ"
+"ラーを返せるようにしたい場合があります。`std::error::Error` トレイトを使用す"
+"ると、あらゆるエラーを含めることができるトレイト オブジェクトを簡単に作成でき"
+"ます。"
 
 #: src/error-handling/error.md
 msgid "\"count.dat\""
-msgstr ""
+msgstr "\"count.dat\""
 
 #: src/error-handling/error.md
 msgid "\"1i3\""
-msgstr ""
+msgstr "\"1i3\""
 
 #: src/error-handling/error.md
 msgid "\"Count: {count}\""
-msgstr ""
+msgstr "\"Count: {count}\""
 
 #: src/error-handling/error.md
 msgid "\"Error: {err}\""
-msgstr ""
+msgstr "\"Error: {err}\""
 
 #: src/error-handling/error.md
 msgid ""
 "The `read_count` function can return `std::io::Error` (from file operations) "
 "or `std::num::ParseIntError` (from `String::parse`)."
 msgstr ""
+"`read_count` 関数は、`std::io::Error`（ファイル オペレーションから）または "
+"`std::num::ParseIntError`（`String::parse` から）を返すことができます。"
 
 #: src/error-handling/error.md
 msgid ""
@@ -11252,6 +11525,10 @@ msgid ""
 "can be a good option in a program where you just want to display the error "
 "message somewhere."
 msgstr ""
+"エラーをボックス化することでコードを節約できますが、プログラムで異なるエラー"
+"ケースを異なる方法で適切に処理する機能が失われます。そのため、ライブラリの公"
+"開 API で `Box<dyn Error>` を使用することは通常おすすめしませんが、エラー "
+"メッセージをどこかに表示したいだけのプログラムでは適切な選択肢となりえます。"
 
 #: src/error-handling/error.md
 msgid ""
@@ -11261,66 +11538,81 @@ msgid ""
 "compatible with `no_std` in [nightly](https://github.com/rust-lang/rust/"
 "issues/103765) only."
 msgstr ""
+"カスタムのエラー型を定義する際は、必ず `std::error::Error` トレイトを実装し、"
+"ボックス化できるようにしてください。ただし `no_std` 属性をサポートする必要が"
+"ある場合は、`std::error::Error` トレイトは現在、[ナイトリー](https://github."
+"com/rust-lang/rust/issues/103765) においてのみ`no_std`と互換性があることに注"
+"意してください。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "The [`thiserror`](https://docs.rs/thiserror/) and [`anyhow`](https://docs.rs/"
 "anyhow/) crates are widely used to simplify error handling."
 msgstr ""
+"[`thiserror`](https://docs.rs/thiserror/) クレートと [`anyhow`](https://docs."
+"rs/anyhow/) クレートは、エラー処理を簡素化するために広く使用されています。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "`thiserror` is often used in libraries to create custom error types that "
 "implement `From<T>`."
 msgstr ""
+"`thiserror`は、`From<T>` を実装するカスタムのエラー型を作成するためにライブラ"
+"リで頻繁に使用されます。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "`anyhow` is often used by applications to help with error handling in "
 "functions, including adding contextual information to your errors."
 msgstr ""
+"`anyhow` は、エラーにコンテキスト情報を追加するなど、関数内でのエラー処理のた"
+"めにアプリでよく使用されます。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Found no username in {0}\""
-msgstr ""
+msgstr "\"Found no username in {0}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Failed to open {path}\""
-msgstr ""
+msgstr "\"Failed to open {path}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Failed to read\""
-msgstr ""
+msgstr "\"Failed to read\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Username: {username}\""
-msgstr ""
+msgstr "\"Username: {username}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "\"Error: {err:?}\""
-msgstr ""
+msgstr "\"Error: {err:?}\""
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "`thiserror`"
-msgstr ""
+msgstr "`thiserror`"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "The `Error` derive macro is provided by `thiserror`, and has lots of useful "
 "attributes to help define error types in a compact way."
 msgstr ""
+"`Error` 導出マクロは `thiserror` によって提供されます。このマクロには、エラー"
+"型を簡潔に定義するのに役立つ属性が数多く用意されています。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "The `std::error::Error` trait is derived automatically."
-msgstr ""
+msgstr "`std::error::Error` トレイトは自動的に導出されます。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "The message from `#[error]` is used to derive the `Display` trait."
 msgstr ""
+"`#[error]` からのメッセージは、`Display` トレイトを導出するために使用されま"
+"す。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "`anyhow`"
-msgstr ""
+msgstr "`anyhow`"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
@@ -11328,15 +11620,18 @@ msgid ""
 "it's again generally not a good choice for the public API of a library, but "
 "is widely used in applications."
 msgstr ""
+"`anyhow::Error` は基本的に `Box<dyn Error>` のラッパーとなっています。そのた"
+"め、ライブラリの公開 API としては一般的には適していませんが、アプリでは広く使"
+"用されています。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
-msgstr ""
+msgstr "`anyhow::Result<V>` は `Result<V, anyhow::Error>` の型エイリアスです。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
 "Actual error type inside of it can be extracted for examination if necessary."
-msgstr ""
+msgstr "必要に応じて、内部の実際のエラー型を抽出して調べることができます。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
@@ -11344,6 +11639,9 @@ msgid ""
 "developers, as it provides similar usage patterns and ergonomics to `(T, "
 "error)` from Go."
 msgstr ""
+"`anyhow::Result<T>` が提供する機能は、Go の `(T, error)` と同様の使用パターン"
+"とエルゴノミクスを備えているため、Go デベロッパーにはなじみがあるかもしれませ"
+"ん。"
 
 #: src/error-handling/thiserror-and-anyhow.md
 msgid ""
@@ -11351,10 +11649,13 @@ msgid ""
 "`Option` types. `use anyhow::Context` is necessary to enable `.context()` "
 "and `.with_context()` on those types."
 msgstr ""
+"`anyhow::Context` は、標準の `Result` 型と `Option` 型に実装されたトレイトで"
+"す。これらの型で `.context()` と `.with_context()` を有効にするには、`use "
+"anyhow::Context` が必要です。"
 
 #: src/error-handling/exercise.md
 msgid "Exercise: Rewriting with Result"
-msgstr ""
+msgstr "演習: Result を使用した書き換え"
 
 #: src/error-handling/exercise.md
 msgid ""
@@ -11363,6 +11664,10 @@ msgid ""
 "error handling and propagate errors to a return from `main`. Feel free to "
 "use `thiserror` and `anyhow`."
 msgstr ""
+"ここでは、式を表す言語の非常にシンプルなパーサーを実装します。ただし、エラー"
+"に対してはパニックしています。代わりに慣用的なエラー処理を使用し、`main` から"
+"の戻り値にエラーを伝播するように書き換えてください。`thiserror` と `anyhow`を"
+"自由に使用してかまいません。"
 
 #: src/error-handling/exercise.md
 msgid ""
@@ -11370,170 +11675,178 @@ msgid ""
 "working correctly, update `Tokenizer` to implement "
 "`Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser."
 msgstr ""
+"ヒント: まず、`parse` 関数のエラー処理を修正します。それができたら"
+"`Iterator<Item=Result<Token, TokenizerError>>` を実装するように`Tokenizer` を"
+"更新し、その結果をパーサーで処理するようにしてください。"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// An arithmetic operator.\n"
-msgstr ""
+msgstr "/// 算術演算子。\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
-#, fuzzy
 msgid "/// A token in the expression language.\n"
-msgstr "// 他の言語と同様の演算\n"
+msgstr "/// 式言語のトークン\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// An expression in the expression language.\n"
-msgstr ""
+msgstr "/// 式言語の式\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A reference to a variable.\n"
-msgstr ""
+msgstr "/// 変数への参照。\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A literal number.\n"
-msgstr ""
+msgstr "/// リテラル数値。\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "/// A binary operation.\n"
-msgstr ""
+msgstr "/// バイナリ演算。\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'z'"
-msgstr ""
+msgstr "'z'"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'_'"
-msgstr ""
+msgstr "'_'"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'+'"
-msgstr ""
+msgstr "'+'"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'-'"
-msgstr ""
+msgstr "'-'"
 
 #: src/error-handling/exercise.md
 msgid "\"Unexpected character {c}\""
-msgstr ""
+msgstr "\"Unexpected character {c}\""
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"Unexpected end of input\""
-msgstr ""
+msgstr "\"Unexpected end of input\""
 
 #: src/error-handling/exercise.md
 msgid "\"Invalid 32-bit integer'\""
-msgstr ""
+msgstr "\"Invalid 32-bit integer'\""
 
 #: src/error-handling/exercise.md
 msgid "\"Unexpected token {tok:?}\""
-msgstr ""
+msgstr "\"Unexpected token {tok:?}\""
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "// Look ahead to parse a binary operation if present.\n"
-msgstr ""
+msgstr "// バイナリ演算が存在する場合はパースします。\n"
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"10+foo+20-30\""
-msgstr ""
+msgstr "\"10+foo+20-30\""
 
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "\"{expr:?}\""
-msgstr ""
+msgstr "\"{expr:?}\""
 
 #: src/error-handling/solution.md
 msgid "\"Unexpected character '{0}' in input\""
-msgstr ""
+msgstr "\"Unexpected character '{0}' in input\""
 
 #: src/error-handling/solution.md
 msgid "\"Tokenizer error: {0}\""
-msgstr ""
+msgstr "\"Tokenizer error: {0}\""
 
 #: src/error-handling/solution.md
 msgid "\"Unexpected token {0:?}\""
-msgstr ""
+msgstr "\"Unexpected token {0:?}\""
 
 #: src/error-handling/solution.md
 msgid "\"Invalid number\""
-msgstr ""
+msgstr "\"Invalid number\""
 
 #: src/unsafe-rust.md
 msgid "[Unsafe](./unsafe-rust/unsafe.md) (5 minutes)"
-msgstr ""
+msgstr "[アンセーフRust](./unsafe-rust/unsafe.md)（5 分）"
 
 #: src/unsafe-rust.md
 msgid ""
 "[Dereferencing Raw Pointers](./unsafe-rust/dereferencing.md) (10 minutes)"
-msgstr ""
+msgstr "[未加工ポインタの参照外し](./unsafe-rust/dereferencing.md)（10 分）"
 
 #: src/unsafe-rust.md
 msgid "[Mutable Static Variables](./unsafe-rust/mutable-static.md) (5 minutes)"
-msgstr ""
+msgstr "[可変の静的変数](./unsafe-rust/mutable-static.md)（5 分）"
 
 #: src/unsafe-rust.md
 msgid "[Unions](./unsafe-rust/unions.md) (5 minutes)"
-msgstr ""
+msgstr "[共用体](./unsafe-rust/unions.md)（5 分）"
 
 #: src/unsafe-rust.md
 msgid "[Unsafe Functions](./unsafe-rust/unsafe-functions.md) (5 minutes)"
-msgstr ""
+msgstr "[アンセーフな関数](./unsafe-rust/unsafe-functions.md)（5 分）"
 
 #: src/unsafe-rust.md
 msgid "[Unsafe Traits](./unsafe-rust/unsafe-traits.md) (5 minutes)"
-msgstr ""
+msgstr "[アンセーフなトレイト](./unsafe-rust/unsafe-traits.md)（5 分）"
 
 #: src/unsafe-rust.md
 msgid "[Exercise: FFI Wrapper](./unsafe-rust/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: FFI ラッパー](./unsafe-rust/exercise.md)（30 分）"
 
 #: src/unsafe-rust/unsafe.md
 msgid "The Rust language has two parts:"
-msgstr ""
+msgstr "Rust 言語は 2 つの部分で構成されています。"
 
 #: src/unsafe-rust/unsafe.md
 msgid "**Safe Rust:** memory safe, no undefined behavior possible."
-msgstr ""
+msgstr "**安全な Rust:** メモリセーフで、未定義の動作は起こりえません。"
 
 #: src/unsafe-rust/unsafe.md
 msgid ""
 "**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
+"**アンセーフRust:** 前提条件に違反した場合、未定義の動作がトリガーされる可能"
+"性があります。"
 
 #: src/unsafe-rust/unsafe.md
 msgid ""
 "We saw mostly safe Rust in this course, but it's important to know what "
 "Unsafe Rust is."
 msgstr ""
+"このコースでは主に安全な Rust を見てきましたが、安全でない Rust とは何かを理"
+"解しておくことが重要です。"
 
 #: src/unsafe-rust/unsafe.md
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
 "carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
+"アンセーフなコードは通常、小規模で分離されており、その正確性は慎重に文書化さ"
+"れている必要があります。通常は安全な抽象化レイヤでラップされています。"
 
 #: src/unsafe-rust/unsafe.md
 msgid "Unsafe Rust gives you access to five new capabilities:"
-msgstr ""
+msgstr "アンセーフRustでは、次の 5 つの新機能を利用できます。"
 
 #: src/unsafe-rust/unsafe.md
 msgid "Dereference raw pointers."
-msgstr ""
+msgstr "生ポインタの参照外し。"
 
 #: src/unsafe-rust/unsafe.md
 msgid "Access or modify mutable static variables."
-msgstr ""
+msgstr "可変の静的変数へのアクセスまたは変更。"
 
 #: src/unsafe-rust/unsafe.md
 msgid "Access `union` fields."
-msgstr ""
+msgstr "`union` フィールドへのアクセス。"
 
 #: src/unsafe-rust/unsafe.md
 msgid "Call `unsafe` functions, including `extern` functions."
-msgstr ""
+msgstr "`extern` 関数を含む `unsafe` 関数の呼び出し。"
 
 #: src/unsafe-rust/unsafe.md
 msgid "Implement `unsafe` traits."
-msgstr ""
+msgstr "`unsafe` トレイトの実装。"
 
 #: src/unsafe-rust/unsafe.md
 msgid ""
@@ -11541,6 +11854,9 @@ msgid ""
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
 "unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
+"次に、安全でない機能について簡単に説明します。詳しくは、[Rust Book の第 19.1 "
+"章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)と、"
+"[Rustonomicon](https://doc.rust-lang.org/nomicon/) をご覧ください。"
 
 #: src/unsafe-rust/unsafe.md
 msgid ""
@@ -11549,14 +11865,18 @@ msgid ""
 "by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
+"アンセーフRustは、コードが正しくないことを意味するものではありません。デベ"
+"ロッパーが一部のコンパイラ安全性機能をオフにし、自分で正しいコードを記述しな"
+"ければならないことを意味します。また、コンパイラがRustのメモリ安全性に関する"
+"ルールを強制しなくなるということを意味します。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
-msgstr ""
+msgstr "ポインタの作成は安全ですが、参照外しには `unsafe` が必要です。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"careful!\""
-msgstr ""
+msgstr "\"careful!\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
@@ -11567,18 +11887,23 @@ msgid ""
 "    // whole unsafe block, and they are not accessed either through the\n"
 "    // references or concurrently through any other pointers.\n"
 msgstr ""
+"// 次の理由により安全: r1 と r2 は参照から取得されており、\n"
+"    // 非 null で適切にアラインされていることが保証されています。\n"
+"    // 取得元である参照の基になるオブジェクトは、\n"
+"    // アンセーフブロック全体を通じて存続します。参照を介したアクセスや、\n"
+"    // 他のポインタを介した同時アクセスは行われません。\n"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"r1 is: {}\""
-msgstr ""
+msgstr "\"r1 is: {}\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"uhoh\""
-msgstr ""
+msgstr "\"uhoh\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid "\"r2 is: {}\""
-msgstr ""
+msgstr "\"r2 is: {}\""
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
@@ -11589,6 +11914,12 @@ msgid ""
 "    println!(\"r3 is: {}\", *r3);\n"
 "    */"
 msgstr ""
+"// 安全でないため、NOT SAFE。このような記述をしないでください。\n"
+"    /*\n"
+"    let r3: &String = unsafe { &*r1 };\n"
+"    drop(s);\n"
+"    println!(\"r3 is: {}\", *r3);\n"
+"    */"
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
@@ -11596,40 +11927,50 @@ msgid ""
 "a comment for each `unsafe` block explaining how the code inside it "
 "satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
+"`unsafe`ブロックごとにコメントを記述し、そのブロック内のコードが行うアンセー"
+"フな操作がどのように安全性要件を満たしているのかを記述することをおすすめしま"
+"す（Android Rust スタイルガイドでも必須とされています）。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
 "In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
+"ポインタ参照外しの場合、これはポインタが [_valid_](https://doc.rust-lang.org/"
+"std/ptr/index.html#safety) でなければならないことを意味します。つまり、次のよ"
+"うになります。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "The pointer must be non-null."
-msgstr ""
+msgstr "ポインタは null 以外でなければならないこと。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
 "The pointer must be _dereferenceable_ (within the bounds of a single "
 "allocated object)."
 msgstr ""
+"ポインタは、（割り当てられた単一のオブジェクトの境界内で）参照外し可能でなけ"
+"ればならない。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "The object must not have been deallocated."
-msgstr ""
+msgstr "オブジェクトが解放されていないこと。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "There must not be concurrent accesses to the same location."
-msgstr ""
+msgstr "同じロケーションに同時アクセスすることがないこと。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
 "If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
 msgstr ""
+"参照をキャストしてポインタを取得した場合、基になるオブジェクトが存続しなけれ"
+"ばならず、他のいかなる参照を通してもそのメモリにアクセスがないこと"
 
 #: src/unsafe-rust/dereferencing.md
 msgid "In most cases the pointer must also be properly aligned."
-msgstr ""
+msgstr "ほとんどの場合、ポインタも適切にアラインされる必要があります。"
 
 #: src/unsafe-rust/dereferencing.md
 msgid ""
@@ -11637,28 +11978,34 @@ msgid ""
 "has the `'static` lifetime, so `r3` has type `&'static String`, and thus "
 "outlives `s`. Creating a reference from a pointer requires _great care_."
 msgstr ""
+"\"NOT SAFE\"というコメントがあるところは、よくあるUBバグの例を示しています。"
+"`*r1` のライフタイムは `'static` であるため、`r3` の型は `&'static String` と"
+"なり、`s` より長く存続します。ポインタからの参照の作成には細心の注意が必要で"
+"す。"
 
 #: src/unsafe-rust/mutable-static.md
 msgid "It is safe to read an immutable static variable:"
-msgstr ""
+msgstr "不変の静的変数は安全に読み取ることができます。"
 
 #: src/unsafe-rust/mutable-static.md
 msgid "\"Hello, world!\""
-msgstr ""
+msgstr "\"Hello, world!\""
 
 #: src/unsafe-rust/mutable-static.md
 msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
-msgstr ""
+msgstr "\"HELLO_WORLD: {HELLO_WORLD}\""
 
 #: src/unsafe-rust/mutable-static.md
 msgid ""
 "However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
+"ただし、データ競合が発生する可能性があるため、可変静的変数の読み取りと書き込"
+"みは安全ではありません。"
 
 #: src/unsafe-rust/mutable-static.md
 msgid "\"COUNTER: {COUNTER}\""
-msgstr ""
+msgstr "\"COUNTER: {COUNTER}\""
 
 #: src/unsafe-rust/mutable-static.md
 msgid ""
@@ -11667,6 +12014,10 @@ msgid ""
 "`unsafe` and see how the compiler explains that it is undefined behavior to "
 "mutate a static from multiple threads."
 msgstr ""
+"このプログラムはシングルスレッドなので安全です。しかし、Rust コンパイラは保守"
+"的で、最悪の事態を想定します。`unsafe` を削除すると、複数のスレッドから静的変"
+"数を変更することは未定義の動作であることを説明するメッセージがコンパイラによ"
+"り表示されるはずです。"
 
 #: src/unsafe-rust/mutable-static.md
 msgid ""
@@ -11674,28 +12025,35 @@ msgid ""
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
 msgstr ""
+"一般的に、可変静的変数を使用することはおすすめしませんが、ヒープ アロケータの"
+"実装や一部の C API の操作など、低レベルの `no_std` コードでは適している場合も"
+"あります。"
 
 #: src/unsafe-rust/unions.md
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
+"共用体は列挙型に似ていますが、アクティブ フィールドを自分でトラッキングする必"
+"要があります。"
 
 #: src/unsafe-rust/unions.md
 msgid "\"int: {}\""
-msgstr ""
+msgstr "\"int: {}\""
 
 #: src/unsafe-rust/unions.md
 msgid "\"bool: {}\""
-msgstr ""
+msgstr "\"bool: {}\""
 
 #: src/unsafe-rust/unions.md
 msgid "// Undefined behavior!\n"
-msgstr ""
+msgstr "// 未定義の動作\n"
 
 #: src/unsafe-rust/unions.md
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
 msgstr ""
+"Rust では、通常は列挙型を使用できるため、共用体はほとんど必要ありません。共用"
+"体は、C ライブラリ API とのやり取りで必要になることがあります。"
 
 #: src/unsafe-rust/unions.md
 msgid ""
@@ -11704,6 +12062,10 @@ msgid ""
 "transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
 "crates/zerocopy) crate."
 msgstr ""
+"バイトを別の型として再解釈したい場合は、[`std::mem::transmute`](https://doc."
+"rust-lang.org/stable/std/mem/fn.transmute.html) か、[`zerocopy`](https://"
+"crates.io/crates/zerocopy) クレートのような安全なラッパーを使用することをおす"
+"すめします。"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "Calling Unsafe Functions"
@@ -11714,6 +12076,8 @@ msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
+"未定義の動作を回避するために満たす必要がある追加の前提条件がある関数またはメ"
+"ソッドは、`unsafe` とマークできます。"
 
 #: src/unsafe-rust/unsafe-functions.md src/unsafe-rust/exercise.md
 #: src/unsafe-rust/solution.md src/android/interoperability/with-c.md
@@ -11724,33 +12088,35 @@ msgstr ""
 #: src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
 msgid "\"C\""
-msgstr ""
+msgstr "\"C\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"🗻∈🌏\""
-msgstr ""
+msgstr "\"🗻∈🌏\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "// Safe because the indices are in the correct order, within the bounds of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
 msgstr ""
+"// インデックスが正しい順序で文字列スライスの境界内にあり、\n"
+"    // UTF-8 シーケンスの境界上にあるため、安全です。\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"emoji: {}\""
-msgstr ""
+msgstr "\"emoji: {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"char count: {}\""
-msgstr ""
+msgstr "\"char count: {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "// Undefined behavior if abs misbehaves.\n"
-msgstr ""
+msgstr "// abs 誤動作の場合の動作は未定義。\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"Absolute value of -3 according to C: {}\""
-msgstr ""
+msgstr "\"Absolute value of -3 according to C: {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
@@ -11759,6 +12125,10 @@ msgid ""
 "    // println!(\"char count: {}\", count_chars(unsafe {\n"
 "    // emojis.get_unchecked(0..3) }));\n"
 msgstr ""
+"// UTF-8 エンコード要件を満たさない場合、メモリの安全性が損なわれます。\n"
+"    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
+"    // println!(\"char count: {}\", count_chars(unsafe {\n"
+"    // emojis.get_unchecked(0..3) }));\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "Writing Unsafe Functions"
@@ -11769,6 +12139,8 @@ msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
 "conditions to avoid undefined behaviour."
 msgstr ""
+"未定義の動作を回避するために特定の条件が必要な場合は、独自の関数を `unsafe` "
+"とマークできます。"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
@@ -11778,14 +12150,19 @@ msgid ""
 "///\n"
 "/// The pointers must be valid and properly aligned.\n"
 msgstr ""
+"/// 指定されたポインタが指す値をスワップします。\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// ポインタが有効で、適切にアラインされている必要があります。\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "// Safe because ...\n"
-msgstr ""
+msgstr "// 安全です。理由は...\n"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid "\"a = {}, b = {}\""
-msgstr ""
+msgstr "\"a = {}, b = {}\""
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
@@ -11796,18 +12173,27 @@ msgid ""
 "might violate Rust's memory model, but in general any C function might have "
 "undefined behaviour under any arbitrary circumstances."
 msgstr ""
+"`get_unchecked` は多くの`_unchecked` 関数と同様に、範囲が正しくない場合に UB "
+"となる可能性があるため、安全ではありません。また、`abs`が安全でないのは、外部"
+"関数（FFI）であるからです。通常、外部関数の呼び出しが問題になるのポインタを使"
+"用してRustのメモリモデルに違反する処理を行う場合のみです。しかし、一般的に C "
+"関数には任意の状況下で未定義の動作が含まれる可能性があります。"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "The `\"C\"` in this example is the ABI; [other ABIs are available too]"
 "(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
+"この例の `\"C\"` は ABI です（[他の ABI も使用できます](https://doc.rust-"
+"lang.org/reference/items/external-blocks.html)）。"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
 "We wouldn't actually use pointers for a `swap` function - it can be done "
 "safely with references."
 msgstr ""
+"実際には、`swap` 関数ではポインタは使用しません。これは参照を使用することで安"
+"全に実行できます。"
 
 #: src/unsafe-rust/unsafe-functions.md
 msgid ""
@@ -11816,6 +12202,10 @@ msgid ""
 "Try adding it and see what happens. This will likely change in a future Rust "
 "edition."
 msgstr ""
+"アンセーフな関数内では、アンセーフなコードを`unsafe`ブロックなしに記述するこ"
+"とができます。これは `#[deny(unsafe_op_in_unsafe_fn)]` で禁止できます。追加す"
+"るとどうなるか見てみましょう。これは、今後の Rust エディションで変更される可"
+"能性があります。"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid "Implementing Unsafe Traits"
@@ -11826,12 +12216,16 @@ msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
 "must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
+"関数と同様に、未定義の動作を回避するために実装で特定の条件を保証する必要があ"
+"る場合は、トレイトを `unsafe` としてマークできます。"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "For example, the `zerocopy` crate has an unsafe trait that looks [something "
 "like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
+"たとえば、`zerocopy` クレートには [このような](https://docs.rs/zerocopy/"
+"latest/zerocopy/trait.AsBytes.html) 安全でないトレイトがあります。"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid ""
@@ -11839,26 +12233,31 @@ msgid ""
 "/// # Safety\n"
 "/// The type must have a defined representation and no padding.\n"
 msgstr ""
+"/// ...\n"
+"/// # Safety\n"
+"/// 型には定義された表現が必要で、パディングがあってはなりません。\n"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid "// Safe because u32 has a defined representation and no padding.\n"
-msgstr ""
+msgstr "// u32 には定義された表現があり、パディングがないため、安全です。\n"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
 msgstr ""
+"Rustdoc には、トレイトを安全に実装するための要件について説明した `# Safety` "
+"セクションが必要です。"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid ""
 "The actual safety section for `AsBytes` is rather longer and more "
 "complicated."
-msgstr ""
+msgstr "`AsBytes` の実際の安全性セクションはより長く、複雑です。"
 
 #: src/unsafe-rust/unsafe-traits.md
 msgid "The built-in `Send` and `Sync` traits are unsafe."
-msgstr ""
+msgstr "組み込みの `Send` トレイトと `Sync` トレイトはアンセーフです。"
 
 #: src/unsafe-rust/exercise.md
 msgid "Safe FFI Wrapper"
@@ -11870,22 +12269,25 @@ msgid ""
 "interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the names of files in a directory."
 msgstr ""
+"Rust は、外部関数インターフェース（FFI）を介した関数呼び出しを強力にサポート"
+"しています。これを使用して、ディレクトリ内のファイル名を読み取るために Cプロ"
+"グラムで使用する `libc` 関数の安全なラッパーを作成します。"
 
 #: src/unsafe-rust/exercise.md
 msgid "You will want to consult the manual pages:"
-msgstr ""
+msgstr "以下のマニュアル ページをご覧ください。"
 
 #: src/unsafe-rust/exercise.md
 msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
-msgstr ""
+msgstr "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
 
 #: src/unsafe-rust/exercise.md
 msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
-msgstr ""
+msgstr "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
 
 #: src/unsafe-rust/exercise.md
 msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
-msgstr ""
+msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
@@ -11893,114 +12295,136 @@ msgid ""
 "ffi/) module. There you find a number of string types which you need for the "
 "exercise:"
 msgstr ""
+"[`std::ffi`](https://doc.rust-lang.org/std/ffi/) モジュールも参照してくださ"
+"い。ここには、この演習で必要な文字列型が多数掲載されています。"
 
 #: src/unsafe-rust/exercise.md
 msgid "Encoding"
-msgstr ""
+msgstr "エンコード"
 
 #: src/unsafe-rust/exercise.md
 msgid "Use"
-msgstr ""
+msgstr "使う"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
 "(https://doc.rust-lang.org/std/string/struct.String.html)"
 msgstr ""
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) と [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
 
 #: src/unsafe-rust/exercise.md
 msgid "UTF-8"
-msgstr ""
+msgstr "UTF-8"
 
 #: src/unsafe-rust/exercise.md
 msgid "Text processing in Rust"
-msgstr ""
+msgstr "Rust でのテキスト処理"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
 "(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 msgstr ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) と [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
 
 #: src/unsafe-rust/exercise.md
 msgid "NUL-terminated"
-msgstr ""
+msgstr "NUL終端文字列"
 
 #: src/unsafe-rust/exercise.md
 msgid "Communicating with C functions"
-msgstr ""
+msgstr "C 関数との通信"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
 "[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
 msgstr ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) と "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
 
 #: src/unsafe-rust/exercise.md
 msgid "OS-specific"
-msgstr ""
+msgstr "OS 固有"
 
 #: src/unsafe-rust/exercise.md
 msgid "Communicating with the OS"
-msgstr ""
+msgstr "OS との通信"
 
 #: src/unsafe-rust/exercise.md
 msgid "You will convert between all these types:"
-msgstr ""
+msgstr "以下のすべての型間で変換を行います。"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "`&str` to `CString`: you need to allocate space for a trailing `\\0` "
 "character,"
 msgstr ""
+"`&str` から `CString`: 末尾の `\\0` 文字にも領域を割り当てる必要があります。"
 
 #: src/unsafe-rust/exercise.md
 msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
-msgstr ""
+msgstr "`CString` から `*const i8`: C 関数を呼び出すためのポインタが必要です。"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
 "character,"
 msgstr ""
+"`*const i8` から `&CStr`: 末尾の `\\0` 文字を検出できるものが必要です。"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
 "unknown data\","
 msgstr ""
+"`&CStr` から `&[u8]`: バイトのスライスは「不明なデータ」用の汎用的な インター"
+"フェースです。"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
 "(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
 msgstr ""
+"`&[u8]` から `&OsStr`: `&OsStr` は `OsString` に変換するための中間ステップで"
+"あり、[`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
+"html) を使用して作成します。"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
 "return it and call `readdir` again."
 msgstr ""
+"`&OsStr`内のデータを返し、さらに再びreaddirを呼び出せるようにするためには"
+"`&OsStr`内のデータをクローンする必要があります。"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
 "useful chapter about FFI."
 msgstr ""
+"[Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) にも、FFI に関する有益"
+"な章があります。"
 
 #: src/unsafe-rust/exercise.md
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
+"以下のコードを <https://play.rust-lang.org/> にコピーし、不足している関数とメ"
+"ソッドを記入します。"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"macos\""
-msgstr ""
+msgstr "\"macos\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
 msgstr ""
+"// オペーク型。https://doc.rust-lang.org/nomicon/ffi.html をご覧ください。\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
@@ -12008,14 +12432,18 @@ msgid ""
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
 msgstr ""
+"// readdir(3) の Linux マニュアル ページに沿ったレイアウト。ino_t と\n"
+"    // off_t は\n"
+"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h} の定義に"
+"従って解決されます。\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Layout according to the macOS man page for dir(5).\n"
-msgstr ""
+msgstr "// macOSマニュアル ページのdir(5)に沿ったレイアウト。\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"x86_64\""
-msgstr ""
+msgstr "\"x86_64\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
@@ -12027,105 +12455,120 @@ msgid ""
 "        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
 "PowerPC.\n"
 msgstr ""
+"// https://github.com/rust-lang/libc/issues/414、および  macOS 版マニュアル "
+"ページのstat(2)における\n"
+"        // _DARWIN_FEATURE_64_BIT_INODE に関するセクションをご覧ください。\n"
+"        //\n"
+"        // 「これらのアップデートが利用可能になる前に存在していたプラット"
+"フォーム(\"Platforms that existed before these updates were available\")」と"
+"は、\n"
+"        // Intel および PowerPC 上の macOS（iOS / wearOS などではない）を指し"
+"ます。\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"readdir$INODE64\""
-msgstr ""
+msgstr "\"readdir$INODE64\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid ""
 "// Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
 msgstr ""
+"// opendir を呼び出し、成功した場合は Ok 値を返し、\n"
+"        // それ以外の場合はメッセージとともに Err を返します。\n"
 
 #: src/unsafe-rust/exercise.md
 msgid "// Keep calling readdir until we get a NULL pointer back.\n"
-msgstr ""
+msgstr "// NULL ポインタが返されるまで readdir を呼び出し続けます。\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "// Call closedir as needed.\n"
-msgstr ""
+msgstr "// 必要に応じて closedir を呼び出します。\n"
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 #: src/android/interoperability/with-c/rust.md
 msgid "\".\""
-msgstr ""
+msgstr "\".\""
 
 #: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
 msgid "\"files: {:#?}\""
-msgstr ""
+msgstr "\"files: {:#?}\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"Invalid path: {err}\""
-msgstr ""
+msgstr "\"Invalid path: {err}\""
 
 #: src/unsafe-rust/solution.md
 msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
-msgstr ""
+msgstr "// SAFETY: path.as_ptr()がNULLであることはありません。\n"
 
 #: src/unsafe-rust/solution.md
 msgid "\"Could not open {:?}\""
-msgstr ""
+msgstr "\"Could not open {:?}\""
 
 #: src/unsafe-rust/solution.md
 msgid ""
 "// Keep calling readdir until we get a NULL pointer back.\n"
 "        // SAFETY: self.dir is never NULL.\n"
 msgstr ""
+"// NULL ポインタが返されるまで readdir を呼び出し続けます。\n"
+"        // SAFETY: self.dir は決して NULL になりません。\n"
 
 #: src/unsafe-rust/solution.md
 msgid "// We have reached the end of the directory.\n"
-msgstr ""
+msgstr "// ディレクトリの最後に到達しました。\n"
 
 #: src/unsafe-rust/solution.md
 msgid ""
 "// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
 "        // terminated.\n"
 msgstr ""
+"// 安全: dirent は NULL ではなく、dirent.d_name は NUL\n"
+"        // 文字終端されています。\n"
 
 #: src/unsafe-rust/solution.md
 msgid "// SAFETY: self.dir is not NULL.\n"
-msgstr ""
+msgstr "// 安全: self.dir は NULL ではありません。\n"
 
 #: src/unsafe-rust/solution.md
 msgid "\"Could not close {:?}\""
-msgstr ""
+msgstr "\"Could not close {:?}\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"no-such-directory\""
-msgstr ""
+msgstr "\"no-such-directory\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"Non UTF-8 character in path\""
-msgstr ""
+msgstr "\"Non UTF-8 character in path\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"..\""
-msgstr ""
+msgstr "\"..\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"foo.txt\""
-msgstr ""
+msgstr "\"foo.txt\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"The Foo Diaries\\n\""
-msgstr ""
+msgstr "\"The Foo Diaries\\n\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"bar.png\""
-msgstr ""
+msgstr "\"bar.png\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"<PNG>\\n\""
-msgstr ""
+msgstr "\"<PNG>\\n\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"crab.rs\""
-msgstr ""
+msgstr "\"crab.rs\""
 
 #: src/unsafe-rust/solution.md
 msgid "\"//! Crab\\n\""
-msgstr ""
+msgstr "\"//! Crab\\n\""
 
 #: src/android.md
 msgid "Welcome to Rust in Android"

--- a/po/ja.po
+++ b/po/ja.po
@@ -14,7 +14,7 @@ msgstr ""
 
 #: src/SUMMARY.md src/index.md
 msgid "Welcome to Comprehensive Rust 🦀"
-msgstr ""
+msgstr "Comprehensive Rust 🦀 へようこそ"
 
 #: src/SUMMARY.md src/running-the-course.md
 msgid "Running the Course"
@@ -22,11 +22,11 @@ msgstr "講座の運営について"
 
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 msgid "Course Structure"
-msgstr ""
+msgstr "講座の構成"
 
 #: src/SUMMARY.md src/running-the-course/keyboard-shortcuts.md
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "キーボード ショートカット"
 
 #: src/SUMMARY.md src/running-the-course/translations.md
 msgid "Translations"
@@ -34,15 +34,15 @@ msgstr "翻訳"
 
 #: src/SUMMARY.md src/cargo.md
 msgid "Using Cargo"
-msgstr ""
+msgstr "Cargoの使用"
 
 #: src/SUMMARY.md
 msgid "Rust Ecosystem"
-msgstr ""
+msgstr "Rust エコシステム"
 
 #: src/SUMMARY.md
 msgid "Code Samples"
-msgstr ""
+msgstr "コードサンプル"
 
 #: src/SUMMARY.md
 msgid "Running Cargo Locally"
@@ -54,11 +54,11 @@ msgstr "Day 1： AM"
 
 #: src/SUMMARY.md
 msgid "Welcome"
-msgstr "Welcome"
+msgstr "ようこそ"
 
 #: src/SUMMARY.md src/hello-world.md src/hello-world/hello-world.md
 msgid "Hello, World"
-msgstr ""
+msgstr "Hello, World"
 
 #: src/SUMMARY.md src/hello-world/what-is-rust.md
 msgid "What is Rust?"
@@ -66,15 +66,15 @@ msgstr "Rustとは？"
 
 #: src/SUMMARY.md src/hello-world/benefits.md
 msgid "Benefits of Rust"
-msgstr ""
+msgstr "Rustのメリット"
 
 #: src/SUMMARY.md src/hello-world/playground.md
 msgid "Playground"
-msgstr ""
+msgstr "プレイグラウンド"
 
 #: src/SUMMARY.md src/types-and-values.md
 msgid "Types and Values"
-msgstr ""
+msgstr "型と値"
 
 #: src/SUMMARY.md src/types-and-values/variables.md
 msgid "Variables"
@@ -82,15 +82,15 @@ msgstr "変数"
 
 #: src/SUMMARY.md src/types-and-values/values.md
 msgid "Values"
-msgstr ""
+msgstr "値"
 
 #: src/SUMMARY.md src/types-and-values/arithmetic.md
 msgid "Arithmetic"
-msgstr ""
+msgstr "算術"
 
 #: src/SUMMARY.md src/types-and-values/strings.md
 msgid "Strings"
-msgstr ""
+msgstr "文字列"
 
 #: src/SUMMARY.md src/types-and-values/inference.md
 msgid "Type Inference"
@@ -98,7 +98,7 @@ msgstr "型推論"
 
 #: src/SUMMARY.md src/types-and-values/exercise.md
 msgid "Exercise: Fibonacci"
-msgstr ""
+msgstr "演習: フィボナッチ"
 
 #: src/SUMMARY.md src/types-and-values/solution.md
 #: src/control-flow-basics/solution.md src/tuples-and-arrays/solution.md
@@ -110,22 +110,20 @@ msgstr ""
 #: src/slices-and-lifetimes/solution.md src/iterators/solution.md
 #: src/modules/solution.md src/testing/solution.md
 #: src/error-handling/solution.md src/unsafe-rust/solution.md
-#, fuzzy
 msgid "Solution"
 msgstr "解答"
 
 #: src/SUMMARY.md src/control-flow-basics.md
-#, fuzzy
 msgid "Control Flow Basics"
-msgstr "制御フロー"
+msgstr "制御フローの基本"
 
 #: src/SUMMARY.md src/control-flow-basics/conditionals.md
 msgid "Conditionals"
-msgstr ""
+msgstr "条件文"
 
 #: src/SUMMARY.md src/control-flow-basics/loops.md
 msgid "Loops"
-msgstr ""
+msgstr "ループ"
 
 #: src/SUMMARY.md src/control-flow-basics/break-continue.md
 msgid "`break` and `continue`"
@@ -133,7 +131,7 @@ msgstr "`break` と `continue`"
 
 #: src/SUMMARY.md src/control-flow-basics/blocks-and-scopes.md
 msgid "Blocks and Scopes"
-msgstr ""
+msgstr "ブロックとスコープ"
 
 #: src/SUMMARY.md src/control-flow-basics/functions.md
 msgid "Functions"
@@ -141,11 +139,11 @@ msgstr "関数"
 
 #: src/SUMMARY.md src/control-flow-basics/macros.md
 msgid "Macros"
-msgstr ""
+msgstr "マクロ"
 
 #: src/SUMMARY.md src/control-flow-basics/exercise.md
 msgid "Exercise: Collatz Sequence"
-msgstr ""
+msgstr "演習: コラッツ数列"
 
 #: src/SUMMARY.md
 msgid "Day 1: Afternoon"
@@ -154,12 +152,11 @@ msgstr "Day 1： PM"
 #: src/SUMMARY.md src/tuples-and-arrays.md
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Tuples and Arrays"
-msgstr ""
+msgstr "タプルと配列"
 
 #: src/SUMMARY.md src/tuples-and-arrays/iteration.md
-#, fuzzy
 msgid "Array Iteration"
-msgstr "Cargoとのインテグレーション"
+msgstr "配列のイテレート"
 
 #: src/SUMMARY.md src/tuples-and-arrays/match.md src/pattern-matching.md
 msgid "Pattern Matching"
@@ -173,27 +170,27 @@ msgstr "列挙型編"
 
 #: src/SUMMARY.md src/tuples-and-arrays/exercise.md
 msgid "Exercise: Nested Arrays"
-msgstr ""
+msgstr "演習: ネストされた配列"
 
 #: src/SUMMARY.md src/references.md
 msgid "References"
-msgstr ""
+msgstr "参照"
 
 #: src/SUMMARY.md src/references/shared.md
 msgid "Shared References"
-msgstr ""
+msgstr "共有参照"
 
 #: src/SUMMARY.md src/references/exclusive.md
 msgid "Exclusive References"
-msgstr ""
+msgstr "排他参照"
 
 #: src/SUMMARY.md src/references/exercise.md
 msgid "Exercise: Geometry"
-msgstr ""
+msgstr "演習: ジオメトリ"
 
 #: src/SUMMARY.md src/user-defined-types.md
 msgid "User-Defined Types"
-msgstr ""
+msgstr "ユーザー定義型"
 
 #: src/SUMMARY.md src/user-defined-types/named-structs.md
 #, fuzzy
@@ -210,17 +207,16 @@ msgid "Enums"
 msgstr "列挙型（enums）"
 
 #: src/SUMMARY.md src/user-defined-types/static-and-const.md
-#, fuzzy
 msgid "Static and Const"
-msgstr "static & const"
+msgstr ""
 
 #: src/SUMMARY.md src/user-defined-types/aliases.md
 msgid "Type Aliases"
-msgstr ""
+msgstr "型エイリアス"
 
 #: src/SUMMARY.md src/user-defined-types/exercise.md
 msgid "Exercise: Elevator Events"
-msgstr ""
+msgstr "演習: エレベーターでのイベント"
 
 #: src/SUMMARY.md
 msgid "Day 2: Morning"
@@ -233,12 +229,11 @@ msgstr "制御フロー"
 
 #: src/SUMMARY.md src/pattern-matching/exercise.md
 msgid "Exercise: Expression Evaluation"
-msgstr ""
+msgstr "演習: 式の評価"
 
 #: src/SUMMARY.md src/methods-and-traits.md
-#, fuzzy
 msgid "Methods and Traits"
-msgstr "ReadとWrite"
+msgstr ""
 
 #: src/SUMMARY.md src/methods-and-traits/methods.md
 msgid "Methods"
@@ -258,9 +253,8 @@ msgid "Trait Objects"
 msgstr "トレイトオブジェクト"
 
 #: src/SUMMARY.md src/methods-and-traits/exercise.md
-#, fuzzy
 msgid "Exercise: Generic Logger"
-msgstr "練習問題"
+msgstr "演習: ジェネリックなロガー"
 
 #: src/SUMMARY.md src/generics.md
 msgid "Generics"
@@ -281,11 +275,11 @@ msgstr "トレイト制約"
 
 #: src/SUMMARY.md src/generics/impl-trait.md
 msgid "`impl Trait`"
-msgstr ""
+msgstr "`impl Trait`"
 
 #: src/SUMMARY.md src/generics/exercise.md
 msgid "Exercise: Generic `min`"
-msgstr ""
+msgstr "演習: ジェネリックな `min`"
 
 #: src/SUMMARY.md
 msgid "Day 2: Afternoon"
@@ -301,35 +295,32 @@ msgid "Standard Library"
 msgstr "標準ライブラリ"
 
 #: src/SUMMARY.md src/std-types/docs.md
-#, fuzzy
 msgid "Documentation"
-msgstr "ドキュメンテーションテスト"
+msgstr "ドキュメント"
 
 #: src/SUMMARY.md
 msgid "`Option`"
-msgstr ""
+msgstr "`Option`"
 
 #: src/SUMMARY.md
 msgid "`Result`"
-msgstr ""
+msgstr "`Result`"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`String`"
-msgstr "文字列（String）"
+msgstr "`String`"
 
 #: src/SUMMARY.md src/std-types/vec.md
 msgid "`Vec`"
-msgstr ""
+msgstr "`Vec`"
 
 #: src/SUMMARY.md src/std-types/hashmap.md src/bare-metal/no_std.md
 msgid "`HashMap`"
-msgstr ""
+msgstr "`HashMap`"
 
 #: src/SUMMARY.md src/std-types/exercise.md
-#, fuzzy
 msgid "Exercise: Counter"
-msgstr "練習問題"
+msgstr "演習: カウンター"
 
 #: src/SUMMARY.md src/std-traits.md
 #, fuzzy
@@ -343,11 +334,11 @@ msgstr "他の言語との比較"
 #: src/SUMMARY.md src/std-traits/operators.md
 #, fuzzy
 msgid "Operators"
-msgstr "Iterator"
+msgstr "イテレータ"
 
 #: src/SUMMARY.md src/std-traits/from-and-into.md
 msgid "`From` and `Into`"
-msgstr ""
+msgstr "`From` と `Into`"
 
 #: src/SUMMARY.md src/std-traits/casting.md
 #, fuzzy
@@ -356,20 +347,19 @@ msgstr "テスト"
 
 #: src/SUMMARY.md src/std-traits/read-and-write.md
 msgid "`Read` and `Write`"
-msgstr ""
+msgstr "`Read` と `Write`"
 
 #: src/SUMMARY.md
 msgid "`Default`, struct update syntax"
-msgstr ""
+msgstr "`Default`、構造体更新記法"
 
 #: src/SUMMARY.md src/std-traits/closures.md
 msgid "Closures"
-msgstr ""
+msgstr "クロージャ"
 
 #: src/SUMMARY.md src/std-traits/exercise.md
-#, fuzzy
 msgid "Exercise: ROT13"
-msgstr "練習問題"
+msgstr "演習: ROT13暗号"
 
 #: src/SUMMARY.md
 msgid "Day 3: Morning"
@@ -381,7 +371,7 @@ msgstr "メモリ管理"
 
 #: src/SUMMARY.md src/memory-management/review.md
 msgid "Review of Program Memory"
-msgstr ""
+msgstr "プログラム メモリの見直し"
 
 #: src/SUMMARY.md src/memory-management/approaches.md
 #, fuzzy
@@ -398,37 +388,36 @@ msgstr "ムーブセマンティクス"
 
 #: src/SUMMARY.md
 msgid "`Clone`"
-msgstr ""
+msgstr "`Clone`"
 
 #: src/SUMMARY.md src/memory-management/copy-types.md
 msgid "Copy Types"
-msgstr ""
+msgstr "Copy 型"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "`Drop`"
-msgstr "Drop"
+msgstr "`Drop`"
 
 #: src/SUMMARY.md src/memory-management/exercise.md
 msgid "Exercise: Builder Type"
-msgstr ""
+msgstr "演習: ビルダー型"
 
 #: src/SUMMARY.md src/smart-pointers.md
 msgid "Smart Pointers"
-msgstr ""
+msgstr "スマートポインタ"
 
 #: src/SUMMARY.md src/smart-pointers/box.md
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`Box<T>`"
-msgstr ""
+msgstr "`Box<T>`"
 
 #: src/SUMMARY.md src/smart-pointers/rc.md
 msgid "`Rc`"
-msgstr ""
+msgstr "`Rc`"
 
 #: src/SUMMARY.md src/smart-pointers/exercise.md
 msgid "Exercise: Binary Tree"
-msgstr ""
+msgstr "演習: バイナリツリー"
 
 #: src/SUMMARY.md
 msgid "Day 3: Afternoon"
@@ -449,14 +438,12 @@ msgid "Borrow Checking"
 msgstr "借用"
 
 #: src/SUMMARY.md src/borrowing/interior-mutability.md
-#, fuzzy
 msgid "Interior Mutability"
-msgstr "相互運用性"
+msgstr "内部可変性"
 
 #: src/SUMMARY.md src/borrowing/exercise.md
-#, fuzzy
 msgid "Exercise: Health Statistics"
-msgstr "健康統計"
+msgstr "演習: 健康に関する統計"
 
 #: src/SUMMARY.md src/slices-and-lifetimes.md
 #, fuzzy
@@ -469,12 +456,10 @@ msgid "Slices: `&[T]`"
 msgstr "スライス型"
 
 #: src/SUMMARY.md src/slices-and-lifetimes/str.md
-#, fuzzy
 msgid "String References"
-msgstr "型推論"
+msgstr "Stringの参照"
 
 #: src/SUMMARY.md src/slices-and-lifetimes/lifetime-annotations.md
-#, fuzzy
 msgid "Lifetime Annotations"
 msgstr "関数とライフタイム"
 
@@ -490,37 +475,36 @@ msgstr "ライフタイム"
 
 #: src/SUMMARY.md src/slices-and-lifetimes/exercise.md
 msgid "Exercise: Protobuf Parsing"
-msgstr ""
+msgstr "演習: Protobufの解析"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Day 4: Morning"
-msgstr "Day 1： AM"
+msgstr "Day 4： AM"
 
 #: src/SUMMARY.md src/iterators.md
 msgid "Iterators"
-msgstr ""
+msgstr "イテレータ"
 
 #: src/SUMMARY.md src/iterators/iterator.md src/bare-metal/no_std.md
 msgid "`Iterator`"
-msgstr ""
+msgstr "`Iterator`"
 
 #: src/SUMMARY.md src/iterators/intoiterator.md
 msgid "`IntoIterator`"
-msgstr ""
+msgstr "`IntoIterator`"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "`FromIterator`"
-msgstr "FromIterator"
+msgstr "`FromIterator`"
 
 #: src/SUMMARY.md src/iterators/exercise.md
 msgid "Exercise: Iterator Method Chaining"
-msgstr ""
+msgstr "演習: イテレータのメソッドチェーン"
 
 #: src/SUMMARY.md src/modules.md src/modules/modules.md
+#, fuzzy
 msgid "Modules"
-msgstr "モジュール"
+msgstr "モジュール タイプ"
 
 #: src/SUMMARY.md src/modules/filesystem.md
 msgid "Filesystem Hierarchy"
@@ -532,12 +516,12 @@ msgstr "可視性"
 
 #: src/SUMMARY.md
 msgid "`use`, `super`, `self`"
-msgstr ""
+msgstr "`use`、`super`、`self`"
 
 #: src/SUMMARY.md src/modules/exercise.md
 #, fuzzy
 msgid "Exercise: Modules for a GUI Library"
-msgstr "GUIライブラリ"
+msgstr "[演習: GUI ライブラリのモジュール](./modules/exercise.md)（15 分）"
 
 #: src/SUMMARY.md src/testing.md src/chromium/testing.md
 msgid "Testing"
@@ -558,15 +542,15 @@ msgstr "便利クレート"
 
 #: src/SUMMARY.md src/testing/googletest.md
 msgid "GoogleTest"
-msgstr ""
+msgstr "GoogleTest"
 
 #: src/SUMMARY.md src/testing/mocking.md
 msgid "Mocking"
-msgstr ""
+msgstr "モック"
 
 #: src/SUMMARY.md src/testing/lints.md
 msgid "Compiler Lints and Clippy"
-msgstr ""
+msgstr "コンパイラの Lints と Clippy"
 
 #: src/SUMMARY.md src/testing/exercise.md
 #, fuzzy
@@ -574,9 +558,8 @@ msgid "Exercise: Luhn Algorithm"
 msgstr "Luhnアルゴリズム"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Day 4: Afternoon"
-msgstr "Day 1： PM"
+msgstr "Day 4： PM"
 
 #: src/SUMMARY.md src/error-handling.md
 msgid "Error Handling"
@@ -597,17 +580,16 @@ msgid "Try Conversions"
 msgstr "暗黙的な型変換"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "`Error` Trait"
-msgstr "他のトレイト"
+msgstr "`Error`トレイト"
 
 #: src/SUMMARY.md src/error-handling/thiserror-and-anyhow.md
 msgid "`thiserror` and `anyhow`"
-msgstr ""
+msgstr "`thiserror` と `anyhow`"
 
 #: src/SUMMARY.md
 msgid "Exercise: Rewriting with `Result`"
-msgstr ""
+msgstr "演習: `Result` を使用した書き換え"
 
 #: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unsafe.md
 msgid "Unsafe Rust"
@@ -631,19 +613,16 @@ msgid "Unions"
 msgstr "共用体"
 
 #: src/SUMMARY.md src/unsafe-rust/unsafe-functions.md
-#, fuzzy
 msgid "Unsafe Functions"
 msgstr "Unsafe関数の呼び出し"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Unsafe Traits"
 msgstr "Unsafeなトレイトの実装"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Exercise: FFI Wrapper"
-msgstr "安全なFFIラッパ"
+msgstr "演習: FFIラッパー"
 
 #: src/SUMMARY.md src/bare-metal/android.md
 msgid "Android"
@@ -723,26 +702,24 @@ msgid "The Bridge Module"
 msgstr "テストモジュール"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Rust Bridge"
-msgstr "Android"
+msgstr "Rustブリッジ"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/generated-cpp.md
 msgid "Generated C++"
-msgstr ""
+msgstr "生成された C++"
 
 #: src/SUMMARY.md
 msgid "C++ Bridge"
-msgstr ""
+msgstr "C++ ブリッジ"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/shared-types.md
-#, fuzzy
 msgid "Shared Types"
-msgstr "状態共有"
+msgstr "共有の型"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/shared-enums.md
 msgid "Shared Enums"
-msgstr ""
+msgstr "共有の列挙型"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/rust-result.md
 #, fuzzy
@@ -756,19 +733,19 @@ msgstr "エラー処理"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
 msgid "Additional Types"
-msgstr ""
+msgstr "その他の型"
 
 #: src/SUMMARY.md
 msgid "Building for Android: C++"
-msgstr ""
+msgstr "Android 向けのビルド: C++"
 
 #: src/SUMMARY.md
 msgid "Building for Android: Genrules"
-msgstr ""
+msgstr "Android 向けのビルド: Genrules"
 
 #: src/SUMMARY.md
 msgid "Building for Android: Rust"
-msgstr ""
+msgstr "Android 向けのビルド: Rust"
 
 #: src/SUMMARY.md
 msgid "With Java"
@@ -782,15 +759,15 @@ msgstr "練習問題"
 
 #: src/SUMMARY.md
 msgid "Chromium"
-msgstr ""
+msgstr "Chromium"
 
 #: src/SUMMARY.md src/chromium/cargo.md
 msgid "Comparing Chromium and Cargo Ecosystems"
-msgstr ""
+msgstr "Chromium と Cargo のエコシステムの比較"
 
 #: src/SUMMARY.md
 msgid "Policy"
-msgstr ""
+msgstr "ポリシー"
 
 #: src/SUMMARY.md
 #, fuzzy
@@ -799,33 +776,32 @@ msgstr "Unsafe Rust"
 
 #: src/SUMMARY.md src/chromium/build-rules/depending.md
 msgid "Depending on Rust Code from Chromium C++"
-msgstr ""
+msgstr "Chromium C++からRustのコードに依存させる"
 
 #: src/SUMMARY.md src/chromium/build-rules/vscode.md
 msgid "Visual Studio Code"
-msgstr ""
+msgstr "Visual Studio Code"
 
 #: src/SUMMARY.md src/exercises/chromium/third-party.md
-#, fuzzy
 msgid "Exercise"
-msgstr "練習問題"
+msgstr "演習"
 
 #: src/SUMMARY.md src/chromium/testing/rust-gtest-interop.md
 msgid "`rust_gtest_interop` Library"
-msgstr ""
+msgstr "`rust_gtest_interop` ライブラリ"
 
 #: src/SUMMARY.md src/chromium/testing/build-gn.md
 msgid "GN Rules for Rust Tests"
-msgstr ""
+msgstr "Rust テスト用の GN ルール"
 
 #: src/SUMMARY.md src/chromium/testing/chromium-import-macro.md
 msgid "`chromium::import!` Macro"
-msgstr ""
+msgstr "`chromium::import!` マクロ"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp.md
 #, fuzzy
 msgid "Interoperability with C++"
-msgstr "相互運用性"
+msgstr "C との相互運用性"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/example-bindings.md
 #, fuzzy
@@ -834,7 +810,7 @@ msgstr "例"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "Limitations of CXX"
-msgstr ""
+msgstr "CXXの限界"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/error-handling.md
 #, fuzzy
@@ -853,77 +829,78 @@ msgstr "エラー処理"
 
 #: src/SUMMARY.md
 msgid "Using CXX in Chromium"
-msgstr ""
+msgstr "Chromium で CXX を使用する"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates.md
 msgid "Adding Third Party Crates"
-msgstr ""
+msgstr "サードパーティのクレートを追加する"
 
 #: src/SUMMARY.md
 msgid "Configuring Cargo.toml"
-msgstr ""
+msgstr "Cargo.toml を構成する"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
 msgid "Configuring `gnrt_config.toml`"
-msgstr ""
+msgstr "`gnrt_config.toml` を構成する"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates/downloading-crates.md
 msgid "Downloading Crates"
-msgstr ""
+msgstr "クレートをダウンロードする"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
 msgid "Generating `gn` Build Rules"
-msgstr ""
+msgstr "`gn` ビルドルールを生成する"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Resolving Problems"
-msgstr ""
+msgstr "問題を解決する"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
 msgid "Build Scripts Which Generate Code"
-msgstr ""
+msgstr "コードを生成するビルドスクリプト"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
 msgid "Build Scripts Which Build C++ or Take Arbitrary Actions"
-msgstr ""
+msgstr "C++をビルドする、もしくは、任意のアクションを実行するビルドスクリプト"
 
 #: src/SUMMARY.md
 #: src/chromium/adding-third-party-crates/depending-on-a-crate.md
 msgid "Depending on a Crate"
-msgstr ""
+msgstr "クレートへの依存を設定する"
 
 #: src/SUMMARY.md
 msgid "Reviews and Audits"
-msgstr ""
+msgstr "審査と監査"
 
 #: src/SUMMARY.md
 msgid "Checking into Chromium Source Code"
-msgstr ""
+msgstr "Chromium ソースコードにチェックインする"
 
 #: src/SUMMARY.md src/chromium/adding-third-party-crates/keeping-up-to-date.md
 msgid "Keeping Crates Up to Date"
-msgstr ""
+msgstr "クレートを最新の状態に保つ"
 
 #: src/SUMMARY.md
 msgid "Bringing It Together - Exercise"
-msgstr ""
+msgstr "まとめ - 演習"
 
 #: src/SUMMARY.md src/exercises/chromium/solutions.md
 #, fuzzy
 msgid "Exercise Solutions"
-msgstr "解答"
+msgstr "演習: 式の評価"
 
 #: src/SUMMARY.md
+#, fuzzy
 msgid "Bare Metal: Morning"
-msgstr "ベアメタル： AM"
+msgstr "ベアメタル Rust：午前の講座"
 
 #: src/SUMMARY.md src/bare-metal/no_std.md
 msgid "`no_std`"
-msgstr ""
+msgstr "`no_std`"
 
 #: src/SUMMARY.md
 msgid "A Minimal Example"
@@ -931,7 +908,7 @@ msgstr "例"
 
 #: src/SUMMARY.md src/bare-metal/no_std.md src/bare-metal/alloc.md
 msgid "`alloc`"
-msgstr ""
+msgstr "`alloc`"
 
 #: src/SUMMARY.md src/bare-metal/microcontrollers.md
 msgid "Microcontrollers"
@@ -959,7 +936,7 @@ msgstr "タイプステートパターン"
 
 #: src/SUMMARY.md src/bare-metal/microcontrollers/embedded-hal.md
 msgid "`embedded-hal`"
-msgstr ""
+msgstr "`embedded-hal`"
 
 #: src/SUMMARY.md src/bare-metal/microcontrollers/probe-rs.md
 #, fuzzy
@@ -993,7 +970,7 @@ msgstr "アプリケーションプロセッサ"
 
 #: src/SUMMARY.md src/bare-metal/aps/entry-point.md
 msgid "Getting Ready to Rust"
-msgstr ""
+msgstr "Rust の準備"
 
 #: src/SUMMARY.md
 msgid "Inline Assembly"
@@ -1037,28 +1014,27 @@ msgstr "例外"
 
 #: src/SUMMARY.md src/bare-metal/useful-crates/zerocopy.md
 msgid "`zerocopy`"
-msgstr ""
+msgstr "`zerocopy`"
 
 #: src/SUMMARY.md src/bare-metal/useful-crates/aarch64-paging.md
 msgid "`aarch64-paging`"
-msgstr ""
+msgstr "`aarch64-paging`"
 
 #: src/SUMMARY.md src/bare-metal/useful-crates/buddy_system_allocator.md
 msgid "`buddy_system_allocator`"
-msgstr ""
+msgstr "`buddy_system_allocator`"
 
 #: src/SUMMARY.md src/bare-metal/useful-crates/tinyvec.md
 msgid "`tinyvec`"
-msgstr ""
+msgstr "`tinyvec`"
 
 #: src/SUMMARY.md src/bare-metal/useful-crates/spin.md
 msgid "`spin`"
-msgstr ""
+msgstr "`spin`"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "`vmbase`"
-msgstr "vmbase"
+msgstr "`vmbase`"
 
 #: src/SUMMARY.md
 msgid "RTC Driver"
@@ -1094,11 +1070,11 @@ msgstr "`Send`と`Sync`"
 
 #: src/SUMMARY.md src/concurrency/send-sync/send.md
 msgid "`Send`"
-msgstr ""
+msgstr "`Send`"
 
 #: src/SUMMARY.md src/concurrency/send-sync/sync.md
 msgid "`Sync`"
-msgstr ""
+msgstr "`Sync`"
 
 #: src/SUMMARY.md src/concurrency/send-sync/examples.md
 msgid "Examples"
@@ -1110,11 +1086,11 @@ msgstr "状態共有"
 
 #: src/SUMMARY.md src/concurrency/shared_state/arc.md
 msgid "`Arc`"
-msgstr ""
+msgstr "`Arc`"
 
 #: src/SUMMARY.md src/concurrency/shared_state/mutex.md
 msgid "`Mutex`"
-msgstr ""
+msgstr "`Mutex`"
 
 #: src/SUMMARY.md src/memory-management/review.md
 #: src/error-handling/try-conversions.md
@@ -1170,11 +1146,11 @@ msgstr "制御フロー"
 
 #: src/SUMMARY.md src/async/control-flow/join.md
 msgid "Join"
-msgstr ""
+msgstr "Join"
 
 #: src/SUMMARY.md src/async/control-flow/select.md
 msgid "Select"
-msgstr ""
+msgstr "Select"
 
 #: src/SUMMARY.md
 msgid "Pitfalls"
@@ -1186,7 +1162,7 @@ msgstr "エグゼキュータのブロッキング"
 
 #: src/SUMMARY.md src/async/pitfalls/pin.md
 msgid "`Pin`"
-msgstr ""
+msgstr "`Pin`"
 
 #: src/SUMMARY.md src/async/pitfalls/async-traits.md
 msgid "Async Traits"
@@ -1212,7 +1188,7 @@ msgstr "ありがとうございました！"
 
 #: src/SUMMARY.md src/glossary.md
 msgid "Glossary"
-msgstr ""
+msgstr "用語集"
 
 #: src/SUMMARY.md
 msgid "Other Resources"
@@ -1223,7 +1199,6 @@ msgid "Credits"
 msgstr "クレジット"
 
 #: src/index.md
-#, fuzzy
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
@@ -1239,7 +1214,9 @@ msgstr ""
 "google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
 "[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 
 #: src/index.md
 #, fuzzy
@@ -1258,6 +1235,8 @@ msgid ""
 "comprehensive-rust/>. If you are reading somewhere else, please check there "
 "for updates."
 msgstr ""
+"コースの最新バージョンは <https://google.github.io/comprehensive-rust/> にあ"
+"ります。他の場所でお読みの場合は、そちらで最新情報をご確認ください。"
 
 #: src/index.md
 msgid ""
@@ -1281,7 +1260,7 @@ msgstr "一般的なRustのイディオムを紹介する。"
 
 #: src/index.md
 msgid "We call the first four course days Rust Fundamentals."
-msgstr ""
+msgstr "コースの最初の4日間を「Rust の基礎」と呼びます。"
 
 #: src/index.md
 #, fuzzy
@@ -1307,8 +1286,10 @@ msgid ""
 "based browsers. This includes interoperability with C++ and how to include "
 "third-party crates in Chromium."
 msgstr ""
-"[Android](android.md)： Androidオープンソースプラットフォーム（AOSP）でRustを"
-"使用するための半日講座。C、C++、およびJavaとの相互運用性も含まれます。"
+"[ChromiumでのRust](../chromium.md) は半日コースで、Chromium ブラウザの一部と"
+"してRustを使用する方法について詳しく説明します。Chromium の `gn` ビルドシステ"
+"ムでRustを使用することで、サードパーティライブラリ（「クレート」）、および C+"
+"+ との相互運用性を導入できます。"
 
 #: src/index.md
 #, fuzzy
@@ -1407,6 +1388,9 @@ msgid ""
 "afternoon class. Both sessions contain multiple breaks and time for students "
 "to work on exercises."
 msgstr ""
+"クラスは通常午前9時から午後4時までで、途中で1時間の昼食休憩があります。つま"
+"り、午前のクラスが3時間、午後のクラスが3時間となります。どちらのセッションに"
+"も、休憩と、受講者が演習に取り組むための時間が複数回含まれています。"
 
 #: src/running-the-course.md
 msgid "Before you run the course, you will want to:"
@@ -1506,146 +1490,148 @@ msgstr ""
 
 #: src/running-the-course/course-structure.md
 msgid "Rust Fundamentals"
-msgstr ""
+msgstr "Rust の基礎"
 
 #: src/running-the-course/course-structure.md
 msgid ""
 "The first four days make up [Rust Fundamentals](../welcome-day-1.md). The "
 "days are fast paced and we cover a lot of ground!"
 msgstr ""
+"[Rust の基礎](../welcome-day-1.md) を構成する最初の 4 日間で、さまざまな項目"
+"を駆け足で学びます。"
 
 #: src/running-the-course/course-structure.md
 msgid "Course schedule:"
-msgstr ""
+msgstr "コースのスケジュール:"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 1 Morning (3 hours, including breaks)"
-msgstr ""
+msgstr "1 日目の午前（休憩を含めて 3 時間）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-1.md) (5 minutes)"
-msgstr ""
+msgstr "[ようこそ](../welcome-day-1.md)（5 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Hello, World](../hello-world.md) (20 minutes)"
-msgstr ""
+msgstr "[Hello, World](../hello-world.md)（20 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Types and Values](../types-and-values.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[型と値](../types-and-values.md)（1 時間 5 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Control Flow Basics](../control-flow-basics.md) (1 hour)"
-msgstr ""
+msgstr "[制御フローの基本](../control-flow-basics.md)（1 時間）"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 1 Afternoon (2 hours and 55 minutes, including breaks)"
-msgstr ""
+msgstr "1 日目の午後（休憩を含めて 2 時間 55 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Tuples and Arrays](../tuples-and-arrays.md) (1 hour)"
-msgstr ""
+msgstr "[タプルと配列](../tuples-and-arrays.md)（1 時間）"
 
 #: src/running-the-course/course-structure.md
 msgid "[References](../references.md) (50 minutes)"
-msgstr ""
+msgstr "[参照](../references.md)（50 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[User-Defined Types](../user-defined-types.md) (50 minutes)"
-msgstr ""
+msgstr "[ユーザー定義型](../user-defined-types.md)（50 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 2 Morning (3 hours and 5 minutes, including breaks)"
-msgstr ""
+msgstr "2 日目の午前（休憩を含めて 3 時間 5 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-2.md) (3 minutes)"
-msgstr ""
+msgstr "[ようこそ](../welcome-day-2.md)（3 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Pattern Matching](../pattern-matching.md) (50 minutes)"
-msgstr ""
+msgstr "[パターン マッチング](../pattern-matching.md)（50 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Methods and Traits](../methods-and-traits.md) (55 minutes)"
-msgstr ""
+msgstr "[メソッドとトレイト](../methods-and-train.md)（55 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Generics](../generics.md) (45 minutes)"
-msgstr ""
+msgstr "[ジェネリクス](../generics.md)（45 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 2 Afternoon (3 hours, including breaks)"
-msgstr ""
+msgstr "2 日目の午後（休憩を含めて 3 時間）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Standard Library Types](../std-types.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[標準ライブラリ型](../std-types.md)（1 時間 10 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Standard Library Traits](../std-traits.md) (1 hour and 40 minutes)"
-msgstr ""
+msgstr "[標準ライブラリ トレイト](../std-train.md)（1 時間 40 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 3 Morning (2 hours and 15 minutes, including breaks)"
-msgstr ""
+msgstr "3 日目の午前（休憩を含めて 2 時間 15 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-3.md) (3 minutes)"
-msgstr ""
+msgstr "[ようこそ](../welcome-day-3.md)（3 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Memory Management](../memory-management.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[メモリ管理](../memory-management.md)（1 時間 10 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Smart Pointers](../smart-pointers.md) (45 minutes)"
-msgstr ""
+msgstr "[スマート ポインタ](../smart-pointers.md)（45 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 3 Afternoon (2 hours and 20 minutes, including breaks)"
-msgstr ""
+msgstr "3 日目の午後（休憩を含めて 2 時間 20 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Borrowing](../borrowing.md) (1 hour)"
-msgstr ""
+msgstr "[借用](../borrowing.md)（1 時間）"
 
 #: src/running-the-course/course-structure.md
 msgid ""
 "[Slices and Lifetimes](../slices-and-lifetimes.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[スライスとライフタイム](../slices-and-lifetimes.md)（1 時間 10 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 4 Morning (3 hours and 5 minutes, including breaks)"
-msgstr ""
+msgstr "4 日目の午前（休憩を含めて 3 時間 5 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Welcome](../welcome-day-4.md) (3 minutes)"
-msgstr ""
+msgstr "[ようこそ](../welcome-day-4.md)（3 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Iterators](../iterators.md) (45 minutes)"
-msgstr ""
+msgstr "[イテレータ](../iterators.md)（45 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Modules](../modules.md) (40 minutes)"
-msgstr ""
+msgstr "[モジュール](../modules.md)（40 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Testing](../testing.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[テスト](../testing.md)（1 時間 5 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "Day 4 Afternoon (2 hours, including breaks)"
-msgstr ""
+msgstr "4 日目の午後（休憩を含めて 2 時間）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Error Handling](../error-handling.md) (45 minutes)"
-msgstr ""
+msgstr "[エラー処理](../error-handling.md)（45 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "[Unsafe Rust](../unsafe-rust.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[Unsafe Rust](../unsafe-rust.md)（1 時間 5 分）"
 
 #: src/running-the-course/course-structure.md
 msgid "Deep Dives"
@@ -1663,7 +1649,7 @@ msgstr ""
 #: src/running-the-course/course-structure.md
 #, fuzzy
 msgid "Rust in Android"
-msgstr "Android"
+msgstr "Android での Rust へようこそ"
 
 #: src/running-the-course/course-structure.md
 #, fuzzy
@@ -1704,7 +1690,7 @@ msgstr ""
 #: src/running-the-course/course-structure.md
 #, fuzzy
 msgid "Rust in Chromium"
-msgstr "Android"
+msgstr "Chromium の Rust へようこそ"
 
 #: src/running-the-course/course-structure.md
 msgid ""
@@ -1713,6 +1699,10 @@ msgid ""
 "Chromium's `gn` build system, bringing in third-party libraries (\"crates\") "
 "and C++ interoperability."
 msgstr ""
+"[Chromium での Rust](../chromium.md) は半日コースで、Chromium ブラウザの一部"
+"として Rust を使用する方法について詳しく説明します。Chromium の `gn` ビルドシ"
+"ステムで Rust を使用することで、サードパーティ ライブラリ（「クレート」）、お"
+"よび C++ との相互運用性を導入できます。"
 
 #: src/running-the-course/course-structure.md
 msgid ""
@@ -1720,6 +1710,9 @@ msgid ""
 "[recommended](../chromium/setup.md) for speed but any build will work. "
 "Ensure that you can run the Chromium browser that you've built."
 msgstr ""
+"受講者は、Chromium をビルドできる必要があります。時間を短縮できるデバッグのコ"
+"ンポーネント ビルドを [推奨](../chromium/setup.md) しますが、どのようなビルド"
+"でも問題ありません。作成した Chromium ブラウザを実行できることを確認します。"
 
 #: src/running-the-course/course-structure.md
 #, fuzzy
@@ -1749,9 +1742,8 @@ msgstr ""
 "明されているように、複数のパッケージをインストールする必要があります。"
 
 #: src/running-the-course/course-structure.md
-#, fuzzy
 msgid "Concurrency in Rust"
-msgstr "Rustでの並行性へようこそ"
+msgstr "Rustでの並行性"
 
 #: src/running-the-course/course-structure.md
 #, fuzzy
@@ -1832,6 +1824,10 @@ msgid ""
 "com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), and "
 "[@henrif75](https://github.com/henrif75)."
 msgstr ""
+"[ポルトガル語（ブラジル）](https://google.github.io/comprehensive-rust/pt-"
+"BR/): [@rastringer](https://github.com/rastringer)、[@hugojacob](https://"
+"github.com/hugojacob)、[@joaovicmendes](https://github.com/joaovicmendes)、"
+"[@henrif75](https://github.com/henrif75)"
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1842,6 +1838,12 @@ msgid ""
 "github.com/superwhd), [@SketchK](https://github.com/SketchK), and [@nodmp]"
 "(https://github.com/nodmp)."
 msgstr ""
+"[中国語（簡体字）](https://google.github.io/comprehensive-rust/zh-CN/): "
+"[@suetfei](https://github.com/suetfei)、[@wnghl](https://github.com/wnghl)、"
+"[@anlunx](https://github.com/anlunx)、[@kongy](https://github.com/kongy)、"
+"[@noahdragon](https://github.com/noahdragon)、[@superwhd](https://github.com/"
+"superwhd)、[@SketchK](https://github.com/SketchK)、[@nodmp](https://github."
+"com/nodmp)"
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1851,6 +1853,11 @@ msgid ""
 "github.com/kuanhungchen), and [@johnathan79717](https://github.com/"
 "johnathan79717)."
 msgstr ""
+"[中国語（繁体字）](https://google.github.io/comprehensive-rust/zh-TW/): "
+"[@hueich](https://github.com/hueich)、[@victorhsieh](https://github.com/"
+"victorhsieh)、[@mingyc](https://github.com/mingyc)、[@kuanhungchen](https://"
+"github.com/kuanhungchen)、[@johnathan79717](https://github.com/"
+"johnathan79717)"
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1858,12 +1865,17 @@ msgid ""
 "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
 "[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
+"[韓国語](https://google.github.io/comprehensive-rust/ko/): [@keispace]"
+"(https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp)、"
+"[@jooyunghan](https://github.com/jooyunghan)"
 
 #: src/running-the-course/translations.md
 msgid ""
 "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
 "(https://github.com/deavid)."
 msgstr ""
+"[スペイン語](https://google.github.io/comprehensive-rust/es/): [@deavid]"
+"(https://github.com/deavid)"
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1879,25 +1891,31 @@ msgstr "翻訳"
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
-msgstr ""
+msgstr "進行中の翻訳が多数あります。最新の翻訳へのリンクを以下に示します。"
 
 #: src/running-the-course/translations.md
 msgid ""
 "[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
 "(https://github.com/raselmandol)."
 msgstr ""
+"[ベンガル語](https://google.github.io/comprehensive-rust/bn/): [@raselmandol]"
+"(https://github.com/raselmandol)"
 
 #: src/running-the-course/translations.md
 msgid ""
 "[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
 "(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
+"[フランス語](https://google.github.io/comprehensive-rust/fr/): [@KookaS]"
+"(https://github.com/KookaS)、[@vcaen](https://github.com/vcaen)"
 
 #: src/running-the-course/translations.md
 msgid ""
 "[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
 "(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
 msgstr ""
+"[ドイツ語](https://google.github.io/comprehensive-rust/de/): [@Throvn]"
+"(https://github.com/Throvn)、[@ronaldfw](https://github.com/ronaldfw)"
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1905,6 +1923,8 @@ msgid ""
 "(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
 "momotaro1105)."
 msgstr ""
+"[日本語](https://google.github.io/comprehensive-rust/ja/): [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ)、[@momotaro1105](https://github.com/momotaro1105)"
 
 #: src/running-the-course/translations.md
 msgid ""
@@ -1937,7 +1957,7 @@ msgstr "インストール"
 
 #: src/cargo.md
 msgid "**Please follow the instructions on <https://rustup.rs/>.**"
-msgstr ""
+msgstr "**<https://rustup.rs/> の手順に沿ってインストールしてください。**"
 
 #: src/cargo.md
 #, fuzzy
@@ -1960,6 +1980,14 @@ msgid ""
 "analyzer.github.io/manual.html#vimneovim), and many others. There is also a "
 "different IDE available called [RustRover](https://www.jetbrains.com/rust/)."
 msgstr ""
+"Rust をインストールしたら、Rust で動作するようにエディタまたは IDE を設定する"
+"必要があります。ほとんどのエディタでは、[rust-analyzer](https://rust-"
+"analyzer.github.io/) と通信することでこれを行います。rust-analyzer は、[VS "
+"Code](https://code.visualstudio.com/)、[Emacs](https://rust-analyzer.github."
+"io/manual.html#emacs)、[Vim / Neovim](https://rust-analyzer.github.io/manual."
+"html#vimneovim) など、多くのエディタ向けにオートコンプリート機能と「定義に移"
+"動」機能を提供します。[RustRover](https://www.jetbrains.com/rust/) という別"
+"の IDE も用意されています。"
 
 #: src/cargo.md
 #, fuzzy
@@ -1975,7 +2003,7 @@ msgstr ""
 
 #: src/cargo/rust-ecosystem.md
 msgid "The Rust Ecosystem"
-msgstr ""
+msgstr "Rust エコシステム"
 
 #: src/cargo/rust-ecosystem.md
 msgid ""
@@ -2051,6 +2079,8 @@ msgid ""
 "Dependencies can also be resolved from alternative [registries](https://doc."
 "rust-lang.org/cargo/reference/registries.html), git, folders, and more."
 msgstr ""
+"依存関係は、代替の [レジストリ](https://doc.rust-lang.org/cargo/reference/"
+"registries.html)、git、フォルダなどから解決することもできます。"
 
 #: src/cargo/rust-ecosystem.md
 msgid ""
@@ -2232,6 +2262,8 @@ msgid ""
 "You can use any later version too since Rust maintains backwards "
 "compatibility."
 msgstr ""
+"Rust は下位互換性を維持しているため、新しいバージョンを使用することもできま"
+"す。"
 
 #: src/cargo/running-locally.md
 #, fuzzy
@@ -2327,47 +2359,47 @@ msgstr "型推論"
 
 #: src/welcome-day-1.md
 msgid "Control flow constructs: loops, conditionals, and so on."
-msgstr ""
+msgstr "制御フローの構造: ループ、条件など。"
 
 #: src/welcome-day-1.md
 msgid "User-defined types: structs and enums."
-msgstr ""
+msgstr "ユーザー定義型: 構造体と列挙型。"
 
 #: src/welcome-day-1.md
 msgid "Pattern matching: destructuring enums, structs, and arrays."
-msgstr ""
+msgstr "パターン マッチング: 列挙型、構造体、配列の分解。"
 
 #: src/welcome-day-1.md src/welcome-day-2.md src/welcome-day-3.md
 #: src/welcome-day-4.md
 msgid "Schedule"
-msgstr ""
+msgstr "スケジュール"
 
 #: src/welcome-day-1.md src/welcome-day-1-afternoon.md src/welcome-day-2.md
 #: src/welcome-day-2-afternoon.md src/welcome-day-3.md
 #: src/welcome-day-3-afternoon.md src/welcome-day-4.md
 #: src/welcome-day-4-afternoon.md
 msgid "In this session:"
-msgstr ""
+msgstr "このセッションの内容:"
 
 #: src/welcome-day-1.md
 msgid "[Welcome](./welcome-day-1.md) (5 minutes)"
-msgstr ""
+msgstr "[ようこそ](./welcome-day-1.md)（5 分）"
 
 #: src/welcome-day-1.md
 msgid "[Hello, World](./hello-world.md) (20 minutes)"
-msgstr ""
+msgstr "[Hello, World](./hello-world.md)（20 分）"
 
 #: src/welcome-day-1.md
 msgid "[Types and Values](./types-and-values.md) (1 hour and 5 minutes)"
-msgstr ""
+msgstr "[型と値](./types-and-values.md)（1 時間 5 分）"
 
 #: src/welcome-day-1.md
 msgid "[Control Flow Basics](./control-flow-basics.md) (1 hour)"
-msgstr ""
+msgstr "[制御フローの基本](./control-flow-basics.md)（1 時間）"
 
 #: src/welcome-day-1.md src/welcome-day-2-afternoon.md
 msgid "Including 10 minute breaks, this session should take about 3 hours"
-msgstr ""
+msgstr "このセッションの所要時間は、10 分間の休憩を入れて約 3 時間です。"
 
 #: src/welcome-day-1.md
 msgid "Please remind the students that:"
@@ -2423,6 +2455,8 @@ msgid ""
 "should have immediate parallels in other languages. The more advanced parts "
 "of Rust come on the subsequent days."
 msgstr ""
+"1 日目は、他の言語にも共通する Rust の「基本的な」事項を示します。Rust のより"
+"高度な部分については、後日説明します。"
 
 #: src/welcome-day-1.md
 msgid ""
@@ -2432,6 +2466,10 @@ msgid ""
 "The times listed here are a suggestion in order to keep the course on "
 "schedule. Feel free to be flexible and adjust as necessary!"
 msgstr ""
+"教室で教える場合は、ここでスケジュールを確認することをおすすめします。各セグ"
+"メントの終わりに演習を行い、休憩を挟んでから答え合わせをしてください。上記の"
+"時間配分は、あくまでコースを予定どおりに進めるための目安ですので、必要に応じ"
+"て柔軟に調整してください。"
 
 #: src/hello-world.md src/types-and-values.md src/control-flow-basics.md
 #: src/tuples-and-arrays.md src/references.md src/user-defined-types.md
@@ -2441,27 +2479,27 @@ msgstr ""
 #: src/iterators.md src/modules.md src/testing.md src/error-handling.md
 #: src/unsafe-rust.md
 msgid "In this segment:"
-msgstr ""
+msgstr "このセグメントの内容:"
 
 #: src/hello-world.md
 msgid "[What is Rust?](./hello-world/what-is-rust.md) (10 minutes)"
-msgstr ""
+msgstr "[Rust とは](./hello-world/what-is-rust.md)（10 分）"
 
 #: src/hello-world.md
 msgid "[Hello, World](./hello-world/hello-world.md) (5 minutes)"
-msgstr ""
+msgstr "[Hello, World](./hello-world/hello-world.md)（5 分）"
 
 #: src/hello-world.md
 msgid "[Benefits of Rust](./hello-world/benefits.md) (3 minutes)"
-msgstr ""
+msgstr "[Rust のメリット](./hello-world/benefits.md)（3 分）"
 
 #: src/hello-world.md
 msgid "[Playground](./hello-world/playground.md) (2 minutes)"
-msgstr ""
+msgstr "[プレイグラウンド](./hello-world/playground.md)（2 分）"
 
 #: src/hello-world.md
 msgid "This segment should take about 20 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 20 分です"
 
 #: src/hello-world/what-is-rust.md
 msgid ""
@@ -2501,23 +2539,23 @@ msgstr "Rustは様々なデバイスで使用されています："
 
 #: src/hello-world/what-is-rust.md
 msgid "firmware and boot loaders,"
-msgstr "ファームウェアやブートローダ"
+msgstr "ファームウェアやブートローダ、"
 
 #: src/hello-world/what-is-rust.md
 msgid "smart displays,"
-msgstr "スマートディスプレイ"
+msgstr "スマートディスプレイ、"
 
 #: src/hello-world/what-is-rust.md
 msgid "mobile phones,"
-msgstr "携帯電話"
+msgstr "携帯電話、"
 
 #: src/hello-world/what-is-rust.md
 msgid "desktops,"
-msgstr "デスクトップ"
+msgstr "デスクトップ、"
 
 #: src/hello-world/what-is-rust.md
 msgid "servers."
-msgstr "サーバ"
+msgstr "サーバ。"
 
 #: src/hello-world/what-is-rust.md
 msgid "Rust fits in the same area as C++:"
@@ -2525,11 +2563,11 @@ msgstr "RustとC++が似ているところ:"
 
 #: src/hello-world/what-is-rust.md
 msgid "High flexibility."
-msgstr "高い柔軟性"
+msgstr "高い柔軟性。"
 
 #: src/hello-world/what-is-rust.md
 msgid "High level of control."
-msgstr "高度な制御性"
+msgstr "高度な制御性。"
 
 #: src/hello-world/what-is-rust.md
 #, fuzzy
@@ -2539,11 +2577,11 @@ msgstr "携帯電話のようなデバイスにまでスケールダウンが可
 
 #: src/hello-world/what-is-rust.md
 msgid "Has no runtime or garbage collection."
-msgstr "ランタイムやガベージコレクションがない"
+msgstr "ランタイムやガベージコレクションがない。"
 
 #: src/hello-world/what-is-rust.md
 msgid "Focuses on reliability and safety without sacrificing performance."
-msgstr "パフォーマンスを犠牲にせず、信頼性と安全性に焦点を当てている"
+msgstr "パフォーマンスを犠牲にせず、信頼性と安全性に焦点を当てている。"
 
 #: src/hello-world/hello-world.md
 msgid ""
@@ -2554,7 +2592,7 @@ msgstr ""
 
 #: src/hello-world/hello-world.md
 msgid "\"Hello 🌍!\""
-msgstr ""
+msgstr "\"Hello 🌍!\""
 
 #: src/hello-world/hello-world.md
 msgid "What you see:"
@@ -2634,6 +2672,10 @@ msgid ""
 "while it is not a functional language, it includes a range of [functional "
 "concepts](https://doc.rust-lang.org/book/ch13-00-functional-features.html)."
 msgstr ""
+"Rust はマルチパラダイムです。たとえば、強力な [オブジェクト指向プログラミング"
+"機能](https://doc.rust-lang.org/book/ch17-00-oop.html) を備えている一方、非関"
+"数型言語であるにもかかわらず、さまざまな [関数的概念](https://doc.rust-lang."
+"org/book/ch13-00-functional-features.html) を内包しています。"
 
 #: src/hello-world/benefits.md
 msgid "Some unique selling points of Rust:"
@@ -2644,6 +2686,8 @@ msgid ""
 "_Compile time memory safety_ - whole classes of memory bugs are prevented at "
 "compile time"
 msgstr ""
+"_コンパイル時のメモリ安全性_ - クラス全体のメモリのバグをコンパイル時に防止し"
+"ます。"
 
 #: src/hello-world/benefits.md
 msgid "No uninitialized variables."
@@ -2678,6 +2722,8 @@ msgid ""
 "_No undefined runtime behavior_ - what a Rust statement does is never left "
 "unspecified"
 msgstr ""
+"_未定義のランタイム動作がない_ - Rust ステートメントで行われる処理が未規定の"
+"まま残ることはありません。"
 
 #: src/hello-world/benefits.md
 msgid "Array access is bounds checked."
@@ -2693,6 +2739,8 @@ msgid ""
 "_Modern language features_ - as expressive and ergonomic as higher-level "
 "languages"
 msgstr ""
+"_最新の言語機能_ - 高水準言語に匹敵する表現力があり、人間が使いやすい機能を備"
+"えています。"
 
 #: src/hello-world/benefits.md
 msgid "Enums and pattern matching."
@@ -2731,6 +2779,8 @@ msgid ""
 "Do not spend much time here. All of these points will be covered in more "
 "depth later."
 msgstr ""
+"ここにはあまり時間をかけないでください。これらのポイントについては、後ほど詳"
+"しく説明します。"
 
 #: src/hello-world/benefits.md
 msgid ""
@@ -2771,12 +2821,17 @@ msgid ""
 "this course. Try running the \"hello-world\" program it starts with. It "
 "comes with a few handy features:"
 msgstr ""
+"このコースの例や演習には、短い Rust プログラムを簡単に実行できる [Rust プレイ"
+"グラウンド](https://play.rust-lang.org/) を使用します。最初の「hello-world」"
+"プログラムを実行してみましょう。次のような便利な機能があります。"
 
 #: src/hello-world/playground.md
 msgid ""
 "Under \"Tools\", use the `rustfmt` option to format your code in the "
 "\"standard\" way."
 msgstr ""
+"「Tools」 にある `rustfmt` オプションを使用して、コードを「standard」の形式で"
+"フォーマットします。"
 
 #: src/hello-world/playground.md
 msgid ""
@@ -2784,12 +2839,18 @@ msgid ""
 "checks, less optimization) and Release (fewer runtime checks, lots of "
 "optimization). These are accessible under \"Debug\" at the top."
 msgstr ""
+"Rust には、コードを生成するための主要な「プロファイル」が 2 つあります。1 つ"
+"は Debug（追加のランタイムチェックがあり、最適化が少ない）で、もう 1 つは "
+"Release（ランタイムチェックが少なく、最適化が多い）です。これらは上部の "
+"[Debug] からアクセスできます。"
 
 #: src/hello-world/playground.md
 msgid ""
 "If you're interested, use \"ASM\" under \"...\" to see the generated "
 "assembly code."
 msgstr ""
+"興味がある場合は、「...」 の下にある 「ASM」 を使用すると、生成されたアセンブ"
+"リ コードを確認できます。"
 
 #: src/hello-world/playground.md
 msgid ""
@@ -2799,59 +2860,68 @@ msgid ""
 "students who want to know more about Rust's optimizations or generated "
 "assembly."
 msgstr ""
+"受講者が休憩に入ったら、プレイグラウンドを開いていろいろ試してみるよう促しま"
+"す。タブを開いたままにして、コースの残りの部分で学習したことを試すようすすめ"
+"ましょう。これは、Rust の最適化や生成されたアセンブリについて詳しく知りたい受"
+"講者に特に役立ちます。"
 
 #: src/types-and-values.md
 msgid "[Variables](./types-and-values/variables.md) (5 minutes)"
-msgstr ""
+msgstr "[変数](./types-and-values/variables.md)（5 分）"
 
 #: src/types-and-values.md
 msgid "[Values](./types-and-values/values.md) (10 minutes)"
-msgstr ""
+msgstr "[値](./types-and-values/values.md)（10 分）"
 
 #: src/types-and-values.md
 msgid "[Arithmetic](./types-and-values/arithmetic.md) (5 minutes)"
-msgstr ""
+msgstr "[算術](./types-and-values/arithmetic.md)（5 分）"
 
 #: src/types-and-values.md
 msgid "[Strings](./types-and-values/strings.md) (10 minutes)"
-msgstr ""
+msgstr "[文字列](./types-and-values/strings.md)（10 分）"
 
 #: src/types-and-values.md
 msgid "[Type Inference](./types-and-values/inference.md) (5 minutes)"
-msgstr ""
+msgstr "[型推論](./types-and-values/inference.md)（5 分）"
 
 #: src/types-and-values.md
 msgid "[Exercise: Fibonacci](./types-and-values/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: フィボナッチ](./types-and-values/exercise.md)（30 分）"
 
 #: src/types-and-values.md src/testing.md src/unsafe-rust.md
 msgid "This segment should take about 1 hour and 5 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 1 時間 5 分です"
 
 #: src/types-and-values/variables.md
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are made with "
 "`let`:"
 msgstr ""
+"Rust は静的型付けによって型安全性を提供します。変数のバインディングは `let` "
+"を使用して行います。"
 
 #: src/types-and-values/variables.md src/control-flow-basics/loops.md
 #: src/control-flow-basics/break-continue.md
 #: src/control-flow-basics/blocks-and-scopes.md
-#, fuzzy
 msgid "\"x: {x}\""
-msgstr "\"{x}\""
+msgstr "\"x: {x}\""
 
 #: src/types-and-values/variables.md
 msgid ""
 "// x = 20;\n"
 "    // println!(\"x: {x}\");\n"
 msgstr ""
+"// x = 20;\n"
+"    // println!(\"x: {x}\");\n"
 
 #: src/types-and-values/variables.md
 msgid ""
 "Uncomment the `x = 20` to demonstrate that variables are immutable by "
 "default. Add the `mut` keyword to allow changes."
 msgstr ""
+"`x = 20` のコメント化を解除して、変数がデフォルトで不変であることを示します。"
+"変更を許可するには、`mut` キーワードを追加します。"
 
 #: src/types-and-values/variables.md
 msgid ""
@@ -2859,105 +2929,107 @@ msgid ""
 "time, but type inference (covered later) allows the programmer to omit it in "
 "many cases."
 msgstr ""
+"ここでの `i32` は変数の型です。これはコンパイル時に指定する必要がありますが、"
+"多くの場合、プログラマーは型推論（後述）を使用することでこれを省略できます。"
 
 #: src/types-and-values/values.md
 msgid ""
 "Here are some basic built-in types, and the syntax for literal values of "
 "each type."
-msgstr ""
+msgstr "基本的な組み込み型と、各型のリテラル値の構文を以下に示します。"
 
 #: src/types-and-values/values.md src/tuples-and-arrays/tuples-and-arrays.md
 #: src/unsafe-rust/exercise.md
 msgid "Types"
-msgstr ""
+msgstr "型"
 
 #: src/types-and-values/values.md src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Literals"
-msgstr ""
+msgstr "リテラル"
 
 #: src/types-and-values/values.md
 msgid "Signed integers"
-msgstr ""
+msgstr "符号付き整数"
 
 #: src/types-and-values/values.md
 msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
-msgstr ""
+msgstr "`i8`、`i16`、`i32`、`i64`、`i128`、`isize`"
 
 #: src/types-and-values/values.md
 msgid "`-10`, `0`, `1_000`, `123_i64`"
-msgstr ""
+msgstr "`-10`、`0`、`1_000`、`123_i64`"
 
 #: src/types-and-values/values.md
 msgid "Unsigned integers"
-msgstr ""
+msgstr "符号なし整数"
 
 #: src/types-and-values/values.md
 msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
-msgstr ""
+msgstr "`u8`、`u16`、`u32`、`u64`、`u128`、`usize`"
 
 #: src/types-and-values/values.md
 msgid "`0`, `123`, `10_u16`"
-msgstr ""
+msgstr "`0`、`123`、`10_u16`"
 
 #: src/types-and-values/values.md
 msgid "Floating point numbers"
-msgstr ""
+msgstr "浮動小数点数"
 
 #: src/types-and-values/values.md
 msgid "`f32`, `f64`"
-msgstr ""
+msgstr "`f32`、`f64`"
 
 #: src/types-and-values/values.md
 msgid "`3.14`, `-10.0e20`, `2_f32`"
-msgstr ""
+msgstr "`3.14`、`-10.0e20`、`2_f32`"
 
 #: src/types-and-values/values.md
 msgid "Unicode scalar values"
-msgstr ""
+msgstr "Unicode スカラー値"
 
 #: src/types-and-values/values.md
 msgid "`char`"
-msgstr ""
+msgstr "`char`"
 
 #: src/types-and-values/values.md
 msgid "`'a'`, `'α'`, `'∞'`"
-msgstr ""
+msgstr "`'a'`、`'α'`、`'∞'`"
 
 #: src/types-and-values/values.md
 msgid "Booleans"
-msgstr ""
+msgstr "ブール値"
 
 #: src/types-and-values/values.md
 msgid "`bool`"
-msgstr ""
+msgstr "`bool`"
 
 #: src/types-and-values/values.md
 msgid "`true`, `false`"
-msgstr ""
+msgstr "`true`、`false`"
 
 #: src/types-and-values/values.md
 msgid "The types have widths as follows:"
-msgstr ""
+msgstr "各型の幅は次のとおりです。"
 
 #: src/types-and-values/values.md
 msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
-msgstr ""
+msgstr "`iN`、`uN`、`fN` は _N_ ビット幅です。"
 
 #: src/types-and-values/values.md
 msgid "`isize` and `usize` are the width of a pointer,"
-msgstr ""
+msgstr "`isize` と `usize` はポインタの幅です。"
 
 #: src/types-and-values/values.md
 msgid "`char` is 32 bits wide,"
-msgstr ""
+msgstr "`char` は 32 ビット幅です。"
 
 #: src/types-and-values/values.md
 msgid "`bool` is 8 bits wide."
-msgstr ""
+msgstr "`bool` は 8 ビット幅です。"
 
 #: src/types-and-values/values.md
 msgid "There are a few syntaxes which are not shown above:"
-msgstr ""
+msgstr "上記には示されていない構文もあります。"
 
 #: src/types-and-values/values.md
 msgid ""
@@ -2965,10 +3037,13 @@ msgid ""
 "`1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written "
 "as `123i64`."
 msgstr ""
+"数字のアンダースコアはすべて省略できます。アンダースコアは読みやすくするため"
+"にのみ使用します。そのため、`1_000` は `1000`（または `10_00`）、`123_i64` "
+"は `123i64` と記述できます。"
 
 #: src/types-and-values/arithmetic.md
 msgid "\"result: {}\""
-msgstr ""
+msgstr "\"result: {}\""
 
 #: src/types-and-values/arithmetic.md
 msgid ""
@@ -2976,10 +3051,13 @@ msgid ""
 "meaning should be clear: it takes three integers, and returns an integer. "
 "Functions will be covered in more detail later."
 msgstr ""
+"`main` 以外の関数が出てきたのは今回が初めてですが、その意味は明確です。つま"
+"り、3 つの整数を取り、1 つの整数を返します。関数については、後で詳しく説明し"
+"ます。"
 
 #: src/types-and-values/arithmetic.md
 msgid "Arithmetic is very similar to other languages, with similar precedence."
-msgstr ""
+msgstr "算術は他の言語とよく似ており、優先順位も類似しています。"
 
 #: src/types-and-values/arithmetic.md
 msgid ""
@@ -2987,6 +3065,9 @@ msgid ""
 "actually undefined, and might do different things on different platforms or "
 "compilers. In Rust, it's defined."
 msgstr ""
+"整数オーバーフローはどうでしょうか。C と C++ では、 _符号付き_ 整数のオーバー"
+"フローは実際には未定義であり、プラットフォームやコンパイラによって動作が異な"
+"る場合があります。Rust では、整数オーバーフローが定義されています。"
 
 #: src/types-and-values/arithmetic.md
 msgid ""
@@ -2996,66 +3077,79 @@ msgid ""
 "with method syntax, e.g., `(a * b).saturating_add(b * c).saturating_add(c * "
 "a)`."
 msgstr ""
+"`i32` を `i16` に変更して、整数オーバーフローを確認します。これは、デバッグビ"
+"ルドではパニックになり（チェックされ）、リリースビルドではラップされます。"
+"オーバーフロー、飽和、キャリーなどのオプションもあり、メソッド構文を使用して"
+"これらのオプションにアクセスします（例: `(a * b).saturating_add(b * c)."
+"saturating_add(c * a)`）。"
 
 #: src/types-and-values/arithmetic.md
 msgid ""
 "In fact, the compiler will detect overflow of constant expressions, which is "
 "why the example requires a separate function."
 msgstr ""
+"実際には、コンパイラは定数式のオーバーフローを検出します。この例で別の関数が"
+"必要になるのはそのためです。"
 
 #: src/types-and-values/strings.md
 msgid ""
 "Rust has two types to represent strings, both of which will be covered in "
 "more depth later. Both _always_ store UTF-8 encoded strings."
 msgstr ""
+"Rust には文字列を表す 2 つの型があります。どちらも後ほど詳しく説明します。両"
+"方とも、 _常に_ UTF-8 でエンコードされた文字列を格納します。"
 
 #: src/types-and-values/strings.md
 msgid "`String` - a modifiable, owned string."
-msgstr ""
+msgstr "`String` - 変更可能で、所有権をもつ文字列。"
 
 #: src/types-and-values/strings.md
 msgid "`&str` - a read-only string. String literals have this type."
-msgstr ""
+msgstr "`&str` - 読み取り専用の文字列。文字列リテラルはこの型です。"
 
 #: src/types-and-values/strings.md
 msgid "\"Greetings\""
-msgstr ""
+msgstr "\"Greetings\""
 
 #: src/types-and-values/strings.md
 msgid "\"🪐\""
-msgstr ""
+msgstr "\"🪐\""
 
 #: src/types-and-values/strings.md
 msgid "\", \""
-msgstr ""
+msgstr "\", \""
 
 #: src/types-and-values/strings.md
 msgid "\"final sentence: {}\""
-msgstr ""
+msgstr "\"final sentence: {}\""
 
 #: src/types-and-values/strings.md src/async/control-flow/join.md
 msgid "\"{:?}\""
-msgstr ""
+msgstr "\"{:?}\""
 
 #: src/types-and-values/strings.md
 msgid "//println!(\"{:?}\", &sentence[12..13]);\n"
-msgstr ""
+msgstr "//println!(\"{:?}\", &sentence[12..13]);\n"
 
 #: src/types-and-values/strings.md
 msgid ""
 "This slide introduces strings. Everything here will be covered in more depth "
 "later, but this is enough for subsequent slides and exercises to use strings."
 msgstr ""
+"このスライドでは文字列を紹介します。ここで取り上げた内容については後ほど詳し"
+"く説明しますが、以降のスライドや演習で文字列を使用するにはこれで十分です。"
 
 #: src/types-and-values/strings.md
 msgid "Invalid UTF-8 in a string is UB, and this not allowed in safe Rust."
-msgstr ""
+msgstr "文字列内の無効な UTF-8 は UB であり、Safe Rust では許可されません。"
 
 #: src/types-and-values/strings.md
 msgid ""
 "`String` is a user-defined type with a constructor (`::new()`) and methods "
 "like `s.push_str(..)`."
 msgstr ""
+"`String` は、コンストラクタ（`::new()` と `s.push_str(..)` などのメソッド）を"
+"持つユーザー定義型です。"
 
 #: src/types-and-values/strings.md
 msgid ""
@@ -3063,6 +3157,9 @@ msgid ""
 "references later, so for now just think of `&str` as a unit meaning \"a read-"
 "only string\"."
 msgstr ""
+"`&str` 内の `&` は、これが参照であることを示します。参照については後ほど説明"
+"しますので、ここでは `&str` を、「読み取り専用の文字列」を意味する単位と考え"
+"てください。"
 
 #: src/types-and-values/strings.md
 msgid ""
@@ -3070,6 +3167,9 @@ msgid ""
 "`12..13` does not end on a character boundary, so the program panics. Adjust "
 "it to a range that does, based on the error message."
 msgstr ""
+"コメントアウトされた行は、バイト位置で文字列をインデックス化しています。"
+"`12..13` は文字境界で終わっていないため、プログラムはパニックします。エラー "
+"メッセージに基づいて、適切な範囲に調整してください。"
 
 #: src/types-and-values/strings.md
 msgid ""
@@ -3077,16 +3177,23 @@ msgid ""
 "`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
 "amount of `#` on either side of the quotes:"
 msgstr ""
+"未加工の文字列を使用すると、エスケープを無効にして `&str` 値を作成できます"
+"（`r\"\\n\" == \"\\\\n\"`）。二重引用符を埋め込むには、引用符の両側に同量の "
+"`#` を使用します。"
 
 #: src/types-and-values/inference.md
 msgid "Rust will look at how the variable is _used_ to determine the type:"
 msgstr ""
+"Rust は、どのように変数が _使用されているか_ を確認することで、型を判別しま"
+"す。"
 
 #: src/types-and-values/inference.md
 msgid ""
 "This slide demonstrates how the Rust compiler infers types based on "
 "constraints given by variable declarations and usages."
 msgstr ""
+"このスライドは、変数の宣言と使用方法による制約に基づいて、Rust コンパイラが型"
+"を推測する仕組みを示しています。"
 
 #: src/types-and-values/inference.md
 msgid ""
@@ -3096,6 +3203,10 @@ msgid ""
 "of a type. The compiler does the job for us and helps us write more concise "
 "code."
 msgstr ""
+"このように宣言された変数は、どのようなデータも保持できる動的な「任意の型」で"
+"はない、という点を強調することが非常に重要です。このような宣言によって生成さ"
+"れたマシンコードは、型の明示的な宣言と同一です。コンパイラが代わりに作業を行"
+"い、より簡潔なコードの作成を支援します。"
 
 #: src/types-and-values/inference.md
 msgid ""
@@ -3103,10 +3214,13 @@ msgid ""
 "`i32`. This sometimes appears as `{integer}` in error messages. Similarly, "
 "floating-point literals default to `f64`."
 msgstr ""
+"整数リテラルの型に制約がない場合、Rust はデフォルトで `i32` を使用します。こ"
+"れは、エラー メッセージに `{integer}` として表示されることがあります。同様"
+"に、浮動小数点リテラルはデフォルトで `f64` になります。"
 
 #: src/types-and-values/inference.md
 msgid "// ERROR: no implementation for `{float} == {integer}`\n"
-msgstr ""
+msgstr "// エラー: `{float} == {integer}` の実装がありません\n"
 
 #: src/types-and-values/exercise.md
 msgid ""
@@ -3114,68 +3228,73 @@ msgid ""
 "Fibonacci number is calculated recursively as the sum of the n-1'th and "
 "n-2'th Fibonacci numbers."
 msgstr ""
+"1 つ目と 2 つ目のフィボナッチ数はどちらも `1` です。n>2 の場合、n 番目のフィ"
+"ボナッチ数は、n-1 番目のフィボナッチ数と n-2 番目のフィボナッチ数の合計として"
+"再帰的に計算されます。"
 
 #: src/types-and-values/exercise.md
 msgid ""
 "Write a function `fib(n)` that calculates the n'th Fibonacci number. When "
 "will this function panic?"
 msgstr ""
+"n 番目のフィボナッチ数を計算する関数 `fib(n)` を記述します。この関数はいつパ"
+"ニックするでしょうか。"
 
 #: src/types-and-values/exercise.md
 msgid "// The base case.\n"
-msgstr ""
+msgstr "// ベースケース。\n"
 
 #: src/types-and-values/exercise.md src/control-flow-basics/exercise.md
-#, fuzzy
 msgid "\"Implement this\""
-msgstr "実装"
+msgstr "ここを実装してください"
 
 #: src/types-and-values/exercise.md
 msgid "// The recursive case.\n"
-msgstr ""
+msgstr "// 再帰的なケース。\n"
 
 #: src/types-and-values/exercise.md src/types-and-values/solution.md
 msgid "\"fib(n) = {}\""
-msgstr ""
+msgstr "\"fib(n) = {}\""
 
 #: src/control-flow-basics.md
 msgid "[Conditionals](./control-flow-basics/conditionals.md) (5 minutes)"
-msgstr ""
+msgstr "[条件文](./control-flow-basics/conditionals.md)（5 分）"
 
 #: src/control-flow-basics.md
 msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
-msgstr ""
+msgstr "[ループ](./control-flow-basics/loops.md)（5 分）"
 
 #: src/control-flow-basics.md
 msgid ""
 "[break and continue](./control-flow-basics/break-continue.md) (5 minutes)"
-msgstr ""
+msgstr "[break と continue](./control-flow-basics/break-continue.md)（5 分）"
 
 #: src/control-flow-basics.md
 msgid ""
 "[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (10 minutes)"
 msgstr ""
+"[ブロックとスコープ](./control-flow-basics/blocks-and-scopes.md)（10 分）"
 
 #: src/control-flow-basics.md
 msgid "[Functions](./control-flow-basics/functions.md) (3 minutes)"
-msgstr ""
+msgstr "[関数](./control-flow-basics/functions.md)（3 分）"
 
 #: src/control-flow-basics.md
 msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
-msgstr ""
+msgstr "[マクロ](./control-flow-basics/macros.md)（2 分）"
 
 #: src/control-flow-basics.md
 msgid ""
 "[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: コラッツ数列](./control-flow-basics/exercise.md)（30 分）"
 
 #: src/control-flow-basics.md src/tuples-and-arrays.md src/borrowing.md
 msgid "This segment should take about 1 hour"
-msgstr ""
+msgstr "このセグメントの所要時間は約 1 時間です"
 
 #: src/control-flow-basics/conditionals.md
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
-msgstr ""
+msgstr "Rust の構文の多くは、C、C++、Java で見覚えがあるでしょう。"
 
 #: src/control-flow-basics/conditionals.md
 #, fuzzy
@@ -3187,14 +3306,15 @@ msgid ""
 "Line comments are started with `//`, block comments are delimited by `/* ... "
 "*/`."
 msgstr ""
+"行コメントは `//` で始まり、ブロック コメントは `/* ... */` で区切られます。"
 
 #: src/control-flow-basics/conditionals.md
 msgid "Keywords like `if` and `while` work the same."
-msgstr ""
+msgstr "`if` や `while` などのキーワードの動作は同じです。"
 
 #: src/control-flow-basics/conditionals.md
 msgid "Variable assignment is done with `=`, comparison is done with `==`."
-msgstr ""
+msgstr "変数の代入は `=` で行われ、比較は `==` で行われます。"
 
 #: src/control-flow-basics/conditionals.md
 msgid "`if` expressions"
@@ -3210,15 +3330,15 @@ msgstr ""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"small\""
-msgstr ""
+msgstr "\"small\""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"biggish\""
-msgstr ""
+msgstr "\"biggish\""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"huge\""
-msgstr ""
+msgstr "\"huge\""
 
 #: src/control-flow-basics/conditionals.md
 msgid ""
@@ -3230,11 +3350,11 @@ msgstr ""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"large\""
-msgstr ""
+msgstr "\"large\""
 
 #: src/control-flow-basics/conditionals.md
 msgid "\"number size: {}\""
-msgstr ""
+msgstr "\"number size: {}\""
 
 #: src/control-flow-basics/conditionals.md
 #, fuzzy
@@ -3253,18 +3373,20 @@ msgid ""
 "separate it from the next statement. Remove the `;` before `println!` to see "
 "the compiler error."
 msgstr ""
+"式で `if` を使用する場合、次のステートメントと区切るために、式に `;` を含める"
+"必要があります。`println!` の前にある `;` を削除すると、コンパイラ エラーが表"
+"示されます。"
 
 #: src/control-flow-basics/loops.md
 msgid "There are three looping keywords in Rust: `while`, `loop`, and `for`:"
 msgstr ""
+"Rust には、`while`、`loop`、`for` の 3 つのループ キーワードがあります。"
 
 #: src/control-flow-basics/loops.md
-#, fuzzy
 msgid "`while`"
-msgstr "`while` ループ"
+msgstr "`while`"
 
 #: src/control-flow-basics/loops.md
-#, fuzzy
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
 "expr.html#predicate-loops) works much like in other languages, executing the "
@@ -3275,45 +3397,50 @@ msgstr ""
 "をします。"
 
 #: src/control-flow-basics/loops.md
-#, fuzzy
 msgid "\"Final x: {x}\""
-msgstr "\" -> {x}\""
+msgstr "\"Final x: {x}\""
 
 #: src/control-flow-basics/loops.md
-#, fuzzy
 msgid "`for`"
-msgstr "`for` ループ"
+msgstr "`for`"
 
 #: src/control-flow-basics/loops.md
 msgid ""
 "The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) iterates "
 "over ranges of values:"
 msgstr ""
+"[`for` ループ](https://doc.rust-lang.org/std/keyword.for.html) は、値の範囲を"
+"反復処理します。"
 
 #: src/control-flow-basics/loops.md
 msgid "`loop`"
-msgstr ""
+msgstr "`loop`"
 
 #: src/control-flow-basics/loops.md
 msgid ""
 "The [`loop` statement](https://doc.rust-lang.org/std/keyword.loop.html) just "
 "loops forever, until a `break`."
 msgstr ""
+"[`loop` ステートメント](https://doc.rust-lang.org/std/keyword.loop.html) は、"
+"`break` まで永久にループするだけです。"
 
 #: src/control-flow-basics/loops.md
 msgid "\"{i}\""
-msgstr ""
+msgstr "\"{i}\""
 
 #: src/control-flow-basics/loops.md
 msgid ""
 "We will discuss iteration later; for now, just stick to range expressions."
 msgstr ""
+"反復処理については後で説明しますので、ここでは範囲式だけに注目してください。"
 
 #: src/control-flow-basics/loops.md
 msgid ""
 "Note that the `for` loop only iterates to `4`. Show the `1..=5` syntax for "
 "an inclusive range."
 msgstr ""
+"なお、この `for` ループは `4` までしか反復処理しません。5 を範囲に含める場合"
+"の構文は `1..=5` であることを示します。"
 
 #: src/control-flow-basics/break-continue.md
 #, fuzzy
@@ -3337,7 +3464,7 @@ msgstr ""
 
 #: src/control-flow-basics/break-continue.md
 msgid "\"{result}\""
-msgstr ""
+msgstr "\"{result}\""
 
 #: src/control-flow-basics/break-continue.md
 msgid ""
@@ -3349,7 +3476,7 @@ msgstr ""
 
 #: src/control-flow-basics/break-continue.md
 msgid "\"x: {x}, i: {i}\""
-msgstr ""
+msgstr "\"x: {x}, i: {i}\""
 
 #: src/control-flow-basics/break-continue.md
 msgid ""
@@ -3386,7 +3513,7 @@ msgstr ""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"y: {y}\""
-msgstr ""
+msgstr "\"y: {y}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
@@ -3401,34 +3528,35 @@ msgstr "スコープとシャドーイング"
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "A variable's scope is limited to the enclosing block."
-msgstr ""
+msgstr "変数のスコープは、囲まれたブロック内に限定されます。"
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
 "the same scope:"
 msgstr ""
+"外側のスコープの変数と、同じスコープの変数の両方をシャドーイングできます。"
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"before: {a}\""
-msgstr ""
+msgstr "\"before: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md src/std-traits/from-and-into.md
 #: src/slices-and-lifetimes/solution.md
 msgid "\"hello\""
-msgstr ""
+msgstr "\"hello\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"inner scope: {a}\""
-msgstr ""
+msgstr "\"inner scope: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"shadowed in inner scope: {a}\""
-msgstr ""
+msgstr "\"shadowed in inner scope: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "\"after: {a}\""
-msgstr ""
+msgstr "\"after: {a}\""
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
@@ -3444,6 +3572,8 @@ msgid ""
 "Show that a variable's scope is limited by adding a `b` in the inner block "
 "in the last example, and then trying to access it outside that block."
 msgstr ""
+"最後の例の内側のブロックに `b` を追加し、そのブロックの外側でアクセスを試みる"
+"ことで、変数のスコープが制限されていることを示します。"
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
@@ -3451,22 +3581,29 @@ msgid ""
 "variable's memory locations exist at the same time. Both are available under "
 "the same name, depending where you use it in the code."
 msgstr ""
+"シャドーイング後は両方の変数のメモリ位置が同時に存在するため、シャドーイング"
+"はミューテーションとは異なります。どちらも、コードで使用する場所に応じて同じ"
+"名前で使用できます。"
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid "A shadowing variable can have a different type."
-msgstr ""
+msgstr "シャドーイング変数の型はさまざまです。"
 
 #: src/control-flow-basics/blocks-and-scopes.md
 msgid ""
 "Shadowing looks obscure at first, but is convenient for holding on to values "
 "after `.unwrap()`."
 msgstr ""
+"シャドーイングは一見わかりにくいように見えますが、`.unwrap()` の後の値を保持"
+"する場合に便利です。"
 
 #: src/control-flow-basics/functions.md
 msgid ""
 "Declaration parameters are followed by a type (the reverse of some "
 "programming languages), then a return type."
 msgstr ""
+"宣言パラメータの後には型（一部のプログラミング言語と逆）、戻り値の型が続きま"
+"す。"
 
 #: src/control-flow-basics/functions.md
 msgid ""
@@ -3475,29 +3612,39 @@ msgid ""
 "keyword can be used for early return, but the \"bare value\" form is "
 "idiomatic at the end of a function (refactor `gcd` to use a `return`)."
 msgstr ""
+"関数本体（または任意のブロック）内の最後の式が戻り値になります。式の末尾の `;"
+"` を省略します。`return` キーワードは早期リターンに使用できますが、関数の最後"
+"は「裸の値」の形式にするのが慣用的です（`return` を使用するには `gcd` をリ"
+"ファクタリングします）。"
 
 #: src/control-flow-basics/functions.md
 msgid ""
 "Some functions have no return value, and return the 'unit type', `()`. The "
 "compiler will infer this if the `-> ()` return type is omitted."
 msgstr ""
+"戻り値がなく、'unit type'、`()` を返す関数もあります。`-> ()` の戻り値の型が"
+"省略されている場合、コンパイラはこれを推測します。"
 
 #: src/control-flow-basics/functions.md
 msgid ""
 "Overloading is not supported -- each function has a single implementation."
-msgstr ""
+msgstr "オーバーロードはサポートされていません。各関数の実装は 1 つです。"
 
 #: src/control-flow-basics/functions.md
 msgid ""
 "Always takes a fixed number of parameters. Default arguments are not "
 "supported. Macros can be used to support variadic functions."
 msgstr ""
+"常に固定数のパラメータを受け取ります。デフォルトの引数はサポートされていませ"
+"ん。マクロを使用して可変関数をサポートできます。"
 
 #: src/control-flow-basics/functions.md
 msgid ""
 "Always takes a single set of parameter types. These types can be generic, "
 "which will be covered later."
 msgstr ""
+"常に 1 つのパラメータ型セットを受け取ります。これらの型は汎用にすることもでき"
+"ますが、これについては後で説明します。"
 
 #: src/control-flow-basics/macros.md
 msgid ""
@@ -3505,38 +3652,49 @@ msgid ""
 "variable number of arguments. They are distinguished by a `!` at the end. "
 "The Rust standard library includes an assortment of useful macros."
 msgstr ""
+"マクロはコンパイル時に Rust コードに展開され、可変長引数を取ることができま"
+"す。これらは末尾の `!` で区別されます。Rust 標準ライブラリには、各種の便利な"
+"マクロが含まれています。"
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "`println!(format, ..)` prints a line to standard output, applying formatting "
 "described in [`std::fmt`](https://doc.rust-lang.org/std/fmt/index.html)."
 msgstr ""
+"`println!(format, ..)`: [`std::fmt`](https://doc.rust-lang.org/std/fmt/index."
+"html) で説明されている書式を適用して、1 行を標準出力に出力します。"
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "`format!(format, ..)` works just like `println!` but returns the result as a "
 "string."
 msgstr ""
+"`format!(format, ..)`: `println!` と同様に機能しますが、結果を文字列として返"
+"します。"
 
 #: src/control-flow-basics/macros.md
 msgid "`dbg!(expression)` logs the value of the expression and returns it."
-msgstr ""
+msgstr "`dbg!(expression)`: 式の値をログに記録して返します。"
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "`todo!()` marks a bit of code as not-yet-implemented. If executed, it will "
 "panic."
 msgstr ""
+"`todo!()`: 一部のコードに未実装のマークを付けます。実行するとパニックが発生し"
+"ます。"
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "`unreachable!()` marks a bit of code as unreachable. If executed, it will "
 "panic."
 msgstr ""
+"`unreachable!()`: コードの一部をアクセス不能としてマークします。実行するとパ"
+"ニックが発生します。"
 
 #: src/control-flow-basics/macros.md
 msgid "\"{n}! = {}\""
-msgstr ""
+msgstr "\"{n}! = {}\""
 
 #: src/control-flow-basics/macros.md
 msgid ""
@@ -3544,225 +3702,231 @@ msgid ""
 "how to use them. Why they are defined as macros, and what they expand to, is "
 "not especially critical."
 msgstr ""
+"このセクションの要点は、マクロの一般的な利便性と、その使用方法を示すことにあ"
+"ります。マクロとして定義されている理由と、展開先は特に重要ではありません。"
 
 #: src/control-flow-basics/macros.md
 msgid ""
 "The course does not cover defining macros, but a later section will describe "
 "use of derive macros."
 msgstr ""
+"マクロの定義についてはコースでは説明しませんが、後のセクションで導出マクロの"
+"使用について説明します。"
 
 #: src/control-flow-basics/exercise.md
 msgid ""
 "The [Collatz Sequence](https://en.wikipedia.org/wiki/Collatz_conjecture) is "
 "defined as follows, for an arbitrary n"
 msgstr ""
+"[コラッツ数列](https://en.wikipedia.org/wiki/Collatz_conjecture) は、ゼロより"
+"大きい任意の n"
 
 #: src/control-flow-basics/exercise.md
 msgid "1"
-msgstr ""
+msgstr "1"
 
 #: src/control-flow-basics/exercise.md
 msgid " greater than zero:"
-msgstr ""
+msgstr "  に対して、次のように定義されます。"
 
 #: src/control-flow-basics/exercise.md
 msgid "If _n"
-msgstr ""
+msgstr "_n"
 
 #: src/control-flow-basics/exercise.md
 msgid "i"
-msgstr ""
+msgstr "i"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ is 1, then the sequence terminates at _n"
-msgstr ""
+msgstr "_ が 1 の場合、数列は _n"
 
 #: src/control-flow-basics/exercise.md
 msgid "_."
-msgstr ""
+msgstr "_で終了します。"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ is even, then _n"
-msgstr ""
+msgstr "_ が偶数の場合、_n"
 
 #: src/control-flow-basics/exercise.md
 msgid "i+1"
-msgstr ""
+msgstr "i+1"
 
 #: src/control-flow-basics/exercise.md
 msgid " = n"
-msgstr ""
+msgstr " = n"
 
 #: src/control-flow-basics/exercise.md
 msgid " / 2_."
-msgstr ""
+msgstr " / 2_ になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ is odd, then _n"
-msgstr ""
+msgstr "_ が奇数の場合、_n"
 
 #: src/control-flow-basics/exercise.md
 msgid " = 3 * n"
-msgstr ""
+msgstr " = 3 * n"
 
 #: src/control-flow-basics/exercise.md
 msgid " + 1_."
-msgstr ""
+msgstr " + 1_ になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "For example, beginning with _n"
-msgstr ""
+msgstr "たとえば、_n"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 3:"
-msgstr ""
+msgstr "_ = 3 で始まる場合は以下のようになります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "3 is odd, so _n"
-msgstr ""
+msgstr "3 は奇数なので、_n"
 
 #: src/control-flow-basics/exercise.md
 msgid "2"
-msgstr ""
+msgstr "2"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 3 * 3 + 1 = 10;"
-msgstr ""
+msgstr "_ = 3 * 3 + 1 = 10 になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "10 is even, so _n"
-msgstr ""
+msgstr "10 は偶数なので、_n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "3"
-msgstr ""
+msgstr "3"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 10 / 2 = 5;"
-msgstr ""
+msgstr "_ = 10 / 2 = 5 になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "5 is odd, so _n"
-msgstr ""
+msgstr "5 は奇数なので、_n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "4"
-msgstr ""
+msgstr "4"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 3 * 5 + 1 = 16;"
-msgstr ""
+msgstr "_ = 3 * 5 + 1 = 16 になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "16 is even, so _n"
-msgstr ""
+msgstr "16 は偶数なので、_n"
 
 #: src/control-flow-basics/exercise.md
 msgid "5"
-msgstr ""
+msgstr "5"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 16 / 2 = 8;"
-msgstr ""
+msgstr "_ = 16 / 2 = 8 になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "8 is even, so _n"
-msgstr ""
+msgstr "8 は偶数なので、_n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "6"
-msgstr ""
+msgstr "6"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 8 / 2 = 4;"
-msgstr ""
+msgstr "_ = 8 / 2 = 4 になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "4 is even, so _n"
-msgstr ""
+msgstr "4 は偶数なので、_n"
 
 #: src/control-flow-basics/exercise.md
 msgid "7"
-msgstr ""
+msgstr "7"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 4 / 2 = 2;"
-msgstr ""
+msgstr "_ = 4 / 2 = 2 になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "2 is even, so _n"
-msgstr ""
+msgstr "2 は偶数なので、_n"
 
 #: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
 msgid "8"
-msgstr ""
+msgstr "8"
 
 #: src/control-flow-basics/exercise.md
 msgid "_ = 1; and"
-msgstr ""
+msgstr "_ = 1 になります。"
 
 #: src/control-flow-basics/exercise.md
 msgid "the sequence terminates."
-msgstr ""
+msgstr "数列は終了します。"
 
 #: src/control-flow-basics/exercise.md
 msgid ""
 "Write a function to calculate the length of the collatz sequence for a given "
 "initial `n`."
 msgstr ""
+"任意の初期値 `n` に対するコラッツ数列の長さを計算する関数を作成します。"
 
 #: src/control-flow-basics/exercise.md src/control-flow-basics/solution.md
 msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
-msgstr ""
+msgstr "/// `n` から始まるコラッツ数列の長さを決定。\n"
 
 #: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
 msgid "\"Length: {}\""
-msgstr ""
+msgstr "\"Length: {}\""
 
 #: src/welcome-day-1-afternoon.md src/welcome-day-2-afternoon.md
 #: src/welcome-day-3-afternoon.md src/welcome-day-4-afternoon.md
-#, fuzzy
 msgid "Welcome Back"
-msgstr "Welcome"
+msgstr "おかえり"
 
 #: src/welcome-day-1-afternoon.md
 msgid "[Tuples and Arrays](./tuples-and-arrays.md) (1 hour)"
-msgstr ""
+msgstr "[タプルと配列](./tuples-and-arrays.md)（1 時間）"
 
 #: src/welcome-day-1-afternoon.md
 msgid "[References](./references.md) (50 minutes)"
-msgstr ""
+msgstr "[参照](./references.md)（50 分）"
 
 #: src/welcome-day-1-afternoon.md
 msgid "[User-Defined Types](./user-defined-types.md) (50 minutes)"
-msgstr ""
+msgstr "[ユーザー定義型](./user-defined-types.md)（50 分）"
 
 #: src/welcome-day-1-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 55 "
 "minutes"
-msgstr ""
+msgstr "このセッションの所要時間は、10 分間の休憩を入れて約 2 時間 55 分です。"
 
 #: src/tuples-and-arrays.md
 msgid ""
 "[Tuples and Arrays](./tuples-and-arrays/tuples-and-arrays.md) (10 minutes)"
-msgstr ""
+msgstr "[タプルと配列](./tuples-and-arrays/tuples-and-arrays.md)（10 分）"
 
 #: src/tuples-and-arrays.md
 msgid "[Array Iteration](./tuples-and-arrays/iteration.md) (3 minutes)"
-msgstr ""
+msgstr "[配列の反復処理](./tuples-and-arrays/iteration.md)（3 分）"
 
 #: src/tuples-and-arrays.md
 msgid "[Pattern Matching](./tuples-and-arrays/match.md) (10 minutes)"
-msgstr ""
+msgstr "[パターン マッチング](./tuples-and-arrays/match.md)（10 分）"
 
 #: src/tuples-and-arrays.md
 msgid "[Destructuring](./tuples-and-arrays/destructuring.md) (5 minutes)"
-msgstr ""
+msgstr "[分解](./tuples-and-arrays/destructuring.md)（5 分）"
 
 #: src/tuples-and-arrays.md
 msgid "[Exercise: Nested Arrays](./tuples-and-arrays/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: ネストされた配列](./tuples-and-arrays/exercise.md)（30 分）"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
@@ -3770,44 +3934,47 @@ msgid ""
 "elements of an array have the same type, while tuples can accommodate "
 "different types. Both types have a size fixed at compile time."
 msgstr ""
+"タプルと配列は、このコースで初めて扱う「複合」型です。配列のすべての要素の型"
+"は同じですが、タプルは異なる型に対応できます。どちらの型もコンパイル時にサイ"
+"ズが固定されます。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 #: src/tuples-and-arrays/destructuring.md
 msgid "Arrays"
-msgstr ""
+msgstr "配列"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`[T; N]`"
-msgstr ""
+msgstr "`[T; N]`"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`[20, 30, 40]`, `[0; 3]`"
-msgstr ""
+msgstr "`[20, 30, 40]`、`[0; 3]`"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 #: src/tuples-and-arrays/destructuring.md
 msgid "Tuples"
-msgstr ""
+msgstr "タプル"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`()`, `(T,)`, `(T1, T2)`, ..."
-msgstr ""
+msgstr "`()`、`(T,)`、`(T1, T2)`、..."
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
-msgstr ""
+msgstr "`()`、`('x',)`、`('x', 1.2)`、..."
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Array assignment and access:"
-msgstr ""
+msgstr "配列の代入とアクセス:"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Tuple assignment and access:"
-msgstr ""
+msgstr "タプルの代入とアクセス:"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Arrays:"
-msgstr ""
+msgstr "配列:"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
@@ -3817,6 +3984,10 @@ msgid ""
 "different types. Slices, which have a size determined at runtime, are "
 "covered later."
 msgstr ""
+"配列型 `[T; N]`には、同じ型 `T` の `N`（コンパイル時定数）個の要素が保持され"
+"ます。なお、配列の長さはその型の一部分です。つまり、`[u8; 3]` と `[u8; 4]` "
+"は 2 つの異なる型とみなされます。スライス（サイズが実行時に決定される）につい"
+"ては後で説明します。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
@@ -3824,10 +3995,13 @@ msgid ""
 "runtime. Rust can usually optimize these checks away, and they can be "
 "avoided using unsafe Rust."
 msgstr ""
+"境界外の配列要素にアクセスしてみてください。配列アクセスは実行時にチェックさ"
+"れます。Rust では通常、これらのチェックを最適化により除去できます（Unsafe "
+"Rust を使用することで回避できます）。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "We can use literals to assign values to arrays."
-msgstr ""
+msgstr "リテラルを使用して配列に値を代入することができます。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
@@ -3837,30 +4011,38 @@ msgid ""
 "only implement the debug output. This means that we must use debug output "
 "here."
 msgstr ""
+"`println!` マクロは、`?` 形式のパラメータを使用してデバッグ実装を要求します。"
+"つまり、`{}` はデフォルトの出力を、`{:?}` はデバッグ出力を提供します。整数や"
+"文字列などの型はデフォルトの出力を実装しますが、配列はデバッグ出力のみを実装"
+"します。そのため、ここではデバッグ出力を使用する必要があります。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
 "Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
 "easier to read."
 msgstr ""
+"`#` を追加すると（例: `{a:#?}`）、読みやすい「プリティ プリント」形式が呼び出"
+"されます。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Tuples:"
-msgstr ""
+msgstr "タプル:"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Like arrays, tuples have a fixed length."
-msgstr ""
+msgstr "配列と同様に、タプルの長さは固定されています。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid "Tuples group together values of different types into a compound type."
-msgstr ""
+msgstr "タプルは、異なる型の値を複合型にグループ化します。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
 "Fields of a tuple can be accessed by the period and the index of the value, "
 "e.g. `t.0`, `t.1`."
 msgstr ""
+"タプルのフィールドには、ピリオドと値のインデックス（例: `t.0`、`t.1`）でアク"
+"セスできます。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
@@ -3869,22 +4051,31 @@ msgid ""
 "its value are expressed as `()`. It is used to indicate, for example, that a "
 "function or expression has no return value, as we'll see in a future slide."
 msgstr ""
+"空のタプル `()` は、「ユニット型」とも呼ばれます。これは型であるとともに、そ"
+"の型で唯一の有効な値です。つまり、型とその値の両方が `()` として表現されま"
+"す。以降のスライドで説明するように、これは関数や式に戻り値がないことを示す場"
+"合などに使用されます。"
 
 #: src/tuples-and-arrays/tuples-and-arrays.md
 msgid ""
 "You can think of it as `void` that can be familiar to you from other "
 "programming languages."
 msgstr ""
+"これは、他のプログラミング言語で馴染みのある `void` と考えることができます。"
 
 #: src/tuples-and-arrays/iteration.md
 msgid "The `for` statement supports iterating over arrays (but not tuples)."
 msgstr ""
+"for ステートメントでは、配列の反復処理がサポートされています（タプルはサポー"
+"トされていません）。"
 
 #: src/tuples-and-arrays/iteration.md
 msgid ""
 "This functionality uses the `IntoIterator` trait, but we haven't covered "
 "that yet."
 msgstr ""
+"この機能は `IntoIterator` トレイトを使用しますが、これはまだ説明していませ"
+"ん。"
 
 #: src/tuples-and-arrays/iteration.md
 msgid ""
@@ -3892,71 +4083,77 @@ msgid ""
 "` macros. These are always checked while, debug-only variants like "
 "`debug_assert!` compile to nothing in release builds."
 msgstr ""
+"ここでは `assert_ne!` マクロが新たに加わっていますが、他にも `assert_eq! マク"
+"ロと`assert!` マクロがあります。これらは常にチェックされますが、"
+"`debug_assert!` などのデバッグ専用の派生ツールは、リリースビルドでは何もコン"
+"パイルされません。"
 
 #: src/tuples-and-arrays/match.md
 msgid ""
 "The `match` keyword lets you match a value against one or more _patterns_. "
 "The comparisons are done from top to bottom and the first match wins."
 msgstr ""
+"`match` キーワードを使用すると、1 つ以上のパターンに対して値を照合できます。"
+"上から順に照合が行われ、最初に一致したパターンのみが実行されます。"
 
 #: src/tuples-and-arrays/match.md
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
-msgstr ""
+msgstr "C や C++ の `switch` と同様に、パターンには単純な値を指定できます。"
 
 #: src/tuples-and-arrays/match.md
 msgid "'x'"
-msgstr ""
+msgstr "'x'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'q'"
-msgstr ""
+msgstr "'q'"
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Quitting\""
-msgstr ""
+msgstr "\"Quitting\""
 
 #: src/tuples-and-arrays/match.md src/std-traits/solution.md
 #: src/error-handling/exercise.md src/error-handling/solution.md
 msgid "'a'"
-msgstr ""
+msgstr "'a'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'s'"
-msgstr ""
+msgstr "'s'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'w'"
-msgstr ""
+msgstr "'w'"
 
 #: src/tuples-and-arrays/match.md
 msgid "'d'"
-msgstr ""
+msgstr "'d'"
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Moving around\""
-msgstr ""
+msgstr "\"Moving around\""
 
 #: src/tuples-and-arrays/match.md src/error-handling/exercise.md
 #: src/error-handling/solution.md
 msgid "'0'"
-msgstr ""
+msgstr "'0'"
 
 #: src/tuples-and-arrays/match.md src/error-handling/exercise.md
 #: src/error-handling/solution.md
 msgid "'9'"
-msgstr ""
+msgstr "'9'"
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Number input\""
-msgstr ""
+msgstr "\"Number input\""
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Lowercase: {key}\""
-msgstr ""
+msgstr "\"Lowercase: {key}\""
 
 #: src/tuples-and-arrays/match.md
 msgid "\"Something else\""
-msgstr ""
+msgstr "\"Something else\""
 
 #: src/tuples-and-arrays/match.md
 msgid ""
@@ -3964,6 +4161,9 @@ msgid ""
 "expressions _must_ be irrefutable, meaning that it covers every possibility, "
 "so `_` is often used as the final catch-all case."
 msgstr ""
+"`_` パターンは、任意の値に一致するワイルドカード パターンです。式は論駁不可能"
+"でなければなりません。つまり、あらゆる可能性をカバーする必要があるため、最後"
+"のキャッチオール ケースとして `_` がよく使用されます。"
 
 #: src/tuples-and-arrays/match.md
 msgid ""
@@ -3971,16 +4171,21 @@ msgid ""
 "the same type. The type is the last expression of the block, if any. In the "
 "example above, the type is `()`."
 msgstr ""
+"一致を式として使用できます。`if` と同様に、各マッチアームは同じ型にする必要が"
+"あります。型は、ブロックの最後の式です（存在する場合）。上記の例では、型は "
+"`()` です。"
 
 #: src/tuples-and-arrays/match.md
 msgid ""
 "A variable in the pattern (`key` in this example) will create a binding that "
 "can be used within the match arm."
 msgstr ""
+"パターンの変数（この例では `key`）により、マッチアーム内で使用できるバイン"
+"ディングが作成されます。"
 
 #: src/tuples-and-arrays/match.md
 msgid "A match guard causes the arm to match only if the condition is true."
-msgstr ""
+msgstr "マッチガードにより、条件が true の場合にのみアームが一致します。"
 
 #: src/tuples-and-arrays/match.md src/user-defined-types/named-structs.md
 #: src/user-defined-types/enums.md src/methods-and-traits/methods.md
@@ -3991,23 +4196,23 @@ msgstr "キーポイント: "
 msgid ""
 "You might point out how some specific characters are being used when in a "
 "pattern"
-msgstr ""
+msgstr "特定の文字がパターンでどのように使用されるかを説明します。"
 
 #: src/tuples-and-arrays/match.md
 msgid "`|` as an `or`"
-msgstr ""
+msgstr "`|` を `or` として指定する"
 
 #: src/tuples-and-arrays/match.md
 msgid "`..` can expand as much as it needs to be"
-msgstr ""
+msgstr "`..` は必要に応じて展開できる"
 
 #: src/tuples-and-arrays/match.md
 msgid "`1..=5` represents an inclusive range"
-msgstr ""
+msgstr "`1..=5` は 5 を含む範囲を表す"
 
 #: src/tuples-and-arrays/match.md
 msgid "`_` is a wild card"
-msgstr ""
+msgstr "`_` はワイルドカードを表す"
 
 #: src/tuples-and-arrays/match.md
 msgid ""
@@ -4015,6 +4220,8 @@ msgid ""
 "we wish to concisely express more complex ideas than patterns alone would "
 "allow."
 msgstr ""
+"パターンのみでは表現できない複雑な概念を簡潔に表現したい場合、独立した構文機"
+"能であるマッチガードは重要かつ必要です。"
 
 #: src/tuples-and-arrays/match.md
 msgid ""
@@ -4023,12 +4230,17 @@ msgid ""
 "match arm is selected. Failing the `if` condition inside of that block won't "
 "result in other arms of the original `match` expression being considered."
 msgstr ""
+"マッチガードは、マッチアーム内の個別の `if` 式とは異なります。分岐ブロック内"
+"（`=>` の後）の `if` 式は、マッチアームが選択された後に実行されます。そのブ"
+"ロック内で `if` 条件が満たされなかった場合、元の `match` 式の他のアームは考慮"
+"されません。"
 
 #: src/tuples-and-arrays/match.md
 msgid ""
 "The condition defined in the guard applies to every expression in a pattern "
 "with an `|`."
 msgstr ""
+"ガードで定義された条件は、`|` が付いたパターン内のすべての式に適用されます。"
 
 #: src/tuples-and-arrays/destructuring.md
 msgid ""
@@ -4036,68 +4248,70 @@ msgid ""
 "pattern that is matched up to the data structure, binding variables to "
 "subcomponents of the data structure."
 msgstr ""
+"分解とは、データ構造に一致するパターンを記述し、変数をデータ構造のサブコン"
+"ポーネントにバインドすることで、データ構造からデータを抽出する方法です。"
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "You can destructure tuples and arrays by matching on their elements:"
-msgstr ""
+msgstr "タプルと配列は、要素を照合することで分解できます。"
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"on Y axis\""
-msgstr ""
+msgstr "\"on Y axis\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"on X axis\""
-msgstr ""
+msgstr "\"on X axis\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"left of Y axis\""
-msgstr ""
+msgstr "\"left of Y axis\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"below X axis\""
-msgstr ""
+msgstr "\"below X axis\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"first quadrant\""
-msgstr ""
+msgstr "\"first quadrant\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"Tell me about {triple:?}\""
-msgstr ""
+msgstr "\"Tell me about {triple:?}\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"First is 0, y = {y}, and z = {z}\""
-msgstr ""
+msgstr "\"First is 0, y = {y}, and z = {z}\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"First is 1 and the rest were ignored\""
-msgstr ""
+msgstr "\"First is 1 and the rest were ignored\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "\"All elements were ignored\""
-msgstr ""
+msgstr "\"All elements were ignored\""
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "Create a new array pattern using `_` to represent an element."
-msgstr ""
+msgstr "`_` を使用して要素を表す新しい配列パターンを作成します。"
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "Add more values to the array."
-msgstr ""
+msgstr "配列に値を追加します。"
 
 #: src/tuples-and-arrays/destructuring.md
 msgid ""
 "Point out that how `..` will expand to account for different number of "
 "elements."
-msgstr ""
+msgstr "要素数が異なる場合に `..` がどのように展開されるかを説明します。"
 
 #: src/tuples-and-arrays/destructuring.md
 msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
-msgstr ""
+msgstr "パターン `[.., b]` と `[a@..,b]` で末尾を照合します。"
 
 #: src/tuples-and-arrays/exercise.md
 msgid "Arrays can contain other arrays:"
-msgstr ""
+msgstr "配列には他の配列を含めることができます。"
 
 #: src/tuples-and-arrays/exercise.md
 #, fuzzy
@@ -4109,53 +4323,56 @@ msgid ""
 "Use an array such as the above to write a function `transpose` which will "
 "transpose a matrix (turn rows into columns):"
 msgstr ""
+"上記のような配列を使用して、行列を転置（行を列に変換）する `transpose` 関数を"
+"記述します。"
 
 #: src/tuples-and-arrays/exercise.md
 msgid "Hard-code both functions to operate on 3 × 3 matrices."
-msgstr ""
+msgstr "3 × 3 の行列で動作するように、両方の関数をハードコードします。"
 
 #: src/tuples-and-arrays/exercise.md
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
+"以下のコードを <https://play.rust-lang.org/> にコピーして、関数を実装します。"
 
 #: src/tuples-and-arrays/exercise.md src/borrowing/exercise.md
 #: src/unsafe-rust/exercise.md
 msgid "// TODO: remove this when you're done with your implementation.\n"
-msgstr ""
+msgstr "// TODO: 実装が完了したら、これを削除します。\n"
 
 #: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "// <-- the comment makes rustfmt add a newline\n"
-msgstr ""
+msgstr "// <-- このコメントにより rustfmt で改行を追加\n"
 
 #: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "\"matrix: {:#?}\""
-msgstr ""
+msgstr "\"matrix: {:#?}\""
 
 #: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
 msgid "\"transposed: {:#?}\""
-msgstr ""
+msgstr "\"transposed: {:#?}\""
 
 #: src/tuples-and-arrays/solution.md
 msgid "//\n"
-msgstr ""
+msgstr "//\n"
 
 #: src/references.md
 msgid "[Shared References](./references/shared.md) (10 minutes)"
-msgstr ""
+msgstr "[共有参照](./references/shared.md)（10 分）"
 
 #: src/references.md
 msgid "[Exclusive References](./references/exclusive.md) (10 minutes)"
-msgstr ""
+msgstr "[排他参照](./references/except.md)（10 分）"
 
 #: src/references.md
 msgid "[Exercise: Geometry](./references/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: ジオメトリ](./references/exercise.md)（30 分）"
 
 #: src/references.md src/user-defined-types.md src/pattern-matching.md
 msgid "This segment should take about 50 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 50 分です"
 
 #: src/references/shared.md
 msgid ""
@@ -4163,6 +4380,9 @@ msgid ""
 "responsibility for the value, and is also called \"borrowing\". Shared "
 "references are read-only, and the referenced data cannot change."
 msgstr ""
+"参照を使用すると、値について責任を負うことなく別の値にアクセスできます。参照"
+"は「借用」とも呼ばれます。共有参照は読み取り専用であり、参照先のデータは変更"
+"できません。"
 
 #: src/references/shared.md
 msgid ""
@@ -4170,10 +4390,12 @@ msgid ""
 "with the `&` operator. The `*` operator \"dereferences\" a reference, "
 "yielding its value."
 msgstr ""
+"型 `T` への共有参照の型は `&T` です。参照値は `&` 演算子で作成されます。`*` "
+"演算子は参照を「逆参照」し、その値を生成します。"
 
 #: src/references/shared.md
 msgid "Rust will statically forbid dangling references:"
-msgstr ""
+msgstr "Rust はダングリング参照を静的に禁止します。"
 
 #: src/references/shared.md
 msgid ""
@@ -4182,6 +4404,10 @@ msgid ""
 "access the value, but is still \"owned\" by the original variable. The "
 "course will get into more detail on ownership in day 3."
 msgstr ""
+"参照とは、参照する値を「借用する」ことだと言われていますが、これはポインタに"
+"慣れていない受講者にとって理解しやすい説明です。コードでは参照を使用して値に"
+"アクセスできますが、その値は元の変数によって「所有」されたままとなります。所"
+"有については、コースの 3 日目で詳しく説明します。"
 
 #: src/references/shared.md
 msgid ""
@@ -4191,12 +4417,16 @@ msgid ""
 "cover how Rust prevents the memory-safety bugs that come from using raw "
 "pointers."
 msgstr ""
+"参照はポインタとして実装されます。主な利点は、参照先よりもはるかに小さくでき"
+"ることです。C または C++ に精通している受講者は、参照をポインタとして認識でき"
+"ます。このコースの後半で、未加工ポインタの使用によるメモリ安全性のバグを "
+"Rust で防止する方法について説明します。"
 
 #: src/references/shared.md
 msgid ""
 "Rust does not automatically create references for you - the `&` is always "
 "required."
-msgstr ""
+msgstr "Rust は参照を自動的に作成しないため、常に `&` を付ける必要があります。"
 
 #: src/references/shared.md
 msgid ""
@@ -4204,6 +4434,8 @@ msgid ""
 "methods (try `r.count_ones()`). There is no need for an `->` operator like "
 "in C++."
 msgstr ""
+"Rust は、特にメソッドを呼び出すとき、自動的に逆参照する場合があります（`r."
+"count_ones()` を試してください）。C++ のような `->` 演算子は必要ありません。"
 
 #: src/references/shared.md
 msgid ""
@@ -4212,12 +4444,17 @@ msgid ""
 "different from C++, where assignment to a reference changes the referenced "
 "value."
 msgstr ""
+"この例では、`r` は可変であるため、再代入が可能です（`r = &b`）。これにより "
+"`r` が再バインドされ、他の値を参照するようになります。これは、参照に代入する"
+"と参照先の値が変更される C++ とは異なります。"
 
 #: src/references/shared.md
 msgid ""
 "A shared reference does not allow modifying the value it refers to, even if "
 "that value was mutable. Try `*r = 'X'`."
 msgstr ""
+"共有参照では、値が可変であっても、参照先の値は変更できません。`*r = 'X'` と指"
+"定してみてください。"
 
 #: src/references/shared.md
 msgid ""
@@ -4226,16 +4463,21 @@ msgid ""
 "a reference to `point`, but `point` will be deallocated when the function "
 "returns, so this will not compile."
 msgstr ""
+"Rust は、すべての参照のライフタイムを追跡して、十分な存続期間を確保していま"
+"す。安全な Rust では、ダングリング参照が発生することはありません。`x_axis` "
+"は `point` への参照を返しますが、関数が戻ると `point` の割り当てが解除される"
+"ため、コンパイルされません。"
 
 #: src/references/shared.md
 msgid "We will talk more about borrowing when we get to ownership."
-msgstr ""
+msgstr "借用については所有権のところで詳しく説明します。"
 
 #: src/references/exclusive.md
 msgid ""
 "Exclusive references, also known as mutable references, allow changing the "
 "value they refer to. They have type `&mut T`."
 msgstr ""
+"排他参照は可変参照とも呼ばれ、参照先の値を変更できます。型は `&mut T` です。"
 
 #: src/references/exclusive.md
 msgid ""
@@ -4245,6 +4487,10 @@ msgid ""
 "exists. Try making an `&point.0` or changing `point.0` while `x_coord` is "
 "alive."
 msgstr ""
+"「排他」とは、この参照のみを使用して値にアクセスできることを意味します。他の"
+"参照（共有または排他）が同時に存在することはできず、排他参照が存在する間は参"
+"照先の値にアクセスできません。`x_coord` が有効な状態で `&point.0` を作成する"
+"か、`point.0` を変更してみてください。"
 
 #: src/references/exclusive.md
 msgid ""
@@ -4253,6 +4499,9 @@ msgid ""
 "bound to different values, while the second represents an exclusive "
 "reference to a mutable value."
 msgstr ""
+"`let mut x_coord: &i32` と `let x_coord: &mut i32` の違いに注意してください。"
+"前者は異なる値にバインドできる共有参照を表すのに対し、後者は可変の値への排他"
+"参照を表します。"
 
 #: src/references/exercise.md
 msgid ""
@@ -4260,6 +4509,8 @@ msgid ""
 "representing a point as `[f64;3]`. It is up to you to determine the function "
 "signatures."
 msgstr ""
+"ここでは、点を `[f64;3]` として表現する 3 次元ジオメトリのユーティリティ関数"
+"をいくつか作成します。関数シグネチャは任意で指定してください。"
 
 #: src/references/exercise.md
 msgid ""
@@ -4269,103 +4520,111 @@ msgid ""
 "square\n"
 "// root, like `v.sqrt()`.\n"
 msgstr ""
+"// 座標の二乗を合計して平方根を取り、\n"
+"// ベクターの大きさを計算します。`sqrt()` メソッドを使用して、`v.sqrt()` と同"
+"様に\n"
+"// 平方根を計算します。\n"
 
 #: src/references/exercise.md
 msgid ""
 "// Normalize a vector by calculating its magnitude and dividing all of its\n"
 "// coordinates by that magnitude.\n"
 msgstr ""
+"// 大きさを計算し、すべての座標をその大きさで割ることで\n"
+"// ベクターを正規化します。\n"
 
 #: src/references/exercise.md
 msgid "// Use the following `main` to test your work.\n"
-msgstr ""
+msgstr "// 次の `main` を使用して処理をテストします。\n"
 
 #: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of a unit vector: {}\""
-msgstr ""
+msgstr "\"Magnitude of a unit vector: {}\""
 
 #: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of {v:?}: {}\""
-msgstr ""
+msgstr "\"Magnitude of {v:?}: {}\""
 
 #: src/references/exercise.md src/references/solution.md
 msgid "\"Magnitude of {v:?} after normalization: {}\""
-msgstr ""
+msgstr "\"Magnitude of {v:?} after normalization: {}\""
 
 #: src/references/solution.md
 msgid "/// Calculate the magnitude of the given vector.\n"
-msgstr ""
+msgstr "/// 指定されたベクターの大きさを計算します。\n"
 
 #: src/references/solution.md
 msgid ""
 "/// Change the magnitude of the vector to 1.0 without changing its "
 "direction.\n"
-msgstr ""
+msgstr "/// 向きを変えずにベクターの大きさを 1.0 に変更します。\n"
 
 #: src/user-defined-types.md
 msgid "[Named Structs](./user-defined-types/named-structs.md) (10 minutes)"
-msgstr ""
+msgstr "[名前付き構造体](./user-defined-types/named-structs.md)（10 分）"
 
 #: src/user-defined-types.md
 msgid "[Tuple Structs](./user-defined-types/tuple-structs.md) (10 minutes)"
-msgstr ""
+msgstr "[タプル構造体](./user-defined-types/tuple-structs.md)（10 分）"
 
 #: src/user-defined-types.md
 msgid "[Enums](./user-defined-types/enums.md) (5 minutes)"
-msgstr ""
+msgstr "[列挙型](./user-defined-types/enums.md)（5 分）"
 
 #: src/user-defined-types.md
 msgid ""
 "[Static and Const](./user-defined-types/static-and-const.md) (5 minutes)"
-msgstr ""
+msgstr "[static と const](./user-defined-types/static-and-const.md)（5 分）"
 
 #: src/user-defined-types.md
 msgid "[Type Aliases](./user-defined-types/aliases.md) (2 minutes)"
-msgstr ""
+msgstr "[型エイリアス](./user-defined-types/aliases.md)（2 分）"
 
 #: src/user-defined-types.md
 msgid ""
 "[Exercise: Elevator Events](./user-defined-types/exercise.md) (15 minutes)"
 msgstr ""
+"[演習: エレベーター イベント](./user-defined-types/exercise.md)（15 分）"
 
 #: src/user-defined-types/named-structs.md
 msgid "Like C and C++, Rust has support for custom structs:"
-msgstr ""
+msgstr "C や C++ と同様に、Rust はカスタム構造体をサポートしています。"
 
 #: src/user-defined-types/named-structs.md
 msgid "\"{} is {} years old\""
-msgstr ""
+msgstr "\"{} is {} years old\""
 
 #: src/user-defined-types/named-structs.md
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"Peter\""
-msgstr ""
+msgstr "\"Peter\""
 
 #: src/user-defined-types/named-structs.md
 msgid "\"Avery\""
-msgstr ""
+msgstr "\"Avery\""
 
 #: src/user-defined-types/named-structs.md
 msgid "\"Jackie\""
-msgstr ""
+msgstr "\"Jackie\""
 
 #: src/user-defined-types/named-structs.md
 msgid "Structs work like in C or C++."
-msgstr ""
+msgstr "構造体は、C や C++ においてと同じように機能します。"
 
 #: src/user-defined-types/named-structs.md
 msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
 msgstr ""
+"C++ と同様に、また C とは異なり、型を定義するのに typedef は必要ありません。"
 
 #: src/user-defined-types/named-structs.md
 msgid "Unlike in C++, there is no inheritance between structs."
-msgstr ""
+msgstr "C++ とは異なり、構造体間に継承はありません。"
 
 #: src/user-defined-types/named-structs.md
 msgid ""
 "This may be a good time to let people know there are different types of "
 "structs."
-msgstr ""
+msgstr "ここで、構造体にはさまざまな型があることを説明しましょう。"
 
 #: src/user-defined-types/named-structs.md
 msgid ""
@@ -4373,18 +4632,23 @@ msgid ""
 "trait on some type but don’t have any data that you want to store in the "
 "value itself."
 msgstr ""
+"サイズがゼロの構造体（例: `struct Foo;`）は、ある型にトレイトを実装しているも"
+"のの、値自体に格納するデータがない場合に使用できます。"
 
 #: src/user-defined-types/named-structs.md
 msgid ""
 "The next slide will introduce Tuple structs, used when the field names are "
 "not important."
 msgstr ""
+"次のスライドでは、フィールド名が重要でない場合に使用されるタプル構造体を紹介"
+"します。"
 
 #: src/user-defined-types/named-structs.md
 msgid ""
 "If you already have variables with the right names, then you can create the "
 "struct using a shorthand."
 msgstr ""
+"適切な名前の変数がすでにある場合は、省略形を使用して構造体を作成できます。"
 
 #: src/user-defined-types/named-structs.md
 msgid ""
@@ -4392,100 +4656,119 @@ msgid ""
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
+"構文 `..avery` を使用すると、明示的にすべてのフィールドを入力しなくても、古い"
+"構造体のフィールドの大部分をコピーできます。この構文は、常に最後の要素にする"
+"必要があります。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid "If the field names are unimportant, you can use a tuple struct:"
-msgstr ""
+msgstr "フィールド名が重要でない場合は、タプル構造体を使用できます。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid "\"({}, {})\""
-msgstr ""
+msgstr "\"({}, {})\""
 
 #: src/user-defined-types/tuple-structs.md
 msgid "This is often used for single-field wrappers (called newtypes):"
 msgstr ""
+"これは多くの場合、単一フィールド ラッパー（ニュータイプと呼ばれます）に使用さ"
+"れます。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid "\"Ask a rocket scientist at NASA\""
-msgstr ""
+msgstr "\"Ask a rocket scientist at NASA\""
 
 #: src/user-defined-types/tuple-structs.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 #: src/bare-metal/microcontrollers/type-state.md
 #: src/async/pitfalls/cancellation.md
 msgid "// ...\n"
-msgstr ""
+msgstr "// ...\n"
 
 #: src/user-defined-types/tuple-structs.md
 msgid ""
 "Newtypes are a great way to encode additional information about the value in "
 "a primitive type, for example:"
 msgstr ""
+"ニュータイプは、プリミティブ型の値に関する追加情報をエンコードする優れた方法"
+"です。次に例を示します。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid "The number is measured in some units: `Newtons` in the example above."
-msgstr ""
+msgstr "数値はいくつかの単位で測定されます（上記の例では `Newtons`）。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid ""
 "The value passed some validation when it was created, so you no longer have "
 "to validate it again at every use: `PhoneNumber(String)` or `OddNumber(u32)`."
 msgstr ""
+"この値は作成時に検証に合格したため、`PhoneNumber(String)` または "
+"`OddNumber(u32)` を使用するたびに再検証する必要はありません。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid ""
 "Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
 "single field in the newtype."
 msgstr ""
+"ニュータイプの 1 つのフィールドにアクセスして、`Newtons` 型に `f64` の値を追"
+"加する方法を示します。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid ""
 "Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
 "for instance using booleans as integers."
 msgstr ""
+"Rust では通常、不明瞭なこと（自動ラップ解除や、整数としてのブール値の使用な"
+"ど）は好まれません。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid "Operator overloading is discussed on Day 3 (generics)."
-msgstr ""
+msgstr "演算子のオーバーロードについては、3 日目（ジェネリクス）で説明します。"
 
 #: src/user-defined-types/tuple-structs.md
 msgid ""
 "The example is a subtle reference to the [Mars Climate Orbiter](https://en."
 "wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
+"この例は、[マーズ クライメイト オービター](https://en.wikipedia.org/wiki/"
+"Mars_Climate_Orbiter)の失敗を参考にしています。"
 
 #: src/user-defined-types/enums.md
 msgid ""
 "The `enum` keyword allows the creation of a type which has a few different "
 "variants:"
 msgstr ""
+"`enum` キーワードを使用すると、いくつかの異なるバリアントを持つ型を作成できま"
+"す。"
 
 #: src/user-defined-types/enums.md
 msgid "// Simple variant\n"
-msgstr ""
+msgstr "// 単純なバリアント\n"
 
 #: src/user-defined-types/enums.md
 #, fuzzy
 msgid "// Tuple variant\n"
-msgstr "// 可変変数のバインディング\n"
+msgstr "// 単純なバリアント\n"
 
 #: src/user-defined-types/enums.md
 msgid "// Struct variant\n"
-msgstr ""
+msgstr "// 構造体バリアント\n"
 
 #: src/user-defined-types/enums.md
 msgid "\"On this turn: {:?}\""
-msgstr ""
+msgstr "\"On this turn: {:?}\""
 
 #: src/user-defined-types/enums.md
 msgid "Enumerations allow you to collect a set of values under one type."
-msgstr ""
+msgstr "列挙型を使用すると、1 つの型で一連の値を収集できます。"
 
 #: src/user-defined-types/enums.md
 msgid ""
 "`Direction` is a type with variants. There are two values of `Direction`: "
 "`Direction::Left` and `Direction::Right`."
 msgstr ""
+"`Direction` はバリアントを持つ型です。`Direction`には、`Direction::Left` と "
+"`Direction::Right` の 2 つの値があります。"
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4493,16 +4776,21 @@ msgid ""
 "Rust will store a discriminant so that it knows at runtime which variant is "
 "in a `PlayerMove` value."
 msgstr ""
+"`PlayerMove` は、3 つのバリアントを持つ型です。Rust はペイロードに加えて判別"
+"式を格納することで、実行時にどのバリアントが `PlayerMove` 値に含まれているか"
+"を把握できるようにします。"
 
 #: src/user-defined-types/enums.md
 msgid "This might be a good time to compare structs and enums:"
-msgstr ""
+msgstr "ここで構造体と列挙型を比較することをおすすめします。"
 
 #: src/user-defined-types/enums.md
 msgid ""
 "In both, you can have a simple version without fields (unit struct) or one "
 "with different types of fields (variant payloads)."
 msgstr ""
+"どちらでも、フィールドのないシンプルなバージョン（単位構造体）か、さまざまな"
+"フィールドがあるバージョン（バリアント ペイロード）を使用できます。"
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4510,14 +4798,17 @@ msgid ""
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum."
 msgstr ""
+"個別の構造体を使用して、列挙型のさまざまなバリアントを実装することもできます"
+"が、その場合、それらがすべて列挙型で定義されている場合と同じ型にはなりませ"
+"ん。"
 
 #: src/user-defined-types/enums.md
 msgid "Rust uses minimal space to store the discriminant."
-msgstr ""
+msgstr "Rust は判別式を保存するために最小限のスペースを使用します。"
 
 #: src/user-defined-types/enums.md
 msgid "If necessary, it stores an integer of the smallest required size"
-msgstr ""
+msgstr "必要に応じて、必要最小限のサイズの整数を格納します。"
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4526,29 +4817,38 @@ msgid ""
 "optimization\"). For example, `Option<&u8>` stores either a pointer to an "
 "integer or `NULL` for the `None` variant."
 msgstr ""
+"許可されたバリアント値がすべてのビットパターンをカバーしていない場合、無効な"
+"ビットパターンを使用して判別式をエンコードします（「ニッチの最適化」）。たと"
+"えば、`Option<&u8>` には `None` バリアントに対する整数へのポインタまたは "
+"`NULL` が格納されます。"
 
 #: src/user-defined-types/enums.md
 msgid ""
 "You can control the discriminant if needed (e.g., for compatibility with C):"
 msgstr ""
+"必要に応じて（たとえば C との互換性を確保するために）判別式を制御できます。"
 
 #: src/user-defined-types/enums.md
 msgid ""
 "Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
 "bytes."
 msgstr ""
+"`repr` がない場合、10001 は 2 バイトに収まるため、判別式の型には 2 バイトが使"
+"用されます。"
 
 #: src/user-defined-types/enums.md src/user-defined-types/static-and-const.md
 #: src/memory-management/review.md src/memory-management/move.md
 #: src/smart-pointers/box.md src/borrowing/shared.md
 msgid "More to Explore"
-msgstr ""
+msgstr "その他"
 
 #: src/user-defined-types/enums.md
 msgid ""
 "Rust has several optimizations it can employ to make enums take up less "
 "space."
 msgstr ""
+"Rust には、列挙型が占めるスペースを少なくするために使用できる最適化がいくつか"
+"あります。"
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4556,6 +4856,9 @@ msgid ""
 "option/#representation), Rust guarantees that `size_of::<T>()` equals "
 "`size_of::<Option<T>>()`."
 msgstr ""
+"null ポインタの最適化: [一部の型](https://doc.rust-lang.org/std/option/"
+"#representation)で、Rust は `size_of::<T>()` が `size_of::<Option<T>>()` と等"
+"しいことを保証します。"
 
 #: src/user-defined-types/enums.md
 msgid ""
@@ -4563,6 +4866,9 @@ msgid ""
 "like in practice. It's important to note that the compiler provides no "
 "guarantees regarding this representation, therefore this is totally unsafe."
 msgstr ""
+"以下のサンプルコードは、ビット単位の表現が実際にどのようになるかを示していま"
+"す。コンパイラはこの表現に関して保証しないので、これはまったく安全ではないこ"
+"とに注意してください。"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
@@ -4570,46 +4876,54 @@ msgid ""
 "scoped values that cannot be moved or reallocated during the execution of "
 "the program."
 msgstr ""
+"静的変数と定数変数は、プログラムの実行中に移動または再割り当てできないグロー"
+"バル スコープの値を作成するための、2 つの異なる方法です。"
 
 #: src/user-defined-types/static-and-const.md
 msgid "`const`"
-msgstr ""
+msgstr "`const`"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
 "Constant variables are evaluated at compile time and their values are "
 "inlined wherever they are used:"
 msgstr ""
+"定数変数はコンパイル時に評価され、使用場所にかかわらずその値がインライン化さ"
+"れます。"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
 "According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
 "vs-static.html) these are inlined upon use."
 msgstr ""
+"[Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
+"によると、定数変数は使用時にインライン化されます。"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
 "Only functions marked `const` can be called at compile time to generate "
 "`const` values. `const` functions can however be called at runtime."
 msgstr ""
+"コンパイル時に `const` 値を生成するために呼び出せるのは、`const` とマークされ"
+"た関数のみです。ただし、`const` 関数は実行時に呼び出すことができます。"
 
 #: src/user-defined-types/static-and-const.md
 msgid "`static`"
-msgstr ""
+msgstr "`static`"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
 "Static variables will live during the whole execution of the program, and "
 "therefore will not move:"
-msgstr ""
+msgstr "静的変数はプログラムの実行全体を通じて存続するため、移動しません。"
 
 #: src/user-defined-types/static-and-const.md
 msgid "\"Welcome to RustOS 3.14\""
-msgstr ""
+msgstr "\"Welcome to RustOS 3.14\""
 
 #: src/user-defined-types/static-and-const.md
 msgid "\"{BANNER}\""
-msgstr ""
+msgstr "\"{BANNER}\""
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
@@ -4620,58 +4934,69 @@ msgid ""
 "globally-scoped value does not have a reason to need object identity, "
 "`const` is generally preferred."
 msgstr ""
+"[Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html) "
+"で説明されているように、静的変数は使用時にインライン化されず、実際の関連する"
+"メモリ位置に存在します。これは安全でないコードや埋め込みコードに有用であり、"
+"変数はプログラムの実行全体を通じて存続します。グローバル スコープの値にオブ"
+"ジェクト ID が必要ない場合は、一般的に `const` が使用されます。"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
-msgstr ""
+msgstr "`const` は C++ の `constexpr` と意味的によく似ていることを説明します。"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
 "`static`, on the other hand, is much more similar to a `const` or mutable "
 "global variable in C++."
 msgstr ""
+"一方、`static` は、C++ の `const` または可変グローバル変数にかなり似ていま"
+"す。"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
 "`static` provides object identity: an address in memory and state as "
 "required by types with interior mutability such as `Mutex<T>`."
 msgstr ""
+"`static` はオブジェクト ID（メモリ内のアドレス）と、内部可変性を持つ型に必要"
+"な状態（`Mutex<T>` など）を提供します。"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
 "It isn't super common that one would need a runtime evaluated constant, but "
 "it is helpful and safer than using a static."
 msgstr ""
+"実行時に評価される定数が必要になることはあまりありませんが、静的変数を使用す"
+"るよりも便利で安全です。"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Properties table:"
-msgstr ""
+msgstr "プロパティの表:"
 
 #: src/user-defined-types/static-and-const.md
 #: src/chromium/adding-third-party-crates.md
 msgid "Property"
-msgstr ""
+msgstr "プロパティ"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Static"
-msgstr ""
+msgstr "静的"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Constant"
-msgstr ""
+msgstr "定数"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Has an address in memory"
-msgstr ""
+msgstr "メモリ内にアドレスがある"
 
 #: src/user-defined-types/static-and-const.md
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "Yes"
-msgstr ""
+msgstr "はい"
 
 #: src/user-defined-types/static-and-const.md
 msgid "No (inlined)"
-msgstr ""
+msgstr "いいえ（インライン化）"
 
 #: src/user-defined-types/static-and-const.md
 #, fuzzy
@@ -4681,27 +5006,27 @@ msgstr "`main`関数はプログラムのエントリーポイントになりま
 #: src/user-defined-types/static-and-const.md
 #: src/chromium/adding-third-party-crates/resolving-problems.md
 msgid "No"
-msgstr ""
+msgstr "いいえ"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Can be mutable"
-msgstr ""
+msgstr "変更可能"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Yes (unsafe)"
-msgstr ""
+msgstr "はい（安全でない）"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Evaluated at compile time"
-msgstr ""
+msgstr "コンパイル時に評価"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Yes (initialised at compile time)"
-msgstr ""
+msgstr "はい（コンパイル時に初期化）"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Inlined wherever it is used"
-msgstr ""
+msgstr "使用場所にかかわらずインライン化"
 
 #: src/user-defined-types/static-and-const.md
 msgid ""
@@ -4709,24 +5034,31 @@ msgid ""
 "`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
 "lang.org/std/sync/struct.Mutex.html), atomic or similar."
 msgstr ""
+"`static` 変数はどのスレッドからでもアクセスできるため、`Sync` である必要があ"
+"ります。内部の可変性は、[`Mutex`](https://doc.rust-lang.org/std/sync/struct."
+"Mutex.html) やアトミックなどの方法で実現できます。"
 
 #: src/user-defined-types/static-and-const.md
 msgid "Thread-local data can be created with the macro `std::thread_local`."
 msgstr ""
+"マクロ `std::thread_local` を使用して、スレッド ローカルのデータを作成できま"
+"す。"
 
 #: src/user-defined-types/aliases.md
 msgid ""
 "A type alias creates a name for another type. The two types can be used "
 "interchangeably."
 msgstr ""
+"型エイリアスは、別の型の名前を作成します。この 2 つの型は同じ意味で使用できま"
+"す。"
 
 #: src/user-defined-types/aliases.md
 msgid "// Aliases are more useful with long, complex types:\n"
-msgstr ""
+msgstr "// エイリアスは長くて複雑な型に使用すると便利です。\n"
 
 #: src/user-defined-types/aliases.md
 msgid "C programmers will recognize this as similar to a `typedef`."
-msgstr ""
+msgstr "C プログラマーは、これを `typedef` と同様のものと考えるでしょう。"
 
 #: src/user-defined-types/exercise.md
 msgid ""
@@ -4735,6 +5067,9 @@ msgid ""
 "various events. Use `#[derive(Debug)]` to allow the types to be formatted "
 "with `{:?}`."
 msgstr ""
+"エレベーター制御システムでイベントを表すデータ構造を作成します。さまざまなイ"
+"ベントを構築するための型と関数を自由に定義して構いません。`#[derive(Debug)]` "
+"を使用して、型を `{:?}` でフォーマットできるようにします。"
 
 #: src/user-defined-types/exercise.md
 msgid ""
@@ -4742,97 +5077,101 @@ msgid ""
 "`main` runs without errors. The next part of the course will cover getting "
 "data out of these structures."
 msgstr ""
+"この演習に必要なのは、`main` がエラーなしで実行されるように、データ構造を作成"
+"して入力することだけです。このコースの次のパートでは、これらの構造からデータ"
+"を取得する方法を説明します。"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid ""
 "/// An event in the elevator system that the controller must react to.\n"
 msgstr ""
+"/// コントローラが反応する必要があるエレベーター システム内のイベント。\n"
 
 #: src/user-defined-types/exercise.md
 msgid "// TODO: add required variants\n"
-msgstr ""
+msgstr "// TODO: 必要なバリアントを追加する\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// A direction of travel.\n"
-msgstr ""
+msgstr "/// 運転方向。\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car has arrived on the given floor.\n"
-msgstr ""
+msgstr "/// かごが所定の階に到着した。\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car doors have opened.\n"
-msgstr ""
+msgstr "/// かごのドアが開いた。\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// The car doors have closed.\n"
-msgstr ""
+msgstr "/// かごのドアが閉まった。\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid ""
 "/// A directional button was pressed in an elevator lobby on the given "
 "floor.\n"
-msgstr ""
+msgstr "/// 所定の階のエレベーター ロビーで方向ボタンが押された。\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "/// A floor button was pressed in the elevator car.\n"
-msgstr ""
+msgstr "/// エレベーターのかごの階数ボタンが押された。\n"
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"A ground floor passenger has pressed the up button: {:?}\""
-msgstr ""
+msgstr "\"A ground floor passenger has pressed the up button: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car has arrived on the ground floor: {:?}\""
-msgstr ""
+msgstr "\"The car has arrived on the ground floor: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car door opened: {:?}\""
-msgstr ""
+msgstr "\"The car door opened: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"A passenger has pressed the 3rd floor button: {:?}\""
-msgstr ""
+msgstr "\"A passenger has pressed the 3rd floor button: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car door closed: {:?}\""
-msgstr ""
+msgstr "\"The car door closed: {:?}\""
 
 #: src/user-defined-types/exercise.md src/user-defined-types/solution.md
 msgid "\"The car has arrived on the 3rd floor: {:?}\""
-msgstr ""
+msgstr "\"The car has arrived on the 3rd floor: {:?}\""
 
 #: src/user-defined-types/solution.md
 msgid "/// A button was pressed.\n"
-msgstr ""
+msgstr "/// ボタンが押された。\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// The car has arrived at the given floor.\n"
-msgstr ""
+msgstr "/// 車両が所定の階に到着した。\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// The car's doors have opened.\n"
-msgstr ""
+msgstr "/// かごのドアが開いた。\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// The car's doors have closed.\n"
-msgstr ""
+msgstr "/// かごのドアが閉まった。\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A floor is represented as an integer.\n"
-msgstr ""
+msgstr "/// 階は整数として表される。\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A user-accessible button.\n"
-msgstr ""
+msgstr "/// ユーザーがアクセスできるボタン。\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A button in the elevator lobby on the given floor.\n"
-msgstr ""
+msgstr "/// 所定の階のエレベーター ロビーにあるボタン。\n"
 
 #: src/user-defined-types/solution.md
 msgid "/// A floor button within the car.\n"
-msgstr ""
+msgstr "/// かご内の階数ボタン。\n"
 
 #: src/welcome-day-2.md
 msgid "Welcome to Day 2"

--- a/po/ja.po
+++ b/po/ja.po
@@ -18491,11 +18491,11 @@ msgstr "Rustのスレッドは他の言語のスレッドと似た挙動をし�
 
 #: src/concurrency/threads.md
 msgid "\"Count in thread: {i}!\""
-msgstr ""
+msgstr "\"Count in thread: {i}!\""
 
 #: src/concurrency/threads.md
 msgid "\"Main thread: {i}\""
-msgstr ""
+msgstr "\"Main thread: {i}\""
 
 #: src/concurrency/threads.md
 msgid "Threads are all daemon threads, the main thread does not wait for them."
@@ -18584,7 +18584,7 @@ msgstr ""
 
 #: src/concurrency/channels.md
 msgid "\"Received: {:?}\""
-msgstr ""
+msgstr "\"Received: {:?}\""
 
 #: src/concurrency/channels.md
 msgid ""
@@ -18611,19 +18611,19 @@ msgstr "Unboundedで非同期的なチャネルは`mpsc::channel()`によって�
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"Message {i}\""
-msgstr ""
+msgstr "\"Message {i}\""
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"{thread_id:?}: sent Message {i}\""
-msgstr ""
+msgstr "\"{thread_id:?}: sent Message {i}\""
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"{thread_id:?}: done\""
-msgstr ""
+msgstr "\"{thread_id:?}: done\""
 
 #: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
 msgid "\"Main: got {msg}\""
-msgstr ""
+msgstr "\"Main: got {msg}\""
 
 #: src/concurrency/channels/bounded.md
 msgid ""
@@ -18777,7 +18777,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md
 msgid "`Send + Sync`"
-msgstr ""
+msgstr "`Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md
 msgid "Most types you come across are `Send + Sync`:"
@@ -18785,15 +18785,15 @@ msgstr "見かけるほとんどの型は`Send + Sync`です："
 
 #: src/concurrency/send-sync/examples.md
 msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
-msgstr ""
+msgstr "`i8`、`f32`、`bool`、`char`、`&str` など"
 
 #: src/concurrency/send-sync/examples.md
 msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
-msgstr ""
+msgstr "`(T1, T2)`、`[T; N]`、`&[T]`、`struct { x: T }` など"
 
 #: src/concurrency/send-sync/examples.md
 msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
-msgstr ""
+msgstr "`String`、`Option<T>`、`Vec<T>`、`Box<T>` など"
 
 #: src/concurrency/send-sync/examples.md
 msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
@@ -18817,7 +18817,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md
 msgid "`Send + !Sync`"
-msgstr ""
+msgstr "`Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md
 msgid ""
@@ -18829,23 +18829,23 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md
 msgid "`mpsc::Sender<T>`"
-msgstr ""
+msgstr "`mpsc::Sender<T>`"
 
 #: src/concurrency/send-sync/examples.md
 msgid "`mpsc::Receiver<T>`"
-msgstr ""
+msgstr "`mpsc::Receiver<T>`"
 
 #: src/concurrency/send-sync/examples.md
 msgid "`Cell<T>`"
-msgstr ""
+msgstr "`Cell<T>`"
 
 #: src/concurrency/send-sync/examples.md
 msgid "`RefCell<T>`"
-msgstr ""
+msgstr "`RefCell<T>`"
 
 #: src/concurrency/send-sync/examples.md
 msgid "`!Send + Sync`"
-msgstr ""
+msgstr "`!Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md
 msgid ""
@@ -18865,7 +18865,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md
 msgid "`!Send + !Sync`"
-msgstr ""
+msgstr "`!Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md
 msgid "These types are not thread-safe and cannot be moved to other threads:"
@@ -18925,11 +18925,11 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md
 msgid "\"{thread_id:?}: {v:?}\""
-msgstr ""
+msgstr "\"{thread_id:?}: {v:?}\""
 
 #: src/concurrency/shared_state/arc.md src/concurrency/shared_state/example.md
 msgid "\"v: {v:?}\""
-msgstr ""
+msgstr "\"v: {v:?}\""
 
 #: src/concurrency/shared_state/arc.md
 msgid ""
@@ -18969,7 +18969,6 @@ msgid "`std::sync::Weak` can help."
 msgstr "`std::sync::Weak` が役立ちます。"
 
 #: src/concurrency/shared_state/mutex.md
-#, fuzzy
 msgid ""
 "[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
 "mutual exclusion _and_ allows mutable access to `T` behind a read-only "
@@ -18982,7 +18981,7 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md
 msgid "\"v: {:?}\""
-msgstr ""
+msgstr "\"v: {:?}\""
 
 #: src/concurrency/shared_state/mutex.md
 msgid ""
@@ -19056,7 +19055,7 @@ msgstr "`Arc` と `Mutex` の動作を見てみましょう："
 
 #: src/concurrency/shared_state/example.md
 msgid "// use std::sync::{Arc, Mutex};\n"
-msgstr ""
+msgstr "// use std::sync::{Arc, Mutex};\n"
 
 #: src/concurrency/shared_state/example.md
 msgid "Possible solution:"
@@ -19099,21 +19098,23 @@ msgstr ""
 
 #: src/exercises/concurrency/morning.md
 msgid "Let us practice our new concurrency skills with"
-msgstr ""
+msgstr "次の演習を行い、並行性に関する新しいスキルを獲得しましょう。"
 
 #: src/exercises/concurrency/morning.md
 msgid "Dining philosophers: a classic problem in concurrency."
-msgstr ""
+msgstr "食事する哲学者：並行性に関する古典的な問題。"
 
 #: src/exercises/concurrency/morning.md
 msgid ""
 "Multi-threaded link checker: a larger project where you'll use Cargo to "
 "download dependencies and then check links in parallel."
 msgstr ""
+"マルチスレッド リンク チェッカー: Cargo を使用して依存関係をダウンロードし、"
+"リンクを同時にチェックする大規模なプロジェクト。"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid "The dining philosophers problem is a classic problem in concurrency:"
-msgstr ""
+msgstr "食事する哲学者の問題は、並行性に関する古典的な問題です。"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid ""
@@ -19126,6 +19127,13 @@ msgid ""
 "not eating. After an individual philosopher finishes eating, they will put "
 "down both forks."
 msgstr ""
+"5 人の哲学者が同じテーブルで食事をしています。それぞれの哲学者がテーブルの定"
+"位置に座り、皿の間にはフォークが 1 本置かれています。提供される料理はスパゲッ"
+"ティで、2 本のフォークで食べる必要があります。哲学者は思索と食事を交互に繰り"
+"返すことしかできません。さらに、哲学者は左右両方のフォークを持っている場合に"
+"のみ、スパゲッティを食べることができます。したがって、2 つのフォークは、両隣"
+"の哲学者が食べるのではなく考えている場合にのみ使用できます。それぞれの哲学者"
+"は、食べ終わった後、両方のフォークを置きます。"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid ""
@@ -19133,6 +19141,9 @@ msgid ""
 "for this exercise. Copy the code below to a file called `src/main.rs`, fill "
 "out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
+"この演習では、ローカルの [Cargo インストール](../../cargo/running-locally.md)"
+"が必要です。以下のコードを `src/main.rs` というファイルにコピーし、空欄を埋め"
+"て、`cargo run` がデッドロックしないことを確認します。"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
@@ -19141,87 +19152,90 @@ msgid ""
 "    // right_fork: ...\n"
 "    // thoughts: ...\n"
 msgstr ""
+"// left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // thoughts: ...\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Eureka! {} has a new idea!\""
-msgstr ""
+msgstr "\"Eureka! {} has a new idea!\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Pick up forks...\n"
-msgstr ""
+msgstr "// Pick up forks...\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"{} is eating...\""
-msgstr ""
+msgstr "\"{} is eating...\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Socrates\""
-msgstr ""
+msgstr "\"Socrates\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Hypatia\""
-msgstr ""
+msgstr "\"Hypatia\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Plato\""
-msgstr ""
+msgstr "\"Plato\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Aristotle\""
-msgstr ""
+msgstr "\"Aristotle\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/solutions-morning.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Pythagoras\""
-msgstr ""
+msgstr "\"Pythagoras\""
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Create forks\n"
-msgstr ""
+msgstr "// フォークを作成する\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Create philosophers\n"
-msgstr ""
+msgstr "// 哲学者を作成する\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid "// Make each of them think and eat 100 times\n"
-msgstr ""
+msgstr "// それぞれの哲学者が思索と食事を 100 回行うようにする\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Output their thoughts\n"
-msgstr ""
+msgstr "// 哲学者の思索を出力する\n"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid "You can use the following `Cargo.toml`:"
-msgstr ""
+msgstr "次の `Cargo.toml` を使用できます。"
 
 #: src/exercises/concurrency/dining-philosophers.md
 msgid ""
@@ -19232,6 +19246,12 @@ msgid ""
 "edition = \"2021\"\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"dining-philosophers\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"```"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
@@ -19240,35 +19260,49 @@ msgid ""
 "should recursively check other pages on the same domain and keep doing this "
 "until all pages have been validated."
 msgstr ""
+"新たに身に付けた知識を活かして、マルチスレッド リンク チェッカーを作成しま"
+"しょう。まず、ウェブページ上のリンクが有効かどうかを確認する必要があります。"
+"同じドメインの他のページを再帰的にチェックし、すべてのページの検証が完了する"
+"までこの処理を繰り返します。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
 "For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
 "reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
+"そのためには、[`reqwest`](https://docs.rs/reqwest/) などの HTTP クライアント"
+"が必要です。次のコマンドで新しい Cargo プロジェクトを作成し、依存関係として "
+"`reqwest` を追加します。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
 "If `cargo add` fails with `error: no such subcommand`, then please edit the "
 "`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
+"`cargo add` が `error: no such subcommand` で失敗する場合は、`Cargo.toml` "
+"ファイルを手動で編集してください。下記の依存関係を追加します。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
 "You will also need a way to find links. We can use [`scraper`](https://docs."
 "rs/scraper/) for that:"
 msgstr ""
+"また、リンクを見つける方法も必要です。これには [`scraper`](https://docs.rs/"
+"scraper/) を使用します。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
 "Finally, we'll need some way of handling errors. We use [`thiserror`]"
 "(https://docs.rs/thiserror/) for that:"
 msgstr ""
+"最後に、エラーを処理する方法が必要になります。これには [`thiserror`](https://"
+"docs.rs/thiserror/) を使用します。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
 "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr ""
+"`cargo add` の呼び出しにより、`Cargo.toml` ファイルは次のように更新されます。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
@@ -19286,64 +19320,81 @@ msgid ""
 "thiserror = \"1.0.37\"\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"link-checker\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"publish = false\n"
+"\n"
+"[dependencies]\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
+"scraper = \"0.13.0\"\n"
+"thiserror = \"1.0.37\"\n"
+"```"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
 "You can now download the start page. Try with a small site such as `https://"
 "www.google.org/`."
 msgstr ""
+"これで、スタートページをダウンロードできるようになりました。`https://www."
+"google.org/` のような小規模なサイトで試してみましょう。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid "Your `src/main.rs` file should look something like this:"
-msgstr ""
+msgstr "`src/main.rs` ファイルは次のようになります。"
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"request error: {0}\""
-msgstr ""
+msgstr "\"request error: {0}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"bad http response: {0}\""
-msgstr ""
+msgstr "\"bad http response: {0}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"Checking {:#}\""
-msgstr ""
+msgstr "\"Checking {:#}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"href\""
-msgstr ""
+msgstr "\"href\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
-msgstr ""
+msgstr "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
 
 #: src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"https://www.google.org\""
-msgstr ""
+msgstr "\"https://www.google.org\""
 
 #: src/exercises/concurrency/link-checker.md
 msgid "\"Links: {links:#?}\""
-msgstr ""
+msgstr "\"Links: {links:#?}\""
 
 #: src/exercises/concurrency/link-checker.md
 msgid "\"Could not extract links: {err:#}\""
-msgstr ""
+msgstr "\"Could not extract links: {err:#}\""
 
 #: src/exercises/concurrency/link-checker.md
 msgid "Run the code in `src/main.rs` with"
-msgstr ""
+msgstr "`src/main.rs` 内のコードを、次のコマンドで実行します。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
 "Use threads to check the links in parallel: send the URLs to be checked to a "
 "channel and let a few threads check the URLs in parallel."
 msgstr ""
+"スレッドを使用してリンクを同時にチェックします。つまり、チェックする URL を"
+"チャンネルに送信し、いくつかのスレッドで同時に URL を確認します。"
 
 #: src/exercises/concurrency/link-checker.md
 msgid ""
@@ -19351,18 +19402,21 @@ msgid ""
 "org` domain. Put an upper limit of 100 pages or so so that you don't end up "
 "being blocked by the site."
 msgstr ""
+"これを拡張して、`www.google.org` ドメインのすべてのページからリンクを再帰的に"
+"抽出します。サイトがブロックされないように、ページ数の上限を 100 程度に設定し"
+"ます。"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "Concurrency Morning Exercise"
-msgstr ""
+msgstr "並行性に関する午前のエクササイズ"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "([back to exercise](dining-philosophers.md))"
-msgstr ""
+msgstr "（[演習に戻る](dining-philosophers.md)）"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"{} is trying to eat\""
-msgstr ""
+msgstr "\"{} is trying to eat\""
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid ""
@@ -19370,10 +19424,13 @@ msgid ""
 "        // somewhere. This will swap the forks without deinitializing\n"
 "        // either of them.\n"
 msgstr ""
+"// デッドロックを避けるために、どこかで対称性を\n"
+"        // 崩す必要があります。下記のコードでは、\n"
+"        // 領域を開放することなく2つのフォークを交換します。\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"{thought}\""
-msgstr ""
+msgstr "\"{thought}\""
 
 #: src/exercises/concurrency/solutions-morning.md
 #, fuzzy
@@ -19382,30 +19439,32 @@ msgstr "マルチスレッド・リンクチェッカー"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "([back to exercise](link-checker.md))"
-msgstr ""
+msgstr "（[演習に戻る](link-checker.md)）"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid ""
 "/// Determine whether links within the given page should be extracted.\n"
-msgstr ""
+msgstr "/// 指定されたページ内のリンクを抽出するかどうかを決定します。\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid ""
 "/// Mark the given page as visited, returning false if it had already\n"
 "    /// been visited.\n"
 msgstr ""
+"/// 指定されたページを訪問済みとしてマークし、すでに訪問済みであれば\n"
+"    /// false を返します。\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "// The sender got dropped. No more commands coming in.\n"
-msgstr ""
+msgstr "// 送信者がドロップされました。今後コマンドは受信されません。\n"
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"Got crawling error: {:#}\""
-msgstr ""
+msgstr "\"Got crawling error: {:#}\""
 
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"Bad URLs: {:#?}\""
-msgstr ""
+msgstr "\"Bad URLs: {:#?}\""
 
 #: src/async.md
 msgid "Async Rust"
@@ -19476,7 +19535,7 @@ msgstr ""
 
 #: src/async/async-await.md
 msgid "\"Count is: {i}!\""
-msgstr ""
+msgstr "\"Count is: {i}!\""
 
 #: src/async/async-await.md
 msgid ""
@@ -19691,11 +19750,11 @@ msgstr "大きなライブラリのエコシステム。"
 
 #: src/async/runtimes/tokio.md
 msgid "\"Count in task: {i}!\""
-msgstr ""
+msgstr "\"Count in task: {i}!\""
 
 #: src/async/runtimes/tokio.md
 msgid "\"Main task: {i}\""
-msgstr ""
+msgstr "\"Main task: {i}\""
 
 #: src/async/runtimes/tokio.md
 msgid "With the `tokio::main` macro we can now make `main` async."
@@ -19736,7 +19795,7 @@ msgstr "`tokio::spawn`から返されたタスクを待機してみてくださ�
 
 #: src/async/tasks.md
 msgid "Rust has a task system, which is a form of lightweight threading."
-msgstr ""
+msgstr "Rust には、軽量のスレッド形式の一種であるタスクシステムがあります。"
 
 #: src/async/tasks.md
 msgid ""
@@ -19755,27 +19814,27 @@ msgstr ""
 
 #: src/async/tasks.md
 msgid "\"127.0.0.1:0\""
-msgstr ""
+msgstr "\"127.0.0.1:0\""
 
 #: src/async/tasks.md
 msgid "\"listening on port {}\""
-msgstr ""
+msgstr "\"listening on port {}\""
 
 #: src/async/tasks.md
 msgid "\"connection from {addr:?}\""
-msgstr ""
+msgstr "\"connection from {addr:?}\""
 
 #: src/async/tasks.md
 msgid "b\"Who are you?\\n\""
-msgstr ""
+msgstr "b\"Who are you?\\n\""
 
 #: src/async/tasks.md
 msgid "\"socket error\""
-msgstr ""
+msgstr "\"socket error\""
 
 #: src/async/tasks.md
 msgid "\"Thanks for dialing in, {name}!\\n\""
-msgstr ""
+msgstr "\"Thanks for dialing in, {name}!\\n\""
 
 #: src/async/tasks.md src/async/control-flow/join.md
 msgid ""
@@ -19789,6 +19848,9 @@ msgid ""
 "com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
 "telnet/)."
 msgstr ""
+"[nc](https://www.unix.com/man-page/linux/1/nc/) や [telnet](https://www.unix."
+"com/man-page/linux/1/telnet/) などの TCP 接続ツールを使用して接続してみてくだ"
+"さい。"
 
 #: src/async/tasks.md
 msgid ""
@@ -19828,23 +19890,23 @@ msgstr ""
 
 #: src/async/channels.md
 msgid "\"Received {count} pings so far.\""
-msgstr ""
+msgstr "\"Received {count} pings so far.\""
 
 #: src/async/channels.md
 msgid "\"ping_handler complete\""
-msgstr ""
+msgstr "\"ping_handler complete\""
 
 #: src/async/channels.md
 msgid "\"Failed to send ping.\""
-msgstr ""
+msgstr "\"Failed to send ping.\""
 
 #: src/async/channels.md
 msgid "\"Sent {} pings so far.\""
-msgstr ""
+msgstr "\"Sent {} pings so far.\""
 
 #: src/async/channels.md
 msgid "\"Something went wrong in ping handler task.\""
-msgstr ""
+msgstr "\"Something went wrong in ping handler task.\""
 
 #: src/async/channels.md
 msgid "Change the channel size to `3` and see how it affects the execution."
@@ -19900,11 +19962,11 @@ msgstr ""
 
 #: src/async/control-flow.md
 msgid "[Join](control-flow/join.md)"
-msgstr ""
+msgstr "[結合](control-flow/join.md)"
 
 #: src/async/control-flow.md
 msgid "[Select](control-flow/select.md)"
-msgstr ""
+msgstr "[選択](control-flow/select.md)"
 
 #: src/async/control-flow/join.md
 msgid ""
@@ -19918,19 +19980,19 @@ msgstr ""
 
 #: src/async/control-flow/join.md
 msgid "\"https://google.com\""
-msgstr ""
+msgstr "\"https://google.com\""
 
 #: src/async/control-flow/join.md
 msgid "\"https://httpbin.org/ip\""
-msgstr ""
+msgstr "\"https://httpbin.org/ip\""
 
 #: src/async/control-flow/join.md
 msgid "\"https://play.rust-lang.org/\""
-msgstr ""
+msgstr "\"https://play.rust-lang.org/\""
 
 #: src/async/control-flow/join.md
 msgid "\"BAD_URL\""
-msgstr ""
+msgstr "\"BAD_URL\""
 
 #: src/async/control-flow/join.md
 msgid ""
@@ -19994,27 +20056,27 @@ msgstr ""
 
 #: src/async/control-flow/select.md
 msgid "\"Felix\""
-msgstr ""
+msgstr "\"Felix\""
 
 #: src/async/control-flow/select.md
 msgid "\"Failed to send cat.\""
-msgstr ""
+msgstr "\"Failed to send cat.\""
 
 #: src/async/control-flow/select.md
 msgid "\"Rex\""
-msgstr ""
+msgstr "\"Rex\""
 
 #: src/async/control-flow/select.md
 msgid "\"Failed to send dog.\""
-msgstr ""
+msgstr "\"Failed to send dog.\""
 
 #: src/async/control-flow/select.md
 msgid "\"Failed to receive winner\""
-msgstr ""
+msgstr "\"Failed to receive winner\""
 
 #: src/async/control-flow/select.md
 msgid "\"Winner is {winner:?}\""
-msgstr ""
+msgstr "\"Winner is {winner:?}\""
 
 #: src/async/control-flow/select.md
 #, fuzzy
@@ -20065,7 +20127,7 @@ msgstr ""
 
 #: src/async/pitfalls.md
 msgid "Pitfalls of async/await"
-msgstr ""
+msgstr "async / await の注意点"
 
 #: src/async/pitfalls.md
 msgid ""
@@ -20074,26 +20136,29 @@ msgid ""
 "with its share of pitfalls and footguns. We illustrate some of them in this "
 "chapter:"
 msgstr ""
+"async / await は、同時実行非同期プログラミングのための便利で効率的な抽象化を"
+"提供します。しかし、Rust の async / await モデルには、注意点や誤用されやすい"
+"機能もいくつかあるため、この章ではその点について説明します。"
 
 #: src/async/pitfalls.md
 msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
-msgstr ""
+msgstr "[エグゼキュータのブロック](pitfalls/blocking-executor.md)"
 
 #: src/async/pitfalls.md
 msgid "[Pin](pitfalls/pin.md)"
-msgstr ""
+msgstr "[Pin](pitfalls/pin.md)"
 
 #: src/async/pitfalls.md
 msgid "[Async Traits](pitfalls/async-traits.md)"
-msgstr ""
+msgstr "[Async トレイト](pitfalls/async-traits.md)"
 
 #: src/async/pitfalls.md
 msgid "[Cancellation](pitfalls/cancellation.md)"
-msgstr ""
+msgstr "[キャンセル](pitfalls/cancellation.md)"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid "Blocking the executor"
-msgstr ""
+msgstr "エグゼキュータのブロック"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
@@ -20102,20 +20167,24 @@ msgid ""
 "being executed. An easy workaround is to use async equivalent methods where "
 "possible."
 msgstr ""
+"ほとんどの非同期ランタイムは、IO タスクの同時実行のみを許可します。つまり、"
+"CPU ブロックタスクはエグゼキュータをブロックし、他のタスクの実行を妨げます。"
+"簡単な回避策は、可能であれば非同期の同等のメソッドを使用することです。"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
-msgstr ""
+msgstr "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
 
 #: src/async/pitfalls/blocking-executor.md
 msgid "\"current_thread\""
-msgstr ""
+msgstr "\"current_thread\""
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
 "Run the code and see that the sleeps happen consecutively rather than "
 "concurrently."
 msgstr ""
+"コードを続けて、スリープが同時ではなく連続して発生することを確認します。"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
@@ -20123,17 +20192,25 @@ msgid ""
 "makes the effect more obvious, but the bug is still present in the multi-"
 "threaded flavor."
 msgstr ""
+"`\"current_thread\"` フレーバーは、すべてのタスクを 1 つのスレッドに配置しま"
+"す。これにより、影響はより明確になりますが、バグはまだマルチスレッド フレー"
+"バーに存在します。"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
 "Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
 msgstr ""
+"`std::thread::sleep` を `tokio::time::sleep` に切り替えて、その結果を待ちま"
+"す。"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
 "Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
 "thread and transforms its handle into a future without blocking the executor."
 msgstr ""
+"もう 1 つの修正策は、`tokio::task::spawn_blocking` を使用することです。これ"
+"は、実際のスレッドを生成し、エグゼキュータをブロックせずにそのハンドルを "
+"Future に変換します。"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
@@ -20144,12 +20221,22 @@ msgid ""
 "OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
 "situations."
 msgstr ""
+"タスクは OS スレッドとはみなすべきではありません。これらは 1 対 1 に対応して"
+"おらず、ほとんどのエグゼキュータは、単一の OS スレッドで多くのタスクを実行す"
+"ることを許可します。これは、FFI を介して他のライブラリとやり取りする場合に特"
+"に問題となります。FFI では、そのライブラリはスレッド ローカル ストレージに依"
+"存しているか、特定の OS スレッド（CUDA など）にマッピングされている可能性があ"
+"るためです。そのような場合は `tokio::task::spawn_blocking` を使用することをお"
+"すすめします。"
 
 #: src/async/pitfalls/blocking-executor.md
 msgid ""
 "Use sync mutexes with care. Holding a mutex over an `.await` may cause "
 "another task to block, and that task may be running on the same thread."
 msgstr ""
+"同期ミューテックスは慎重に使用してください。`.await` でミューテックスを保持す"
+"ると、別のタスクがブロックされ、そのタスクが同じスレッドで実行される可能性が"
+"あります。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20157,6 +20244,9 @@ msgid ""
 "type returned is the result of a compiler transformation which turns local "
 "variables into data stored inside the future."
 msgstr ""
+"非同期ブロックと関数は、`Future` トレイトを実装する型を返します。返される型"
+"は、ローカル変数を Future の内部に格納されるデータに変換するコンパイラ変換の"
+"結果です。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20164,6 +20254,8 @@ msgid ""
 "of that, the future should never be moved to a different memory location, as "
 "it would invalidate those pointers."
 msgstr ""
+"これらの変数の一部は、他のローカル変数へのポインタを保持できます。これらのポ"
+"インタが無効になるため、Futureを別のメモリ位置に移動しないでください。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20172,67 +20264,79 @@ msgid ""
 "operations that would move the instance it points to into a different memory "
 "location."
 msgstr ""
+"メモリ内の Future 型が移動するのを防ぐには、固定されたポインタのみを介して"
+"ポーリングするようにします。`Pin` は参照のラッパーで、参照先のインスタンスを"
+"別のメモリ位置に移動するオペレーションをすべて禁止します。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
 "// A work item. In this case, just sleep for the given time and respond\n"
 "// with a message on the `respond_on` channel.\n"
 msgstr ""
+"// 作業アイテム。この場合、指定された時間だけスリープし、\n"
+"// `respond_on` チャンネルでメッセージを返します。\n"
 
 #: src/async/pitfalls/pin.md
 msgid "// A worker which listens for work on a queue and performs it.\n"
-msgstr ""
+msgstr "// キュー上の処理をリッスンして実行するワーカー。\n"
 
 #: src/async/pitfalls/pin.md
 msgid "// Pretend to work.\n"
-msgstr ""
+msgstr "// Pretend to work.\n"
 
 #: src/async/pitfalls/pin.md
 msgid "\"failed to send response\""
-msgstr ""
+msgstr "\"failed to send response\""
 
 #: src/async/pitfalls/pin.md
 msgid "// TODO: report number of iterations every 100ms\n"
-msgstr ""
+msgstr "// TODO: 100 ミリ秒ごとの反復処理の回数をレポート\n"
 
 #: src/async/pitfalls/pin.md
 msgid "// A requester which requests work and waits for it to complete.\n"
-msgstr ""
+msgstr "// 処理をリクエストし、処理が完了するまで待機するリクエスト元。\n"
 
 #: src/async/pitfalls/pin.md
 msgid "\"failed to send on work queue\""
-msgstr ""
+msgstr "\"failed to send on work queue\""
 
 #: src/async/pitfalls/pin.md
 msgid "\"failed waiting for response\""
-msgstr ""
+msgstr "\"failed waiting for response\""
 
 #: src/async/pitfalls/pin.md
 msgid "\"work result for iteration {i}: {resp}\""
-msgstr ""
+msgstr "\"work result for iteration {i}: {resp}\""
 
 #: src/async/pitfalls/pin.md
 msgid ""
 "You may recognize this as an example of the actor pattern. Actors typically "
 "call `select!` in a loop."
 msgstr ""
+"これはアクターのパターンの一例です。アクターは通常、ループ内で `select!` を呼"
+"び出します。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
 "This serves as a summation of a few of the previous lessons, so take your "
 "time with it."
 msgstr ""
+"これはこれまでのレッスンの一部をまとめたものですので、時間をかけて復習してく"
+"ださい。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
 "Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
 "the `select!`. This will never execute. Why?"
 msgstr ""
+"`_ = sleep(Duration::from_millis(100)) => { println!(..) }` を `select!` に追"
+"加しただけでは、実行されません。なぜでしょうか？"
 
 #: src/async/pitfalls/pin.md
 msgid ""
 "Instead, add a `timeout_fut` containing that future outside of the `loop`:"
 msgstr ""
+"代わりに、`loop` の外側で、その Future を含む `timeout_fut` を追加します。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20240,6 +20344,9 @@ msgid ""
 "`timeout_fut` in the `select!` to work around the move, then using `Box::"
 "pin`:"
 msgstr ""
+"これでもうまくいきません。コンパイルエラーにあるように、`select!` 内の "
+"`timeout_fut` に `&mut` を追加して移動を回避してから、`Box::pin` を使用しま"
+"す。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20247,6 +20354,9 @@ msgid ""
 "iteration (a fused future would help with this). Update to reset "
 "`timeout_fut` every time it expires."
 msgstr ""
+"これはコンパイルされますが、タイムアウトになると、すべての反復処理で `Poll::"
+"Ready` になります（融合された Future がこれに役立ちます）。期限が切れるたび"
+"に `timeout_fut` をリセットするように更新します。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20254,12 +20364,17 @@ msgid ""
 "stabilized, with older code often using `tokio::pin!`) is also an option, "
 "but that is difficult to use for a future that is reassigned."
 msgstr ""
+"Box でヒープに割り当てます。場合によっては `std::pin::pin!`（最近安定化された"
+"ばかりで、古いコードでは多くの場合に `tokio::pin!` を使用します）も使用できま"
+"すが、再割り当てされる Future に使用することは困難です。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
 "Another alternative is to not use `pin` at all but spawn another task that "
 "will send to a `oneshot` channel every 100ms."
 msgstr ""
+"別の方法としては、`pin` をまったく使用せずに、100 ミリ秒ごとに `oneshot` チャ"
+"ネルに送信する別のタスクを生成するという方法もあります。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20269,6 +20384,10 @@ msgid ""
 "code transformation for async blocks and functions is not verified by the "
 "borrow checker."
 msgstr ""
+"それ自体へのポインタを含むデータは、自己参照と呼ばれます。通常、Rust 借用"
+"チェッカーは、参照が参照先のデータより長く存続できないため、自己参照データの"
+"移動を防ぎます。ただし、非同期ブロックと関数のコード変換は、借用チェッカーに"
+"よって検証されません。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20276,6 +20395,9 @@ msgid ""
 "place using a pinned pointer. However, it can still be moved through an "
 "unpinned pointer."
 msgstr ""
+"`Pin` は参照のラッパーです。固定されたポインタを使用して、オブジェクトをその"
+"場所から移動することはできません。ただし、固定されていないポインタを介して移"
+"動することは可能です。"
 
 #: src/async/pitfalls/pin.md
 msgid ""
@@ -20283,6 +20405,9 @@ msgid ""
 "`&mut Self` to refer to the instance. That's why it can only be called on a "
 "pinned pointer."
 msgstr ""
+"`Future` トレイトの `poll` メソッドは、`&mut Self` ではなく `Pin<&mut Self>` "
+"を使用してインスタンスを参照します。固定されたポインタでのみ呼び出すことがで"
+"きるのはこのためです。"
 
 #: src/async/pitfalls/async-traits.md
 msgid ""
@@ -20291,26 +20416,34 @@ msgid ""
 "term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-"
 "nightly.html))"
 msgstr ""
+"トレイトの非同期メソッドは、Stable チャンネルではまだサポートされていません"
+"（[試験運用版の機能はナイトリーに存在するため、中期的には安定するはずです。]"
+"(https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly."
+"html)）"
 
 #: src/async/pitfalls/async-traits.md
 msgid ""
 "The crate [async_trait](https://docs.rs/async-trait/latest/async_trait/) "
 "provides a workaround through a macro:"
 msgstr ""
+"クレート [async_trait](https://docs.rs/async-trait/latest/async_trait/) は、"
+"マクロによる回避策を提供します。"
 
 #: src/async/pitfalls/async-traits.md
 msgid "\"running all sleepers..\""
-msgstr ""
+msgstr "\"running all sleepers..\""
 
 #: src/async/pitfalls/async-traits.md
 msgid "\"slept for {}ms\""
-msgstr ""
+msgstr "\"slept for {}ms\""
 
 #: src/async/pitfalls/async-traits.md
 msgid ""
 "`async_trait` is easy to use, but note that it's using heap allocations to "
 "achieve this. This heap allocation has performance overhead."
 msgstr ""
+"`async_trait` は簡単に使用できますが、ヒープ割り当てを使用してこれを実現して"
+"います。このヒープ割り当てには、パフォーマンス オーバーヘッドが伴います。"
 
 #: src/async/pitfalls/async-traits.md
 msgid ""
@@ -20320,12 +20453,18 @@ msgid ""
 "blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
 "digging deeper."
 msgstr ""
+"`async trait` の言語サポートにおける課題は、Rust の中でも難解な部類に入るた"
+"め、ここでは詳しく説明する必要はないでしょう。Niko Matsakis が [こちらの投稿]"
+"(https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-"
+"are-hard/) で詳しく説明していますので、深く掘り下げたい方はご覧ください。"
 
 #: src/async/pitfalls/async-traits.md
 msgid ""
 "Try creating a new sleeper struct that will sleep for a random amount of "
 "time and adding it to the Vec."
 msgstr ""
+"ランダムな時間スリープする新しいスリーパー構造体を作成し、Vec に追加してみま"
+"しょう。"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
@@ -20334,50 +20473,62 @@ msgid ""
 "ensure the system works correctly even when futures are cancelled. For "
 "example, it shouldn't deadlock or lose data."
 msgstr ""
+"Future をドロップすると、その Future を再度ポーリングすることはできません。こ"
+"れはキャンセルと呼ばれ、どの `await` ポイントでも発生する可能性があります。そ"
+"のため、Future がキャンセルされた場合でも、システムが正常に動作するようにして"
+"おく必要があります。たとえば、デッドロックやデータの消失があってはなりませ"
+"ん。"
 
 #: src/async/pitfalls/cancellation.md
 msgid "\"not UTF-8\""
-msgstr ""
+msgstr "\"not UTF-8\""
 
 #: src/async/pitfalls/cancellation.md
 msgid "\"hi\\nthere\\n\""
-msgstr ""
+msgstr "\"hi\\nthere\\n\""
 
 #: src/async/pitfalls/cancellation.md
 msgid "\"tick!\""
-msgstr ""
+msgstr "\"tick!\""
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
 "The compiler doesn't help with cancellation-safety. You need to read API "
 "documentation and consider what state your `async fn` holds."
 msgstr ""
+"コンパイラではキャンセル安全性を確保できません。API ドキュメントを読み、"
+"`async fn` が保持する状態を考慮する必要があります。"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
 "Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
 "error-handling)."
 msgstr ""
+"`panic` や `?`とは異なり、キャンセルは（エラー処理ではなく）通常の制御フロー"
+"の一部です。"
 
 #: src/async/pitfalls/cancellation.md
 msgid "The example loses parts of the string."
-msgstr ""
+msgstr "この例では、文字列の一部が失われています。"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
 "Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
 "dropped."
 msgstr ""
+"`tick()` 分岐が先に終了するたびに、`next()` とその `buf` がドロップされます。"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
 "`LinesReader` can be made cancellation-safe by making `buf` part of the "
 "struct:"
 msgstr ""
+"`buf` を構造体の一部にすることで、`LinesReader` にキャンセル安全性を持たせる"
+"ことができます。"
 
 #: src/async/pitfalls/cancellation.md
 msgid "// prefix buf and bytes with self.\n"
-msgstr ""
+msgstr "// buf と bytes の先頭に self を付加します。\n"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
@@ -20385,6 +20536,9 @@ msgid ""
 "html#method.tick) is cancellation-safe because it keeps track of whether a "
 "tick has been 'delivered'."
 msgstr ""
+"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
+"html#method.tick) は、ティックが「配信済み」かどうかを追跡しているため、安全"
+"にキャンセルできます。"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
@@ -20392,6 +20546,9 @@ msgid ""
 "AsyncReadExt.html#method.read) is cancellation-safe because it either "
 "returns or doesn't read data."
 msgstr ""
+"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncReadExt.html#method.read) は、データを返すか、データを読み取らないかのい"
+"ずれかであるため、安全にキャンセルできます。"
 
 #: src/async/pitfalls/cancellation.md
 msgid ""
@@ -20399,23 +20556,30 @@ msgid ""
 "AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
 "cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
+"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncBufReadExt.html#method.read_line) はこの例と類似しており、安全にキャンセ"
+"ルできません。詳細と代替方法については、ドキュメントをご覧ください。"
 
 #: src/exercises/concurrency/afternoon.md
 msgid ""
 "To practice your Async Rust skills, we have again two exercises for you:"
-msgstr ""
+msgstr "非同期 Rust のスキルを磨くため、ここでも 2 つの演習を行います。"
 
 #: src/exercises/concurrency/afternoon.md
 msgid ""
 "Dining philosophers: we already saw this problem in the morning. This time "
 "you are going to implement it with Async Rust."
 msgstr ""
+"食事する哲学者: この問題は午前の部ですでに取り上げましたが、今回は非同期 "
+"Rust を使用してこれを実装します。"
 
 #: src/exercises/concurrency/afternoon.md
 msgid ""
 "A Broadcast Chat Application: this is a larger project that allows you "
 "experiment with more advanced Async Rust features."
 msgstr ""
+"ブロードキャスト チャット アプリ: より高度な非同期 Rust 機能をテストできる大"
+"規模なプロジェクトです。"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
@@ -20428,6 +20592,8 @@ msgid ""
 "See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
+"この問題の詳細については、[食事する哲学者](dining-philosophers.md) をご覧くだ"
+"さい。"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 msgid ""
@@ -20435,17 +20601,22 @@ msgid ""
 "locally.md) for this exercise. Copy the code below to a file called `src/"
 "main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
+"前と同様に、この演習でもローカルの [Cargo インストール](../../cargo/running-"
+"locally.md) が必要です。以下のコードを `src/main.rs` というファイルにコピー"
+"し、空欄を埋めて、`cargo run` がデッドロックしないことを確認します。"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Make them think and eat\n"
-msgstr ""
+msgstr "// 哲学者が思索と食事を行うようにする\n"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 msgid ""
 "Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
+"今回は非同期 Rust を使用するため、`tokio` 依存関係が必要になります。次の "
+"`Cargo.toml` を使用できます。"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 msgid ""
@@ -20460,16 +20631,28 @@ msgid ""
 "\"rt-multi-thread\"] }\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"dining-philosophers-async-dine\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"\n"
+"[dependencies]\n"
+"tokio = { version = \"1.26.0\", features = [\"sync\", \"time\", \"macros\", "
+"\"rt-multi-thread\"] }\n"
+"```"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 msgid ""
 "Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
+"また、今度は `tokio` クレートの `Mutex` モジュールと `mpsc` モジュールを使用"
+"する必要があることにも注意してください。"
 
 #: src/exercises/concurrency/dining-philosophers-async.md
 msgid "Can you make your implementation single-threaded?"
-msgstr ""
+msgstr "実装をシングルスレッドにできますか？"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20479,6 +20662,11 @@ msgid ""
 "input, and sends them to the server. The chat server broadcasts each message "
 "that it receives to all the clients."
 msgstr ""
+"この演習では、新たに身に付けた知識を活かしてブロードキャスト チャット アプリ"
+"を実装します。クライアントが接続してメッセージを公開するチャット サーバーがあ"
+"ります。クライアントは標準入力からユーザー メッセージを読み取り、サーバーに送"
+"信します。チャット サーバーは受信した各メッセージをすべてのクライアントにブ"
+"ロードキャストします。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20487,14 +20675,18 @@ msgid ""
 "(https://docs.rs/tokio-websockets/) for the communication between the client "
 "and the server."
 msgstr ""
+"このために、サーバー上の [ブロードキャスト チャンネル](https://docs.rs/tokio/"
+"latest/tokio/sync/broadcast/fn.channel.html) を使用し、クライアントとサーバー"
+"間の通信には [`tokio_websockets`](https://docs.rs/tokio-websockets/) を使用し"
+"ます。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Create a new Cargo project and add the following dependencies:"
-msgstr ""
+msgstr "新しい Cargo プロジェクトを作成し、次の依存関係を追加します。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "_Cargo.toml_:"
-msgstr ""
+msgstr "_Cargo.toml_:"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20512,10 +20704,23 @@ msgid ""
 "\"fastrand\", \"server\", \"sha1_smol\"] }\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"chat-async\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2021\"\n"
+"\n"
+"[dependencies]\n"
+"futures-util = { version = \"0.3.30\", features = [\"sink\"] }\n"
+"http = \"1.0.0\"\n"
+"tokio = { version = \"1.28.1\", features = [\"full\"] }\n"
+"tokio-websockets = { version = \"0.5.1\", features = [\"client\", "
+"\"fastrand\", \"server\", \"sha1_smol\"] }\n"
+"```"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "The required APIs"
-msgstr ""
+msgstr "必要な API"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20523,6 +20728,8 @@ msgid ""
 "[`tokio_websockets`](https://docs.rs/tokio-websockets/). Spend a few minutes "
 "to familiarize yourself with the API."
 msgstr ""
+"`tokio` と [`tokio_websockets`](https://docs.rs/tokio-websockets/) の以下の関"
+"数が必要になります。少し時間をかけて API に対する理解を深めてください。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20530,6 +20737,9 @@ msgid ""
 "trait.StreamExt.html#method.next) implemented by `WebSocketStream`: for "
 "asynchronously reading messages from a Websocket Stream."
 msgstr ""
+"`WebSocketStream` によって実装された [StreamExt::next()](https://docs.rs/"
+"futures-util/0.3.28/futures_util/stream/trait.StreamExt.html#method.next): "
+"Websocket Stream からのメッセージを非同期で読み取ります。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20537,6 +20747,9 @@ msgid ""
 "trait.SinkExt.html#method.send) implemented by `WebSocketStream`: for "
 "asynchronously sending messages on a Websocket Stream."
 msgstr ""
+"`WebSocketStream` によって実装された [SinkExt::send()](https://docs.rs/"
+"futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send): "
+"Websocket Stream 上でメッセージを非同期で送信します。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20544,16 +20757,22 @@ msgid ""
 "html#method.next_line): for asynchronously reading user messages from the "
 "standard input."
 msgstr ""
+"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): 標準入力からのユーザー メッセージを非同期で読み取りま"
+"す。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
 "[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
 "struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): ブロードキャスト チャンネルをサブスクラ"
+"イブします。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Two binaries"
-msgstr ""
+msgstr "2 つのバイナリ"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20565,6 +20784,13 @@ msgid ""
 "(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
 "targets.html#binaries))."
 msgstr ""
+"通常、Cargo プロジェクトに含めることができるのは 1 つのバイナリと 1 つの "
+"`src/main.rs` ファイルのみです。このプロジェクトには 2 つのバイナリが必要で"
+"す。1 つはクライアント用、もう 1 つはサーバー用です。2 つの独立した Cargo プ"
+"ロジェクトを作成することもできますが、ここでは 1 つの Cargo プロジェクトに 2 "
+"つのバイナリを入れます。そのためには、クライアントとサーバーのコードを `src/"
+"bin` に配置する必要があります（[ドキュメント](https://doc.rust-lang.org/"
+"cargo/reference/cargo-targets.html#binaries) をご覧ください）。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20572,61 +20798,64 @@ msgid ""
 "bin/client.rs`, respectively. Your task is to complete these files as "
 "described below."
 msgstr ""
+"次のサーバーとクライアントのコードを、それぞれ`src/bin/server.rs` と `src/"
+"bin/client.rs` にコピーします。ここでのタスクは、以下で説明するように、これら"
+"のファイルを完成させることです。"
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "_src/bin/server.rs_:"
-msgstr ""
+msgstr "_src/bin/server.rs_:"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "// TODO: For a hint, see the description of the task below.\n"
-msgstr ""
+msgstr "// TODO: ヒントについては、以下のタスクの説明をご覧ください。\n"
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"127.0.0.1:2000\""
-msgstr ""
+msgstr "\"127.0.0.1:2000\""
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"listening on port 2000\""
-msgstr ""
+msgstr "\"listening on port 2000\""
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"New connection from {addr:?}\""
-msgstr ""
+msgstr "\"New connection from {addr:?}\""
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Wrap the raw TCP stream into a websocket.\n"
-msgstr ""
+msgstr "// 未加工の TCP ストリームを WebSocket にラップします。\n"
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "_src/bin/client.rs_:"
-msgstr ""
+msgstr "_src/bin/client.rs_:"
 
 #: src/exercises/concurrency/chat-app.md
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"ws://127.0.0.1:2000\""
-msgstr ""
+msgstr "\"ws://127.0.0.1:2000\""
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Running the binaries"
-msgstr ""
+msgstr "バイナリの実行"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Run the server with:"
-msgstr ""
+msgstr "次のコマンドでサーバーを実行します。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "and the client with:"
-msgstr ""
+msgstr "次のコマンドでクライアントを実行します。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
-msgstr ""
+msgstr "`src/bin/server.rs` に `handle_connection` 関数を実装します。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20634,10 +20863,14 @@ msgid ""
 "continuous loop. One task receives messages from the client and broadcasts "
 "them. The other sends messages received by the server to the client."
 msgstr ""
+"ヒント: 2 つのタスクを連続ループで同時に実行するには、`tokio::select!` を使用"
+"します。1 つのタスクは、クライアントからメッセージを受信してブロードキャスト"
+"します。もう 1 つのタスクは、サーバーで受信したメッセージをクライアントに送信"
+"します。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid "Complete the main function in `src/bin/client.rs`."
-msgstr ""
+msgstr "`src/bin/client.rs` のメイン関数を完成させます。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
@@ -20646,30 +20879,37 @@ msgid ""
 "sending them to the server, and (2) receiving messages from the server, and "
 "displaying them for the user."
 msgstr ""
+"ヒント: 前の例と同様に、`tokio::select!` を連続ループで使用し、（1）標準入力"
+"からユーザー メッセージを読み取ってサーバーに送信するタスクと、（2）サーバー"
+"からメッセージを受信してユーザーに表示するタスクを同時に実行します。"
 
 #: src/exercises/concurrency/chat-app.md
 msgid ""
 "Optional: Once you are done, change the code to broadcast messages to all "
 "clients, but the sender of the message."
 msgstr ""
+"省略可: 完了したら、メッセージの送信者以外のすべてのクライアントにメッセージ"
+"をブロードキャストするようにコードを変更します。"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "Concurrency Afternoon Exercise"
-msgstr ""
+msgstr "午後の同時実行のエクササイズ"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "([back to exercise](dining-philosophers-async.md))"
-msgstr ""
+msgstr "（[演習に戻る](dining-philosophers-async.md)）"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid ""
 "// Add a delay before picking the second fork to allow the execution\n"
 "        // to transfer to another task\n"
 msgstr ""
+"// 実行を別のタスクに転送できるよう、2 番目のフォークを選択する前に\n"
+"        // 遅延を追加します。\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// The locks are dropped here\n"
-msgstr ""
+msgstr "// ここでロックがドロップされます。\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid ""
@@ -20677,22 +20917,27 @@ msgid ""
 "            // somewhere. This will swap the forks without deinitializing\n"
 "            // either of them.\n"
 msgstr ""
+"// デッドロックを避けるために、どこかで対称性を\n"
+"            // 崩す必要があります。これにより、いずれのフォークも初期化解除す"
+"ることなく、フォークが\n"
+"            // スワップされます。\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
 msgstr ""
+"// tx はここでドロップされるので、後で明示的に削除する必要はありません。\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Here is a thought: {thought}\""
-msgstr ""
+msgstr "\"Here is a thought: {thought}\""
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "([back to exercise](chat-app.md))"
-msgstr ""
+msgstr "（[演習に戻る](chat-app.md)）"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"Welcome to chat! Type a message\""
-msgstr ""
+msgstr "\"Welcome to chat! Type a message\""
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid ""
@@ -20700,24 +20945,28 @@ msgid ""
 "    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
 "    // messages on `bcast_rx` and sending them to the client.\n"
 msgstr ""
+"// (1) `ws_stream` からメッセージを受信してブロードキャストするタスクと、\n"
+"    // （2）`bcast_rx` でメッセージを受信してクライアントに送信しするタスク"
+"を\n"
+"    // 同時に実行するための連続ループ。\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"From client {addr:?} {text:?}\""
-msgstr ""
+msgstr "\"From client {addr:?} {text:?}\""
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "// Continuous loop for concurrently sending and receiving messages.\n"
-msgstr ""
+msgstr "// メッセージの同時送受信のための継続的なループ。\n"
 
 #: src/exercises/concurrency/solutions-afternoon.md
 msgid "\"From server: {}\""
-msgstr ""
+msgstr "\"From server: {}\""
 
 #: src/thanks.md
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
 "that it was useful."
-msgstr ""
+msgstr "Comprehensive Rust 🦀! を受講いただきありがとうございました。"
 
 #: src/thanks.md
 msgid ""
@@ -20726,6 +20975,10 @@ msgid ""
 "please get in [contact with us on GitHub](https://github.com/google/"
 "comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
+"ここまで多くのことを学んできましたが、このコースは完璧ではないため、間違いを"
+"見つけた場合や改善のアイデアがある場合は [GitHub でお知らせください](https://"
+"github.com/google/comprehensive-rust/discussions)。皆さんからのフィードバック"
+"をお待ちしています。"
 
 #: src/glossary.md
 msgid ""
@@ -20733,18 +20986,24 @@ msgid ""
 "Rust terms. For translations, this also serves to connect the term back to "
 "the English original."
 msgstr ""
+"以下は、Rust の多くの用語を簡単に定義することを目的とした用語集です。翻訳時に"
+"用語を英語の原文に関連付けるのにも役立ちます。"
 
 #: src/glossary.md
 msgid ""
 "allocate:  \n"
 "Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md)."
 msgstr ""
+"割り当て（allocate）:  \n"
+"[ヒープ](memory-management/stack-vs-heap.md) での動的メモリ割り当て。"
 
 #: src/glossary.md
 msgid ""
 "argument:  \n"
 "Information that is passed into a function or method."
 msgstr ""
+"引数（argument）:  \n"
+"関数またはメソッドに渡される情報。"
 
 #: src/glossary.md
 msgid ""
@@ -20752,30 +21011,41 @@ msgid ""
 "Low-level Rust development, often deployed to a system without an operating "
 "system. See [Bare-metal Rust](bare-metal.md)."
 msgstr ""
+"ベアメタル Rust（Bare-metal Rust）:  \n"
+"低レベルの Rust 開発。多くの場合、オペレーティング システムのないシステムにデ"
+"プロイされます。[ベアメタル Rust](bare-metal.md) をご覧ください。"
 
 #: src/glossary.md
 msgid ""
 "block:  \n"
 "See [Blocks](control-flow/blocks.md) and _scope_."
 msgstr ""
+"ブロック（block）:  \n"
+"[ブロック](control-flow/blocks.md) とスコープをご覧ください。"
 
 #: src/glossary.md
 msgid ""
 "borrow:  \n"
 "See [Borrowing](ownership/borrowing.md)."
 msgstr ""
+"借用（borrow）:  \n"
+"[借用](ownership/borrowing.md) をご覧ください。"
 
 #: src/glossary.md
 msgid ""
 "borrow checker:  \n"
 "The part of the Rust compiler which checks that all borrows are valid."
 msgstr ""
+"借用チェッカー（borrow checker）:  \n"
+"Rust コンパイラの一部。すべての借用が有効かどうかをチェックします。"
 
 #: src/glossary.md
 msgid ""
 "brace:  \n"
 "`{` and `}`. Also called _curly brace_, they delimit _blocks_."
 msgstr ""
+"中かっこ（brace）:  \n"
+"`{` and `}`。ブロックを区切ります。"
 
 #: src/glossary.md
 msgid ""
@@ -20783,42 +21053,57 @@ msgid ""
 "The process of converting source code into executable code or a usable "
 "program."
 msgstr ""
+"ビルド（build）:  \n"
+"ソースコードを実行可能なコードまたは使用可能なプログラムに変換するプロセス。"
 
 #: src/glossary.md
 msgid ""
 "call:  \n"
 "To invoke or execute a function or method."
 msgstr ""
+"呼び出し（call）:  \n"
+"関数またはメソッドを呼び出します。"
 
 #: src/glossary.md
 msgid ""
 "channel:  \n"
 "Used to safely pass messages [between threads](concurrency/channels.md)."
 msgstr ""
+"チャンネル（channel）:  \n"
+"[スレッド間](concurrency/channels.md) でメッセージを安全に渡すために使用され"
+"ます。"
 
 #: src/glossary.md
 msgid ""
 "Comprehensive Rust 🦀:  \n"
 "The courses here are jointly called Comprehensive Rust 🦀."
 msgstr ""
+"Comprehensive Rust 🦀:  \n"
+"このコースは、まとめて Comprehensive Rust 🦀 と呼びます。"
 
 #: src/glossary.md
 msgid ""
 "concurrency:  \n"
 "The execution of multiple tasks or processes at the same time."
 msgstr ""
+"同時実行（concurrency）:  \n"
+"複数のタスクまたはプロセスを同時に実行することを指します。"
 
 #: src/glossary.md
 msgid ""
 "Concurrency in Rust:  \n"
 "See [Concurrency in Rust](concurrency.md)."
 msgstr ""
+"Rust での同時実行（Concurrency in Rust）:  \n"
+"[Rust での同時実行](concurrency.md) をご覧ください。"
 
 #: src/glossary.md
 msgid ""
 "constant:  \n"
 "A value that does not change during the execution of a program."
 msgstr ""
+"定数（constant）:  \n"
+"プログラムの実行中に変更されない値。"
 
 #: src/glossary.md
 msgid ""
@@ -20826,12 +21111,16 @@ msgid ""
 "The order in which the individual statements or instructions are executed in "
 "a program."
 msgstr ""
+"制御フロー（control flow）:  \n"
+"個々のステートメントまたは命令がプログラム内で実行される順序。"
 
 #: src/glossary.md
 msgid ""
 "crash:  \n"
 "An unexpected and unhandled failure or termination of a program."
 msgstr ""
+"クラッシュ（crash）:  \n"
+"予期しない制御不能なエラーまたは終了。"
 
 #: src/glossary.md
 msgid ""
@@ -20839,12 +21128,17 @@ msgid ""
 "A data type that holds one of several named constants, possibly with an "
 "associated tuple or struct."
 msgstr ""
+"列挙型（enumeration）:  \n"
+"複数の名前付き定数のうちの 1 つを保持するデータ型。関連するタプルまたは構造体"
+"を伴う場合があります。"
 
 #: src/glossary.md
 msgid ""
 "error:  \n"
 "An unexpected condition or result that deviates from the expected behavior."
 msgstr ""
+"エラー（error）:  \n"
+"想定された動作から逸脱した、予期しない条件または結果。"
 
 #: src/glossary.md
 msgid ""
@@ -20852,18 +21146,24 @@ msgid ""
 "The process of managing and responding to errors that occur during program "
 "execution."
 msgstr ""
+"エラー処理（error handling）:  \n"
+"プログラムの実行中に発生するエラーを管理し、それに対応するプロセス。"
 
 #: src/glossary.md
 msgid ""
 "exercise:  \n"
 "A task or problem designed to practice and test programming skills."
 msgstr ""
+"演習（exercise:）:  \n"
+"プログラミング スキルの向上とテストを目的としたタスクまたは問題。"
 
 #: src/glossary.md
 msgid ""
 "function:  \n"
 "A reusable block of code that performs a specific task."
 msgstr ""
+"関数（function）:  \n"
+"特定のタスクを実行する再利用可能なコードブロック。"
 
 #: src/glossary.md
 msgid ""
@@ -20871,6 +21171,9 @@ msgid ""
 "A mechanism that automatically frees up memory occupied by objects that are "
 "no longer in use."
 msgstr ""
+"ガベージ コレクタ（garbage collector）:  \n"
+"使用されなくなったオブジェクトが占有していたメモリを自動的に解放するメカニズ"
+"ム。"
 
 #: src/glossary.md
 msgid ""
@@ -20878,12 +21181,17 @@ msgid ""
 "A feature that allows writing code with placeholders for types, enabling "
 "code reuse with different data types."
 msgstr ""
+"ジェネリクス（generics）:  \n"
+"型のプレースホルダを使用してコードを記述し、さまざまなデータ型でコードを再利"
+"用できるようにする機能。"
 
 #: src/glossary.md
 msgid ""
 "immutable:  \n"
 "Unable to be changed after creation."
 msgstr ""
+"不変（immutable）:  \n"
+" 作成後に変更できないこと。"
 
 #: src/glossary.md
 msgid ""
@@ -20891,6 +21199,8 @@ msgid ""
 "A type of test that verifies the interactions between different parts or "
 "components of a system."
 msgstr ""
+"統合テスト（integration test）:  \n"
+"システムのさまざまな部分やコンポーネント間の相互作用を検証するテストの一種。"
 
 #: src/glossary.md
 msgid ""
@@ -20898,12 +21208,17 @@ msgid ""
 "A reserved word in a programming language that has a specific meaning and "
 "cannot be used as an identifier."
 msgstr ""
+"キーワード（keyword）:  \n"
+"特定の意味を持ち、識別子として使用できない、プログラミング言語の予約語。"
 
 #: src/glossary.md
 msgid ""
 "library:  \n"
 "A collection of precompiled routines or code that can be used by programs."
 msgstr ""
+"ライブラリ（library）:  \n"
+"プログラムで使用できるプリコンパイル済みのルーチンまたはコードのコレクショ"
+"ン。"
 
 #: src/glossary.md
 msgid ""
@@ -20912,12 +21227,18 @@ msgid ""
 "normal functions are not enough. A typical example is `format!`, which takes "
 "a variable number of arguments, which isn't supported by Rust functions."
 msgstr ""
+"マクロ（macro）:  \n"
+"Rust マクロは名前に `!` を含めることで認識できます。マクロは、通常の関数では"
+"不十分な場合に使用されます。典型的な例が `format!` です。これは可変長引数を取"
+"りますが、Rust 関数ではサポートされていません。"
 
 #: src/glossary.md
 msgid ""
 "`main` function:  \n"
 "Rust programs start executing with the `main` function."
 msgstr ""
+"`main` 関数（`main` function）:  \n"
+"Rust プログラムの実行は `main` 関数で開始されます。"
 
 #: src/glossary.md
 msgid ""
@@ -20925,6 +21246,8 @@ msgid ""
 "A control flow construct in Rust that allows for pattern matching on the "
 "value of an expression."
 msgstr ""
+"一致（match）:  \n"
+"式の値に対するパターン マッチングを可能にする、Rust の制御フロー構造。"
 
 #: src/glossary.md
 msgid ""
@@ -20932,12 +21255,17 @@ msgid ""
 "A situation where a program fails to release memory that is no longer "
 "needed, leading to a gradual increase in memory usage."
 msgstr ""
+"メモリリーク（memory leak）:  \n"
+"プログラムで不要になったメモリの解放に失敗し、メモリ使用量が徐々に増加する状"
+"況。"
 
 #: src/glossary.md
 msgid ""
 "method:  \n"
 "A function associated with an object or a type in Rust."
 msgstr ""
+"メソッド（method）:  \n"
+"Rust のオブジェクトまたは型に関連付けられた関数。"
 
 #: src/glossary.md
 msgid ""
@@ -20945,12 +21273,17 @@ msgid ""
 "A namespace that contains definitions, such as functions, types, or traits, "
 "to organize code in Rust."
 msgstr ""
+"モジュール（module）:  \n"
+"関数、型、トレイトなどの定義を含む名前空間。Rust でコードを整理するために使用"
+"されます。"
 
 #: src/glossary.md
 msgid ""
 "move:  \n"
 "The transfer of ownership of a value from one variable to another in Rust."
 msgstr ""
+"移動（move）:  \n"
+"Rust である変数から別の変数に値の所有権を移動すること。"
 
 #: src/glossary.md
 msgid ""
@@ -20958,6 +21291,8 @@ msgid ""
 "A property in Rust that allows variables to be modified after they have been "
 "declared."
 msgstr ""
+"可変（mutable）:  \n"
+"宣言後の変数の変更を可能にする Rust のプロパティ。"
 
 #: src/glossary.md
 msgid ""
@@ -20965,6 +21300,9 @@ msgid ""
 "The concept in Rust that defines which part of the code is responsible for "
 "managing the memory associated with a value."
 msgstr ""
+"所有権（ownership）:  \n"
+"値に関連付けられたメモリの管理をコードのどの部分が担うかを定義する Rust の概"
+"念。"
 
 #: src/glossary.md
 msgid ""
@@ -20972,12 +21310,16 @@ msgid ""
 "An unrecoverable error condition in Rust that results in the termination of "
 "the program."
 msgstr ""
+"パニック（panic）:  \n"
+"プログラムの終了を引き起こす、Rust の回復不能なエラー状態。"
 
 #: src/glossary.md
 msgid ""
 "parameter:  \n"
 "A value that is passed into a function or method when it is called."
 msgstr ""
+"パラメータ（parameter）:  \n"
+"関数またはメソッドが呼び出されたときに渡される値。"
 
 #: src/glossary.md
 msgid ""
@@ -20985,12 +21327,16 @@ msgid ""
 "A combination of values, literals, or structures that can be matched against "
 "an expression in Rust."
 msgstr ""
+"パターン（pattern）:  \n"
+"Rust の式と照合できる値、リテラル、構造体の組み合わせ。"
 
 #: src/glossary.md
 msgid ""
 "payload:  \n"
 "The data or information carried by a message, event, or data structure."
 msgstr ""
+"ペイロード（payload）:  \n"
+"メッセージ、イベント、またはデータ構造体で保持されるデータまたは情報。"
 
 #: src/glossary.md
 msgid ""
@@ -20998,12 +21344,17 @@ msgid ""
 "A set of instructions that a computer can execute to perform a specific task "
 "or solve a particular problem."
 msgstr ""
+"プログラム（program）:  \n"
+"特定のタスクを実行したり、特定の問題を解決したりするためにコンピュータが実行"
+"できる一連の命令。"
 
 #: src/glossary.md
 msgid ""
 "programming language:  \n"
 "A formal system used to communicate instructions to a computer, such as Rust."
 msgstr ""
+"プログラミング言語（programming language）:  \n"
+"コンピュータに命令を伝えるために使用される正式なシステム（Rust など）。"
 
 #: src/glossary.md
 msgid ""
@@ -21011,6 +21362,8 @@ msgid ""
 "The first parameter in a Rust method that represents the instance on which "
 "the method is called."
 msgstr ""
+"レシーバ（receiver）:  \n"
+"メソッドが呼び出されたインスタンスを表す Rust メソッドの最初のパラメータ。"
 
 #: src/glossary.md
 msgid ""
@@ -21018,12 +21371,17 @@ msgid ""
 "A memory management technique in which the number of references to an object "
 "is tracked, and the object is deallocated when the count reaches zero."
 msgstr ""
+"参照カウント（reference counting）:  \n"
+"オブジェクトへの参照の数をトラッキングし、カウントがゼロになるとオブジェクト"
+"の割り当てを解除するメモリ管理技術。"
 
 #: src/glossary.md
 msgid ""
 "return:  \n"
 "A keyword in Rust used to indicate the value to be returned from a function."
 msgstr ""
+"戻り値（return）:  \n"
+"関数から返される値を示すために使用される Rust のキーワード。"
 
 #: src/glossary.md
 msgid ""
@@ -21031,24 +21389,32 @@ msgid ""
 "A systems programming language that focuses on safety, performance, and "
 "concurrency."
 msgstr ""
+"Rust:  \n"
+"安全性、パフォーマンス、同時実行に重点を置いたシステム プログラミング言語。"
 
 #: src/glossary.md
 msgid ""
 "Rust Fundamentals:  \n"
 "Days 1 to 3 of this course."
 msgstr ""
+"Rust の基礎（Rust Fundamentals）:  \n"
+"このコースの 1～3 日目。"
 
 #: src/glossary.md
 msgid ""
 "Rust in Android:  \n"
 "See [Rust in Android](android.md)."
 msgstr ""
+"Android での Rust（Rust in Android）:  \n"
+"[Android での Rust](android.md) をご覧ください。"
 
 #: src/glossary.md
 msgid ""
 "Rust in Chromium:  \n"
 "See [Rust in Chromium](chromium.md)."
 msgstr ""
+"Chromium での Rust（Rust in Chromium）:  \n"
+"[Chromium での Rust](chromium.md) をご覧ください。"
 
 #: src/glossary.md
 msgid ""
@@ -21056,18 +21422,25 @@ msgid ""
 "Refers to code that adheres to Rust's ownership and borrowing rules, "
 "preventing memory-related errors."
 msgstr ""
+"安全（safe）:  \n"
+"Rust の所有権と借用に関するルールに従って、メモリ関連のエラーを防止するコード"
+"を指します。"
 
 #: src/glossary.md
 msgid ""
 "scope:  \n"
 "The region of a program where a variable is valid and can be used."
 msgstr ""
+"スコープ（scope）:  \n"
+"変数が有効かつ使用可能なプログラムの領域。"
 
 #: src/glossary.md
 msgid ""
 "standard library:  \n"
 "A collection of modules providing essential functionality in Rust."
 msgstr ""
+"標準ライブラリ（standard library）:  \n"
+"Rust の必須機能を提供するモジュールのコレクション。"
 
 #: src/glossary.md
 msgid ""
@@ -21075,6 +21448,9 @@ msgid ""
 "A keyword in Rust used to define static variables or items with a `'static` "
 "lifetime."
 msgstr ""
+"静的（static）:  \n"
+"静的な変数や `'static` ライフタイムを持つアイテムを定義するために使用される "
+"Rust のキーワード。"
 
 #: src/glossary.md
 msgid ""
@@ -21082,6 +21458,9 @@ msgid ""
 "A data type storing textual data. See [`String` vs `str`](basic-syntax/"
 "string-slices.html) for more."
 msgstr ""
+"文字列（string）:  \n"
+"テキストデータを格納するデータ型。詳しくは、[`String` と `str`](basic-syntax/"
+"string-slices.html) をご覧ください。"
 
 #: src/glossary.md
 msgid ""
@@ -21089,6 +21468,8 @@ msgid ""
 "A composite data type in Rust that groups together variables of different "
 "types under a single name."
 msgstr ""
+"構造体（struct）:  \n"
+"異なる型の変数を 1 つの名前でグループ化する Rust の複合データ型。"
 
 #: src/glossary.md
 msgid ""
@@ -21096,12 +21477,16 @@ msgid ""
 "A Rust module containing functions that test the correctness of other "
 "functions."
 msgstr ""
+"テスト（test）:  \n"
+"他の関数の正しさをテストする関数を含む Rust モジュール。"
 
 #: src/glossary.md
 msgid ""
 "thread:  \n"
 "A separate sequence of execution in a program, allowing concurrent execution."
 msgstr ""
+"スレッド（thread）:  \n"
+"同時実行を可能にする、プログラム内の独立した実行シーケンス。"
 
 #: src/glossary.md
 msgid ""
@@ -21109,6 +21494,8 @@ msgid ""
 "The property of a program that ensures correct behavior in a multithreaded "
 "environment."
 msgstr ""
+"スレッドセーフ（thread safety）:  \n"
+"マルチスレッド環境で正しい動作を保証するプログラムの特性。"
 
 #: src/glossary.md
 msgid ""
@@ -21116,6 +21503,9 @@ msgid ""
 "A collection of methods defined for an unknown type, providing a way to "
 "achieve polymorphism in Rust."
 msgstr ""
+"トレイト（trait）:  \n"
+"未知の型に対して定義されたメソッドのコレクション。Rust でポリモーフィズムを実"
+"現する方法を提供します。"
 
 #: src/glossary.md
 msgid ""
@@ -21123,6 +21513,8 @@ msgid ""
 "An abstraction where you can require types to implement some traits of your "
 "interest."
 msgstr ""
+"トレイト境界（trait bound）:  \n"
+"特定のトレイトを実装するために型を要求できる抽象化。"
 
 #: src/glossary.md
 msgid ""
@@ -21130,6 +21522,9 @@ msgid ""
 "A composite data type that contains variables of different types. Tuple "
 "fields have no names, and are accessed by their ordinal numbers."
 msgstr ""
+"タプル（tuple）:  \n"
+"さまざまな型の変数を含む複合データ型。タプル フィールドには名前がなく、序数で"
+"アクセスします。"
 
 #: src/glossary.md
 msgid ""
@@ -21137,6 +21532,8 @@ msgid ""
 "A classification that specifies which operations can be performed on values "
 "of a particular kind in Rust."
 msgstr ""
+"型（type）:  \n"
+"Rust の特定の種類の値に対してどのオペレーションを実行できるかを指定する分類。"
 
 #: src/glossary.md
 msgid ""
@@ -21144,6 +21541,8 @@ msgid ""
 "The ability of the Rust compiler to deduce the type of a variable or "
 "expression."
 msgstr ""
+"型推論（type inference）:  \n"
+"変数または式の型を推測する Rust コンパイラの機能。"
 
 #: src/glossary.md
 msgid ""
@@ -21151,12 +21550,17 @@ msgid ""
 "Actions or conditions in Rust that have no specified result, often leading "
 "to unpredictable program behavior."
 msgstr ""
+"未定義の動作（undefined behavior）:  \n"
+"結果が指定されていない Rust のアクションまたは条件。多くの場合、プログラムの"
+"予測不能な動作を引き起こします。"
 
 #: src/glossary.md
 msgid ""
 "union:  \n"
 "A data type that can hold values of different types but only one at a time."
 msgstr ""
+"共用体（union）:  \n"
+"異なる型の値を一度に 1 つだけ保持できるデータ型。"
 
 #: src/glossary.md
 msgid ""
@@ -21164,12 +21568,18 @@ msgid ""
 "Rust comes with built-in support for running small unit tests and larger "
 "integration tests. See [Unit Tests](testing/unit-tests.html)."
 msgstr ""
+"単体テスト（unit test）:  \n"
+"Rust には、小規模な単体テストと大規模な統合テストを実行するための組み込みサ"
+"ポートが付属しています。[単体テスト](testing/unit-tests.html) をご覧くださ"
+"い。"
 
 #: src/glossary.md
 msgid ""
 "unit type:  \n"
 "Type that holds no data, written as a tuple with no members."
 msgstr ""
+"ユニット型（unit type）:  \n"
+"データを保持しない型。メンバーのないタプルとして記述されます。"
 
 #: src/glossary.md
 msgid ""
@@ -21177,30 +21587,38 @@ msgid ""
 "The subset of Rust which allows you to trigger _undefined behavior_. See "
 "[Unsafe Rust](unsafe.html)."
 msgstr ""
+"安全でない（unsafe）:  \n"
+"未定義の動作をトリガーできる Rust のサブセット。[安全でない Rust](unsafe."
+"html) をご覧ください。"
 
 #: src/glossary.md
 msgid ""
 "variable:  \n"
 "A memory location storing data. Variables are valid in a _scope_."
 msgstr ""
+"変数（variable）:  \n"
+"データを格納するメモリの場所。変数はスコープ内で有効です。"
 
 #: src/other-resources.md
 msgid "Other Rust Resources"
-msgstr ""
+msgstr "Rust のその他のリソース"
 
 #: src/other-resources.md
 msgid ""
 "The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
+"Rust コミュニティは、高品質な無料のリソースをオンラインで多数提供しています。"
 
 #: src/other-resources.md
 msgid "Official Documentation"
-msgstr ""
+msgstr "正式なドキュメント"
 
 #: src/other-resources.md
 msgid "The Rust project hosts many resources. These cover Rust in general:"
 msgstr ""
+"Rust プロジェクトは多くのリソースをホストしており、これらは Rust 全般に対応し"
+"ています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21208,6 +21626,9 @@ msgid ""
 "canonical free book about Rust. Covers the language in detail and includes a "
 "few projects for people to build."
 msgstr ""
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): Rust の標準"
+"的な書籍で、無料で利用できます。Rust について詳しく説明されているほか、ビルド"
+"できるプロジェクトがいくつか含まれています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21216,22 +21637,29 @@ msgid ""
 "Sometimes includes small exercises where you are asked to expand on the code "
 "in the examples."
 msgstr ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): さまざまな構造"
+"を示す一連のサンプルを使用して、Rust の構文を解説しています。小規模な演習がい"
+"くつか用意されており、そこでサンプルのコードを拡張するよう求められます。"
 
 #: src/other-resources.md
 msgid ""
 "[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
 "of the standard library for Rust."
 msgstr ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): Rust の標準ライブラ"
+"リの完全なドキュメントです。"
 
 #: src/other-resources.md
 msgid ""
 "[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
 "book which describes the Rust grammar and memory model."
 msgstr ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): Rust の文法とメモ"
+"リモデルについて説明している未完成の書籍です。"
 
 #: src/other-resources.md
 msgid "More specialized guides hosted on the official Rust site:"
-msgstr ""
+msgstr "Rust の公式サイトでホストされている、より専門的なガイド:"
 
 #: src/other-resources.md
 msgid ""
@@ -21239,6 +21667,9 @@ msgid ""
 "including working with raw pointers and interfacing with other languages "
 "(FFI)."
 msgstr ""
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): 未加工のポインタの操"
+"作や、他の言語（FFI）とのやり取りなど、安全でない Rust について説明していま"
+"す。"
 
 #: src/other-resources.md
 msgid ""
@@ -21246,6 +21677,9 @@ msgid ""
 "covers the new asynchronous programming model which was introduced after the "
 "Rust Book was written."
 msgstr ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"Rust Book の執筆後に導入された新しい非同期プログラミング モデルについて説明し"
+"ています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21253,20 +21687,25 @@ msgid ""
 "an introduction to using Rust on embedded devices without an operating "
 "system."
 msgstr ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): オ"
+"ペレーティング システムのない組み込みデバイスで Rust を使用する方法を紹介して"
+"います。"
 
 #: src/other-resources.md
 msgid "Unofficial Learning Material"
-msgstr ""
+msgstr "非公式の学習教材"
 
 #: src/other-resources.md
 msgid "A small selection of other guides and tutorial for Rust:"
-msgstr ""
+msgstr "Rust に関するその他のガイドとチュートリアル:"
 
 #: src/other-resources.md
 msgid ""
 "[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
 "from the perspective of low-level C programmers."
 msgstr ""
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): 高度な知識を"
+"持たない C プログラマーの視点で Rust を解説しています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21274,6 +21713,9 @@ msgid ""
 "rust_for_c/): covers Rust from the perspective of developers who write "
 "firmware in C."
 msgstr ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): ファームウェアを C で記述するデベロッパーの観点から Rust を解説"
+"しています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21281,12 +21723,17 @@ msgid ""
 "covers the syntax of Rust using side-by-side comparisons with other "
 "languages such as C, C++, Java, JavaScript, and Python."
 msgstr ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): 他の"
+"言語（C、C++、Java、JavaScript、Python など）と並べて比較しながら、Rust の構"
+"文について説明しています。"
 
 #: src/other-resources.md
 msgid ""
 "[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
 "you learn Rust."
 msgstr ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): Rust の学習に役立つ "
+"100 以上の演習が用意されています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21295,6 +21742,10 @@ msgid ""
 "and advanced part of the Rust language. Other topics such as WebAssembly, "
 "and async/await are also covered."
 msgstr ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): Rust 言語の基本的な部分と高度な部分の両方をカバーした、"
+"一連のコンパクトなプレゼンテーションです。WebAssembly、async / await などの他"
+"のトピックも扱っています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21304,6 +21755,11 @@ msgid ""
 "new developers. The first is a set of 35 videos and the second is a set of "
 "11 modules which covers Rust syntax and basic constructs."
 msgstr ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/ja-jp/shows/beginners-"
+"series-to-rust/) および [Take your first steps with Rust](https://docs."
+"microsoft. com/en-us/learn/paths/rust-first-steps/): 初心者のデベロッパーを対"
+"象とした 2 つの Rust ガイドです。1 つ目は 35 個の動画で構成され、2 つ目は "
+"Rust の構文と基本的な構造を説明する 11 のモジュールで構成されています。"
 
 #: src/other-resources.md
 msgid ""
@@ -21311,12 +21767,17 @@ msgid ""
 "github.io/too-many-lists/): in-depth exploration of Rust's memory management "
 "rules, through implementing a few different types of list structures."
 msgstr ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): いくつかの異なるタイプのリスト構造の実装を通じ"
+"て、Rust のメモリ管理ルールを深く掘り下げています。"
 
 #: src/other-resources.md
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
 "for even more Rust books."
 msgstr ""
+"Rust に関するその他の書籍については、[Little Book of Rust Books](https://"
+"lborb.github.io/book/) をご覧ください。"
 
 #: src/credits.md
 msgid ""
@@ -21324,6 +21785,9 @@ msgid ""
 "documentation. See the page on [other resources](other-resources.md) for a "
 "full list of useful resources."
 msgstr ""
+"ここで紹介する教材は、多くの優れた Rust ドキュメントのソースに基づいていま"
+"す。役立つリソースの一覧については、[その他のリソース](other-resources.md) の"
+"ページをご覧ください。"
 
 #: src/credits.md
 msgid ""
@@ -21331,10 +21795,13 @@ msgid ""
 "2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
 "rust/blob/main/LICENSE) for details."
 msgstr ""
+"Comprehensive Rust の教材は、Apache 2.0 ライセンスの規約により使用が許諾され"
+"ています。詳細については、[`LICENSE`](https://github.com/google/"
+"comprehensive-rust/blob/main/LICENSE) をご覧ください。"
 
 #: src/credits.md
 msgid "Rust by Example"
-msgstr ""
+msgstr "Rust by Example"
 
 #: src/credits.md
 msgid ""
@@ -21343,10 +21810,13 @@ msgid ""
 "`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
+"一部の例と演習は、[Rust by Example](https://doc.rust-lang.org/rust-by-"
+"example/) からコピーして編集したものです。ライセンス規約などの詳細について"
+"は、`third_party/rust-by-example/` ディレクトリを参照してください。"
 
 #: src/credits.md
 msgid "Rust on Exercism"
-msgstr ""
+msgstr "Rust on Exercism"
 
 #: src/credits.md
 msgid ""
@@ -21354,10 +21824,13 @@ msgid ""
 "exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
 "directory for details, including the license terms."
 msgstr ""
+"一部の演習は、[Rust on Exercism](https://exercism.org/tracks/rust) をコピーし"
+"て編集したものです。ライセンス規約などの詳細については、`third_party/rust-on-"
+"exercism/` ディレクトリを参照してください。"
 
 #: src/credits.md
 msgid "CXX"
-msgstr ""
+msgstr "CXX"
 
 #: src/credits.md
 msgid ""
@@ -21365,6 +21838,9 @@ msgid ""
 "uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
 "directory for details, including the license terms."
 msgstr ""
+"[C++ との相互運用性](android/interoperability/cpp.md) セクションでは、[CXX]"
+"(https://cxx.rs/) の画像を使用しています。ライセンス規約などの詳細について"
+"は、`third_party/cxx/` ディレクトリを参照してください。"
 
 #, fuzzy
 #~ msgid "With C++)"

--- a/po/ja.po
+++ b/po/ja.po
@@ -12572,7 +12572,7 @@ msgstr "\"//! Crab\\n\""
 
 #: src/android.md
 msgid "Welcome to Rust in Android"
-msgstr ""
+msgstr "Android での Rust へようこそ"
 
 #: src/android.md
 msgid ""
@@ -12580,6 +12580,9 @@ msgid ""
 "write new services, libraries, drivers or even firmware in Rust (or improve "
 "existing code as needed)."
 msgstr ""
+"Rust は Android のシステム ソフトウェアでサポートされています。つまり、新しい"
+"サービス、ライブラリ、ドライバ、さらにはファームウェアを Rust で作成できます"
+"（または、必要に応じて既存のコードを改善できます）。"
 
 #: src/android.md
 msgid ""
@@ -12588,170 +12591,211 @@ msgid ""
 "to Rust. The fewer dependencies and \"exotic\" types the better. Something "
 "that parses some raw bytes would be ideal."
 msgstr ""
+"本日は、皆さんのプロジェクトの一つから Rust を呼び出してみたいと思います。"
+"コードベースの小さな隅を見つけて、数行のコードを Rust に書き換えてみましょ"
+"う。依存関係が少なく、「珍しい」型がよいでしょう。未加工のバイトを解析するも"
+"のが理想的です。"
 
 #: src/android.md
 msgid ""
 "The speaker may mention any of the following given the increased use of Rust "
 "in Android:"
 msgstr ""
+"Android で Rust が使用されることが増えているため、次のいずれかに言及すること"
+"をおすすめします。"
 
 #: src/android.md
 msgid ""
 "Service example: [DNS over HTTP](https://security.googleblog.com/2022/07/dns-"
 "over-http3-in-android.html)"
 msgstr ""
+"サービスの例: [DNS over HTTP](https://security.googleblog.com/2022/07/dns-"
+"over-http3-in-android.html)"
 
 #: src/android.md
 msgid ""
 "Libraries: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
 "appendix/rutabaga_gfx.html)"
 msgstr ""
+"ライブラリ: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
+"appendix/rutabaga_gfx.html)"
 
 #: src/android.md
 msgid ""
 "Kernel Drivers: [Binder](https://lore.kernel.org/rust-for-linux/20231101-"
 "rust-binder-v1-0-08ba9197f637@google.com/)"
 msgstr ""
+"カーネル ドライバ: [Binder](https://lore.kernel.org/rust-for-linux/20231101-"
+"rust-binder-v1-0-08ba9197f637@google.com/)"
 
 #: src/android.md
 msgid ""
 "Firmware: [pKVM firmware](https://security.googleblog.com/2023/10/bare-metal-"
 "rust-in-android.html)"
 msgstr ""
+"ファームウェア: [pKVM ファームウェア](https://security.googleblog."
+"com/2023/10/bare-metal-rust-in-android.html)"
 
 #: src/android/setup.md
 msgid ""
 "We will be using a Cuttlefish Android Virtual Device to test our code. Make "
 "sure you have access to one or create a new one with:"
 msgstr ""
+"コードのテストのためにCuttlefish Android Virtual Device を使用します。既存の"
+"Deviceがあればそれにアクセスできることを確認し、そうでなければ以下のコマンド"
+"により作成しておいてください。"
 
 #: src/android/setup.md
 msgid ""
 "Please see the [Android Developer Codelab](https://source.android.com/docs/"
 "setup/start) for details."
 msgstr ""
+"詳しくは、[Android デベロッパー Codelab](https://source.android.com/docs/"
+"setup/start) をご覧ください。"
 
 #: src/android/setup.md
 msgid ""
 "Cuttlefish is a reference Android device designed to work on generic Linux "
 "desktops. MacOS support is also planned."
 msgstr ""
+"Cuttlefish は、一般的な Linux デスクトップで動作するように設計されたリファレ"
+"ンス Android デバイスです。macOS のサポートも予定されています。"
 
 #: src/android/setup.md
 msgid ""
 "The Cuttlefish system image maintains high fidelity to real devices, and is "
 "the ideal emulator to run many Rust use cases."
 msgstr ""
+"Cuttlefish システム イメージは、実際のデバイスに対する高い忠実度を維持してい"
+"るため、多くの Rust ユースケースを実行するのに理想的なエミュレータです。"
 
 #: src/android/build-rules.md
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr ""
+"Android ビルドシステム（Soong）は、さまざまなモジュールを通じて Rust をサポー"
+"トしています。"
 
 #: src/android/build-rules.md
 msgid "Module Type"
-msgstr ""
+msgstr "モジュール タイプ"
 
 #: src/android/build-rules.md
 msgid "Description"
-msgstr ""
+msgstr "説明"
 
 #: src/android/build-rules.md
 msgid "`rust_binary`"
-msgstr ""
+msgstr "`rust_binary`"
 
 #: src/android/build-rules.md
 msgid "Produces a Rust binary."
-msgstr ""
+msgstr "Rust バイナリを生成します。"
 
 #: src/android/build-rules.md
 msgid "`rust_library`"
-msgstr ""
+msgstr "`rust_library`"
 
 #: src/android/build-rules.md
 msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
 msgstr ""
+"Rust ライブラリを生成し、`rlib` と `dylib` の両方のバリアントを提供します。"
 
 #: src/android/build-rules.md
 msgid "`rust_ffi`"
-msgstr ""
+msgstr "`rust_ffi`"
 
 #: src/android/build-rules.md
 msgid ""
 "Produces a Rust C library usable by `cc` modules, and provides both static "
 "and shared variants."
 msgstr ""
+"`cc` モジュールで使用できる Rust C ライブラリを生成し、静的バリアントと共有バ"
+"リアントの両方を提供します。"
 
 #: src/android/build-rules.md
 msgid "`rust_proc_macro`"
-msgstr ""
+msgstr "`rust_proc_macro`"
 
 #: src/android/build-rules.md
 msgid ""
 "Produces a `proc-macro` Rust library. These are analogous to compiler "
 "plugins."
 msgstr ""
+"`proc-macro` Rust ライブラリを生成します。これらはコンパイラ プラグインに似て"
+"います。"
 
 #: src/android/build-rules.md
 msgid "`rust_test`"
-msgstr ""
+msgstr "`rust_test`"
 
 #: src/android/build-rules.md
 msgid "Produces a Rust test binary that uses the standard Rust test harness."
-msgstr ""
+msgstr "標準の Rust テストハーネスを使用する Rust テストバイナリを生成します。"
 
 #: src/android/build-rules.md
 msgid "`rust_fuzz`"
-msgstr ""
+msgstr "`rust_fuzz`"
 
 #: src/android/build-rules.md
 msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
-msgstr ""
+msgstr "`libfuzzer` を利用して、Rust ファズバイナリを生成します。"
 
 #: src/android/build-rules.md
 msgid "`rust_protobuf`"
-msgstr ""
+msgstr "`rust_protobuf`"
 
 #: src/android/build-rules.md
 msgid ""
 "Generates source and produces a Rust library that provides an interface for "
 "a particular protobuf."
 msgstr ""
+"ソースを生成し、特定の protobuf 用のインターフェースを提供する Rust ライブラ"
+"リを生成します。"
 
 #: src/android/build-rules.md
 msgid "`rust_bindgen`"
-msgstr ""
+msgstr "`rust_bindgen`"
 
 #: src/android/build-rules.md
 msgid ""
 "Generates source and produces a Rust library containing Rust bindings to C "
 "libraries."
 msgstr ""
+"ソースを生成し、C ライブラリへの Rust バインディングを含む Rust ライブラリを"
+"生成します。"
 
 #: src/android/build-rules.md
 msgid "We will look at `rust_binary` and `rust_library` next."
-msgstr ""
+msgstr "次に `rust_binary` と `rust_library` を見ていきます。"
 
 #: src/android/build-rules.md
 msgid "Additional items speaker may mention:"
-msgstr ""
+msgstr "追加で次の項目に言及することをおすすめします。"
 
 #: src/android/build-rules.md
 msgid ""
 "Cargo is not optimized for multi-language repos, and also downloads packages "
 "from the internet."
 msgstr ""
+"Cargo は多言語リポジトリ用に最適化されていません。また、インターネットから"
+"パッケージをダウンロードします。"
 
 #: src/android/build-rules.md
 msgid ""
 "For compliance and performance, Android must have crates in-tree. It must "
 "also interop with C/C++/Java code. Soong fills that gap."
 msgstr ""
+"コンプライアンスおよびパフォーマンス上の理由から、Android ではクレートをツ"
+"リー内に配置する必要があります。また、C /C++ / Java コードとの相互運用性も必"
+"要です。Soong を使用することで、そのギャップを埋めることができます。"
 
 #: src/android/build-rules.md
 msgid ""
 "Soong has many similarities to Bazel, which is the open-source variant of "
 "Blaze (used in google3)."
 msgstr ""
+"Soong には、Blaze（google3 で使用）のオープンソース版である Bazel と多くの類"
+"似点があります。"
 
 #: src/android/build-rules.md
 msgid ""
@@ -12760,57 +12804,66 @@ msgid ""
 "com/chromiumos/bazel/), and [Fuchsia](https://source.android.com/docs/setup/"
 "build/bazel/introduction) to Bazel."
 msgstr ""
+"[Android](https://source.android.com/docs/setup/build/bazel/introduction)、"
+"[ChromeOS](https://chromium.googlesource.com/chromiumos/bazel/)、[Fuchsia]"
+"(https://source.android.com/docs/setup/build/bazel/introduction) を Bazel に"
+"移行する計画があります。"
 
 #: src/android/build-rules.md
 msgid "Learning Bazel-like build rules is useful for all Rust OS developers."
 msgstr ""
+"Bazel のようなビルドルールを学ぶことは、すべての Rust OS デベロッパーに役立ち"
+"ます。"
 
 #: src/android/build-rules.md
 msgid "Fun fact: Data from Star Trek is a Soong-type Android."
 msgstr ""
+"豆知識: スタートレックの「データ」は、スン（Soong）型アンドロイドです。"
 
 #: src/android/build-rules/binary.md
 msgid "Rust Binaries"
-msgstr ""
+msgstr "Rust バイナリ"
 
 #: src/android/build-rules/binary.md
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
 "create the following files:"
 msgstr ""
+"簡単なアプリから始めましょう。AOSP チェックアウトのルートで、次のファイルを作"
+"成します。"
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "_hello_rust/Android.bp_:"
-msgstr ""
+msgstr "_hello_rust/Android.bp_:"
 
 #: src/android/build-rules/binary.md
 msgid "\"hello_rust\""
-msgstr ""
+msgstr "\"hello_rust\""
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 #: src/android/logging.md
 msgid "\"src/main.rs\""
-msgstr ""
+msgstr "\"src/main.rs\""
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "_hello_rust/src/main.rs_:"
-msgstr ""
+msgstr "_hello_rust/src/main.rs_:"
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "//! Rust demo.\n"
-msgstr ""
+msgstr "//! Rust のデモ。\n"
 
 #: src/android/build-rules/binary.md src/android/build-rules/library.md
 msgid "/// Prints a greeting to standard output.\n"
-msgstr ""
+msgstr "/// 挨拶を標準出力に出力します。\n"
 
 #: src/android/build-rules/binary.md src/exercises/chromium/build-rules.md
 msgid "\"Hello from Rust!\""
-msgstr ""
+msgstr "\"Hello from Rust!\""
 
 #: src/android/build-rules/binary.md
 msgid "You can now build, push, and run the binary:"
-msgstr ""
+msgstr "これで、バイナリをビルド、push、実行できます。"
 
 #: src/android/build-rules/binary.md
 msgid ""
@@ -12820,22 +12873,28 @@ msgid ""
 "adb shell /data/local/tmp/hello_rust\n"
 "```"
 msgstr ""
+"```shell\n"
+"m hello_rust\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust\" /data/local/tmp\n"
+"adb shell /data/local/tmp/hello_rust\n"
+"```"
 
 #: src/android/build-rules/library.md
 msgid "Rust Libraries"
-msgstr ""
+msgstr "Rust ライブラリ"
 
 #: src/android/build-rules/library.md
 msgid "You use `rust_library` to create a new Rust library for Android."
 msgstr ""
+"`rust_library` を使用して、Android 用の新しい Rust ライブラリを作成します。"
 
 #: src/android/build-rules/library.md
 msgid "Here we declare a dependency on two libraries:"
-msgstr ""
+msgstr "ここでは、2 つのライブラリへの依存関係を宣言します。"
 
 #: src/android/build-rules/library.md
 msgid "`libgreeting`, which we define below,"
-msgstr ""
+msgstr "`libgreeting`: 以下で定義します。"
 
 #: src/android/build-rules/library.md
 msgid ""
@@ -12843,51 +12902,54 @@ msgid ""
 "(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
 "crates/)."
 msgstr ""
+"`libtextwrap`: すでに[`external/rust/crates/`](https://cs.android.com/"
+"android/platform/superproject/+/master:external/rust/crates/) に取り込まれて"
+"いるクレートです。"
 
 #: src/android/build-rules/library.md
 msgid "\"hello_rust_with_dep\""
-msgstr ""
+msgstr "\"hello_rust_with_dep\""
 
 #: src/android/build-rules/library.md
 msgid "\"libgreetings\""
-msgstr ""
+msgstr "\"libgreetings\""
 
 #: src/android/build-rules/library.md
 msgid "\"libtextwrap\""
-msgstr ""
+msgstr "\"libtextwrap\""
 
 #: src/android/build-rules/library.md
 msgid "// Need this to avoid dynamic link error.\n"
-msgstr ""
+msgstr "// ダイナミック リンク エラーを回避するために必要です。\n"
 
 #: src/android/build-rules/library.md
 msgid "\"greetings\""
-msgstr ""
+msgstr "\"greetings\""
 
 #: src/android/build-rules/library.md src/android/aidl/implementation.md
 #: src/android/interoperability/java.md
 msgid "\"src/lib.rs\""
-msgstr ""
+msgstr "\"src/lib.rs\""
 
 #: src/android/build-rules/library.md
 msgid "_hello_rust/src/lib.rs_:"
-msgstr ""
+msgstr "_hello_rust/src/lib.rs_:"
 
 #: src/android/build-rules/library.md
 msgid "//! Greeting library.\n"
-msgstr ""
+msgstr "//! 挨拶ライブラリ。\n"
 
 #: src/android/build-rules/library.md
 msgid "/// Greet `name`.\n"
-msgstr ""
+msgstr "/// `name` に挨拶します。\n"
 
 #: src/android/build-rules/library.md
 msgid "\"Hello {name}, it is very nice to meet you!\""
-msgstr ""
+msgstr "\"Hello {name}, it is very nice to meet you!\""
 
 #: src/android/build-rules/library.md
 msgid "You build, push, and run the binary like before:"
-msgstr ""
+msgstr "前と同じようにバイナリをビルド、push、実行します。"
 
 #: src/android/build-rules/library.md
 msgid ""
@@ -12898,151 +12960,162 @@ msgid ""
 "adb shell /data/local/tmp/hello_rust_with_dep\n"
 "```"
 msgstr ""
+"```shell\n"
+"m hello_rust_with_dep\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/hello_rust_with_dep\n"
+"```"
 
 #: src/android/aidl.md
 msgid ""
 "The [Android Interface Definition Language (AIDL)](https://developer.android."
 "com/guide/components/aidl) is supported in Rust:"
 msgstr ""
+"Rust では [Android インターフェース定義言語（AIDL）](https://developer."
+"android.com/guide/components/aidl) がサポートされています。"
 
 #: src/android/aidl.md
 msgid "Rust code can call existing AIDL servers,"
-msgstr ""
+msgstr "Rust コードは既存の AIDL サーバーを呼び出すことができます。"
 
 #: src/android/aidl.md
 msgid "You can create new AIDL servers in Rust."
-msgstr ""
+msgstr "Rust では新しい AIDL サーバーを作成できます。"
 
 #: src/android/aidl/interface.md
 msgid "AIDL Interfaces"
-msgstr ""
+msgstr "AIDL インターフェース"
 
 #: src/android/aidl/interface.md
 msgid "You declare the API of your service using an AIDL interface:"
-msgstr ""
+msgstr "サービスの API を宣言するには、AIDL インターフェースを使用します。"
 
 #: src/android/aidl/interface.md
 msgid ""
 "_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 
 #: src/android/aidl/interface.md src/android/aidl/changing.md
 msgid "/** Birthday service interface. */"
-msgstr ""
+msgstr "/** 誕生日サービスのインターフェース。*/"
 
 #: src/android/aidl/interface.md src/android/aidl/changing.md
 msgid "/** Generate a Happy Birthday message. */"
-msgstr ""
+msgstr "/** 「お誕生日おめでとう」というメッセージを生成します。*/"
 
 #: src/android/aidl/interface.md
 msgid "_birthday_service/aidl/Android.bp_:"
-msgstr ""
+msgstr "_birthday_service/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md
 msgid "\"com.example.birthdayservice\""
-msgstr ""
+msgstr "\"com.example.birthdayservice\""
 
 #: src/android/aidl/interface.md
 msgid "\"com/example/birthdayservice/*.aidl\""
-msgstr ""
+msgstr "\"com/example/birthdayservice/*.aidl\""
 
 #: src/android/aidl/interface.md
 msgid "// Rust is not enabled by default\n"
-msgstr ""
+msgstr "// Rust はデフォルトでは無効です。\n"
 
 #: src/android/aidl/interface.md
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
 "vendor partition."
 msgstr ""
+"AIDL ファイルがベンダー パーティション内のバイナリで使用されている場合は、"
+"`vendor_available: true` を追加します。"
 
 #: src/android/aidl/implementation.md
 msgid "Service Implementation"
-msgstr ""
+msgstr "サービスの実装"
 
 #: src/android/aidl/implementation.md
 msgid "We can now implement the AIDL service:"
-msgstr ""
+msgstr "次に、AIDL サービスを実装します。"
 
 #: src/android/aidl/implementation.md
 msgid "_birthday_service/src/lib.rs_:"
-msgstr ""
+msgstr "_birthday_service/src/lib.rs_:"
 
 #: src/android/aidl/implementation.md
 msgid "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-msgstr ""
+msgstr "//! `IBirthdayService` AIDL インターフェースの実装。\n"
 
 #: src/android/aidl/implementation.md
 msgid "/// The `IBirthdayService` implementation.\n"
-msgstr ""
+msgstr "/// `IBirthdayService` の実装。\n"
 
 #: src/android/aidl/implementation.md
 msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
-msgstr ""
+msgstr "\"Happy Birthday {name}, congratulations with the {years} years!\""
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
 msgid "_birthday_service/Android.bp_:"
-msgstr ""
+msgstr "_birthday_service/Android.bp_:"
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 msgid "\"libbirthdayservice\""
-msgstr ""
+msgstr "\"libbirthdayservice\""
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
 msgid "\"birthdayservice\""
-msgstr ""
+msgstr "\"birthdayservice\""
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
 msgid "\"com.example.birthdayservice-rust\""
-msgstr ""
+msgstr "\"com.example.birthdayservice-rust\""
 
 #: src/android/aidl/implementation.md src/android/aidl/server.md
 #: src/android/aidl/client.md
 msgid "\"libbinder_rs\""
-msgstr ""
+msgstr "\"libbinder_rs\""
 
 #: src/android/aidl/server.md
 msgid "AIDL Server"
-msgstr ""
+msgstr "AIDL サーバー"
 
 #: src/android/aidl/server.md
 msgid "Finally, we can create a server which exposes the service:"
-msgstr ""
+msgstr "次に、サービスを公開するサーバーを作成します。"
 
 #: src/android/aidl/server.md
 msgid "_birthday_service/src/server.rs_:"
-msgstr ""
+msgstr "_birthday_service/src/server.rs_:"
 
 #: src/android/aidl/server.md src/android/aidl/client.md
 msgid "//! Birthday service.\n"
-msgstr ""
+msgstr "//! 誕生日サービス。\n"
 
 #: src/android/aidl/server.md
 msgid "/// Entry point for birthday service.\n"
-msgstr ""
+msgstr "/// 誕生日サービスのエントリ ポイント。\n"
 
 #: src/android/aidl/server.md
 msgid "\"Failed to register service\""
-msgstr ""
+msgstr "\"Failed to register service\""
 
 #: src/android/aidl/server.md
 msgid "\"birthday_server\""
-msgstr ""
+msgstr "\"birthday_server\""
 
 #: src/android/aidl/server.md
 msgid "\"src/server.rs\""
-msgstr ""
+msgstr "\"src/server.rs\""
 
 #: src/android/aidl/server.md src/android/aidl/client.md
 msgid "// To avoid dynamic link error.\n"
-msgstr ""
+msgstr "// ダイナミック リンク エラーを回避するためです。\n"
 
 #: src/android/aidl/deploy.md
 msgid "We can now build, push, and start the service:"
-msgstr ""
+msgstr "次に、サービスをビルド、push、開始します。"
 
 #: src/android/aidl/deploy.md
 msgid ""
@@ -13054,58 +13127,66 @@ msgid ""
 "adb shell /data/local/tmp/birthday_server\n"
 "```"
 msgstr ""
+"```shell\n"
+"m birthday_server\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server\" /data/local/"
+"tmp\n"
+"adb root\n"
+"adb shell /data/local/tmp/birthday_server\n"
+"```"
 
 #: src/android/aidl/deploy.md
 msgid "In another terminal, check that the service runs:"
-msgstr ""
+msgstr "別のターミナルで、サービスが実行されていることを確認します。"
 
 #: src/android/aidl/deploy.md
 msgid "You can also call the service with `service call`:"
-msgstr ""
+msgstr "`service call` を使用してサービスを呼び出すこともできます。"
 
 #: src/android/aidl/client.md
 msgid "AIDL Client"
-msgstr ""
+msgstr "AIDL クライアント"
 
 #: src/android/aidl/client.md
 msgid "Finally, we can create a Rust client for our new service."
-msgstr ""
+msgstr "ようやくここで、新しいサービス用の Rust クライアントを作成します。"
 
 #: src/android/aidl/client.md
 msgid "_birthday_service/src/client.rs_:"
-msgstr ""
+msgstr "_birthday_service/src/client.rs_:"
 
 #: src/android/aidl/client.md
 msgid "/// Connect to the BirthdayService.\n"
-msgstr ""
+msgstr "/// BirthdayService に接続します。\n"
 
 #: src/android/aidl/client.md
 msgid "/// Call the birthday service.\n"
-msgstr ""
+msgstr "/// 誕生日サービスを呼び出します。\n"
 
 #: src/android/aidl/client.md
 msgid "\"Failed to connect to BirthdayService\""
-msgstr ""
+msgstr "\"Failed to connect to BirthdayService\""
 
 #: src/android/aidl/client.md
 msgid "\"{msg}\""
-msgstr ""
+msgstr "\"{msg}\""
 
 #: src/android/aidl/client.md
 msgid "\"birthday_client\""
-msgstr ""
+msgstr "\"birthday_client\""
 
 #: src/android/aidl/client.md
 msgid "\"src/client.rs\""
-msgstr ""
+msgstr "\"src/client.rs\""
 
 #: src/android/aidl/client.md
 msgid "Notice that the client does not depend on `libbirthdayservice`."
 msgstr ""
+"クライアントが `libbirthdayservice` に依存していないことに注目してください。"
 
 #: src/android/aidl/client.md
 msgid "Build, push, and run the client on your device:"
-msgstr ""
+msgstr "デバイスでクライアントをビルド、push、実行します。"
 
 #: src/android/aidl/client.md
 msgid ""
@@ -13116,67 +13197,77 @@ msgid ""
 "adb shell /data/local/tmp/birthday_client Charlie 60\n"
 "```"
 msgstr ""
+"```shell\n"
+"m birthday_client\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/birthday_client Charlie 60\n"
+"```"
 
 #: src/android/aidl/changing.md
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
 "specify a list of lines for the birthday card:"
 msgstr ""
+"APIを拡張して、クライアントが誕生日カードに追加する複数行のメッセージを指定で"
+"きるようにします。"
 
 #: src/android/logging.md
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
 "or `stdout` (on-host):"
 msgstr ""
+"`log` クレートを使用して、自動的に （デバイス上では）`logcat` または （ホスト"
+"上では）`stdout`にログを記録するようにします。"
 
 #: src/android/logging.md
 msgid "_hello_rust_logs/Android.bp_:"
-msgstr ""
+msgstr "_hello_rust_logs/Android.bp_:"
 
 #: src/android/logging.md
 msgid "\"hello_rust_logs\""
-msgstr ""
+msgstr "\"hello_rust_logs\""
 
 #: src/android/logging.md
 msgid "\"liblog_rust\""
-msgstr ""
+msgstr "\"liblog_rust\""
 
 #: src/android/logging.md
 msgid "\"liblogger\""
-msgstr ""
+msgstr "\"liblogger\""
 
 #: src/android/logging.md
 msgid "_hello_rust_logs/src/main.rs_:"
-msgstr ""
+msgstr "_hello_rust_logs/src/main.rs_:"
 
 #: src/android/logging.md
 msgid "//! Rust logging demo.\n"
-msgstr ""
+msgstr "//! Rust ロギングのデモ。\n"
 
 #: src/android/logging.md
 msgid "/// Logs a greeting.\n"
-msgstr ""
+msgstr "/// 挨拶をログに記録します。\n"
 
 #: src/android/logging.md
 msgid "\"rust\""
-msgstr ""
+msgstr "\"rust\""
 
 #: src/android/logging.md
 msgid "\"Starting program.\""
-msgstr ""
+msgstr "\"Starting program.\""
 
 #: src/android/logging.md
 msgid "\"Things are going fine.\""
-msgstr ""
+msgstr "\"Things are going fine.\""
 
 #: src/android/logging.md
 msgid "\"Something went wrong!\""
-msgstr ""
+msgstr "\"Something went wrong!\""
 
 #: src/android/logging.md src/android/interoperability/with-c/bindgen.md
 #: src/android/interoperability/with-c/rust.md
 msgid "Build, push, and run the binary on your device:"
-msgstr ""
+msgstr "デバイスでバイナリをビルド、push、実行します。"
 
 #: src/android/logging.md
 msgid ""
@@ -13187,176 +13278,196 @@ msgid ""
 "adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 msgstr ""
+"```shell\n"
+"m hello_rust_logs\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/hello_rust_logs\n"
+"```"
 
 #: src/android/logging.md
 msgid "The logs show up in `adb logcat`:"
-msgstr ""
+msgstr "`adb logcat` でログを表示できます。"
 
 #: src/android/interoperability.md
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
 "means that you can:"
-msgstr ""
+msgstr "Rust は他の言語との相互運用性に優れているため、次のことが可能です。"
 
 #: src/android/interoperability.md
 msgid "Call Rust functions from other languages."
-msgstr ""
+msgstr "他の言語から Rust 関数を呼び出す。"
 
 #: src/android/interoperability.md
 msgid "Call functions written in other languages from Rust."
-msgstr ""
+msgstr "Rust から他の言語で記述された関数を呼び出す。"
 
 #: src/android/interoperability.md
 msgid ""
 "When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
+"他の言語の関数を呼び出す場合は、外部関数インターフェース（FFI: _foreign "
+"function interface_）を使用します。"
 
 #: src/android/interoperability/with-c.md
 msgid "Interoperability with C"
-msgstr ""
+msgstr "C との相互運用性"
 
 #: src/android/interoperability/with-c.md
 msgid ""
 "Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
+"Rust は、C の呼び出し規則によるオブジェクト ファイルのリンクを完全にサポート"
+"しています。同様に、Rust 関数をエクスポートして C から呼び出すことができま"
+"す。"
 
 #: src/android/interoperability/with-c.md
 msgid "You can do it by hand if you want:"
-msgstr ""
+msgstr "これは手動で行うこともできます。"
 
 #: src/android/interoperability/with-c.md
 msgid "\"{x}, {abs_x}\""
-msgstr ""
+msgstr "\"{x}, {abs_x}\""
 
 #: src/android/interoperability/with-c.md
 msgid ""
 "We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
 "safe-ffi-wrapper.md)."
 msgstr ""
+"これは、[安全な FFI ラッパーの演習](../../exercises/day-3/safe-ffi-wrapper."
+"md)ですでに取り扱いました。"
 
 #: src/android/interoperability/with-c.md
 msgid ""
 "This assumes full knowledge of the target platform. Not recommended for "
 "production."
 msgstr ""
+"これは、ターゲット プラットフォームを完全に理解していることを前提としていま"
+"す。本番環境での使用推奨されません。"
 
 #: src/android/interoperability/with-c.md
 msgid "We will look at better options next."
-msgstr ""
+msgstr "次に、より良い選択肢を見ていきます。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "Using Bindgen"
-msgstr ""
+msgstr "Bindgen の使用"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
 "tool can auto-generate bindings from a C header file."
 msgstr ""
+"[bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) ツール"
+"を使用すると、C ヘッダー ファイルからバインディングを自動生成できます。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "First create a small C library:"
-msgstr ""
+msgstr "まず、小さな C ライブラリを作成します。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/libbirthday.h_:"
-msgstr ""
+msgstr "_interoperability/bindgen/libbirthday.h_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/libbirthday.c_:"
-msgstr ""
+msgstr "_interoperability/bindgen/libbirthday.c_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "<stdio.h>"
-msgstr ""
+msgstr "<stdio.h>"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday.h\""
-msgstr ""
+msgstr "\"libbirthday.h\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"+--------------\\n\""
-msgstr ""
+msgstr "\"+--------------\\n\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"| Happy Birthday %s!\\n\""
-msgstr ""
+msgstr "\"| Happy Birthday %s!\\n\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"| Congratulations with the %i years!\\n\""
-msgstr ""
+msgstr "\"| Congratulations with the %i years!\\n\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "Add this to your `Android.bp` file:"
-msgstr ""
+msgstr "これを `Android.bp` ファイルに追加します。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/Android.bp_:"
-msgstr ""
+msgstr "_interoperability/bindgen/Android.bp_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday\""
-msgstr ""
+msgstr "\"libbirthday\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday.c\""
-msgstr ""
+msgstr "\"libbirthday.c\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid ""
 "Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
+"ライブラリのラッパー ヘッダー ファイルを作成します（この例では必須ではありま"
+"せん）。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
-msgstr ""
+msgstr "_interoperability/bindgen/libbirthday_wrapper.h_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "You can now auto-generate the bindings:"
-msgstr ""
+msgstr "これで、バインディングを自動生成できます。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_bindgen\""
-msgstr ""
+msgstr "\"libbirthday_bindgen\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"birthday_bindgen\""
-msgstr ""
+msgstr "\"birthday_bindgen\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_wrapper.h\""
-msgstr ""
+msgstr "\"libbirthday_wrapper.h\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"bindings\""
-msgstr ""
+msgstr "\"bindings\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "Finally, we can use the bindings in our Rust program:"
-msgstr ""
+msgstr "これで、Rust プログラムでバインディングを使用できます。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"print_birthday_card\""
-msgstr ""
+msgstr "\"print_birthday_card\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"main.rs\""
-msgstr ""
+msgstr "\"main.rs\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "_interoperability/bindgen/main.rs_:"
-msgstr ""
+msgstr "_interoperability/bindgen/main.rs_:"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "//! Bindgen demo.\n"
-msgstr ""
+msgstr "//! Bindgen のデモ。\n"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "// SAFETY: `print_card` is safe to call with a valid `card` pointer.\n"
 msgstr ""
+"// SAFETY: `print_card` は有効な `card` ポインタで安全に呼び出せます。\n"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid ""
@@ -13367,102 +13478,110 @@ msgid ""
 "adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
+"```shell\n"
+"m print_birthday_card\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/print_birthday_card\n"
+"```"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
+"これで、自動生成されたテストを実行して、バインディングが機能していることを確"
+"認できます。"
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"libbirthday_bindgen_test\""
-msgstr ""
+msgstr "\"libbirthday_bindgen_test\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\":libbirthday_bindgen\""
-msgstr ""
+msgstr "\":libbirthday_bindgen\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"general-tests\""
-msgstr ""
+msgstr "\"general-tests\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "\"none\""
-msgstr ""
+msgstr "\"none\""
 
 #: src/android/interoperability/with-c/bindgen.md
 msgid "// Generated file, skip linting\n"
-msgstr ""
+msgstr "// 生成されたファイル、lint チェックをスキップ\n"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "Calling Rust"
-msgstr ""
+msgstr "Rust の呼び出し"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "Exporting Rust functions and types to C is easy:"
-msgstr ""
+msgstr "Rust の関数と型は、C に簡単にエクスポートできます。"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/libanalyze/analyze.rs_"
-msgstr ""
+msgstr "_interoperability/rust/libanalyze/analyze.rs_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "//! Rust FFI demo.\n"
-msgstr ""
+msgstr "//! Rust FFI のデモ。\n"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "/// Analyze the numbers.\n"
-msgstr ""
+msgstr "/// 数値を分析します。\n"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"x ({x}) is smallest!\""
-msgstr ""
+msgstr "\"x ({x}) is smallest!\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"y ({y}) is probably larger than x ({x})\""
-msgstr ""
+msgstr "\"y ({y}) is probably larger than x ({x})\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/libanalyze/analyze.h_"
-msgstr ""
+msgstr "_interoperability/rust/libanalyze/analyze.h_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/libanalyze/Android.bp_"
-msgstr ""
+msgstr "_interoperability/rust/libanalyze/Android.bp_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"libanalyze_ffi\""
-msgstr ""
+msgstr "\"libanalyze_ffi\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze_ffi\""
-msgstr ""
+msgstr "\"analyze_ffi\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze.rs\""
-msgstr ""
+msgstr "\"analyze.rs\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "We can now call this from a C binary:"
-msgstr ""
+msgstr "これで、これを C バイナリから呼び出せるようになりました。"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/analyze/main.c_"
-msgstr ""
+msgstr "_interoperability/rust/analyze/main.c_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze.h\""
-msgstr ""
+msgstr "\"analyze.h\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "_interoperability/rust/analyze/Android.bp_"
-msgstr ""
+msgstr "_interoperability/rust/analyze/Android.bp_"
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"analyze_numbers\""
-msgstr ""
+msgstr "\"analyze_numbers\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid "\"main.c\""
-msgstr ""
+msgstr "\"main.c\""
 
 #: src/android/interoperability/with-c/rust.md
 msgid ""
@@ -13473,6 +13592,12 @@ msgid ""
 "adb shell /data/local/tmp/analyze_numbers\n"
 "```"
 msgstr ""
+"```shell\n"
+"m analyze_numbers\n"
+"adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers\" /data/local/"
+"tmp\n"
+"adb shell /data/local/tmp/analyze_numbers\n"
+"```"
 
 #: src/android/interoperability/with-c/rust.md
 msgid ""
@@ -13480,16 +13605,21 @@ msgid ""
 "will just be the name of the function. You can also use `#[export_name = "
 "\"some_name\"]` to specify whatever name you want."
 msgstr ""
+"`#[no_mangle]` により Rust の通常の名前のマングリングが無効になるため、エクス"
+"ポートされたシンボルは単に関数の名前になります。`#[export_name = "
+"\"some_name\"]` を使用して任意の名前を指定することもできます。"
 
 #: src/android/interoperability/cpp.md
 msgid ""
 "The [CXX crate](https://cxx.rs/) makes it possible to do safe "
 "interoperability between Rust and C++."
 msgstr ""
+"[CXX クレート](https://cxx.rs/)を使用すると、Rust と C++ の間で安全な相互運用"
+"性を確保できます。"
 
 #: src/android/interoperability/cpp.md
 msgid "The overall approach looks like this:"
-msgstr ""
+msgstr "全体的なアプローチは次のようになります。"
 
 #: src/android/interoperability/cpp/bridge.md
 msgid ""
@@ -13497,19 +13627,22 @@ msgid ""
 "from each language to the other. You provide this description using extern "
 "blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
+"CXX は、各言語から他の言語に公開される関数シグネチャの記述に依存します。この"
+"記述は、`#[cxx::bridge]` 属性マクロでアノテーションされた Rust モジュール内"
+"の extern ブロックを使用して指定します。"
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "\"org::blobstore\""
-msgstr ""
+msgstr "\"org::blobstore\""
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "// Shared structs with fields visible to both languages.\n"
-msgstr ""
+msgstr "// 両方の言語からアクセスできるフィールドを持つ共有構造体。\n"
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/generated-cpp.md
 msgid "// Rust types and signatures exposed to C++.\n"
-msgstr ""
+msgstr "// C++ に公開される Rust の型とシグネチャ。\n"
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/rust-bridge.md
@@ -13518,30 +13651,29 @@ msgstr ""
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 #: src/chromium/interoperability-with-cpp/error-handling-qr.md
 #: src/chromium/interoperability-with-cpp/error-handling-png.md
-#, fuzzy
 msgid "\"Rust\""
-msgstr "Rustdoc"
+msgstr "\"Rust\""
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "// C++ types and signatures exposed to Rust.\n"
-msgstr ""
+msgstr "// Rust に公開される C++ の型とシグネチャ。\n"
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 #: src/android/interoperability/cpp/cpp-exception.md
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "\"C++\""
-msgstr ""
+msgstr "\"C++\""
 
 #: src/android/interoperability/cpp/bridge.md
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"include/blobstore.h\""
-msgstr ""
+msgstr "\"include/blobstore.h\""
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "The bridge is generally declared in an `ffi` module within your crate."
-msgstr ""
+msgstr "ブリッジは通常、クレート内の `ffi` モジュールで宣言します。"
 
 #: src/android/interoperability/cpp/bridge.md
 msgid ""
@@ -13549,6 +13681,8 @@ msgid ""
 "Rust and C++ type/function definitions in order to expose those items to "
 "both languages."
 msgstr ""
+"ブリッジ モジュールで行われた宣言から、CXX はマッチする Rust と C++ の型 / 関"
+"数の定義を生成し、これらのアイテムを両方の言語に公開します。"
 
 #: src/android/interoperability/cpp/bridge.md
 msgid ""
@@ -13557,22 +13691,26 @@ msgid ""
 "examples you would use `cargo expand ::ffi` to expand just the `ffi` module "
 "(though this doesn't apply for Android projects)."
 msgstr ""
+"生成された Rust コードを表示するには、[cargo-expand](https://github.com/"
+"dtolnay/cargo-expand) を使用して、展開された proc マクロを表示します。ほとん"
+"どの例では、`cargo expand ::ffi` を使用して `ffi` モジュールのみを展開します"
+"（ただし、これは Android プロジェクトには当てはまりません）。"
 
 #: src/android/interoperability/cpp/bridge.md
 msgid "To view the generated C++ code, look in `target/cxxbridge`."
-msgstr ""
+msgstr "生成された C++ コードを表示するには、`target/cxxbridge` を確認します。"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid "Rust Bridge Declarations"
-msgstr ""
+msgstr "Rust のブリッジ宣言"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid "// Opaque type\n"
-msgstr ""
+msgstr "// オペーク型\n"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid "// Method on `MyType`\n"
-msgstr ""
+msgstr "// `MyType` のメソッド\n"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 #, fuzzy
@@ -13584,6 +13722,8 @@ msgid ""
 "Items declared in the `extern \"Rust\"` reference items that are in scope in "
 "the parent module."
 msgstr ""
+"親モジュールのスコープ内にある `extern \"Rust\"` 参照アイテムで宣言されたアイ"
+"テム。"
 
 #: src/android/interoperability/cpp/rust-bridge.md
 msgid ""
@@ -13592,26 +13732,30 @@ msgid ""
 "header has the same path as the Rust source file containing the bridge, "
 "except with a .rs.h file extension."
 msgstr ""
+"CXX コード ジェネレータは、`extern \"Rust\"` セクションを使用して、対応する "
+"C++ 宣言を含む C++ ヘッダー ファイルを生成します。生成されるヘッダーのパス"
+"は、rs.hというファイル拡張子部分を除き、ブリッジを含む Rust ソースファイルと"
+"同じになります。"
 
 #: src/android/interoperability/cpp/generated-cpp.md
 msgid "Results in (roughly) the following C++:"
-msgstr ""
+msgstr "おおよそ次のような C++ が生成されます。"
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "C++ Bridge Declarations"
-msgstr ""
+msgstr "C++ のブリッジ宣言"
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "Results in (roughly) the following Rust:"
-msgstr ""
+msgstr "おおよそ次のような Rust が生成されます。"
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
-msgstr ""
+msgstr "\"org$blobstore$cxxbridge1$new_blobstore_client\""
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
-msgstr ""
+msgstr "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid ""
@@ -13619,20 +13763,25 @@ msgid ""
 "in are accurate. CXX performs static assertions that the signatures exactly "
 "correspond with what is declared in C++."
 msgstr ""
+"プログラマーは、入力したシグネチャが正確であることを保証する必要はありませ"
+"ん。CXX は、シグネチャが C++ で宣言されたものと完全に対応するということを静的"
+"に保証します。"
 
 #: src/android/interoperability/cpp/cpp-bridge.md
 msgid ""
 "`unsafe extern` blocks allow you to declare C++ functions that are safe to "
 "call from Rust."
 msgstr ""
+"`unsafe extern` ブロックを使用すると、Rust から安全に呼び出せる C++ 関数を宣"
+"言できます。"
 
 #: src/android/interoperability/cpp/shared-types.md
 msgid "// A=1, J=11, Q=12, K=13\n"
-msgstr ""
+msgstr "// A=1、J=11、Q=12、K=13\n"
 
 #: src/android/interoperability/cpp/shared-types.md
 msgid "Only C-like (unit) enums are supported."
-msgstr ""
+msgstr "C のような（単位）列挙型のみがサポートされています。"
 
 #: src/android/interoperability/cpp/shared-types.md
 msgid ""
@@ -13641,15 +13790,17 @@ msgid ""
 "derive `Hash` also generates an implementation of `std::hash` for the "
 "corresponding C++ type."
 msgstr ""
+"共有型の `#[derive()]` では、サポートされるトレイトの数が限られています。対応"
+"する機能は C++ コードでも生成されます。たとえば、`Hash` を導出すると、対応す"
+"る C++ 型の `std::hash` の実装も生成されます。"
 
 #: src/android/interoperability/cpp/shared-enums.md
-#, fuzzy
 msgid "Generated Rust:"
-msgstr "Unsafe Rust"
+msgstr "生成された Rust:"
 
 #: src/android/interoperability/cpp/shared-enums.md
 msgid "Generated C++:"
-msgstr ""
+msgstr "生成された C++:"
 
 #: src/android/interoperability/cpp/shared-enums.md
 msgid ""
@@ -13658,20 +13809,24 @@ msgid ""
 "class to hold a value different from all of the listed variants, and our "
 "Rust representation needs to have the same behavior."
 msgstr ""
+"Rust 側では、共有列挙型に対して生成されるコードは、実際には数値をラップした構"
+"造体です。これは、列挙型クラスがリストされたすべてのバリアントとは異なる値を"
+"保持することは C++ では UB ではなく、Rust 表現は同じ動作をする必要があるため"
+"です。"
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid "\"fallible1 requires depth > 0\""
-msgstr ""
+msgstr "\"fallible1 requires depth > 0\""
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid "\"Success!\""
-msgstr ""
+msgstr "\"Success!\""
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid ""
 "Rust functions that return `Result` are translated to exceptions on the C++ "
 "side."
-msgstr ""
+msgstr "`Result` を返す Rust 関数は、C++ 側で例外に変換されます。"
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid ""
@@ -13679,26 +13834,33 @@ msgid ""
 "exposes a way to get the error message string. The error message will come "
 "from the error type's `Display` impl."
 msgstr ""
+"スローされる例外は常に `rust::Error` 型で、主にエラー メッセージの文字列を取"
+"得する手段を提供します。エラー メッセージは、エラー型の `Display` の実装から"
+"取得されます。"
 
 #: src/android/interoperability/cpp/rust-result.md
 msgid ""
 "A panic unwinding from Rust to C++ will always cause the process to "
 "immediately terminate."
 msgstr ""
+"Rust から C++ にパニック アンワインドを行うと、プロセスは必ず直ちに終了しま"
+"す。"
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid "\"example/include/example.h\""
-msgstr ""
+msgstr "\"example/include/example.h\""
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid "\"Error: {}\""
-msgstr ""
+msgstr "\"Error: {}\""
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid ""
 "C++ functions declared to return a `Result` will catch any thrown exception "
 "on the C++ side and return it as an `Err` value to the calling Rust function."
 msgstr ""
+"`Result` を返すように宣言された C++ 関数は、C++ 側でスローされたあらゆる例外"
+"をキャッチし、呼び出し元の Rust 関数に `Err` 値として返します。"
 
 #: src/android/interoperability/cpp/cpp-exception.md
 msgid ""
@@ -13707,139 +13869,150 @@ msgid ""
 "terminate`. The behavior is equivalent to the same exception being thrown "
 "through a `noexcept` C++ function."
 msgstr ""
+"CXX ブリッジでResultを返すように宣言されていないextern \"C++\"関数から例外が"
+"スローされると、`Result`が返されると、プログラムは C++ の`std::terminate`を呼"
+"び出します。この動作は、同じ例外が`noexcept` C++ 関数でスローされた場合と同等"
+"です。"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "Rust Type"
-msgstr "再帰的データ型"
+msgstr "Rust 型"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "C++ Type"
-msgstr ""
+msgstr "C++ 型"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`rust::String`"
-msgstr "文字列（String）"
+msgstr "`rust::String`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`&str`"
-msgstr ""
+msgstr "`&str`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Str`"
-msgstr ""
+msgstr "`rust::Str`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 #, fuzzy
 msgid "`CxxString`"
-msgstr "文字列（String）"
+msgstr "`CxxString`"
 
 #: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
 msgid "`std::string`"
-msgstr "文字列（String）"
+msgstr "`std::string`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`&[T]`/`&mut [T]`"
-msgstr ""
+msgstr "`&[T]`/`&mut [T]`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Slice`"
-msgstr ""
+msgstr "`rust::Slice`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Box<T>`"
-msgstr ""
+msgstr "`rust::Box<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`UniquePtr<T>`"
-msgstr ""
+msgstr "`UniquePtr<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`std::unique_ptr<T>`"
-msgstr ""
+msgstr "`std::unique_ptr<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`Vec<T>`"
-msgstr ""
+msgstr "`Vec<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`rust::Vec<T>`"
-msgstr ""
+msgstr "`rust::Vec<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`CxxVector<T>`"
-msgstr ""
+msgstr "`CxxVector<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid "`std::vector<T>`"
-msgstr ""
+msgstr "`std::vector<T>`"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "These types can be used in the fields of shared structs and the arguments "
 "and returns of extern functions."
 msgstr ""
+"これらの型は、共有構造体のフィールドと、extern 関数の引数と戻り値で使用できま"
+"す。"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "Note that Rust's `String` does not map directly to `std::string`. There are "
 "a few reasons for this:"
 msgstr ""
+"Rust の `String` は `std::string` に直接マッピングされません。これには次のよ"
+"うな理由があります。"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "`std::string` does not uphold the UTF-8 invariant that `String` requires."
-msgstr ""
+msgstr "`std::string` は、`String` が必要とする UTF-8 不変条件を満たしません。"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "The two types have different layouts in memory and so can't be passed "
 "directly between languages."
 msgstr ""
+"この 2 つの型はメモリ内のレイアウトが異なるため、言語間で直接渡すことはできま"
+"せん。"
 
 #: src/android/interoperability/cpp/type-mapping.md
 msgid ""
 "`std::string` requires move constructors that don't match Rust's move "
 "semantics, so a `std::string` can't be passed by value to Rust."
 msgstr ""
+"`std::string` は、Rust のムーブ セマンティクスと一致しないムーブコンストラク"
+"タを必要とするため、`std::string` を Rust に値で渡すことはできません。"
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 #: src/android/interoperability/cpp/android-build-rust.md
 #, fuzzy
 msgid "Building in Android"
-msgstr "Android"
+msgstr "Android 向けのビルド"
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
 "Create a `cc_library_static` to build the C++ library, including the CXX "
 "generated header and source file."
 msgstr ""
+"`cc_library_static` を作成して、CXX で生成されたヘッダーとソースファイルを含"
+"む C++ ライブラリをビルドします。"
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"libcxx_test_cpp\""
-msgstr ""
+msgstr "\"libcxx_test_cpp\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid "\"cxx_test.cpp\""
-msgstr ""
+msgstr "\"cxx_test.cpp\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid "\"cxx-bridge-header\""
-msgstr ""
+msgstr "\"cxx-bridge-header\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"libcxx_test_bridge_header\""
-msgstr ""
+msgstr "\"libcxx_test_bridge_header\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"libcxx_test_bridge_code\""
-msgstr ""
+msgstr "\"libcxx_test_bridge_code\""
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
@@ -13847,12 +14020,17 @@ msgid ""
 "the dependencies for the CXX-generated C++ bindings. We'll show how these "
 "are setup on the next slide."
 msgstr ""
+"`libcxx_test_bridge_header` と `libcxx_test_bridge_code` が、CXX CXXにより生"
+"成される C++ バインディングに対する依存関係であることを説明します。次のスライ"
+"ドで、これらがどのような記述になっているかを説明します。"
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
 "Note that you also need to depend on the `cxx-bridge-header` library in "
 "order to pull in common CXX definitions."
 msgstr ""
+"また、一般的な CXX 定義を取得するためには、`cxx-bridge-header` ライブラリに依"
+"存する必要があることにも注意してください。"
 
 #: src/android/interoperability/cpp/android-build-cpp.md
 msgid ""
@@ -13862,53 +14040,65 @@ msgid ""
 "that link with the class so that students know where they can find these "
 "instructions again in the future."
 msgstr ""
+"Android で CXX を使用するための詳細なドキュメントについては、[Android のド"
+"キュメント](https://source.android.com/docs/setup/build/rust/building-rust-"
+"modules/android-rust-patterns#rust-cpp-interop-using-cxx)をご覧ください。その"
+"リンクをクラスと共有して、受講者が後で手順を確認できるようにすることをおすす"
+"めします。"
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "Create two genrules: One to generate the CXX header, and one to generate the "
 "CXX source file. These are then used as inputs to the `cc_library_static`."
 msgstr ""
+"genrule を 2 つ作成します。1 つは CXX ヘッダーの生成用、もう 1 つは CXX ソー"
+"スファイルの生成用です。これらは `cc_library_static` への入力として使用されま"
+"す。"
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "// Generate a C++ header containing the C++ bindings\n"
 "// to the Rust exported functions in lib.rs.\n"
 msgstr ""
+"// lib.rs にある Rustからエクスポートされた関数に対する\n"
+"// C++ バインディングを含む C++ ヘッダーを生成します。\n"
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"cxxbridge\""
-msgstr ""
+msgstr "\"cxxbridge\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
-msgstr ""
+msgstr "\"$(location cxxbridge) $(in) --header > $(out)\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"lib.rs\""
-msgstr ""
+msgstr "\"lib.rs\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"lib.rs.h\""
-msgstr ""
+msgstr "\"lib.rs.h\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "// Generate the C++ code that Rust calls into.\n"
-msgstr ""
+msgstr "// Rust が呼び出す C++ コードを生成します。\n"
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"$(location cxxbridge) $(in) > $(out)\""
-msgstr ""
+msgstr "\"$(location cxxbridge) $(in) > $(out)\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid "\"lib.rs.cc\""
-msgstr ""
+msgstr "\"lib.rs.cc\""
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
 "The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
 "bridge module. It is included in Android and available as a Soong tool."
 msgstr ""
+"`cxxbridge` ツールは、ブリッジ モジュールの C++ 側を生成するスタンドアロン "
+"ツールです。Android に組み込まれており、Soong ツールとして利用できます。"
 
 #: src/android/interoperability/cpp/android-cpp-genrules.md
 msgid ""
@@ -13916,23 +14106,26 @@ msgid ""
 "named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
 "convention isn't enforced, though."
 msgstr ""
+"慣例として、Rust ソースファイルが `lib.rs` の場合、ヘッダー ファイルの名前は "
+"`lib.rs.h`、ソースファイルの名前は `lib.rs.cc` となります。ただし、この命名規"
+"則は強制ではありません。"
 
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid ""
 "Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
-msgstr ""
+msgstr "`libcxx` と `cc_library_static`に依存する `rust_binary` を作成します。"
 
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"cxx_test\""
-msgstr ""
+msgstr "\"cxx_test\""
 
 #: src/android/interoperability/cpp/android-build-rust.md
 msgid "\"libcxx\""
-msgstr ""
+msgstr "\"libcxx\""
 
 #: src/android/interoperability/java.md
 msgid "Interoperability with Java"
-msgstr ""
+msgstr "Java との相互運用性"
 
 #: src/android/interoperability/java.md
 msgid ""
@@ -13940,90 +14133,98 @@ msgid ""
 "wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
 "jni/) allows you to create a compatible library."
 msgstr ""
+"Java では、[Java Native Interface（JNI）](https://en.wikipedia.org/wiki/"
+"Java_Native_Interface) を介して共有オブジェクトを読み込むことができます。"
+"[`jni` クレート](https://docs.rs/jni/) を使用すると、互換性のあるライブラリを"
+"作成できます。"
 
 #: src/android/interoperability/java.md
 msgid "First, we create a Rust function to export to Java:"
-msgstr ""
+msgstr "まず、Java にエクスポートする Rust 関数を作成します。"
 
 #: src/android/interoperability/java.md
 msgid "_interoperability/java/src/lib.rs_:"
-msgstr ""
+msgstr "_interoperability/java/src/lib.rs_:"
 
 #: src/android/interoperability/java.md
 msgid "//! Rust <-> Java FFI demo.\n"
-msgstr ""
+msgstr "//! Rust <-> Java FFI のデモ。\n"
 
 #: src/android/interoperability/java.md
 msgid "/// HelloWorld::hello method implementation.\n"
-msgstr ""
+msgstr "/// HelloWorld::hello メソッドの実装。\n"
 
 #: src/android/interoperability/java.md
 msgid "\"system\""
-msgstr ""
+msgstr "\"system\""
 
 #: src/android/interoperability/java.md
 msgid "\"Hello, {input}!\""
-msgstr ""
+msgstr "\"Hello, {input}!\""
 
 #: src/android/interoperability/java.md
 msgid "_interoperability/java/Android.bp_:"
-msgstr ""
+msgstr "_interoperability/java/Android.bp_:"
 
 #: src/android/interoperability/java.md
 msgid "\"libhello_jni\""
-msgstr ""
+msgstr "\"libhello_jni\""
 
 #: src/android/interoperability/java.md
 msgid "\"hello_jni\""
-msgstr ""
+msgstr "\"hello_jni\""
 
 #: src/android/interoperability/java.md
 msgid "\"libjni\""
-msgstr ""
+msgstr "\"libjni\""
 
 #: src/android/interoperability/java.md
 msgid "We then call this function from Java:"
-msgstr ""
+msgstr "次に、Java からこの関数を呼び出します。"
 
 #: src/android/interoperability/java.md
 msgid "_interoperability/java/HelloWorld.java_:"
-msgstr ""
+msgstr "_interoperability/java/HelloWorld.java_:"
 
 #: src/android/interoperability/java.md
 msgid "\"helloworld_jni\""
-msgstr ""
+msgstr "\"helloworld_jni\""
 
 #: src/android/interoperability/java.md
 msgid "\"HelloWorld.java\""
-msgstr ""
+msgstr "\"HelloWorld.java\""
 
 #: src/android/interoperability/java.md
 msgid "\"HelloWorld\""
-msgstr ""
+msgstr "\"HelloWorld\""
 
 #: src/android/interoperability/java.md
 msgid "Finally, you can build, sync, and run the binary:"
-msgstr ""
+msgstr "最後に、バイナリをビルド、同期、実行します。"
 
 #: src/exercises/android/morning.md
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
 "and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
+"これはグループ演習です。皆さんが取り組んでいるプロジェクトの一つを題材に、そ"
+"こに Rust を統合してみましょう。以下にヒントを示します。"
 
 #: src/exercises/android/morning.md
 msgid "Call your AIDL service with a client written in Rust."
-msgstr ""
+msgstr "Rust で記述されたクライアントを使用して AIDL サービスを呼び出します。"
 
 #: src/exercises/android/morning.md
 msgid "Move a function from your project to Rust and call it."
-msgstr ""
+msgstr "プロジェクトから Rust に関数を移動して呼び出します。"
 
 #: src/exercises/android/morning.md
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
 "in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
+"この演習は自由回答形式であるため、解答は用意されていません。クラスの誰かが"
+"コードを持っていて、その場で Rust に変換できることを前提としています。"
 
 #: src/chromium.md
 msgid "Welcome to Rust in Chromium"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7714,125 +7714,131 @@ msgstr "'A'"
 
 #: src/welcome-day-3.md
 msgid "Welcome to Day 3"
-msgstr ""
+msgstr "3 日目のトレーニングにようこそ"
 
 #: src/welcome-day-3.md
 msgid "Today, we will cover:"
-msgstr ""
+msgstr "本日の内容:"
 
 #: src/welcome-day-3.md
 msgid ""
 "Memory management, lifetimes, and the borrow checker: how Rust ensures "
 "memory safety."
 msgstr ""
+"メモリ管理、ライフタイム、借用チェッカー: Rust がメモリの安全性を確保する仕組"
+"み。"
 
 #: src/welcome-day-3.md
 msgid "Smart pointers: standard library pointer types."
-msgstr ""
+msgstr "スマートポインタ: 標準ライブラリのポインタ型。"
 
 #: src/welcome-day-3.md
 msgid "[Welcome](./welcome-day-3.md) (3 minutes)"
-msgstr ""
+msgstr "[ようこそ](./welcome-day-3.md)（3 分）"
 
 #: src/welcome-day-3.md
 msgid "[Memory Management](./memory-management.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[メモリ管理](./memory-management.md)（1 時間 10 分）"
 
 #: src/welcome-day-3.md
 msgid "[Smart Pointers](./smart-pointers.md) (45 minutes)"
-msgstr ""
+msgstr "[スマート ポインタ](./smart-pointers.md)（45 分）"
 
 #: src/welcome-day-3.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 15 "
 "minutes"
-msgstr ""
+msgstr "このセッションの所要時間は、10 分間の休憩を入れて約 2 時間 15 分です。"
 
 #: src/memory-management.md
 msgid "[Review of Program Memory](./memory-management/review.md) (5 minutes)"
-msgstr ""
+msgstr "[プログラム メモリの復習](./memory-management/review.md)（5 分）"
 
 #: src/memory-management.md
 msgid ""
 "[Approaches to Memory Management](./memory-management/approaches.md) (10 "
 "minutes)"
-msgstr ""
+msgstr "[メモリ管理の方法](./memory-management/approaches.md)（10 分）"
 
 #: src/memory-management.md
 msgid "[Ownership](./memory-management/ownership.md) (5 minutes)"
-msgstr ""
+msgstr "[所有権](./memory-management/ownership.md)（5 分）"
 
 #: src/memory-management.md
 msgid "[Move Semantics](./memory-management/move.md) (10 minutes)"
-msgstr ""
+msgstr "[ムーブ セマンティクス](./memory-management/move.md)（10 分）"
 
 #: src/memory-management.md
 msgid "[Clone](./memory-management/clone.md) (2 minutes)"
-msgstr ""
+msgstr "[Clone](./memory-management/clone.md)（2 分）"
 
 #: src/memory-management.md
 msgid "[Copy Types](./memory-management/copy-types.md) (5 minutes)"
-msgstr ""
+msgstr "[Copy 型](./memory-management/copy-types.md)（5 分）"
 
 #: src/memory-management.md
 msgid "[Drop](./memory-management/drop.md) (10 minutes)"
-msgstr ""
+msgstr "[Drop](./memory-management/drop.md)（10 分）"
 
 #: src/memory-management.md
 msgid "[Exercise: Builder Type](./memory-management/exercise.md) (20 minutes)"
-msgstr ""
+msgstr "[演習: ビルダー型](./memory-management/exercise.md)（20 分）"
 
 #: src/memory-management/review.md
 msgid "Programs allocate memory in two ways:"
-msgstr ""
+msgstr "プログラムは、次の 2 つの方法でメモリを割り当てます。"
 
 #: src/memory-management/review.md
 msgid "Stack: Continuous area of memory for local variables."
-msgstr ""
+msgstr "スタック: ローカル変数用の連続したメモリ領域。"
 
 #: src/memory-management/review.md
 msgid "Values have fixed sizes known at compile time."
-msgstr ""
+msgstr "値のサイズは固定されており、コンパイル時に判明しています。"
 
 #: src/memory-management/review.md
 msgid "Extremely fast: just move a stack pointer."
-msgstr ""
+msgstr "非常に高速: スタック ポインタを移動するだけです。"
 
 #: src/memory-management/review.md
 msgid "Easy to manage: follows function calls."
-msgstr ""
+msgstr "関数呼び出しによって行われるため、管理が容易です。"
 
 #: src/memory-management/review.md
 msgid "Great memory locality."
-msgstr ""
+msgstr "メモリ局所性に優れています。"
 
 #: src/memory-management/review.md
 msgid "Heap: Storage of values outside of function calls."
-msgstr ""
+msgstr "ヒープ: 関数呼び出しに依存しない値の保持領域。"
 
 #: src/memory-management/review.md
 msgid "Values have dynamic sizes determined at runtime."
-msgstr ""
+msgstr "値のサイズは動的で、実行時に決定されます。"
 
 #: src/memory-management/review.md
 msgid "Slightly slower than the stack: some book-keeping needed."
-msgstr ""
+msgstr "スタックよりやや低速で、何らかののブックキーピングが必要です。"
 
 #: src/memory-management/review.md
 msgid "No guarantee of memory locality."
-msgstr ""
+msgstr "メモリの局所性が保証されません。"
 
 #: src/memory-management/review.md
 msgid ""
 "Creating a `String` puts fixed-sized metadata on the stack and dynamically "
 "sized data, the actual string, on the heap:"
 msgstr ""
+"`String` を作成すると、スタックには固定サイズのメタデータが配置され、ヒープに"
+"はサイズが動的に決定されるデータ（実際の文字列）が配置されます。"
 
 #: src/memory-management/review.md
 msgid ""
 "Mention that a `String` is backed by a `Vec`, so it has a capacity and "
 "length and can grow if mutable via reallocation on the heap."
 msgstr ""
+"`String` は `Vec` により実現されているため、容量と長さがあり、可変であれば"
+"ヒープ上の再割り当てによって拡張できることを説明します。"
 
 #: src/memory-management/review.md
 msgid ""
@@ -7841,20 +7847,26 @@ msgid ""
 "struct.System.html) and custom allocators can be implemented using the "
 "[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
+"受講者から尋ねられた場合は、[システム アロケータ](https://doc.rust-lang.org/"
+"std/alloc/struct.System.html)を使用してメモリ領域がヒープから割り当てられるこ"
+"と、[Allocator API](https://doc.rust-lang.org/std/alloc/index.html) を使用し"
+"てカスタム アロケータを実装できることを説明してください。"
 
 #: src/memory-management/review.md
 msgid ""
 "We can inspect the memory layout with `unsafe` Rust. However, you should "
 "point out that this is rightfully unsafe!"
 msgstr ""
+"`unsafe` Rust を使用してメモリ レイアウトを調べることが出来ます。ただし、これ"
+"は当然ながら安全でないことを指摘する必要があります。"
 
 #: src/memory-management/review.md src/testing/unit-tests.md
 msgid "' '"
-msgstr ""
+msgstr "' '"
 
 #: src/memory-management/review.md
 msgid "\"world\""
-msgstr ""
+msgstr "\"world\""
 
 #: src/memory-management/review.md
 msgid ""
@@ -7863,68 +7875,80 @@ msgid ""
 "to\n"
 "    // undefined behavior.\n"
 msgstr ""
+"// 自宅では行わないでください。これは説明のみを目的としています。\n"
+"    // String はそのレイアウトを保証しないため、未定義の動作が\n"
+"    // 発生する可能性があります。\n"
 
 #: src/memory-management/review.md
 msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
-msgstr ""
+msgstr "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
 
 #: src/memory-management/approaches.md
 msgid "Traditionally, languages have fallen into two broad categories:"
-msgstr ""
+msgstr "伝統的に、言語は大きく 2 つのカテゴリに分類されます。"
 
 #: src/memory-management/approaches.md
 msgid "Full control via manual memory management: C, C++, Pascal, ..."
-msgstr ""
+msgstr "手動でのメモリ管理による完全な制御: C、C++、Pascal など"
 
 #: src/memory-management/approaches.md
 msgid "Programmer decides when to allocate or free heap memory."
 msgstr ""
+"プログラマーがヒープメモリを割り当てまたは解放するタイミングを決定します。"
 
 #: src/memory-management/approaches.md
 msgid ""
 "Programmer must determine whether a pointer still points to valid memory."
 msgstr ""
+"プログラマーは、ポインタがまだ有効なメモリを指しているかどうかを判断する必要"
+"があります。"
 
 #: src/memory-management/approaches.md
 msgid "Studies show, programmers make mistakes."
-msgstr ""
+msgstr "調査によると、プログラマーは判断を誤ることがあります。"
 
 #: src/memory-management/approaches.md
 msgid ""
 "Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
+"実行時の自動メモリ管理による完全な安全性: Java、Python、Go、Haskell など"
 
 #: src/memory-management/approaches.md
 msgid ""
 "A runtime system ensures that memory is not freed until it can no longer be "
 "referenced."
 msgstr ""
+"ランタイム システムにより、メモリは参照できなくなるまで解放されません。"
 
 #: src/memory-management/approaches.md
 msgid ""
 "Typically implemented with reference counting, garbage collection, or RAII."
 msgstr ""
+"通常、参照カウント、ガベージ コレクション、または RAII を使用して実装されま"
+"す。"
 
 #: src/memory-management/approaches.md
 msgid "Rust offers a new mix:"
-msgstr ""
+msgstr "Rust ではこの 2 つを融合することで、新たに以下の特徴を提供します。"
 
 #: src/memory-management/approaches.md
 msgid ""
 "Full control _and_ safety via compile time enforcement of correct memory "
 "management."
-msgstr ""
+msgstr "コンパイル時の適切なメモリ管理の適用による、完全な制御と安全性。"
 
 #: src/memory-management/approaches.md
 msgid "It does this with an explicit ownership concept."
-msgstr ""
+msgstr "これは、明示的な所有権の概念によって実現されます。"
 
 #: src/memory-management/approaches.md
 msgid ""
 "This slide is intended to help students coming from other languages to put "
 "Rust in context."
 msgstr ""
+"このスライドは、他の言語を習得済みの受講者に、その文脈の中で Rust を理解して"
+"もらうことを目的としています。"
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -7932,6 +7956,10 @@ msgid ""
 "forgetting to call `free`, calling it multiple times for the same pointer, "
 "or dereferencing a pointer after the memory it points to has been freed."
 msgstr ""
+"C では、`malloc` と `free` を使用してヒープを手動で管理する必要があります。よ"
+"くあるエラーとしては、`free`の呼び出しを忘れる、同じポインタに対して複数回呼"
+"び出す、ポイントしているメモリが解放された後にポインタを逆参照する、などがあ"
+"ります。"
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -7940,6 +7968,10 @@ msgid ""
 "is freed when a function returns. It is still quite easy to mis-use these "
 "tools and create similar bugs to C."
 msgstr ""
+"C++ にはスマート ポインタ（`unique_ptr`、`shared_ptr` など）のツールがあり、"
+"デストラクタの呼び出しに関する言語保証を利用して、関数が戻ったときにメモリが"
+"解放されるようにします。これらのツールを誤用して C と同様のバグを作成すること"
+"がよくあります。"
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -7948,6 +7980,10 @@ msgid ""
 "be dereferenced, eliminating use-after-free and other classes of bugs. But, "
 "GC has a runtime cost and is difficult to tune properly."
 msgstr ""
+"Java、Go、Pythonでは、アクセスできなくなったメモリの特定と破棄をガーベジコレ"
+"クタに依存します。これにより、あらゆるポインタの逆参照が可能になり、解放後の"
+"使用などのバグがなくなります。ただし、GC (ガーベジコレクション) にはランタイ"
+"ムコストがかかり、適切なチューニングが困難です。"
 
 #: src/memory-management/approaches.md
 msgid ""
@@ -7958,24 +7994,36 @@ msgid ""
 "are even third-party crates available to support runtime garbage collection "
 "(not covered in this class)."
 msgstr ""
+"Rust の所有権と借用モデルは、多くの場合、割り当てオペレーションと解放オペレー"
+"ションを正確に必要な場所で行うことにより、ゼロコストで C のパフォーマンスを実"
+"現できます。また、C++ のスマートポインタに似たツールも用意されています。必要"
+"に応じて、参照カウントなどの他のオプションを利用できます。また、ランタイムガ"
+"ベージコレクションをサポートするためのサードパーティのクレートも使用できます"
+"（このクラスでは扱いません）。"
 
 #: src/memory-management/ownership.md
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
 "to use a variable outside its scope:"
 msgstr ""
+"すべての変数バインディングには有効なスコープがあり、スコープ外で変数を使用す"
+"るとエラーになります。"
 
 #: src/memory-management/ownership.md
 msgid ""
 "We say that the variable _owns_ the value. Every Rust value has precisely "
 "one owner at all times."
 msgstr ""
+"これを、変数が値を _所有_ していると表現します。すべての Rustの値所有者は常"
+"に 1 人です。"
 
 #: src/memory-management/ownership.md
 msgid ""
 "At the end of the scope, the variable is _dropped_ and the data is freed. A "
 "destructor can run here to free up resources."
 msgstr ""
+"スコープから外れると変数が破棄 _(drop)_ され、データが解放されます。ここでデ"
+"ストラクタを実行してリソースを解放できます。"
 
 #: src/memory-management/ownership.md
 msgid ""
@@ -7983,42 +8031,46 @@ msgid ""
 "garbage collector starts with a set of \"roots\" to find all reachable "
 "memory. Rust's \"single owner\" principle is a similar idea."
 msgstr ""
+"ガベージ コレクションの実装に精通している受講者は、ガベージ コレクタが一連の"
+"「ルート」から開始して到達可能なすべてのメモリを見つけることを知っています。"
+"Rust の「単一オーナー」の原則も、同様の考え方に基づいています。"
 
 #: src/memory-management/move.md
 msgid "An assignment will transfer _ownership_ between variables:"
-msgstr ""
+msgstr "代入すると、変数間で _所有権_ が移動します。"
 
 #: src/memory-management/move.md
 msgid "\"Hello!\""
-msgstr ""
+msgstr "\"Hello!\""
 
 #: src/memory-management/move.md src/slices-and-lifetimes/str.md
 msgid "\"s2: {s2}\""
-msgstr ""
+msgstr "\"s2: {s2}\""
 
 #: src/memory-management/move.md
 msgid "// println!(\"s1: {s1}\");\n"
-msgstr ""
+msgstr "// println!(\"s1: {s1}\");\n"
 
 #: src/memory-management/move.md
 msgid "The assignment of `s1` to `s2` transfers ownership."
-msgstr ""
+msgstr "`s1` を `s2` に代入すると、所有権が移動します。"
 
 #: src/memory-management/move.md
 msgid "When `s1` goes out of scope, nothing happens: it does not own anything."
 msgstr ""
+"`s1` がスコープ外になると、何も所有してないからです（何も所有しません）。"
 
 #: src/memory-management/move.md
 msgid "When `s2` goes out of scope, the string data is freed."
-msgstr ""
+msgstr "`s2` がスコープ外になると、文字列データは解放されます。"
 
 #: src/memory-management/move.md
 msgid "Before move to `s2`:"
-msgstr ""
+msgstr "`s2` に移動する前:"
 
 #: src/memory-management/move.md
 msgid "After move to `s2`:"
-msgstr ""
+msgstr "`s2` に移動した後:"
 
 #: src/memory-management/move.md
 msgid ""
@@ -8043,30 +8095,54 @@ msgid ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 msgstr ""
+"```bob\n"
+" スタック                             ヒープ\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1 \"（アクセス不可）\"    :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :  |  :                           :\n"
+":   +-----------+-------+   :  |  :                           :\n"
+":                           :  |  `- - - - - - - - - - - - - -'\n"
+":    s2                     :  |\n"
+":   +-----------+-------+   :  |\n"
+":   | ptr       |   o---+---+--'\n"
+":   | len       |     4 |   :\n"
+":   | capacity  |     4 |   :\n"
+":   +-----------+-------+   :\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
 
 #: src/memory-management/move.md
 msgid ""
 "When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
+"次の例のように、関数に値を渡すと、その値は関数パラメータに代入されます。これ"
+"により、所有権が移動します。"
 
 #: src/memory-management/move.md
 msgid "\"Hello {name}\""
-msgstr ""
+msgstr "\"Hello {name}\""
 
 #: src/memory-management/move.md src/android/interoperability/java.md
 msgid "\"Alice\""
-msgstr ""
+msgstr "\"Alice\""
 
 #: src/memory-management/move.md
 msgid "// say_hello(name);\n"
-msgstr ""
+msgstr "// say_hello(name);\n"
 
 #: src/memory-management/move.md
 msgid ""
 "Mention that this is the opposite of the defaults in C++, which copies by "
 "value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
+"これは、`std::move` を使用しない限り（かつムーブ コンストラクタが定義されてい"
+"ない限り）値をコピーする、C++ のデフォルトとは逆であることを説明します。"
 
 #: src/memory-management/move.md
 msgid ""
@@ -8074,49 +8150,64 @@ msgid ""
 "to manipulate the data itself is a matter of optimization, and such copies "
 "are aggressively optimized away."
 msgstr ""
+"移動するのは所有権のみです。データ自体を操作するためにマシンコードが生成され"
+"るかどうかは最適化の問題であり、そのようなコピーのためのマシンコードは積極的"
+"に最適化されてなくなります。"
 
 #: src/memory-management/move.md
 msgid ""
 "Simple values (such as integers) can be marked `Copy` (see later slides)."
 msgstr ""
+"単純な値（整数など）には `Copy` のマークを付けることができます（後のスライド"
+"を参照）。"
 
 #: src/memory-management/move.md
 msgid "In Rust, clones are explicit (by using `clone`)."
-msgstr ""
+msgstr "Rust では、クローンは明示的に `clone` を使用して行われます。"
 
 #: src/memory-management/move.md
 msgid "In the `say_hello` example:"
-msgstr ""
+msgstr "`say_hello` の例の内容は次のとおりです。"
 
 #: src/memory-management/move.md
 msgid ""
 "With the first call to `say_hello`, `main` gives up ownership of `name`. "
 "Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
+"`say_hello` の最初の呼び出しで、`main` は `name` の所有権を放棄します。その後"
+"は `main` 内で `name` が使用できなくなります。"
 
 #: src/memory-management/move.md
 msgid ""
 "The heap memory allocated for `name` will be freed at the end of the "
 "`say_hello` function."
 msgstr ""
+"`name` に割り当てられたヒープメモリは、`say_hello` 関数の最後で解放されます。"
 
 #: src/memory-management/move.md
 msgid ""
 "`main` can retain ownership if it passes `name` as a reference (`&name`) and "
 "if `say_hello` accepts a reference as a parameter."
 msgstr ""
+"`main` が`name` を参照として渡し（`&name`）、`say_hello` がパラメータとして参"
+"照を受け入れる場合、`main` は所有権を保持できます。"
 
 #: src/memory-management/move.md
 msgid ""
 "Alternatively, `main` can pass a clone of `name` in the first call (`name."
 "clone()`)."
 msgstr ""
+"または、`main` が最初の呼び出しで `name` のクローン（`name.clone()`）を渡すこ"
+"ともできます。"
 
 #: src/memory-management/move.md
 msgid ""
 "Rust makes it harder than C++ to inadvertently create copies by making move "
 "semantics the default, and by forcing programmers to make clones explicit."
 msgstr ""
+"Rust では、ムーブ セマンティクスをデフォルトにし、クローンをプログラマに明示"
+"的に行わせています。これにより、C++ に比べて意図せずコピーを作成するリスクが"
+"低減されています。"
 
 #: src/memory-management/move.md
 #, fuzzy
@@ -8125,32 +8216,33 @@ msgstr "現代C++の二重解放"
 
 #: src/memory-management/move.md
 msgid "Modern C++ solves this differently:"
-msgstr ""
+msgstr "最新の C++ では、この問題を別の方法で解決します。"
 
 #: src/memory-management/move.md
 msgid "\"Cpp\""
-msgstr ""
+msgstr "\"Cpp\""
 
 #: src/memory-management/move.md
 msgid "// Duplicate the data in s1.\n"
-msgstr ""
+msgstr "// s1 にデータを複製します。\n"
 
 #: src/memory-management/move.md
 msgid ""
 "The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
+"`s1` からのヒープデータが複製され、`s2` は自身の独立したコピーを取得します。"
 
 #: src/memory-management/move.md
 msgid "When `s1` and `s2` go out of scope, they each free their own memory."
-msgstr ""
+msgstr "`s1` と `s2` がスコープ外になると、それぞれ自身のメモリを解放します。"
 
 #: src/memory-management/move.md
 msgid "Before copy-assignment:"
-msgstr ""
+msgstr "コピー代入前:"
 
 #: src/memory-management/move.md
 msgid "After copy-assignment:"
-msgstr ""
+msgstr "コピー代入後:"
 
 #: src/memory-management/move.md
 msgid ""
@@ -8158,6 +8250,9 @@ msgid ""
 "the string data has to be cloned. Otherwise we would get a double-free when "
 "either string goes out of scope."
 msgstr ""
+"C++ のアプローチは、Rust とは若干異なります。`=` を使用するとデータがコピーさ"
+"れるため、文字列データのクローンを作成する必要があるためです。そうしないと、"
+"いずれかの文字列がスコープ外になったときに二重解放が発生します。"
 
 #: src/memory-management/move.md
 msgid ""
@@ -8167,22 +8262,29 @@ msgid ""
 "move, `s1` would be in a valid but unspecified state. Unlike Rust, the "
 "programmer is allowed to keep using `s1`."
 msgstr ""
+"C++ には [`std::move`](https://en.cppreference.com/w/cpp/utility/move) もあり"
+"ますが、これは値をムーブできるタイミングを示すために使用されます。この例で "
+"`s2 = std::move(s1)` となっていた場合は、ヒープ割り当ては行われません。ムーブ"
+"後、`s1` は有効であるものの、未指定の状態になります。Rust とは異なり、プログ"
+"ラマーは `s1` を引き続き使用できます。"
 
 #: src/memory-management/move.md
 msgid ""
 "Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
 "which is being copied or moved."
 msgstr ""
+"Rust とは異なり、C++ の `=` は、コピーまたは移動される型によって決定される任"
+"意のコードを実行できます。"
 
 #: src/memory-management/clone.md
 msgid "Clone"
-msgstr ""
+msgstr "複製"
 
 #: src/memory-management/clone.md
 msgid ""
 "Sometimes you _want_ to make a copy of a value. The `Clone` trait "
 "accomplishes this."
-msgstr ""
+msgstr "値のコピーを作成したい場合は、`Clone` トレイトを使用できます。"
 
 #: src/memory-management/clone.md
 msgid ""
@@ -8190,140 +8292,164 @@ msgid ""
 "occurring. Look for `.clone()` and a few others like `Vec::new` or `Box::"
 "new`."
 msgstr ""
+"`Clone` はヒープ割当が起きる場所を見つけやすくすることを目的としたものです。"
+"`.clone()` のほか、`Vec::new` や `Box::new` などを探してください。"
 
 #: src/memory-management/clone.md
 msgid ""
 "It's common to \"clone your way out\" of problems with the borrow checker, "
 "and return later to try to optimize those clones away."
 msgstr ""
+"借用チェッカーが通らない場合に「とりあえずクローンを作成して切り抜けておい"
+"て」、あとからクローンのないコードへの最適化を試みるのもよくあることです。"
 
 #: src/memory-management/copy-types.md
 msgid ""
 "While move semantics are the default, certain types are copied by default:"
 msgstr ""
+"言語としてのデフォルトはムーブセマンティクスですが、特定の型ではデフォルトで"
+"コピーが行われます。"
 
 #: src/memory-management/copy-types.md
 msgid "These types implement the `Copy` trait."
-msgstr ""
+msgstr "これらの型は `Copy` トレイトを実装しているからです。"
 
 #: src/memory-management/copy-types.md
 msgid "You can opt-in your own types to use copy semantics:"
 msgstr ""
+"あなたが定義した独自の型のデフォルトをコピーセマンティクスにすることが出来ま"
+"す。"
 
 #: src/memory-management/copy-types.md
 msgid "After the assignment, both `p1` and `p2` own their own data."
-msgstr ""
+msgstr "代入後は、`p1` と `p2` の両方が独自のデータを所有します。"
 
 #: src/memory-management/copy-types.md
 msgid "We can also use `p1.clone()` to explicitly copy the data."
-msgstr ""
+msgstr "`p1.clone()` を使用してデータを明示的にコピーすることもできます。"
 
 #: src/memory-management/copy-types.md
 msgid "Copying and cloning are not the same thing:"
-msgstr ""
+msgstr "コピーとクローン作成は同じではありません。"
 
 #: src/memory-management/copy-types.md
 msgid ""
 "Copying refers to bitwise copies of memory regions and does not work on "
 "arbitrary objects."
 msgstr ""
+"コピーとは、メモリ領域のビット単位コピーのことであり、任意のオブジェクトでは"
+"機能しません。"
 
 #: src/memory-management/copy-types.md
 msgid ""
 "Copying does not allow for custom logic (unlike copy constructors in C++)."
 msgstr ""
+"コピーではカスタムロジックは使用できません（C++ のコピーコンストラクタとは異"
+"なります）。"
 
 #: src/memory-management/copy-types.md
 msgid ""
 "Cloning is a more general operation and also allows for custom behavior by "
 "implementing the `Clone` trait."
 msgstr ""
+"クローン作成はより一般的なオペレーションであり、`Clone` トレイトを実装するこ"
+"とでカスタム動作も可能になります。"
 
 #: src/memory-management/copy-types.md
 msgid "Copying does not work on types that implement the `Drop` trait."
-msgstr ""
+msgstr "`Drop` トレイトを実装している型では、コピーは出来ません。"
 
 #: src/memory-management/copy-types.md
 msgid "In the above example, try the following:"
-msgstr ""
+msgstr "上記の例で、次の方法を試してください。"
 
 #: src/memory-management/copy-types.md
 msgid ""
 "Add a `String` field to `struct Point`. It will not compile because `String` "
 "is not a `Copy` type."
 msgstr ""
+"`String` フィールドを`struct Point` に追加します。`String` が `Copy` 型ではな"
+"いため、コンパイルできなくなります。"
 
 #: src/memory-management/copy-types.md
 msgid ""
 "Remove `Copy` from the `derive` attribute. The compiler error is now in the "
 "`println!` for `p1`."
 msgstr ""
+"`derive` 属性から `Copy` を削除します。`p1` の `println!` でコンパイラ エラー"
+"が発生します。"
 
 #: src/memory-management/copy-types.md
 msgid "Show that it works if you clone `p1` instead."
-msgstr ""
+msgstr "代わりに `p1` のクローンを作成すれば解決できることを示します。"
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.mdmd
 msgid "The `Drop` Trait"
-msgstr ""
+msgstr "`Drop` トレイト"
 
 #: src/memory-management/drop.md
 msgid ""
 "Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
 "html) can specify code to run when they go out of scope:"
 msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) を実装している値"
+"では、スコープから外れるときに実行するコードを指定できます。"
 
 #: src/memory-management/drop.md
 msgid "\"Dropping {}\""
-msgstr ""
+msgstr "\"Dropping {}\""
 
 #: src/memory-management/drop.md src/exercises/concurrency/link-checker.md
 #: src/exercises/concurrency/solutions-morning.md
 msgid "\"a\""
-msgstr ""
+msgstr "\"a\""
 
 #: src/memory-management/drop.md src/testing/googletest.md
 msgid "\"b\""
-msgstr ""
+msgstr "\"b\""
 
 #: src/memory-management/drop.md
 msgid "\"c\""
-msgstr ""
+msgstr "\"c\""
 
 #: src/memory-management/drop.md
 msgid "\"d\""
-msgstr ""
+msgstr "\"d\""
 
 #: src/memory-management/drop.md
 msgid "\"Exiting block B\""
-msgstr ""
+msgstr "\"Exiting block B\""
 
 #: src/memory-management/drop.md
 msgid "\"Exiting block A\""
-msgstr ""
+msgstr "\"Exiting block A\""
 
 #: src/memory-management/drop.md
 msgid "\"Exiting main\""
-msgstr ""
+msgstr "\"Exiting main\""
 
 #: src/memory-management/drop.md
 msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
-msgstr ""
+msgstr "`std::mem::drop` は `std::ops::Drop::drop` と同じではありません。"
 
 #: src/memory-management/drop.md
 msgid "Values are automatically dropped when they go out of scope."
-msgstr ""
+msgstr "スコープ外になると、値は自動的にドロップされます。"
 
 #: src/memory-management/drop.md
 msgid ""
 "When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
 "drop` implementation will be called."
 msgstr ""
+"値がドロップされる際、`std::ops::Drop` を実装している場合は、その `Drop::"
+"drop` 実装が呼び出されます。"
 
 #: src/memory-management/drop.md
 msgid ""
 "All its fields will then be dropped too, whether or not it implements `Drop`."
 msgstr ""
+"その後、`Drop` を実装しているかどうかにかかわらず、すべてのフィールドもドロッ"
+"プされます。"
 
 #: src/memory-management/drop.md
 msgid ""
@@ -8332,26 +8458,34 @@ msgid ""
 "scope it gets dropped. This makes it a convenient way to explicitly drop "
 "values earlier than they would otherwise go out of scope."
 msgstr ""
+"`std::mem::drop` は、任意の値を受け取る空の関数にすぎません。重要なのは、この"
+"関数が値の所有権を取得することで、スコープの最後で値がドロップされることで"
+"す。これは、スコープ外になる前に値を明示的にドロップするための便利な方法で"
+"す。"
 
 #: src/memory-management/drop.md
 msgid ""
 "This can be useful for objects that do some work on `drop`: releasing locks, "
 "closing files, etc."
 msgstr ""
+"この方法は、`drop` で何らかの処理（ロックの解放、ファイルのクローズなど）を行"
+"うオブジェクトに使用すると便利です。"
 
 #: src/memory-management/drop.md
 msgid "Why doesn't `Drop::drop` take `self`?"
-msgstr ""
+msgstr "`Drop::drop` が `self` をパラメータとして取らないのはなぜですか？"
 
 #: src/memory-management/drop.md
 msgid ""
 "Short-answer: If it did, `std::mem::drop` would be called at the end of the "
 "block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
+"短い回答: その場合、ブロックの最後に `std::mem::drop` が呼び出されるため、別"
+"の `Drop::drop` が呼び出され、スタック オーバーフローが発生します。"
 
 #: src/memory-management/drop.md
 msgid "Try replacing `drop(a)` with `a.drop()`."
-msgstr ""
+msgstr "`drop(a)` を `a.drop()` に置き換えてみてください。"
 
 #: src/memory-management/exercise.md
 msgid ""
@@ -8359,131 +8493,139 @@ msgid ""
 "data. We will use the \"builder pattern\" to support building a new value "
 "piece-by-piece, using convenience functions."
 msgstr ""
+"この例では、すべてのデータを持つ複雑なデータ型を実装します。「ビルダー パター"
+"ン」で便利な関数を使用して、新しい値を 1 つずつ構築できるようにします。"
 
 #: src/memory-management/exercise.md
 msgid "Fill in the missing pieces."
-msgstr ""
+msgstr "抜けている部分を記入してください。"
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// A representation of a software package.\n"
-msgstr ""
+msgstr "/// ソフトウェア パッケージの表現。\n"
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid ""
 "/// Return a representation of this package as a dependency, for use in\n"
 "    /// building other packages.\n"
 msgstr ""
+"/// このパッケージの表現を依存関係として返し、\n"
+"    /// 他のパッケージのビルドに使用します。\n"
 
 #: src/memory-management/exercise.md
 msgid "\"1\""
-msgstr ""
+msgstr "\"1\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid ""
 "/// A builder for a Package. Use `build()` to create the `Package` itself.\n"
 msgstr ""
+"/// パッケージのビルダー。`build()` を使用して `Package` 自体を作成します。\n"
 
 #: src/memory-management/exercise.md
 msgid "\"2\""
-msgstr ""
+msgstr "\"2\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the package version.\n"
-msgstr ""
+msgstr "/// パッケージのバージョンを設定します。\n"
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the package authors.\n"
-msgstr ""
+msgstr "/// パッケージ作成者を設定します。\n"
 
 #: src/memory-management/exercise.md
 msgid "\"3\""
-msgstr ""
+msgstr "\"3\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Add an additional dependency.\n"
-msgstr ""
+msgstr "/// 依存関係を追加します。\n"
 
 #: src/memory-management/exercise.md
 msgid "\"4\""
-msgstr ""
+msgstr "\"4\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "/// Set the language. If not set, language defaults to None.\n"
 msgstr ""
+"/// 言語を設定します。設定しない場合、言語はデフォルトで None になります。\n"
 
 #: src/memory-management/exercise.md
 msgid "\"5\""
-msgstr ""
+msgstr "\"5\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"base64\""
-msgstr ""
+msgstr "\"base64\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"0.13\""
-msgstr ""
+msgstr "\"0.13\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"base64: {base64:?}\""
-msgstr ""
+msgstr "\"base64: {base64:?}\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"log\""
-msgstr ""
+msgstr "\"log\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"0.4\""
-msgstr ""
+msgstr "\"0.4\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"log: {log:?}\""
-msgstr ""
+msgstr "\"log: {log:?}\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"serde\""
-msgstr ""
+msgstr "\"serde\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"djmitche\""
-msgstr ""
+msgstr "\"djmitche\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"4.0\""
-msgstr ""
+msgstr "\"4.0\""
 
 #: src/memory-management/exercise.md src/memory-management/solution.md
 msgid "\"serde: {serde:?}\""
-msgstr ""
+msgstr "\"serde: {serde:?}\""
 
 #: src/memory-management/solution.md
 msgid "\"0.1\""
-msgstr ""
+msgstr "\"0.1\""
 
 #: src/smart-pointers.md
 msgid "[Box"
-msgstr ""
+msgstr "[Box"
 
 #: src/smart-pointers.md
 msgid "](./smart-pointers/box.md) (10 minutes)"
-msgstr ""
+msgstr "](./smart-pointers/box.md)（10 分）"
 
 #: src/smart-pointers.md
 msgid "[Rc](./smart-pointers/rc.md) (5 minutes)"
-msgstr ""
+msgstr "[Rc](./smart-pointers/rc.md)（5 分）"
 
 #: src/smart-pointers.md
 msgid "[Exercise: Binary Tree](./smart-pointers/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: バイナリツリー](./smart-pointers/exercise.md)（30 分）"
 
 #: src/smart-pointers/box.md
 msgid ""
 "[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
 "pointer to data on the heap:"
 msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) は、ヒープ上の"
+"データへの所有ポインタです。"
 
 #: src/smart-pointers/box.md
 msgid "\"five: {}\""
-msgstr ""
+msgstr "\"five: {}\""
 
 #: src/smart-pointers/box.md
 msgid ""
@@ -8491,23 +8633,28 @@ msgid ""
 "methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
 "trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
+"`Box<T>` は `Deref<Target = T>` を実装しているため、[`Box<T>` に対して T のメ"
+"ソッドを直接呼び出す](https://doc.rust-lang.org/std/ops/trait.Deref."
+"html#more-on-deref-coercion)ことができます。"
 
 #: src/smart-pointers/box.md
 msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
+"再帰データ型、またはサイズが動的なデータ型では、`Box` を使用する必要がありま"
+"す。"
 
 #: src/smart-pointers/box.md
 msgid "/// A non-empty list: first element and the rest of the list.\n"
-msgstr ""
+msgstr "/// 空でないリスト: 最初の要素とリストの残り。\n"
 
 #: src/smart-pointers/box.md
 msgid "/// An empty list.\n"
-msgstr ""
+msgstr "/// 空のリスト。\n"
 
 #: src/smart-pointers/box.md
 msgid "\"{list:?}\""
-msgstr ""
+msgstr "\"{list:?}\""
 
 #: src/smart-pointers/box.md
 msgid ""
@@ -8530,22 +8677,44 @@ msgid ""
 "- - - - -'\n"
 "```"
 msgstr ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - - - .     .- - - - - - - - - - - - - - - - - - - - "
+"- - - - -.\n"
+":                            :     :                                                 :\n"
+":    "
+"list                    :     :                                                 :\n"
+":   +---------+----+----+    :     :    +---------+----+----+    +------+----"
+"+----+  :\n"
+":   | Element | 1  | o--+----+-----+--->| Element | 2  | o--+--->| Nil  | // "
+"| // |  :\n"
+":   +---------+----+----+    :     :    +---------+----+----+    +------+----"
+"+----+  :\n"
+":                            :     :                                                 :\n"
+":                            :     :                                                 :\n"
+"'- - - - - - - - - - - - - - '     '- - - - - - - - - - - - - - - - - - - - "
+"- - - - -'\n"
+"```"
 
 #: src/smart-pointers/box.md
 msgid ""
 "`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
 "not null."
 msgstr ""
+"`Box` は C++ の `std::unique_ptr` と似ていますが、null ではないことが保証され"
+"ている点が異なります。"
 
 #: src/smart-pointers/box.md
 msgid "A `Box` can be useful when you:"
-msgstr ""
+msgstr "`Box` は次のような場合に役立ちます。"
 
 #: src/smart-pointers/box.md
 msgid ""
 "have a type whose size that can't be known at compile time, but the Rust "
 "compiler wants to know an exact size."
 msgstr ""
+"コンパイル時にサイズを把握できない型があるが、Rust コンパイラがその正確なサイ"
+"ズを知る必要がある場合。"
 
 #: src/smart-pointers/box.md
 msgid ""
@@ -8553,19 +8722,27 @@ msgid ""
 "amounts of data on the stack, instead store the data on the heap in a `Box` "
 "so only the pointer is moved."
 msgstr ""
+"大量のデータの所有権をムーブしたい場合。スタック上の大量のデータがコピーされ"
+"ないようにするには、代わりに`Box` によりヒープ上にデータを格納し、ポインタの"
+"みが移動されるようにします。"
 
 #: src/smart-pointers/box.md
 msgid ""
 "If `Box` was not used and we attempted to embed a `List` directly into the "
-"`List`, the compiler would not compute a fixed size of the struct in memory "
-"(`List` would be of infinite size)."
+"`List`, the compiler would not be able to compute a fixed size for the "
+"struct in memory (the `List` would be of infinite size)."
 msgstr ""
+" 仮に`Box` を使用せずに `List` を `List` に直接埋め込もうとすると、コンパイラ"
+"はメモリ内の構造体の固定サイズを計算しようとしません（`List` は無限サイズにな"
+"ります）。"
 
 #: src/smart-pointers/box.md
 msgid ""
 "`Box` solves this problem as it has the same size as a regular pointer and "
 "just points at the next element of the `List` in the heap."
 msgstr ""
+"`Box` がこの問題を解決できるのは、そのサイズが通常のポインタと同じであり、単"
+"にヒープ内の List の次の要素を指すだけだけだからです。"
 
 #: src/smart-pointers/box.md
 msgid ""
@@ -8573,6 +8750,9 @@ msgid ""
 "\"Recursive with indirection\" is a hint you might want to use a Box or "
 "reference of some kind, instead of storing a value directly."
 msgstr ""
+"List 定義の `Box` を削除して、コンパイラ エラーを表示します。\"Recursive "
+"with indirection\" は、値を直接保持するのではなく、Boxや何らかの参照を使用し"
+"たら良いことを示唆するものです。"
 
 #: src/smart-pointers/box.md
 msgid "Niche Optimization"
@@ -8583,6 +8763,8 @@ msgid ""
 "A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
+"`Box` を空にすることはできないため、ポインタは常に有効かつ非 `null` になりま"
+"す。これにより、コンパイラがメモリ レイアウトを最適化できます。"
 
 #: src/smart-pointers/box.md
 msgid ""
@@ -8599,6 +8781,18 @@ msgid ""
 "'- - - - - - - - - - - - - - '     '- - - - - - - - - - - - - -'\n"
 "```"
 msgstr ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - - - .     .- - - - - - - - - - - - - -.\n"
+":                            :     :                           :\n"
+":    list                    :     :                           :\n"
+":   +---------+----+----+    :     :    +---------+----+----+  :\n"
+":   | Element | 1  | o--+----+-----+--->| Element | 2  | // |  :\n"
+":   +---------+----+----+    :     :    +---------+----+----+  :\n"
+":                            :     :                           :\n"
+":                            :     :                           :\n"
+"'- - - - - - - - - - - - - - '     '- - - - - - - - - - - - - -'\n"
+"```"
 
 #: src/smart-pointers/rc.md
 msgid ""
@@ -8606,14 +8800,17 @@ msgid ""
 "counted shared pointer. Use this when you need to refer to the same data "
 "from multiple places:"
 msgstr ""
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) は、参照カウントされ"
+"た共有ポインタです。複数の場所から同じデータを参照する必要がある場合に使用し"
+"ます。"
 
 #: src/smart-pointers/rc.md
 msgid "\"a: {a}\""
-msgstr ""
+msgstr "\"a: {a}\""
 
 #: src/smart-pointers/rc.md
 msgid "\"b: {b}\""
-msgstr ""
+msgstr "\"b: {b}\""
 
 #: src/smart-pointers/rc.md
 msgid ""
@@ -8621,22 +8818,28 @@ msgid ""
 "rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
 "context."
 msgstr ""
+"マルチスレッドのコンテキストに関しては、[`Arc`](../concurrency/shared_state/"
+"arc.md) と [`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) を"
+"ご覧ください。"
 
 #: src/smart-pointers/rc.md
 msgid ""
 "You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
 "org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
+"共有ポインタを [`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) ポ"
+"インタにダウングレード _(downgrade)_ すると、ドロップされるサイクルを作成でき"
+"ます。"
 
 #: src/smart-pointers/rc.md
 msgid ""
 "`Rc`'s count ensures that its contained value is valid for as long as there "
 "are references."
-msgstr ""
+msgstr "`Rc` のカウントは、参照がある限り有効であることを保証します。"
 
 #: src/smart-pointers/rc.md
 msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
-msgstr ""
+msgstr "Rust の `Rc` は C++ の `std::shared_ptr` に似ています。"
 
 #: src/smart-pointers/rc.md
 msgid ""
@@ -8644,22 +8847,30 @@ msgid ""
 "increases the reference count. Does not make a deep clone and can generally "
 "be ignored when looking for performance issues in code."
 msgstr ""
+"`Rc::clone`の動作は軽量です。同じ割り当て領域へのポインタを作成し、参照カウン"
+"トを増やすだけです。デープクローンを作成しないので、性能上の問題箇所をコード"
+"から探す場合には通常無視することが出来ます。"
 
 #: src/smart-pointers/rc.md
 msgid ""
 "`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
 "and returns a mutable reference."
 msgstr ""
+"`make_mut` は、必要に応じて内部の値のクローンを作成し（「clone-on-write」）、"
+"可変参照を返します。"
 
 #: src/smart-pointers/rc.md
 msgid "Use `Rc::strong_count` to check the reference count."
-msgstr ""
+msgstr "`Rc::strong_count` を使用して参照カウントを確認します。"
 
 #: src/smart-pointers/rc.md
 msgid ""
 "`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
 "cycles that will be dropped properly (likely in combination with `RefCell`)."
 msgstr ""
+"`Rc::downgrade` は、（多くの場合、`RefCell` と組み合わせて）適切にドロップさ"
+"れるサイクルを作成するための弱参照カウント _(weakly reference-counted)_ オブ"
+"ジェクトを提供します。"
 
 #: src/smart-pointers/exercise.md
 msgid ""
@@ -8668,24 +8879,28 @@ msgid ""
 "value. For a given node N, all nodes in a N's left subtree contain smaller "
 "values, and all nodes in N's right subtree will contain larger values."
 msgstr ""
+"バイナリツリーは、すべてのノードに 2 つの子（左と右）があるツリー型のデータ構"
+"造です。ここでは、各ノードが値を格納するツリーを作成します。ある特定のノード "
+"N について、N の左側のサブツリー内のすべてのノードにはより小さい値が含まれ、"
+"N の右側のサブツリー内のすべてのノードにはより大きい値が含まれます。"
 
 #: src/smart-pointers/exercise.md
 msgid "Implement the following types, so that the given tests pass."
-msgstr ""
+msgstr "次の型を実装して、指定されたテストが通るようにします。"
 
 #: src/smart-pointers/exercise.md
 msgid ""
 "Extra Credit: implement an iterator over a binary tree that returns the "
 "values in order."
-msgstr ""
+msgstr "追加の実習: バイナリツリーに値を順番に返すイテレータを実装します。"
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "/// A node in the binary tree.\n"
-msgstr ""
+msgstr "/// バイナリツリーのノード。\n"
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "/// A possibly-empty subtree.\n"
-msgstr ""
+msgstr "/// 空の可能性のあるサブツリー。\n"
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid ""
@@ -8693,73 +8908,80 @@ msgid ""
 "///\n"
 "/// If the same value is added multiple times, it is only stored once.\n"
 msgstr ""
+"/// バイナリツリーを使用して一連の値を格納するコンテナ。\n"
+"///\n"
+"/// 同じ値が複数回追加された場合、その値は 1 回だけ格納される。\n"
 
 #: src/smart-pointers/exercise.md
 msgid "// Implement `new`, `insert`, `len`, and `has`.\n"
-msgstr ""
+msgstr "// `new`、`insert`、`len`、`has` を実装します。\n"
 
 #: src/smart-pointers/exercise.md src/smart-pointers/solution.md
 msgid "// not a unique item\n"
-msgstr ""
+msgstr "// 固有のアイテムではない\n"
 
 #: src/smart-pointers/solution.md src/testing/googletest.md
 msgid "\"bar\""
-msgstr ""
+msgstr "\"bar\""
 
 #: src/welcome-day-3-afternoon.md
 msgid "[Borrowing](./borrowing.md) (1 hour)"
-msgstr ""
+msgstr "[借用](./borrowing.md)（1 時間）"
 
 #: src/welcome-day-3-afternoon.md
 msgid ""
 "[Slices and Lifetimes](./slices-and-lifetimes.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[スライスとライフタイム](./slices-and-lifetimes.md)（1 時間 10 分）"
 
 #: src/welcome-day-3-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 20 "
 "minutes"
-msgstr ""
+msgstr "このセッションの所要時間は、10 分間の休憩を入れて約 2 時間 20 分です。"
 
 #: src/borrowing.md
 msgid "[Borrowing a Value](./borrowing/shared.md) (10 minutes)"
-msgstr ""
+msgstr "[値の借用](./borrowing/shared.md)（10 分）"
 
 #: src/borrowing.md
 msgid "[Borrow Checking](./borrowing/borrowck.md) (10 minutes)"
-msgstr ""
+msgstr "[借用チェック](./borrowing/borrowck.md)（10 分）"
 
 #: src/borrowing.md
 msgid "[Interior Mutability](./borrowing/interior-mutability.md) (10 minutes)"
-msgstr ""
+msgstr "[内部可変性](./borrowing/interior-mutability.md)（10 分）"
 
 #: src/borrowing.md
 msgid "[Exercise: Health Statistics](./borrowing/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: 健康に関する統計情報](./borrowing/exercise.md)（30 分）"
 
 #: src/borrowing/shared.md
 msgid ""
 "As we saw before, instead of transferring ownership when calling a function, "
 "you can let a function _borrow_ the value:"
 msgstr ""
+"前に説明したように、関数を呼び出すときに所有権を移動する代わりに、関数で値を"
+"借用できます。"
 
 #: src/borrowing/shared.md
 msgid "The `add` function _borrows_ two points and returns a new point."
-msgstr ""
+msgstr "`add` 関数は 2 つのポイントを _借用_ し、新しいポイントを返します。"
 
 #: src/borrowing/shared.md
 msgid "The caller retains ownership of the inputs."
-msgstr ""
+msgstr "呼び出し元は入力の所有権を保持します。"
 
 #: src/borrowing/shared.md
 msgid ""
 "This slide is a review of the material on references from day 1, expanding "
 "slightly to include function arguments and return values."
 msgstr ""
+"このスライドでは、1 日目の参照に関する資料を振り返りですが、少し対象を広げ、"
+"関数の引数と戻り値も含めています。"
 
 #: src/borrowing/shared.md
 msgid "Notes on stack returns:"
-msgstr ""
+msgstr "スタックの戻り値に関する注意事項:"
 
 #: src/borrowing/shared.md
 msgid ""
@@ -8771,10 +8993,17 @@ msgid ""
 "\"DEBUG\" optimization level, the addresses should change, while they stay "
 "the same when changing to the \"RELEASE\" setting:"
 msgstr ""
+"コンパイラはコピー オペレーションを省略できるため、`add` からのリターンはコス"
+"トであることを示します。スタック アドレスを出力するように上記のコードを変更"
+"し、[Playground](https://play.rust-lang.org/?"
+"version=stable&mode=release&edition=2021&gist=0cb13be1c05d7e3446686ad9947c4671)"
+"で実行するか、[Godbolt](https://rust.godbolt.org/) のアセンブリを確認します。"
+"「DEBUG」最適化レベルではアドレスが変更されますが、「RELEASE」設定に変更した"
+"場合はアドレスが変更されません。"
 
 #: src/borrowing/shared.md
 msgid "The Rust compiler can do return value optimization (RVO)."
-msgstr ""
+msgstr "Rust コンパイラは戻り値の最適化（RVO）を行うことができます。"
 
 #: src/borrowing/shared.md
 msgid ""
@@ -8783,38 +9012,50 @@ msgid ""
 "RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
 "copy."
 msgstr ""
+"C++ では、コンストラクタが副作用をもたらす可能性があるため、言語仕様でコピー"
+"省略を定義する必要があります。Rust では、これはまったく問題になりません。RVO "
+"が行われなかった場合でも、Rust は常にシンプルで効率的な `memcpy` コピーを実行"
+"します。"
 
 #: src/borrowing/borrowck.md
 msgid ""
 "Rust's _borrow checker_ puts constraints on the ways you can borrow values. "
 "For a given value, at any time:"
 msgstr ""
+"Rust の _借用チェッカー_ は、値を借用する方法に制限を設けます。任意の値に対し"
+"て、常に次の制限が課されます。"
 
 #: src/borrowing/borrowck.md
 msgid "You can have one or more shared references to the value, _or_"
-msgstr ""
+msgstr "値への共有参照を 1 つ以上持つことが出来ます。または、"
 
 #: src/borrowing/borrowck.md
 msgid "You can have exactly one exclusive reference to the value."
-msgstr ""
+msgstr "値への排他参照を 1 つだけ持つことが出来ます。"
 
 #: src/borrowing/borrowck.md
 msgid ""
 "Note that the requirement is that conflicting references not _exist_ at the "
 "same point. It does not matter where the reference is dereferenced."
 msgstr ""
+"要件は、競合する参照が同じ時点に存在しないことです。参照がどこで外されていて"
+"も構いません。"
 
 #: src/borrowing/borrowck.md
 msgid ""
 "The above code does not compile because `a` is borrowed as mutable (through "
 "`c`) and as immutable (through `b`) at the same time."
 msgstr ""
+"上記のコードは、`a` が `c` を通じて可変として借用されていると同時に、`b` を通"
+"じて不変として借用されているため、コンパイルできません。"
 
 #: src/borrowing/borrowck.md
 msgid ""
 "Move the `println!` statement for `b` before the scope that introduces `c` "
 "to make the code compile."
 msgstr ""
+"`b` の `println!` ステートメントを `c` を導入するスコープの前に移動して、コー"
+"ドをコンパイル出来るようにします。"
 
 #: src/borrowing/borrowck.md
 msgid ""
@@ -8822,6 +9063,9 @@ msgid ""
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
+"この変更後、コンパイラは c を通じたa の可変参照よりも前にしかbが使われていな"
+"いことを認識します。これは「ノンレキシカル ライフタイム(_\"non-lexical "
+"lifetimes\"_)」と呼ばれる借用チェッカーの機能です。"
 
 #: src/borrowing/borrowck.md
 msgid ""
@@ -8830,6 +9074,10 @@ msgid ""
 "optimize code. For example, a value behind a shared reference can be safely "
 "cached in a register for the lifetime of that reference."
 msgstr ""
+"排他参照制約は非常に強力です。Rust はこの制約を使用して、データへの競合が発生"
+"しないようにするとともに、コードを最適化しています。たとえば、共有参照を通し"
+"て得られる値は、その参照が存続する間、安全にレジスタにキャッシュすることが出"
+"来ます"
 
 #: src/borrowing/borrowck.md
 msgid ""
@@ -8838,6 +9086,10 @@ msgid ""
 "time. But, there are some situations where it doesn't quite \"get it\" and "
 "this often results in \"fighting with the borrow checker.\""
 msgstr ""
+"借用チェッカーは、構造体内の異なるフィールドへの排他参照を同時に取得するな"
+"ど、多くの一般的なパターンに対応するように設計されています。しかし、状況に"
+"よっては借用チェッカーがコードを正しく理解できず、「借用チェッカーとの戦い」"
+"に発展することが多くあります。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8845,6 +9097,9 @@ msgid ""
 "only) reference. For example, a shared data structure might have an internal "
 "cache, and wish to update that cache from read-only methods."
 msgstr ""
+"場合によっては、共有（読み取り専用）参照の背後にあるデータを変更する必要があ"
+"ります。たとえば、共有データ構造に内部キャッシュがあり、そのキャッシュを読み"
+"取り専用メソッドから更新する必要がある場合があります。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8852,22 +9107,25 @@ msgid ""
 "a shared reference. The standard library provides several ways to do this, "
 "all while still ensuring safety, typically by performing a runtime check."
 msgstr ""
+"「内部可変性」パターンは、共有参照を通した排他的（可変）アクセスを可能にしま"
+"す。標準ライブラリには、これを安全に行うための方法がいくつか用意されており、"
+"通常はランタイム チェックを実行することで安全性を確保します。"
 
 #: src/borrowing/interior-mutability.md
 msgid "`RefCell`"
-msgstr ""
+msgstr "`RefCell`"
 
 #: src/borrowing/interior-mutability.md
 msgid "\"graph: {root:#?}\""
-msgstr ""
+msgstr "\"graph: {root:#?}\""
 
 #: src/borrowing/interior-mutability.md
 msgid "\"graph sum: {}\""
-msgstr ""
+msgstr "\"graph sum: {}\""
 
 #: src/borrowing/interior-mutability.md
 msgid "`Cell`"
-msgstr ""
+msgstr "`Cell`"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8875,6 +9133,8 @@ msgid ""
 "shared reference to the `Cell`. However, it does not allow any references to "
 "the value. Since there are no references, borrowing rules cannot be broken."
 msgstr ""
+"`Cell` は、値をラップし、`Cell` の共有参照を通してでもその値を取得または設定"
+"可能にしています。ただし、その内包する値への参照は許していません。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8882,6 +9142,9 @@ msgid ""
 "ways to modify data behind a shared reference. There are a variety of ways "
 "to ensure that safety, and `RefCell` and `Cell` are two of them."
 msgstr ""
+"このスライドで重要なのは、Rust には、共有参照の背後にあるデータを変更する安全"
+"な方法が用意されているということです。安全性を確保するにはさまざまな方法があ"
+"りますが、ここでは `RefCell` と `Cell` を取り上げます。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8890,6 +9153,9 @@ msgid ""
 "case, all borrows are very short and never overlap, so the checks always "
 "succeed."
 msgstr ""
+"`RefCell` は、ランタイム チェックとともに Rust の通常の借用ルール（複数の共有"
+"参照または単一の排他参照）を適用します。この場合、すべての借用は非常に短く、"
+"重複しないため、チェックは常に成功します。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8897,6 +9163,9 @@ msgid ""
 "purpose is to allow (and count) many references. But we want to modify the "
 "value, so we need interior mutability."
 msgstr ""
+"`Rc` は多くの参照を許可（およびカウント）することを目的としているため、コンテ"
+"ンツへの共有（読み取り専用）アクセスのみを許可します。しかし、ここでは値を変"
+"更したいので、内部可変性が必要です。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8904,12 +9173,16 @@ msgid ""
 "`&self`. This needs no runtime check, but requires moving values, which can "
 "have its own cost."
 msgstr ""
+"`Cell` は安全性を確保するためのよりシンプルな手段であり、`&self` を受け取る "
+"`set` メソッドを備えています。ランタイム チェックは必要ありませんが、値を移動"
+"する必要があり、それによってコストが発生することがあります。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
 "Demonstrate that reference loops can be created by adding `root` to `subtree."
 "children`."
 msgstr ""
+"`subtree.children` に `root` を追加して参照ループを作成できることを示します。"
 
 #: src/borrowing/interior-mutability.md
 msgid ""
@@ -8918,12 +9191,18 @@ msgid ""
 "the presence of the reference loop, with `thread 'main' panicked at 'already "
 "borrowed: BorrowMutError'`."
 msgstr ""
+"実行時のパニックを示すため、`self.value` をインクリメントしてその子に対して同"
+"じメソッドを呼び出す `fn inc(&mut self)` を追加します。これは、参照ループがあ"
+"るとパニックとなり、`thread 'main' panicked at 'already borrowed: "
+"BorrowMutError'` というエラーが出力されます。"
 
 #: src/borrowing/exercise.md
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
 "you need to keep track of users' health statistics."
 msgstr ""
+"健康管理システムの実装の一環として、ユーザーの健康に関する統計情報を追跡する"
+"必要があります。"
 
 #: src/borrowing/exercise.md
 msgid ""
@@ -8931,78 +9210,90 @@ msgid ""
 "struct definition. Your goal is to implement the stubbed out method on the "
 "`User` `struct` defined in the `impl` block."
 msgstr ""
+"`impl` ブロックのスタブ関数と、`User` 構造体の定義がある状態から開始します。"
+"`User` 構造体の `impl` ブロックにおいてスタブ化された関数を実装することです。"
 
 #: src/borrowing/exercise.md
 msgid ""
 "Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "method:"
 msgstr ""
+"以下のコードを <https://play.rust-lang.org/> にコピーし、実体がないメソッドの"
+"中身を実装します。"
 
 #: src/borrowing/exercise.md
 msgid ""
 "\"Update a user's statistics based on measurements from a visit to the "
 "doctor\""
 msgstr ""
+"\"Update a user's statistics based on measurements from a visit to the "
+"doctor\""
 
 #: src/borrowing/exercise.md src/borrowing/solution.md
 #: src/android/build-rules/library.md src/android/aidl/client.md
 msgid "\"Bob\""
-msgstr ""
+msgstr "\"Bob\""
 
 #: src/borrowing/exercise.md src/borrowing/solution.md
 msgid "\"I'm {} and my age is {}\""
-msgstr ""
+msgstr "\"I'm {} and my age is {}\""
 
 #: src/slices-and-lifetimes.md
 msgid "[Slices: &\\[T\\]](./slices-and-lifetimes/slices.md) (10 minutes)"
-msgstr ""
+msgstr "[Slices: &\\[T\\]](./slices-and-lifetimes/slices.md)（10 分）"
 
 #: src/slices-and-lifetimes.md
 msgid "[String References](./slices-and-lifetimes/str.md) (10 minutes)"
-msgstr ""
+msgstr "[文字列参照](./slices-and-lifetimes/str.md)（10 分）"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Lifetime Annotations](./slices-and-lifetimes/lifetime-annotations.md) (10 "
 "minutes)"
 msgstr ""
+"[ライフタイム アノテーション](./slices-and-lifetimes/lifetime-annotations.md)"
+"（10 分）"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Lifetime Elision](./slices-and-lifetimes/lifetime-elision.md) (5 minutes)"
 msgstr ""
+"[ライフタイムの省略](./slices-and-lifetimes/lifetime-elision.md)（5 分）"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Struct Lifetimes](./slices-and-lifetimes/struct-lifetimes.md) (5 minutes)"
 msgstr ""
+"[構造体のライフタイム](./slices-and-lifetimes/struct-lifetimes.md)（5 分）"
 
 #: src/slices-and-lifetimes.md
 msgid ""
 "[Exercise: Protobuf Parsing](./slices-and-lifetimes/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: Protobuf の解析](./slices-and-lifetimes/exercise.md)（30 分）"
 
 #: src/slices-and-lifetimes/slices.md
 msgid "Slices"
-msgstr "スライス型"
+msgstr "Slices"
 
 #: src/slices-and-lifetimes/slices.md
 msgid "A slice gives you a view into a larger collection:"
-msgstr ""
+msgstr "スライスは、より大きなコレクションに対するビューを提供します。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid "Slices borrow data from the sliced type."
-msgstr ""
+msgstr "スライスは、スライスされた型からデータを借用します。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
-msgstr ""
+msgstr "質問: `s` を出力する直前に `a[3]` を変更するとどうなるでしょうか？"
 
 #: src/slices-and-lifetimes/slices.md
 msgid ""
 "We create a slice by borrowing `a` and specifying the starting and ending "
 "indexes in brackets."
 msgstr ""
+"スライスを作成するには、`a` を借用し、開始インデックスと終了インデックスを角"
+"かっこで囲んで指定します。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid ""
@@ -9010,17 +9301,22 @@ msgid ""
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
 "identical."
 msgstr ""
+"スライスがインデックス 0 から始まる場合、Rust の範囲構文により開始インデック"
+"スを省略できます。つまり、`&a[0..a.len()]` と `&a[..a.len()]` は同じです。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid ""
 "The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
 "identical."
 msgstr ""
+"最後のインデックスについても同じことが言えるので、`&a[2..a.len()]` と "
+"`&a[2..]` は同じです。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid ""
 "To easily create a slice of the full array, we can therefore use `&a[..]`."
 msgstr ""
+"配列全体のスライスを簡単に作成するには、`&a[..]` と書くことが出来ます。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid ""
@@ -9028,12 +9324,17 @@ msgid ""
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
 "computation on slices of different sizes."
 msgstr ""
+"`s` は i32 のスライスへの参照です。`s` の型（`&[i32]`）に配列の長さが含まれな"
+"くなったことに注目してください。これにより、さまざまなサイズのスライスに対し"
+"て計算を実行できます。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid ""
 "Slices always borrow from another object. In this example, `a` has to remain "
 "'alive' (in scope) for at least as long as our slice."
 msgstr ""
+"スライスは常に別のオブジェクトから借用します。この例では、`a` は少なくともス"
+"ライスが存在する間は「存続」 している（スコープ内にある)必要があります。"
 
 #: src/slices-and-lifetimes/slices.md
 msgid ""
@@ -9043,36 +9344,44 @@ msgid ""
 "safely. It works before you created the slice, and again after the "
 "`println`, when the slice is no longer used."
 msgstr ""
+"`a[3]` の変更に関する質問は興味深い議論のきっかけになるかもしれませんが、メモ"
+"リ安全性上の理由から、この時点では `a` を使用して変更することはできない、とい"
+"う回答になります。ただし、`a` と `s` の両方のデータを安全に読み取ることはでき"
+"ます。これは、スライスを作成する前と、`println` の後でスライスが使用されなく"
+"なったあとであれば、変更することが出来ます。"
 
 #: src/slices-and-lifetimes/str.md
 msgid ""
 "We can now understand the two string types in Rust: `&str` is almost like "
 "`&[char]`, but with its data stored in a variable-length encoding (UTF-8)."
 msgstr ""
+"これで、Rust の 2 つの文字列型を理解できるようになりました。`&str` は "
+"`&[char]` とほぼ同じですが、そのデータは可変長エンコード（UTF-8）で保存されま"
+"す。"
 
 #: src/slices-and-lifetimes/str.md
 msgid "\"s1: {s1}\""
-msgstr ""
+msgstr "\"s1: {s1}\""
 
 #: src/slices-and-lifetimes/str.md
 msgid "\"Hello \""
-msgstr ""
+msgstr "\"Hello \""
 
 #: src/slices-and-lifetimes/str.md
 msgid "\"s3: {s3}\""
-msgstr ""
+msgstr "\"s3: {s3}\""
 
 #: src/slices-and-lifetimes/str.md
 msgid "Rust terminology:"
-msgstr ""
+msgstr "Rust の用語:"
 
 #: src/slices-and-lifetimes/str.md
 msgid "`&str` an immutable reference to a string slice."
-msgstr ""
+msgstr "`&str`: 文字列スライスへの不変の参照。"
 
 #: src/slices-and-lifetimes/str.md
 msgid "`String` a mutable string buffer."
-msgstr ""
+msgstr "`String`: 可変の文字列バッファ。"
 
 #: src/slices-and-lifetimes/str.md
 msgid ""
@@ -9080,12 +9389,17 @@ msgid ""
 "encoded string data stored in a block of memory. String literals "
 "(`”Hello”`), are stored in the program’s binary."
 msgstr ""
+"`&str` は文字列スライスを導入します。これは、メモリブロックに保存されている "
+"UTF-8 でエンコードされた文字列データへの不変の参照です。文字列リテラル"
+"（`”Hello”`）は、プログラムのバイナリに格納されます。"
 
 #: src/slices-and-lifetimes/str.md
 msgid ""
 "Rust’s `String` type is a wrapper around a vector of bytes. As with a "
 "`Vec<T>`, it is owned."
 msgstr ""
+"Rust の `String` 型は、バイトのベクターのラッパーです。`Vec<T>` と同様、所有"
+"されます。"
 
 #: src/slices-and-lifetimes/str.md
 msgid ""
@@ -9093,12 +9407,17 @@ msgid ""
 "literal; `String::new()` creates a new empty string, to which string data "
 "can be added using the `push()` and `push_str()` methods."
 msgstr ""
+"他の多くの型と同様に、`String::from()` は文字列リテラルから文字列を作成しま"
+"す。`String::new()` は新しい空の文字列を作成します。`push()` メソッドと "
+"`push_str()` メソッドを使用して、そこに文字列データを追加できます。"
 
 #: src/slices-and-lifetimes/str.md
 msgid ""
 "The `format!()` macro is a convenient way to generate an owned string from "
 "dynamic values. It accepts the same format specification as `println!()`."
 msgstr ""
+"`format!()` マクロを使用すると、動的な値から所有文字列を簡単に生成できます。"
+"これは println!() と同じ形式指定を受け入れます。"
 
 #: src/slices-and-lifetimes/str.md
 msgid ""
@@ -9107,6 +9426,10 @@ msgid ""
 "boundaries, the expression will panic. The `chars` iterator iterates over "
 "characters and is preferred over trying to get character boundaries right."
 msgstr ""
+"`&` を使用して `String` から `&str` スライスを借用し、必要に応じて範囲を選択"
+"できます。文字境界に揃えられていないバイト範囲を選択すると、その式でパニック"
+"を起こします。`chars` イテレータは文字単位で処理するため、正しい文字境界を取"
+"得しようとすることよりも、このイテレータを使用するほうが望ましいです。"
 
 #: src/slices-and-lifetimes/str.md
 msgid ""
@@ -9115,16 +9438,22 @@ msgid ""
 "equivalent of `std::string` from C++ (main difference: it can only contain "
 "UTF-8 encoded bytes and will never use a small-string optimization)."
 msgstr ""
+"C++ プログラマー向けの説明：`&str` は常にメモリ上の有効な文字列を指しているよ"
+"うなC++ の std::string_view と考えられます。Rust の `String` は、C++ の "
+"`std::string` とおおむね同等です（主な違いは、UTF-8 でエンコードされたバイト"
+"のみを含めることができ、短い文字列に対する最適化が行われないことです）。"
 
 #: src/slices-and-lifetimes/str.md
 msgid "Byte strings literals allow you to create a `&[u8]` value directly:"
-msgstr ""
+msgstr "バイト文字列リテラルを使用すると、`&[u8]` 値を直接作成できます。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
 "A reference has a _lifetime_, which must not \"outlive\" the value it refers "
 "to. This is verified by the borrow checker."
 msgstr ""
+"参照にはライフタイムがあり、これは参照する値よりも「長く存続」してはなりませ"
+"ん。これは借用チェッカーによって検証されます。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
@@ -9133,6 +9462,10 @@ msgid ""
 "`'` and `'a` is a typical default name. Read `&'a Point` as \"a borrowed "
 "`Point` which is valid for at least the lifetime `a`\"."
 msgstr ""
+"これまで見てきたとおり、ライフタイムは暗黙に扱えますが、`&'a Point`、"
+"`&'document str` のように明示的に指定することもできます。ライフタイムは `'` "
+"で始まり、`'a` が一般的なデフォルト名です。`&'a Point` は、「少なくともライフ"
+"タイム `a` の間は有効な、借用した `Point`」とと解釈します。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
@@ -9140,44 +9473,57 @@ msgid ""
 "yourself. Explicit lifetime annotations create constraints where there is "
 "ambiguity; the compiler verifies that there is a valid solution."
 msgstr ""
+"ライフタイムは常にコンパイラによって推測されます。自分でライフタイムを割り当"
+"てることはできません。明示的なライフタイム アノテーションを使用すると、あいま"
+"いなところに制約を課すことができます。それに対し、コンパイラはその制約を満た"
+"すライフタイムを設定できることを検証します。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
 "Lifetimes become more complicated when considering passing values to and "
 "returning values from functions."
 msgstr ""
+"関数に値を渡し、関数から値を返すことを考慮する場合、ライフタイムはより複雑に"
+"なります。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid "// What is the lifetime of p3?\n"
-msgstr ""
+msgstr "// p3 のライフタイムは？\n"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid "\"p3: {p3:?}\""
-msgstr ""
+msgstr "\"p3: {p3:?}\""
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
-"In this example, the the compiler does not know what lifetime to infer for "
-"`p3`. Looking inside the function body shows that it can only safely assume "
-"that `p3`'s lifetime is the shorter of `p1` and `p2`. But just like types, "
-"Rust requires explicit annotations of lifetimes on function arguments and "
-"return values."
+"In this example, the compiler does not know what lifetime to infer for `p3`. "
+"Looking inside the function body shows that it can only safely assume that "
+"`p3`'s lifetime is the shorter of `p1` and `p2`. But just like types, Rust "
+"requires explicit annotations of lifetimes on function arguments and return "
+"values."
 msgstr ""
+"この例では、コンパイラは `p3` のライフライムを推測するこが出来ませんん。関数"
+"本体の内部を見ると、`p3` のライフタイムは `p1` と `p2` のいずれか短いしかし想"
+"定できることがわかります。ただし、型と同様に、Rust では関数の引数や戻り値にラ"
+"イフタイムの明示的なアノテーションが必要です。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid "Add `'a` appropriately to `left_most`:"
-msgstr ""
+msgstr "`left_most` に `'a` を適切に追加します。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
 "This says, \"given p1 and p2 which both outlive `'a`, the return value lives "
 "for at least `'a`."
 msgstr ""
+"これは、「p1 と p2 の両方が `'a` より長く存続すると、戻り値は少なくとも `'a` "
+"の間存続する」という意味になります。"
 
 #: src/slices-and-lifetimes/lifetime-annotations.md
 msgid ""
 "In common cases, lifetimes can be elided, as described on the next slide."
 msgstr ""
+"一般的なケースでは、次のスライドで説明するようにライフタイムを省略できます。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "Lifetimes in Function Calls"
@@ -9190,36 +9536,51 @@ msgid ""
 "rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html). This is not "
 "inference -- it is just a syntactic shorthand."
 msgstr ""
+"関数の引数や戻り値のライフタイムは完全に指定する必要がありますが、Rust ではほ"
+"とんどの場合、[いくつかの簡単なルール](https://doc.rust-lang.org/nomicon/"
+"lifetime-elision.html)により、ライフタイムを省略できます。これは推論ではな"
+"く、構文の省略形にすぎません。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "Each argument which does not have a lifetime annotation is given one."
 msgstr ""
+"ライフタイム アノテーションが付いていない各引数には、1 つのライフタイムが与え"
+"られます。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
 "If there is only one argument lifetime, it is given to all un-annotated "
 "return values."
 msgstr ""
+"引数のライフタイムが 1 つしかない場合、アノテーションのない戻り値すべてにその"
+"ライフタイムが与えられます。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
 "If there are multiple argument lifetimes, but the first one is for `self`, "
 "that lifetime is given to all un-annotated return values."
 msgstr ""
+"引数のライフタイムが複数あり、最初のライフタイムが `self` である場合、アノ"
+"テーションのない戻り値すべてにそのライフタイムが与えられます。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "In this example, `cab_distance` is trivially elided."
 msgstr ""
+"この例では、`cab_distance` に関するライフタイムの記述は省略されています。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
 "The `nearest` function provides another example of a function with multiple "
 "references in its arguments that requires explicit annotation."
 msgstr ""
+"`nearest` 関数は、明示的なアノテーションを必要とする複数の参照を引数に含む関"
+"数のもう一つの例です。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid "Try adjusting the signature to \"lie\" about the lifetimes returned:"
 msgstr ""
+"返されるライフタイムについて嘘のアノテーションを付けるようにシグネチャを調整"
+"してみましょう。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
@@ -9227,6 +9588,10 @@ msgid ""
 "validity by the compiler. Note that this is not the case for raw pointers "
 "(unsafe), and this is a common source of errors with unsafe Rust."
 msgstr ""
+"そうするとコンパイルが通らなくなります。これは、すなわち、コンパイラがアノ"
+"テーションの妥当性をチェックしているということを示すものです。ただし、これは"
+"生のポインタ（安全ではない）には当てはまりません。アンセーフRustを使用する場"
+"合に、これはよくあるエラーの原因となっています。"
 
 #: src/slices-and-lifetimes/lifetime-elision.md
 msgid ""
@@ -9236,6 +9601,12 @@ msgid ""
 "help resolve ambiguity. Often, especially when prototyping, it's easier to "
 "just work with owned data by cloning values where necessary."
 msgstr ""
+"ライフタイムをどのような場合に使うべきか、受講者から質問を受けるかもしれませ"
+"ん。Rust の借用では常にライフタイムを使用します。ほとんどの場合、省略や型推"
+"論 により、ライフタイムを記述する必要はありません。より複雑なケースでは、ライ"
+"フタイム アノテーションを使用することであいまいさを解決できます。多くの場合、"
+"特にプロトタイピングでは、必要に応じて値をクローニングして所有データを処理す"
+"る方が簡単です。"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "Lifetimes in Data Structures"
@@ -9245,26 +9616,28 @@ msgstr "データ構造とライフタイム"
 msgid ""
 "If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
+"データ型が借用データを内部に保持する場合、ライフタイムアノテーションを付ける"
+"必要があります。"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"Bye {text}!\""
-msgstr ""
+msgstr "\"Bye {text}!\""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"The quick brown fox jumps over the lazy dog.\""
-msgstr ""
+msgstr "\"The quick brown fox jumps over the lazy dog.\""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "// erase(text);\n"
-msgstr ""
+msgstr "// 消去（テキスト）;\n"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"{fox:?}\""
-msgstr ""
+msgstr "\"{fox:?}\""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "\"{dog:?}\""
-msgstr ""
+msgstr "\"{dog:?}\""
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid ""
@@ -9272,12 +9645,17 @@ msgid ""
 "underlying the contained `&str` lives at least as long as any instance of "
 "`Highlight` that uses that data."
 msgstr ""
+"上記の例では、`Highlight` のアノテーションにより、内包される`&str` の参照先の"
+"データは、少なくともそのデータを使用する `Highlight` のインスタンスが存在する"
+"限り存続しなければならなくなります。"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid ""
 "If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
 "the borrow checker throws an error."
 msgstr ""
+"`fox`（または `dog`）のライフタイムが終了する前に `text` が使用されると、借用"
+"チェッカーはエラーをスローします。"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid ""
@@ -9285,10 +9663,13 @@ msgid ""
 "can be useful for creating lightweight views, but it generally makes them "
 "somewhat harder to use."
 msgstr ""
+"消費したデータが含まれる型では、ユーザーは元のデータを保持せざるを得なくなり"
+"ます。これは軽量のビューを作成する場合に便利ですが、一般的には使いにくくなり"
+"ます。"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid "When possible, make data structures own their data directly."
-msgstr ""
+msgstr "可能であれば、データ構造がデータを直接所有できるようにします。"
 
 #: src/slices-and-lifetimes/struct-lifetimes.md
 msgid ""
@@ -9297,6 +9678,10 @@ msgid ""
 "relationships between the references themselves, in addition to the lifetime "
 "of the struct itself. Those are very advanced use cases."
 msgstr ""
+"内部に複数の参照がある構造体には、複数のライフタイム アノテーションが含まれる"
+"場合があります。これが必要になるのは、構造体自体のライフタイムだけでなく、参"
+"照同士のライフタイムの関係を記述する必要がある場合です。これは非常に高度な"
+"ユースケースです。"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
@@ -9305,6 +9690,10 @@ msgid ""
 "simpler than it seems! This illustrates a common parsing pattern, passing "
 "slices of data. The underlying data itself is never copied."
 msgstr ""
+"この演習では、[protobuf バイナリ エンコード](https://protobuf.dev/"
+"programming-guides/encoding/)用のパーサーを作成します。見かけよりも簡単ですの"
+"で、心配はいりません。これは、データのスライスを渡す一般的な解析パターンを示"
+"しています。基になるデータ自体がコピーされることはありません。"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
@@ -9313,10 +9702,14 @@ msgid ""
 "file. In this exercise, we'll encode that information into `match` "
 "statements in functions that get called for each field."
 msgstr ""
+"protobuf メッセージを完全に解析するには、フィールド番号でインデックス付けされ"
+"たフィールドの型を知る必要があります。これは通常、`proto` ファイルで提供され"
+"ます。この演習では、フィールドごとに呼び出される関数の `match` ステートメント"
+"に、その情報をエンコードします。"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid "We'll use the following proto:"
-msgstr ""
+msgstr "次の proto を使用します。"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
@@ -9325,6 +9718,10 @@ msgid ""
 "number (e.g., `2` for the `id` field of a `Person` message) and a wire type "
 "defining how the payload should be determined from the byte stream."
 msgstr ""
+"proto メッセージは、連続するフィールドとしてエンコードされます。それぞれが後"
+"ろに値を伴う「タグ」として実装されます。タグにはフィールド番号（例: `Person` "
+"メッセージの `id` フィールドには `2`）と、バイト ストリームからペイロードがど"
+"のように決定されるかを定義するワイヤータイプが含まれます。"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
@@ -9333,44 +9730,51 @@ msgid ""
 "code also defines callbacks to handle `Person` and `PhoneNumber` fields, and "
 "to parse a message into a series of calls to those callbacks."
 msgstr ""
+"タグを含む整数は、VARINT と呼ばれる可変長エンコードで表されます。幸いにも、"
+"`parse_varint` は以下ですでに定義されています。また、このコードでは、"
+"`Person` フィールドと `PhoneNumber` フィールドを処理し、メッセージを解析して"
+"これらのコールバックに対する一連の呼び出しに変換するコールバックも定義してい"
+"ます。"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
 "What remains for you is to implement the `parse_field` function and the "
 "`ProtoMessage` trait for `Person` and `PhoneNumber`."
 msgstr ""
+"残る作業は、`parse_field` 関数と、`Person` および `PhoneNumber` の "
+"`ProtoMessage` トレイトを実装するだけです。"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid varint\""
-msgstr ""
+msgstr "\"Invalid varint\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid wire-type\""
-msgstr ""
+msgstr "\"Invalid wire-type\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Unexpected EOF\""
-msgstr ""
+msgstr "\"Unexpected EOF\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid length\""
-msgstr ""
+msgstr "\"Invalid length\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Unexpected wire-type)\""
-msgstr ""
+msgstr "\"Unexpected wire-type)\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "\"Invalid string (not UTF-8)\""
-msgstr ""
+msgstr "\"Invalid string (not UTF-8)\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// A wire type as seen on the wire.\n"
-msgstr ""
+msgstr "/// ワイヤー上で見えるワイヤータイプ。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// The Varint WireType indicates the value is a single VARINT.\n"
-msgstr ""
+msgstr "/// Varint WireType は、値が単一の VARINT であることを示します。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
@@ -9379,61 +9783,72 @@ msgid ""
 "a\n"
 "    /// VARINT followed by exactly that number of bytes.\n"
 msgstr ""
+"//I64、  -- この演習では不要\n"
+"    /// Len WireType は、値が VARINT で表され、その後にちょうどそのバイト数"
+"が\n"
+"    /// 続くものであることを示します。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
 "/// The I32 WireType indicates that the value is precisely 4 bytes in\n"
 "    /// little-endian order containing a 32-bit signed integer.\n"
 msgstr ""
+"/// I32 WireType は、値が 32 ビット符号付き整数を含むリトル エンディアン"
+"で、\n"
+"    /// 正確に 4 バイトであることを示します。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// A field's value, typed based on the wire type.\n"
-msgstr ""
+msgstr "/// ワイヤータイプに基づいて型指定されたフィールドの値。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "//I64(i64),  -- not needed for this exercise\n"
-msgstr ""
+msgstr "//I64（i64）、  -- この演習では不要\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// A field, containing the field number and its value.\n"
-msgstr ""
+msgstr "/// フィールド番号とその値を含むフィールド。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "//1 => WireType::I64,  -- not needed for this exercise\n"
-msgstr ""
+msgstr "//1 => WireType::I64、  -- この演習では不要\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
 "/// Parse a VARINT, returning the parsed value and the remaining bytes.\n"
-msgstr ""
+msgstr "/// VARINT を解析し、解析した値と残りのバイトを返します。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
 "// This is the last byte of the VARINT, so convert it to\n"
 "            // a u64 and return it.\n"
 msgstr ""
+"// これは VARINT の最後のバイトであるため、\n"
+"            // u64 に変換して返します。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "// More than 7 bytes is invalid.\n"
-msgstr ""
+msgstr "// 7 バイトを超える値は無効です。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// Convert a tag into a field number and a WireType.\n"
-msgstr ""
+msgstr "/// タグをフィールド番号と WireType に変換します。\n"
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid "/// Parse a field, returning the remaining bytes\n"
-msgstr ""
+msgstr "/// フィールドを解析して残りのバイトを返します。\n"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid ""
 "\"Based on the wire type, build a Field, consuming as many bytes as "
 "necessary.\""
 msgstr ""
+"\"ワイヤータイプに応じて、フィールドを構築し、必要な量のバイトを消費しま"
+"す。\""
 
 #: src/slices-and-lifetimes/exercise.md
 msgid "\"Return the field, and any un-consumed bytes.\""
-msgstr ""
+msgstr "\"フィールドと、未消費のバイトを返します。\""
 
 #: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
 msgid ""
@@ -9443,22 +9858,27 @@ msgid ""
 "///\n"
 "/// The entire input is consumed.\n"
 msgstr ""
+"/// 指定されたデータ内のメッセージを解析し、メッセージのフィールドごとに\n"
+"/// `T::add_field` を呼び出します。\n"
+"///\n"
+"/// 入力全体が消費されます。\n"
 
 #: src/slices-and-lifetimes/exercise.md
 msgid "// TODO: Implement ProtoMessage for Person and PhoneNumber.\n"
-msgstr ""
+msgstr "// TODO: Person と PhoneNumber の ProtoMessage を実装します。\n"
 
 #: src/slices-and-lifetimes/solution.md
 msgid "// Unwrap error because `value` is definitely 4 bytes long.\n"
 msgstr ""
+"// `value` の長さは明らかに 4 バイトであるため、エラーをアンラップします。\n"
 
 #: src/slices-and-lifetimes/solution.md
 msgid "// skip everything else\n"
-msgstr ""
+msgstr "// それ以外をすべてスキップ\n"
 
 #: src/slices-and-lifetimes/solution.md
 msgid "b\"hello\""
-msgstr ""
+msgstr "b\"hello\""
 
 #: src/welcome-day-4.md
 #, fuzzy

--- a/po/ja.po
+++ b/po/ja.po
@@ -3246,7 +3246,7 @@ msgstr "// ベースケース。\n"
 
 #: src/types-and-values/exercise.md src/control-flow-basics/exercise.md
 msgid "\"Implement this\""
-msgstr "ここを実装してください"
+msgstr "\"ここを実装してください\""
 
 #: src/types-and-values/exercise.md
 msgid "// The recursive case.\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -5175,74 +5175,79 @@ msgstr "/// かご内の階数ボタン。\n"
 
 #: src/welcome-day-2.md
 msgid "Welcome to Day 2"
-msgstr ""
+msgstr "2日目の講座へようこそ"
 
 #: src/welcome-day-2.md
 msgid ""
 "Now that we have seen a fair amount of Rust, today will focus on Rust's type "
 "system:"
 msgstr ""
+"Rust についてかなり多くのことを学んできましたが、今日は Rust の型システムに焦"
+"点を当てます。"
 
 #: src/welcome-day-2.md
 msgid "Pattern matching: extracting data from structures."
-msgstr ""
+msgstr "パターン マッチング: 構造からのデータの抽出。"
 
 #: src/welcome-day-2.md
 msgid "Methods: associating functions with types."
-msgstr ""
+msgstr "メソッド: 関数と型の関連付け。"
 
 #: src/welcome-day-2.md
 msgid "Traits: behaviors shared by multiple types."
-msgstr ""
+msgstr "トレイト: 複数の型で共有される挙動。"
 
 #: src/welcome-day-2.md
 msgid "Generics: parameterizing types on other types."
-msgstr ""
+msgstr "ジェネリクス: 他の型での型のパラメータ化。"
 
 #: src/welcome-day-2.md
 msgid ""
 "Standard library types and traits: a tour of Rust's rich standard library."
-msgstr ""
+msgstr "標準ライブラリの型とトレイト: Rust の豊富な標準ライブラリの紹介。"
 
 #: src/welcome-day-2.md
 msgid "[Welcome](./welcome-day-2.md) (3 minutes)"
-msgstr ""
+msgstr "[ようこそ](./welcome-day-2.md)（3 分）"
 
 #: src/welcome-day-2.md
 msgid "[Pattern Matching](./pattern-matching.md) (50 minutes)"
-msgstr ""
+msgstr "[パターン マッチング](./pattern-matching.md)（50 分）"
 
 #: src/welcome-day-2.md
+#, fuzzy
 msgid "[Methods and Traits](./methods-and-traits.md) (55 minutes)"
-msgstr ""
+msgstr "[メソッドとトレイト](./methods-and-train.md)（45 分）"
 
 #: src/welcome-day-2.md
 msgid "[Generics](./generics.md) (45 minutes)"
-msgstr ""
+msgstr "[ジェネリクス](./generics.md)（45 分）"
 
 #: src/welcome-day-2.md src/welcome-day-4.md
 msgid ""
 "Including 10 minute breaks, this session should take about 3 hours and 5 "
 "minutes"
-msgstr ""
+msgstr "このセッションの所要時間は、10 分間の休憩を入れて約 3 時間 5 分です。"
 
 #: src/pattern-matching.md
 msgid "[Destructuring](./pattern-matching/destructuring.md) (10 minutes)"
-msgstr ""
+msgstr "[デストラクト](./pattern-matching/destructuring.md)（10 分）"
 
 #: src/pattern-matching.md
 msgid "[Let Control Flow](./pattern-matching/let-control-flow.md) (10 minutes)"
 msgstr ""
+"[let による制御フロー](./pattern-matching/let-control-flow.md)（10 分）"
 
 #: src/pattern-matching.md
 msgid ""
 "[Exercise: Expression Evaluation](./pattern-matching/exercise.md) (30 "
 "minutes)"
-msgstr ""
+msgstr "[演習: 式の評価](./pattern-matching/exercise.md)（30 分）"
 
 #: src/pattern-matching/destructuring.md
 msgid "Like tuples, structs and enums can also be destructured by matching:"
 msgstr ""
+"タプルと同様に、構造体と列挙型もパターンマッチによりデストラクトできます。"
 
 #: src/pattern-matching/destructuring.md
 msgid "Structs"
@@ -5250,15 +5255,15 @@ msgstr "構造体（structs）"
 
 #: src/pattern-matching/destructuring.md
 msgid "\"x.0 = 1, b = {b}, y = {y}\""
-msgstr ""
+msgstr "\"x.0 = 1, b = {b}, y = {y}\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"y = 2, x = {i:?}\""
-msgstr ""
+msgstr "\"y = 2, x = {i:?}\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"y = {y}, other fields were ignored\""
-msgstr ""
+msgstr "\"y = {y}, other fields were ignored\""
 
 #: src/pattern-matching/destructuring.md
 msgid ""
@@ -5266,18 +5271,20 @@ msgid ""
 "how you inspect the structure of your types. Let us start with a simple "
 "`enum` type:"
 msgstr ""
+"パターンは、変数を値の一部にバインドするためにも使用できます。以下のようにし"
+"て、型の構造を調べることができます。単純な `enum` から始めましょう。"
 
 #: src/pattern-matching/destructuring.md
 msgid "\"cannot divide {n} into two equal parts\""
-msgstr ""
+msgstr "\"cannot divide {n} into two equal parts\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"{n} divided in two is {half}\""
-msgstr ""
+msgstr "\"{n} divided in two is {half}\""
 
 #: src/pattern-matching/destructuring.md
 msgid "\"sorry, an error happened: {msg}\""
-msgstr ""
+msgstr "\"sorry, an error happened: {msg}\""
 
 #: src/pattern-matching/destructuring.md
 msgid ""
@@ -5285,14 +5292,18 @@ msgid ""
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
 "arm, `msg` is bound to the error message."
 msgstr ""
+"ここでは、アーム（arm, パターンを並べたもの）を使用して `Result` 値の分解を"
+"行っています。最初のアームでは、`half` は `Ok` バリアント内の値にバインドされ"
+"ます。2 つ目のアームでは `msg` がエラー メッセージにバインドされます。"
 
 #: src/pattern-matching/destructuring.md
 msgid "Change the literal values in `foo` to match with the other patterns."
-msgstr ""
+msgstr "`foo` のリテラル値を他のパターンと一致するように変更します。"
 
 #: src/pattern-matching/destructuring.md
 msgid "Add a new field to `Foo` and make changes to the pattern as needed."
 msgstr ""
+"`Foo` に新しいフィールドを追加し、必要に応じてパターンに変更を加えます。"
 
 #: src/pattern-matching/destructuring.md
 msgid ""
@@ -5300,12 +5311,16 @@ msgid ""
 "spot. Try changing the `2` in the second arm to a variable, and see that it "
 "subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
+"キャプチャと定数式を区別しづらい場合があります。2 つ目のアームの `2` を変数に"
+"変更してみて、うまく機能しないことを確認します。これを `const` に変更して、再"
+"び動作することを確認します。"
 
 #: src/pattern-matching/destructuring.md
 msgid ""
 "The `if`/`else` expression is returning an enum that is later unpacked with "
 "a `match`."
 msgstr ""
+"`if`/`else` 式は、後で `match` でアンパックされる列挙型を返しています。"
 
 #: src/pattern-matching/destructuring.md
 msgid ""
@@ -5313,18 +5328,24 @@ msgid ""
 "errors when running the code. Point out the places where your code is now "
 "inexhaustive and how the compiler tries to give you hints."
 msgstr ""
+"列挙型の定義に 3 つ目のバリアント（列挙型の要素のこと）を追加し、コード実行時"
+"にエラーを表示してみましょう。コードが網羅されていない箇所を示し、コンパイラ"
+"がどのようにヒントを提供しようとしているかを説明します。"
 
 #: src/pattern-matching/destructuring.md
 msgid ""
 "The values in the enum variants can only be accessed after being pattern "
 "matched."
 msgstr ""
+"列挙型バリアントの値には、パターンが一致した場合にのみアクセスできます。"
 
 #: src/pattern-matching/destructuring.md
 msgid ""
 "Demonstrate what happens when the search is inexhaustive. Note the advantage "
 "the Rust compiler provides by confirming when all cases are handled."
 msgstr ""
+"検索が網羅的でない場合にどうなるかを示します。すべてのケースが処理されるタイ"
+"ミングを確認することで、Rust コンパイラの利点を強調します。"
 
 #: src/pattern-matching/destructuring.md
 msgid ""
@@ -5335,25 +5356,32 @@ msgid ""
 "io/rfcs/2005-match-ergonomics.html) appeared in Rust 2018. If you want to "
 "support older Rust, replace `msg` with `ref msg` in the pattern."
 msgstr ""
+"`divide_in_two` の結果を `result` 変数に保存し、ループで `match` します。一致"
+"した場合は `msg` が使用されるため、コンパイルされません。これを修正するには、"
+"`result` ではなく `&result` でマッチします。これにより、`msg` は参照になるた"
+"め、使用されなくなります。この [「マッチエルゴノミクス」](https://rust-lang."
+"github.io/rfcs/2005-match-ergonomics.html) は、Rust 2018 で登場しました。古い"
+"Rustをサポートする場合は、パターン内の`msg`を`ref msg` に置き換えてください。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
 "Rust has a few control flow constructs which differ from other languages. "
 "They are used for pattern matching:"
 msgstr ""
+"Rust には、他の言語とは異なる制御フロー構造がいくつかあります。これらはパター"
+"ン マッチングに使用されます。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "`if let` expressions"
-msgstr ""
+msgstr "`if let` 式"
 
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "`while let` expressions"
-msgstr "while let式"
+msgstr "`while let` 式"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "`match` expressions"
-msgstr ""
+msgstr "`match` 式"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5361,15 +5389,17 @@ msgid ""
 "expr.html#if-let-expressions) lets you execute different code depending on "
 "whether a value matches a pattern:"
 msgstr ""
+"[`if let` 式](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-let-expressions) を使用すると、値がパターンに一致するかどうかに応じて"
+"異なるコードを実行できます。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"slept for {:?}\""
-msgstr ""
+msgstr "\"slept for {:?}\""
 
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "`let else` expressions"
-msgstr "while let式"
+msgstr "`let else` 式"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5378,28 +5408,32 @@ msgid ""
 "let_else.html). The \"else\" case must diverge (`return`, `break`, or panic "
 "- anything but falling off the end of the block)."
 msgstr ""
+"パターンをマッチして関数から戻るという一般的なケースでは、[`let else`]"
+"(https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) を使用"
+"します。「else」ケースは発散する必要があります（`return`、`break`、パニックな"
+"ど、ブロックから抜けるもの以外のすべて）。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"got None\""
-msgstr ""
+msgstr "\"got None\""
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"got empty string\""
-msgstr ""
+msgstr "\"got empty string\""
 
 #: src/pattern-matching/let-control-flow.md
 msgid "\"not a hex digit\""
-msgstr ""
+msgstr "\"not a hex digit\""
 
 #: src/pattern-matching/let-control-flow.md src/pattern-matching/solution.md
 msgid "\"result: {:?}\""
-msgstr ""
+msgstr "\"result: {:?}\""
 
 #: src/pattern-matching/let-control-flow.md src/generics/trait-bounds.md
 #: src/smart-pointers/solution.md src/testing/googletest.md
 #: src/testing/solution.md
 msgid "\"foo\""
-msgstr ""
+msgstr "\"foo\""
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5407,6 +5441,9 @@ msgid ""
 "reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
 "repeatedly tests a value against a pattern:"
 msgstr ""
+"`if let` に似た [`while let`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#predicate-pattern-loops) 派生物もあります。これ"
+"は、パターンに照らして値をテストします。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5415,29 +5452,38 @@ msgid ""
 "which it will return `None`. The `while let` lets us keep iterating through "
 "all items."
 msgstr ""
+"ここで [`String::pop`](https://doc.rust-lang.org/stable/std/string/struct."
+"String.html#method.pop) は、文字列が空になるまで `Some(c)` を返し、その後 "
+"`None` を返します。`while let` を使用すると、すべてのアイテムに対して反復処理"
+"を続行できます。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "if-let"
-msgstr ""
+msgstr "if-let"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
 "Unlike `match`, `if let` does not have to cover all branches. This can make "
 "it more concise than `match`."
 msgstr ""
+"`match` とは異なり、`if let` ではすべての分岐を網羅する必要はないため、"
+"`match` よりも簡潔になります。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "A common usage is handling `Some` values when working with `Option`."
 msgstr ""
+"一般的な使用方法は、`Option` を操作するときに `Some` 値を処理することです。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
 "Unlike `match`, `if let` does not support guard clauses for pattern matching."
 msgstr ""
+"`match` とは異なり、`if let` はパターン マッチングでガード節をサポートしてい"
+"ません。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "let-else"
-msgstr ""
+msgstr "let-else"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5445,20 +5491,25 @@ msgid ""
 "flattening this nested code. Rewrite the awkward version for students, so "
 "they can see the transformation."
 msgstr ""
+"次に示すように、`if let` は積み重なってしまうことがあります。`let-else` の構"
+"成は、このネストされたコードを平坦にする助けとなります。読みづらいバージョン"
+"を受講者向けに書き直して、受講者が変化を確認できるようにします。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "The rewritten version is:"
-msgstr ""
+msgstr "書き換えたバージョンは次のとおりです。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "while-let"
-msgstr ""
+msgstr "while-let"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
 "Point out that the `while let` loop will keep going as long as the value "
 "matches the pattern."
 msgstr ""
+"値がパターンに一致する限り、`while let` ループが繰り返されることを説明しま"
+"す。"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5466,10 +5517,13 @@ msgid ""
 "statement that breaks when there is no value to unwrap for `name.pop()`. The "
 "`while let` provides syntactic sugar for the above scenario."
 msgstr ""
+"`name.pop()` でunwrapする値がない場合に中断する if ステートメントを使用して、"
+"`while let` ループを無限ループに書き換えることができます。`while let` は、上"
+"記のシナリオの糖衣構文として使用できます。"
 
 #: src/pattern-matching/exercise.md
 msgid "Let's write a simple recursive evaluator for arithmetic expressions."
-msgstr ""
+msgstr "演算式用の簡単な再帰エバリュエータを作成してみましょう。"
 
 #: src/pattern-matching/exercise.md
 msgid ""
@@ -5478,6 +5532,10 @@ msgid ""
 "tests. To evaluate a boxed expression, use the deref operator (`*`) to "
 "\"unbox\" it: `eval(*boxed_expr)`."
 msgstr ""
+"ここでの `Box` 型はスマート ポインタです。詳細はこの講座で後ほど説明します。"
+"テストで見られるように、式は `Box::new` で「ボックス化」できます。ボックス化"
+"された式を評価するには、逆参照演算子（`*`）を使用して「ボックス化解除」します"
+"（`eval(*boxed_expr)`）。"
 
 #: src/pattern-matching/exercise.md
 msgid ""
@@ -5487,6 +5545,10 @@ msgid ""
 "(`Ok(Value)`) or an error (`Err(String)`). We will cover this type in detail "
 "later."
 msgstr ""
+"一部の式は評価できず、エラーが返されます。標準の [`Result<Value, String>`]"
+"(https://doc.rust-lang.org/std/result/enum.Result.html) 型は、成功した値"
+"（`Ok(Value)`）またはエラー（`Err(String)`）のいずれかを表す列挙型です。この"
+"型については、後ほど詳しく説明します。"
 
 #: src/pattern-matching/exercise.md
 msgid ""
@@ -5495,121 +5557,136 @@ msgid ""
 "`todo!()` and get the tests to pass one-by-one. You can also skip a test "
 "temporarily with `#[ignore]`:"
 msgstr ""
+"コードをコピーして Rust プレイグラウンドに貼り付け、`eval` の実装を開始しま"
+"す。完成したエバリュエータはテストに合格する必要があります。`todo!()` を使用"
+"して、テストを 1 つずつ実施することをおすすめします。`#[ignore]` を使用して、"
+"テストを一時的にスキップすることもできます。"
 
 #: src/pattern-matching/exercise.md
 msgid ""
 "If you finish early, try writing a test that results in division by zero or "
 "integer overflow. How could you handle this with `Result` instead of a panic?"
 msgstr ""
+"早めに終了した場合は、ゼロ除算や整数オーバーフローが発生するテストを記述して"
+"みてください。`Result` を使用して、パニックを発生させずにこれを処理するにはど"
+"うすればよいでしょうか。"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An operation to perform on two subexpressions.\n"
-msgstr ""
+msgstr "/// 2 つのサブ式に対して実行する演算。\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An expression, in tree form.\n"
-msgstr ""
+msgstr "/// ツリー形式の式。\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// An operation on two subexpressions.\n"
-msgstr ""
+msgstr "/// 2 つのサブ式に対する演算。\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "/// A literal value\n"
-msgstr ""
+msgstr "/// リテラル値\n"
 
 #: src/pattern-matching/exercise.md src/pattern-matching/solution.md
 msgid "\"division by zero\""
-msgstr ""
+msgstr "\"division by zero\""
 
 #: src/pattern-matching/solution.md
 msgid "\"expr: {:?}\""
-msgstr ""
+msgstr "\"expr: {:?}\""
 
 #: src/methods-and-traits.md
 msgid "[Methods](./methods-and-traits/methods.md) (10 minutes)"
-msgstr ""
+msgstr "[メソッド](./methods-and-train/methods.md)（10 分）"
 
 #: src/methods-and-traits.md
 msgid "[Traits](./methods-and-traits/traits.md) (10 minutes)"
-msgstr ""
+msgstr "[トレイト](./methods-and-features/train.md)（10 分）"
 
 #: src/methods-and-traits.md
 msgid "[Deriving](./methods-and-traits/deriving.md) (5 minutes)"
-msgstr ""
+msgstr "[導出](./methods-and-train/deriving.md)（5 分）"
 
 #: src/methods-and-traits.md
 msgid "[Trait Objects](./methods-and-traits/trait-objects.md) (10 minutes)"
-msgstr ""
+msgstr "[トレイトオブジェクト](./methods-and-features/train.md)（10 分）"
 
 #: src/methods-and-traits.md
 msgid ""
 "[Exercise: Generic Logger](./methods-and-traits/exercise.md) (20 minutes)"
-msgstr ""
+msgstr "[演習: ジェネリックなロガー](./methods-and-train/exercise.md)（20 分）"
 
 #: src/methods-and-traits.md
 msgid "This segment should take about 55 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 55 分です"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
 "an `impl` block:"
 msgstr ""
+"Rust を使用すると、関数を新しい型に関連付けることができます。これは `impl` ブ"
+"ロックで実行します。"
 
 #: src/methods-and-traits/methods.md
 msgid "// No receiver, a static method\n"
-msgstr ""
+msgstr "// レシーバなし、静的メソッド\n"
 
 #: src/methods-and-traits/methods.md
 msgid "// Exclusive borrowed read-write access to self\n"
-msgstr ""
+msgstr "// 自身に対する排他的な読み取り / 書き込み借用アクセス\n"
 
 #: src/methods-and-traits/methods.md
 msgid "// Shared and read-only borrowed access to self\n"
-msgstr ""
+msgstr "// 自身に対する共有および読み取り専用の借用アクセス\n"
 
 #: src/methods-and-traits/methods.md
 msgid "\"Recorded {} laps for {}:\""
-msgstr ""
+msgstr "\"Recorded {} laps for {}:\""
 
 #: src/methods-and-traits/methods.md
 msgid "\"Lap {idx}: {lap} sec\""
-msgstr ""
+msgstr "\"Lap {idx}: {lap} sec\""
 
 #: src/methods-and-traits/methods.md
 msgid "// Exclusive ownership of self\n"
-msgstr ""
+msgstr "// 自身の排他的所有権\n"
 
 #: src/methods-and-traits/methods.md
 msgid "\"Race {} is finished, total lap time: {}\""
-msgstr ""
+msgstr "\"Race {} is finished, total lap time: {}\""
 
 #: src/methods-and-traits/methods.md
 msgid "\"Monaco Grand Prix\""
-msgstr ""
+msgstr "\"Monaco Grand Prix\""
 
 #: src/methods-and-traits/methods.md
 msgid "// race.add_lap(42);\n"
-msgstr ""
+msgstr "// race.add_lap(42);\n"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "The `self` arguments specify the \"receiver\" - the object the method acts "
 "on. There are several common receivers for a method:"
 msgstr ""
+"`self` 引数は、「レシーバ」、つまりメソッドが操作するオブジェクトを指定しま"
+"す。メソッドの一般的なレシーバは次のとおりです。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "`&self`: borrows the object from the caller using a shared and immutable "
 "reference. The object can be used again afterwards."
 msgstr ""
+"`&self`: 共有の不変参照を使用して、呼び出し元からオブジェクトを借用します。こ"
+"のオブジェクトは後で再び使用できます。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "`&mut self`: borrows the object from the caller using a unique and mutable "
 "reference. The object can be used again afterwards."
 msgstr ""
+"`&mut self`: 一意の可変参照を使用して、呼び出し元からオブジェクトを借用しま"
+"す。このオブジェクトは後で再び使用できます。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
@@ -5618,26 +5695,34 @@ msgid ""
 "(deallocated) when the method returns, unless its ownership is explicitly "
 "transmitted. Complete ownership does not automatically mean mutability."
 msgstr ""
+"`self`: オブジェクトの所有権を取得し、呼び出し元から遠ざけます。メソッドがオ"
+"ブジェクトの所有者になります。所有権が明示的に送信されない限り、メソッドが戻"
+"ると、オブジェクトは破棄（デアロケート）されます。完全な所有権は、必ずしも可"
+"変性を意味するわけではありません。"
 
 #: src/methods-and-traits/methods.md
 msgid "`mut self`: same as above, but the method can mutate the object."
-msgstr ""
+msgstr "`mut self`: 上記と同じですが、メソッドはオブジェクトを変更できます。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "No receiver: this becomes a static method on the struct. Typically used to "
 "create constructors which are called `new` by convention."
 msgstr ""
+"レシーバなし: 構造体の静的メソッドになります。通常は、`new` と呼ばれるコンス"
+"トラクタを作成するために使用されます。"
 
 #: src/methods-and-traits/methods.md
 msgid "It can be helpful to introduce methods by comparing them to functions."
-msgstr ""
+msgstr "メソッドを関数と比較して紹介するとよいでしょう。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "Methods are called on an instance of a type (such as a struct or enum), the "
 "first parameter represents the instance as `self`."
 msgstr ""
+"メソッドは型（構造体や列挙型など）のインスタンスで呼び出されます。最初のパラ"
+"メータはインスタンスを `self` として表します。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
@@ -5645,34 +5730,46 @@ msgid ""
 "syntax and to help keep them more organized. By using methods we can keep "
 "all the implementation code in one predictable place."
 msgstr ""
+"デベロッパーは、メソッド レシーバ構文でコードを整理する目的で、メソッドを使用"
+"することもできます。メソッドを使用することで、すべての実装コードを 1 つの予測"
+"可能な場所にまとめることができます。"
 
 #: src/methods-and-traits/methods.md
 msgid "Point out the use of the keyword `self`, a method receiver."
 msgstr ""
+"メソッド レシーバである `self` というキーワードの使用について説明します。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "Show that it is an abbreviated term for `self: Self` and perhaps show how "
 "the struct name could also be used."
 msgstr ""
+"`self: Self` の略語であることを示し、構造体名の使用方法についても説明すること"
+"をおすすめします。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "Explain that `Self` is a type alias for the type the `impl` block is in and "
 "can be used elsewhere in the block."
 msgstr ""
+"`Self` は `impl` ブロックが存在する型の型エイリアスであり、ブロック内の他の場"
+"所で使用できることを説明します。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "Note how `self` is used like other structs and dot notation can be used to "
 "refer to individual fields."
 msgstr ""
+"`self` は他の構造体と同様に使用され、ドット表記を使用して個々のフィールドを参"
+"照できることを説明します。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
 "This might be a good time to demonstrate how the `&self` differs from `self` "
 "by trying to run `finish` twice."
 msgstr ""
+"ここで `finish` を 2 回実行して、`&self` と `self` の違いを示すことをおすすめ"
+"します。"
 
 #: src/methods-and-traits/methods.md
 msgid ""
@@ -5680,6 +5777,9 @@ msgid ""
 "doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
 "receiver types, such as `Box<Self>`."
 msgstr ""
+"`self` のバリアント以外にも、レシーバ型として許可されている [特別なラッパー"
+"型](https://doc.rust-lang.org/reference/special-types-and-traits.html)"
+"（`Box<Self>` など）もあります。"
 
 #: src/methods-and-traits/traits.md
 msgid ""
@@ -5690,29 +5790,31 @@ msgstr ""
 
 #: src/methods-and-traits/traits.md
 msgid "\"Oh you're a cutie! What's your name? {}\""
-msgstr ""
+msgstr "\"Oh you're a cutie! What's your name? {}\""
 
 #: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
 msgid "\"Woof, my name is {}!\""
-msgstr ""
+msgstr "\"Woof, my name is {}!\""
 
 #: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
 msgid "\"Miau!\""
-msgstr ""
+msgstr "\"Miau!\""
 
 #: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
 msgid "\"Fido\""
-msgstr ""
+msgstr "\"Fido\""
 
 #: src/methods-and-traits/traits.md
 msgid ""
 "A trait defines a number of methods that types must have in order to "
 "implement the trait."
 msgstr ""
+"トレイトは、そのトレイトを実装するために各型に必要な多数のメソッドを定義しま"
+"す。"
 
 #: src/methods-and-traits/traits.md
 msgid "Traits are implemented in an `impl <trait> for <type> { .. }` block."
-msgstr ""
+msgstr "トレイトは `impl <trait> for <type> { .. }` ブロックに実装されます。"
 
 #: src/methods-and-traits/traits.md
 #, fuzzy
@@ -5730,26 +5832,28 @@ msgid ""
 "Supported traits can be automatically implemented for your custom types, as "
 "follows:"
 msgstr ""
+"サポートされているトレイトは、次のようにカスタム型に自動的に実装できます。"
 
 #: src/methods-and-traits/deriving.md
 msgid "// Default trait adds `default` constructor.\n"
-msgstr ""
+msgstr "// デフォルト トレイトで `default` コンストラクタを追加します。\n"
 
 #: src/methods-and-traits/deriving.md
 msgid "// Clone trait adds `clone` method.\n"
-msgstr ""
+msgstr "// クローン トレイトで `clone` メソッドを追加します。\n"
 
 #: src/methods-and-traits/deriving.md
 msgid "\"EldurScrollz\""
-msgstr ""
+msgstr "\"EldurScrollz\""
 
 #: src/methods-and-traits/deriving.md
 msgid "// Debug trait adds support for printing with `{:?}`.\n"
 msgstr ""
+"// デバッグ トレイトで、`{:?}` を使用した出力のサポートを追加します。\n"
 
 #: src/methods-and-traits/deriving.md
 msgid "\"{:?} vs. {:?}\""
-msgstr ""
+msgstr "\"{:?} vs. {:?}\""
 
 #: src/methods-and-traits/deriving.md
 msgid ""
@@ -5757,6 +5861,9 @@ msgid ""
 "macros to add useful functionality. For example, `serde` can derive "
 "serialization support for a struct using `#[derive(Serialize)]`."
 msgstr ""
+"導出はマクロで実装され、多くのクレートには有用な機能を追加するための便利な導"
+"出マクロが用意されています。たとえば、`serde` は `#[derive(Serialize)]` を使"
+"用して、構造体のシリアル化のサポートを導出できます。"
 
 #: src/methods-and-traits/trait-objects.md
 msgid ""
@@ -5768,7 +5875,7 @@ msgstr ""
 
 #: src/methods-and-traits/trait-objects.md
 msgid "\"Hello, who are you? {}\""
-msgstr ""
+msgstr "\"Hello, who are you? {}\""
 
 #: src/methods-and-traits/trait-objects.md
 msgid "Memory layout after allocating `pets`:"
@@ -5834,6 +5941,63 @@ msgid ""
 "- -'\n"
 "```"
 msgstr ""
+"```bob\n"
+" スタック                             ヒープ\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                           :     :                                             :\n"
+":    pets                   :     :                     +----+----+----+----"
+"+   :\n"
+":   +-----------+-------+   :     :   +-----+-----+  .->| F  | i  | d  | o  "
+"|   :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o |  |  +----+----+----+----"
+"+   :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-+  "
+"`---------.                :\n"
+":   | capacity  |     2 |   :     :     | |   | |    data      "
+"|                :\n"
+":   +-----------+-------+   :     :     | |   | |   +-------+--|-------"
+"+        :\n"
+":                           :     :     | |   | '-->| name  |  o, 4, 4 "
+"|        :\n"
+":                           :     :     | |   |     | age   |        5 "
+"|        :\n"
+"`- - - - - - - - - - - - - -'     :     | |   |     +-------+----------"
+"+        :\n"
+"                                  :     | |   "
+"|                                 :\n"
+"                                  :     | |   |      "
+"vtable                     :\n"
+"                                  :     | |   |     +----------------------"
+"+    :\n"
+"                                  :     | |   '---->| \"<Dog as Pet>::talk\" "
+"|    :\n"
+"                                  :     | |         +----------------------"
+"+    :\n"
+"                                  :     | "
+"|                                     :\n"
+"                                  :     | |    "
+"data                             :\n"
+"                                  :     | |   +-------+-------"
+"+                 :\n"
+"                                  :     | '-->| lives |     9 "
+"|                 :\n"
+"                                  :     |     +-------+-------"
+"+                 :\n"
+"                                  :     "
+"|                                       :\n"
+"                                  :     |      "
+"vtable                           :\n"
+"                                  :     |     +----------------------"
+"+          :\n"
+"                                  :     '---->| \"<Cat as Pet>::talk\" "
+"|          :\n"
+"                                  :           +----------------------"
+"+          :\n"
+"                                  :                                             :\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
 
 #: src/methods-and-traits/trait-objects.md
 msgid ""
@@ -5889,7 +6053,7 @@ msgstr "上の例において、下のコードによる出力結果を比べて
 
 #: src/methods-and-traits/trait-objects.md src/std-traits/closures.md
 msgid "\"{} {}\""
-msgstr ""
+msgstr "\"{} {}\""
 
 #: src/methods-and-traits/trait-objects.md src/std-traits/exercise.md
 #: src/std-traits/solution.md src/modules/exercise.md src/modules/solution.md
@@ -5897,7 +6061,7 @@ msgstr ""
 #: src/android/interoperability/cpp/rust-bridge.md
 #: src/async/pitfalls/cancellation.md
 msgid "\"{}\""
-msgstr ""
+msgstr "\"{}\""
 
 #: src/methods-and-traits/exercise.md
 msgid ""
@@ -5906,6 +6070,11 @@ msgid ""
 "In testing, this might put messages in the test logfile, while in a "
 "production build it would send messages to a log server."
 msgstr ""
+"トレイト `Logger` と `log` メソッドを使用して、シンプルなロギングユーティリ"
+"ティを設計してみましょう。進行状況をログに記録するコードは、その後に `&impl "
+"Logger` を受け取ることができます。この場合、テストではテストログファイルに"
+"メッセージが書き込まれますが、本番環境ビルドではログサーバーにメッセージが送"
+"信されます。"
 
 #: src/methods-and-traits/exercise.md
 msgid ""
@@ -5913,6 +6082,9 @@ msgid ""
 "verbosity. Your task is to write a `VerbosityFilter` type that will ignore "
 "messages above a maximum verbosity."
 msgstr ""
+"ただし、以下の `StderrLogger` は、詳細度(verbosity)に関係なく、すべてのメッ"
+"セージをログに記録します。ここでのタスクは、最大の詳細度を超えるメッセージを"
+"無視する `VerbosityFilter` 型を作成することです。"
 
 #: src/methods-and-traits/exercise.md
 msgid ""
@@ -5920,54 +6092,57 @@ msgid ""
 "implementing that same trait, adding behavior in the process. What other "
 "kinds of wrappers might be useful in a logging utility?"
 msgstr ""
+"これは一般的なパターンです。つまり、トレイト実装をラップして同じトレイトを実"
+"装し、その過程で挙動を追加していく構造体です。ロギングユーティリティでは他に"
+"どのような種類のラッパーが役立つでしょうか。"
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "/// Log a message at the given verbosity level.\n"
-msgstr ""
+msgstr "/// 指定された詳細度レベルでメッセージをログに記録します。\n"
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"verbosity={verbosity}: {message}\""
-msgstr ""
+msgstr "\"verbosity={verbosity}: {message}\""
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"FYI\""
-msgstr ""
+msgstr "\"FYI\""
 
 #: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
 msgid "\"Uhoh\""
-msgstr ""
+msgstr "\"Uhoh\""
 
 #: src/methods-and-traits/exercise.md
 msgid "// TODO: Define and implement `VerbosityFilter`.\n"
-msgstr ""
+msgstr "// TODO: `VerbosityFilter` を定義して実装します。\n"
 
 #: src/methods-and-traits/solution.md
 msgid "/// Only log messages up to the given verbosity level.\n"
-msgstr ""
+msgstr "/// 指定された詳細度レベルまでのメッセージのみをログに記録。\n"
 
 #: src/generics.md
 msgid "[Generic Functions](./generics/generic-functions.md) (5 minutes)"
-msgstr ""
+msgstr "[ジェネリック関数](./generics/generic-functions.md)（5 分）"
 
 #: src/generics.md
 msgid "[Generic Data Types](./generics/generic-data.md) (15 minutes)"
-msgstr ""
+msgstr "[ジェネリック データ型](./generics/generic-data.md)（15 分）"
 
 #: src/generics.md
 msgid "[Trait Bounds](./generics/trait-bounds.md) (10 minutes)"
-msgstr ""
+msgstr "[トレイト境界](./generics/trait-bounds.md)（10 分）"
 
 #: src/generics.md
 msgid "[impl Trait](./generics/impl-trait.md) (5 minutes)"
-msgstr ""
+msgstr "[impl トレイト](./generics/impl-trait.md)（5 分）"
 
 #: src/generics.md
 msgid "[Exercise: Generic min](./generics/exercise.md) (10 minutes)"
-msgstr ""
+msgstr "[演習: ジェネリックな min](./generics/exercise.md)（10 分）"
 
 #: src/generics.md src/smart-pointers.md src/iterators.md src/error-handling.md
 msgid "This segment should take about 45 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 45 分です"
 
 #: src/generics/generic-functions.md
 #, fuzzy
@@ -5981,29 +6156,29 @@ msgstr ""
 
 #: src/generics/generic-functions.md
 msgid "/// Pick `even` or `odd` depending on the value of `n`.\n"
-msgstr ""
+msgstr "/// `n` の値に応じて `even` または `odd` を選択します。\n"
 
 #: src/generics/generic-functions.md
 msgid "\"picked a number: {:?}\""
-msgstr ""
+msgstr "\"picked a number: {:?}\""
 
 #: src/generics/generic-functions.md
 msgid "\"picked a tuple: {:?}\""
-msgstr ""
+msgstr "\"picked a tuple: {:?}\""
 
 #: src/generics/generic-functions.md
 msgid "\"dog\""
-msgstr ""
+msgstr "\"dog\""
 
 #: src/generics/generic-functions.md
 msgid "\"cat\""
-msgstr ""
+msgstr "\"cat\""
 
 #: src/generics/generic-functions.md
 msgid ""
 "Rust infers a type for T based on the types of the arguments and return "
 "value."
-msgstr ""
+msgstr "Rust は引数と戻り値の型に基づいて T の型を推測します。"
 
 #: src/generics/generic-functions.md
 msgid ""
@@ -6013,6 +6188,11 @@ msgid ""
 "`n == 0`. Even if only the `pick` instantiation with integers is used, Rust "
 "still considers it invalid. C++ would let you do this."
 msgstr ""
+"これは C++ テンプレートに似ていますが、Rust はジェネリック関数を部分的にすぐ"
+"にコンパイルするため、その関数は制約に一致するすべての型に対して有効である必"
+"要があります。たとえば、`n == 0` の場合は `even + odd` を返すように `pick` を"
+"変更してみてください。整数を使用した `pick` インスタンス化のみが使用されてい"
+"る場合でも、Rust はそれを無効とみなします。C++ ではこれを行うことができます。"
 
 #: src/generics/generic-functions.md
 #, fuzzy
@@ -6031,15 +6211,15 @@ msgstr ""
 
 #: src/generics/generic-data.md
 msgid "// fn set_x(&mut self, x: T)\n"
-msgstr ""
+msgstr "// fn set_x(&mut self, x: T)\n"
 
 #: src/generics/generic-data.md
 msgid "\"{integer:?} and {float:?}\""
-msgstr ""
+msgstr "\"{integer:?} and {float:?}\""
 
 #: src/generics/generic-data.md
 msgid "\"coords: {:?}\""
-msgstr ""
+msgstr "\"coords: {:?}\""
 
 #: src/generics/generic-data.md
 msgid ""
@@ -6082,6 +6262,9 @@ msgid ""
 "code to allow points that have elements of different types, by using two "
 "type variables, e.g., `T` and `U`."
 msgstr ""
+"新しい変数 `let p = Point { x: 5, y: 10.0 };` を宣言してみてください。2 つの"
+"変数（`T` と `U` など）を使用して、異なる型の要素を持つポイントを許可するよう"
+"にコードを更新します。"
 
 #: src/generics/trait-bounds.md
 msgid ""
@@ -6101,19 +6284,19 @@ msgstr "そうしたことは`T: Trait` や `impl Trait`を用いて行えます
 
 #: src/generics/trait-bounds.md
 msgid "// struct NotClonable;\n"
-msgstr ""
+msgstr "// struct NotClonable;\n"
 
 #: src/generics/trait-bounds.md
 msgid "\"{pair:?}\""
-msgstr ""
+msgstr "\"{pair:?}\""
 
 #: src/generics/trait-bounds.md
 msgid "Try making a `NonClonable` and passing it to `duplicate`."
-msgstr ""
+msgstr "`NonClonable` を作成して`duplicate` に渡してみてください。"
 
 #: src/generics/trait-bounds.md
 msgid "When multiple traits are necessary, use `+` to join them."
-msgstr ""
+msgstr "複数のトレイトが必要な場合は、`+` を使って結合します。"
 
 #: src/generics/trait-bounds.md
 msgid "Show a `where` clause, students will encounter it when reading code."
@@ -6144,6 +6327,9 @@ msgid ""
 "Note that Rust does not (yet) support specialization. For example, given the "
 "original `duplicate`, it is invalid to add a specialized `duplicate(a: u32)`."
 msgstr ""
+"なお、Rust はまだ特化(specialization)をサポートしていません。たとえば、元の "
+"`duplicate` がある場合は、特化された `duplicate(a: u32)` を追加することはでき"
+"ません。"
 
 #: src/generics/impl-trait.md
 msgid ""
@@ -6158,18 +6344,20 @@ msgid ""
 "// Syntactic sugar for:\n"
 "//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
 msgstr ""
+"// 以下の糖衣構文:\n"
+"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
 
 #: src/generics/impl-trait.md
 msgid "\"{many}\""
-msgstr ""
+msgstr "\"{many}\""
 
 #: src/generics/impl-trait.md
 msgid "\"{many_more}\""
-msgstr ""
+msgstr "\"{many_more}\""
 
 #: src/generics/impl-trait.md
 msgid "\"debuggable: {debuggable:?}\""
-msgstr ""
+msgstr "\"debuggable: {debuggable:?}\""
 
 #: src/generics/impl-trait.md
 #, fuzzy
@@ -6217,78 +6405,84 @@ msgid ""
 "What is the type of `debuggable`? Try `let debuggable: () = ..` to see what "
 "the error message shows."
 msgstr ""
+"`debuggable` の型は何でしょうか。`let debuggable: () = ..` を試して、エラー "
+"メッセージの内容を確認してください。"
 
 #: src/generics/exercise.md
 msgid ""
 "In this short exercise, you will implement a generic `min` function that "
 "determines the minimum of two values, using a `LessThan` trait."
 msgstr ""
+"この短い演習では、`LessThan` トレイトを使用して、2 つの値の最小値を決定する"
+"ジェネリックな `min` 関数を実装します。"
 
 #: src/generics/exercise.md src/generics/solution.md
 msgid "/// Return true if self is less than other.\n"
-msgstr ""
+msgstr "/// 自身がその他より小さい場合は true を返します。\n"
 
 #: src/generics/exercise.md
 msgid "// TODO: implement the `min` function used in `main`.\n"
-msgstr ""
+msgstr "// TODO: `main` で使用する `min` 関数を実装します。\n"
 
 #: src/generics/exercise.md src/generics/solution.md
 msgid "\"Shapiro\""
-msgstr ""
+msgstr "\"Shapiro\""
 
 #: src/generics/exercise.md src/generics/solution.md
 msgid "\"Baumann\""
-msgstr ""
+msgstr "\"Baumann\""
 
 #: src/welcome-day-2-afternoon.md
 msgid "[Standard Library Types](./std-types.md) (1 hour and 10 minutes)"
-msgstr ""
+msgstr "[標準ライブラリ型](./std-types.md)（1 時間 10 分）"
 
 #: src/welcome-day-2-afternoon.md
 msgid "[Standard Library Traits](./std-traits.md) (1 hour and 40 minutes)"
-msgstr ""
+msgstr "[標準ライブラリ トレイト](./std-train.md)（1 時間 40 分）"
 
 #: src/std-types.md
 msgid "[Standard Library](./std-types/std.md) (3 minutes)"
-msgstr ""
+msgstr "[標準ライブラリ](./std-types/std.md)（3 分）"
 
 #: src/std-types.md
 msgid "[Documentation](./std-types/docs.md) (5 minutes)"
-msgstr ""
+msgstr "[ドキュメント](./std-types/docs.md)（5 分）"
 
 #: src/std-types.md
 msgid "[Option](./std-types/option.md) (10 minutes)"
-msgstr ""
+msgstr "[Option](./std-types/option.md)（10 分）"
 
 #: src/std-types.md
 msgid "[Result](./std-types/result.md) (10 minutes)"
-msgstr ""
+msgstr "[Result](./std-types/result.md)（10 分）"
 
 #: src/std-types.md
 msgid "[String](./std-types/string.md) (10 minutes)"
-msgstr ""
+msgstr "[String](./std-types/string.md)（10 分）"
 
 #: src/std-types.md
 msgid "[Vec](./std-types/vec.md) (10 minutes)"
-msgstr ""
+msgstr "[Vec](./std-types/vec.md)（10 分）"
 
 #: src/std-types.md
 msgid "[HashMap](./std-types/hashmap.md) (10 minutes)"
-msgstr ""
+msgstr "[HashMap](./std-types/hashmap.md)（10 分）"
 
 #: src/std-types.md
 msgid "[Exercise: Counter](./std-types/exercise.md) (10 minutes)"
-msgstr ""
+msgstr "[演習: カウンタ](./std-types/exercise.md)（10 分）"
 
 #: src/std-types.md src/memory-management.md src/slices-and-lifetimes.md
 msgid "This segment should take about 1 hour and 10 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 1 時間 10 分です"
 
 #: src/std-types.md
 msgid ""
 "For each of the slides in this section, spend some time reviewing the "
 "documentation pages, highlighting some of the more common methods."
 msgstr ""
+"このセクションの各スライドでは、時間をかけてドキュメント ページを確認し、より"
+"一般的なメソッドをいくつか取り上げてください。"
 
 #: src/std-types/std.md
 msgid ""
@@ -6296,33 +6490,45 @@ msgid ""
 "types used by Rust libraries and programs. This way, two libraries can work "
 "together smoothly because they both use the same `String` type."
 msgstr ""
+"Rust には、Rust のライブラリとプログラムで使用される一般的な型のセットを確立"
+"するのに役立つ標準ライブラリが付属しています。2 つのライブラリをスムーズに連"
+"携させることができるのは、このように両方とも同じ `String` 型を使用しているた"
+"めです。"
 
 #: src/std-types/std.md
 msgid ""
 "In fact, Rust contains several layers of the Standard Library: `core`, "
 "`alloc` and `std`."
 msgstr ""
+"実際、Rust には標準ライブラリ（`core`、`alloc`、`std`）の複数のレイヤが含まれ"
+"ています。"
 
 #: src/std-types/std.md
 msgid ""
 "`core` includes the most basic types and functions that don't depend on "
 "`libc`, allocator or even the presence of an operating system."
 msgstr ""
+"`core` には、`libc` やアロケータ、さらにはオペレーティング システムの存在にも"
+"依存しない、最も基本的な型と関数が含まれます。"
 
 #: src/std-types/std.md
 msgid ""
 "`alloc` includes types which require a global heap allocator, such as `Vec`, "
 "`Box` and `Arc`."
 msgstr ""
+"`alloc` には、`Vec`、`Box`、`Arc` など、グローバルヒープアロケータを必要とす"
+"る型が含まれます。"
 
 #: src/std-types/std.md
 msgid ""
 "Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
+"多くの場合、埋め込みの Rust アプリは `core` のみを使用し、場合によっては "
+"`alloc` を使用します。"
 
 #: src/std-types/docs.md
 msgid "Rust comes with extensive documentation. For example:"
-msgstr ""
+msgstr "Rust には詳細なドキュメントが用意されています。次に例を示します。"
 
 #: src/std-types/docs.md
 #, fuzzy
@@ -6338,6 +6544,8 @@ msgid ""
 "Primitive types like [`u8`](https://doc.rust-lang.org/stable/std/primitive."
 "u8.html)."
 msgstr ""
+"[`u8`](https://doc.rust-lang.org/stable/std/primitive.u8.html) のようなプリミ"
+"ティブ型。"
 
 #: src/std-types/docs.md
 msgid ""
@@ -6345,10 +6553,13 @@ msgid ""
 "option/enum.Option.html) or [`BinaryHeap`](https://doc.rust-lang.org/stable/"
 "std/collections/struct.BinaryHeap.html)."
 msgstr ""
+"[`Option`](https://doc.rust-lang.org/stable/std/option/enum.Option.html) や "
+"[`BinaryHeap`](https://doc.rust-lang.org/stable/std/collections/struct."
+"BinaryHeap.html) などの標準ライブラリ型。"
 
 #: src/std-types/docs.md
 msgid "In fact, you can document your own code:"
-msgstr ""
+msgstr "実際、独自のコードにドキュメントをつけることができます。"
 
 #: src/std-types/docs.md
 msgid ""
@@ -6357,6 +6568,9 @@ msgid ""
 "///\n"
 "/// If the second argument is zero, the result is false.\n"
 msgstr ""
+"/// 最初の引数が 2 番目の引数で割り切れるかどうかを判定します。\n"
+"///\n"
+"/// 2 番目の引数がゼロの場合、結果は false になります。\n"
 
 #: src/std-types/docs.md
 msgid ""
@@ -6365,29 +6579,37 @@ msgid ""
 "(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
+"コンテンツはマークダウンとして扱われます。公開されたすべての Rust ライブラリ "
+"クレートは、[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc."
+"html) ツールを使用して、[`docs.rs`](https://docs.rs) で自動的にドキュメントが"
+"まとめられます。このパターンを使用して、すべての公開アイテムを API でドキュメ"
+"ント化するのが慣用的です。"
 
 #: src/std-types/docs.md
 msgid ""
 "To document an item from inside the item (such as inside a module), use `//!"
 "` or `/*! .. */`, called \"inner doc comments\":"
 msgstr ""
+"アイテム内（モジュール内など）からアイテムをドキュメント化するには、「内部ド"
+"キュメントのコメント」と呼ばれる `//!` または `/*! .. */` を使用します。"
 
 #: src/std-types/docs.md
 msgid ""
 "//! This module contains functionality relating to divisibility of "
 "integers.\n"
-msgstr ""
+msgstr "//! このモジュールには、整数の整除に関連する機能が含まれています。\n"
 
 #: src/std-types/docs.md
 msgid ""
 "Show students the generated docs for the `rand` crate at <https://docs.rs/"
 "rand>."
 msgstr ""
+"<https://docs.rs/rand> で `rand` クレート用に生成されたドキュメントを受講者に"
+"示します。"
 
 #: src/std-types/option.md
-#, fuzzy
 msgid "Option"
-msgstr "例外"
+msgstr "Option"
 
 #: src/std-types/option.md
 msgid ""
@@ -6395,26 +6617,30 @@ msgid ""
 "type `T` or nothing. For example, [`String::find`](https://doc.rust-lang.org/"
 "stable/std/string/struct.String.html#method.find) returns an `Option<usize>`."
 msgstr ""
+"`Option<T>` の使用方法についてはすでにいくつか見てきましたが、これは型 `T` の"
+"値を格納するか、何も格納しません。たとえば、[`String::find`](https://doc."
+"rust-lang.org/stable/std/string/struct.String.html#method.find) は "
+"`Option<usize>` を返します。"
 
 #: src/std-types/option.md
 msgid "\"Löwe 老虎 Léopard Gepardi\""
-msgstr ""
+msgstr "\"Löwe 老虎 Léopard Gepardi\""
 
 #: src/std-types/option.md
 msgid "'é'"
-msgstr ""
+msgstr "'é'"
 
 #: src/std-types/option.md
 msgid "\"find returned {position:?}\""
-msgstr ""
+msgstr "\"find returned {position:?}\""
 
 #: src/std-types/option.md
 msgid "'Z'"
-msgstr ""
+msgstr "'Z'"
 
 #: src/std-types/option.md
 msgid "\"Character not found\""
-msgstr ""
+msgstr "\"Character not found\""
 
 #: src/std-types/option.md
 #, fuzzy
@@ -6426,28 +6652,36 @@ msgid ""
 "`unwrap` will return the value in an `Option`, or panic. `expect` is similar "
 "but takes an error message."
 msgstr ""
+"`unwrap` は `Option` 内の値を返すか、パニックになります。`expect` も同様です"
+"が、エラーメッセージを受け取ります。"
 
 #: src/std-types/option.md
 msgid ""
 "You can panic on None, but you can't \"accidentally\" forget to check for "
 "None."
 msgstr ""
+"None でパニックになる場合もありますが、「誤って」None のチェックを忘れること"
+"はありません。"
 
 #: src/std-types/option.md
 msgid ""
 "It's common to `unwrap`/`expect` all over the place when hacking something "
 "together, but production code typically handles `None` in a nicer fashion."
 msgstr ""
+"何かを一緒にハッキングする場合は、あちこちで `unwrap`/`expect` を行うのが一般"
+"的ですが、本番環境のコードは通常、`None` をより適切に処理します。"
 
 #: src/std-types/option.md
 msgid ""
 "The niche optimization means that `Option<T>` often has the same size in "
 "memory as `T`."
 msgstr ""
+"ニッチな最適化とは、`Option<T>` がメモリ内で `T` と同じサイズであることが多い"
+"ということです。"
 
 #: src/std-types/result.md
 msgid "Result"
-msgstr ""
+msgstr "Result"
 
 #: src/std-types/result.md
 msgid ""
@@ -6456,22 +6690,26 @@ msgid ""
 "in the expression exercise, but generic: `Result<T, E>` where `T` is used in "
 "the `Ok` variant and `E` appears in the `Err` variant."
 msgstr ""
+"`Result` は `Option` に似ていますが、オペレーションの成功または失敗を、それぞ"
+"れ異なる型で示します。これは式の演習で定義されていた `Res` に似ているものの、"
+"汎用的で、`Result<T, E>` の形式を取ります（`T` は `Ok` バリアントで使用され、"
+"`E` は `Err` バリアントで使用されます）。"
 
 #: src/std-types/result.md
 msgid "\"diary.txt\""
-msgstr ""
+msgstr "\"diary.txt\""
 
 #: src/std-types/result.md
 msgid "\"Dear diary: {contents} ({bytes} bytes)\""
-msgstr ""
+msgstr "\"Dear diary: {contents} ({bytes} bytes)\""
 
 #: src/std-types/result.md
 msgid "\"Could not read file content\""
-msgstr ""
+msgstr "\"Could not read file content\""
 
 #: src/std-types/result.md
 msgid "\"The diary could not be opened: {err}\""
-msgstr ""
+msgstr "\"The diary could not be opened: {err}\""
 
 #: src/std-types/result.md
 msgid ""
@@ -6480,6 +6718,10 @@ msgid ""
 "case where an error should never happen, `unwrap()` or `expect()` can be "
 "called, and this is a signal of the developer intent too."
 msgstr ""
+"`Option` と同様に、成功した値は `Result` の内部にあり、デベロッパーはそれを明"
+"示的に抽出する必要があります。これにより、エラーチェックが促進されます。エ"
+"ラーが発生してはならない場合は、`unwrap()` または `expect()` を呼び出すことが"
+"できます。これもデベロッパーのインテントのシグナルです。"
 
 #: src/std-types/result.md
 msgid ""
@@ -6487,12 +6729,15 @@ msgid ""
 "is worth mentioning. It contains a lot of convenience methods and functions "
 "that help functional-style programming."
 msgstr ""
+"`Result` のドキュメントを読むことをすすめましょう。この講座では取り上げません"
+"が、言及する価値があります。このドキュメントには、関数型プログラミングに役立"
+"つ便利なメソッドや関数が多数含まれています。"
 
 #: src/std-types/result.md
 msgid ""
 "`Result` is the standard type to implement error handling as we will see on "
 "Day 3."
-msgstr ""
+msgstr "`Result` は、3 日目で説明するエラー処理を実装する標準型です。"
 
 #: src/std-types/string.md
 msgid "String"
@@ -6503,32 +6748,34 @@ msgid ""
 "[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
 "standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) は、標準"
+"的なヒープ割り当ての拡張可能な UTF-8 文字列バッファです。"
 
 #: src/std-types/string.md src/std-traits/read-and-write.md
 #: src/memory-management/review.md src/testing/unit-tests.md
 #: src/concurrency/scoped-threads.md
 msgid "\"Hello\""
-msgstr ""
+msgstr "\"Hello\""
 
 #: src/std-types/string.md
 msgid "\"s1: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"s1: len = {}, capacity = {}\""
 
 #: src/std-types/string.md
 msgid "'!'"
-msgstr ""
+msgstr "'!'"
 
 #: src/std-types/string.md
 msgid "\"s2: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"s2: len = {}, capacity = {}\""
 
 #: src/std-types/string.md
 msgid "\"🇨🇭\""
-msgstr ""
+msgstr "\"🇨🇭\""
 
 #: src/std-types/string.md
 msgid "\"s3: len = {}, number of chars = {}\""
-msgstr ""
+msgstr "\"s3: len = {}, number of chars = {}\""
 
 #: src/std-types/string.md
 msgid ""
@@ -6536,18 +6783,25 @@ msgid ""
 "string/struct.String.html#deref-methods-str), which means that you can call "
 "all `str` methods on a `String`."
 msgstr ""
+"`String` は [`Deref<Target = str>`](https://doc.rust-lang.org/std/string/"
+"struct.String.html#deref-methods-str) を実装します。つまり、`String` のすべて"
+"の `str` メソッドを呼び出すことができます。"
 
 #: src/std-types/string.md
 msgid ""
 "`String::new` returns a new empty string, use `String::with_capacity` when "
 "you know how much data you want to push to the string."
 msgstr ""
+"`String::new` は新しい空の文字列を返します。文字列にプッシュするデータの量が"
+"わかっている場合は `String::with_capacity` を使用します。"
 
 #: src/std-types/string.md
 msgid ""
 "`String::len` returns the size of the `String` in bytes (which can be "
 "different from its length in characters)."
 msgstr ""
+"`String::len` は、`String` のサイズをバイト単位で返します（文字数とは異なる場"
+"合があります）。"
 
 #: src/std-types/string.md
 msgid ""
@@ -6556,34 +6810,46 @@ msgid ""
 "to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
 "unicode_segmentation/struct.Graphemes.html)."
 msgstr ""
+"`String::chars` は、実際の文字のイテレータを返します。[書記素クラスタ]"
+"(https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct."
+"Graphemes.html)により、`char` は人間が「文字」と見なすものとは異なる場合があ"
+"ります。"
 
 #: src/std-types/string.md
 msgid ""
 "When people refer to strings they could either be talking about `&str` or "
 "`String`."
 msgstr ""
+"人々が文字列について言及する場合、単に `&str` または `String` のことを話して"
+"いる可能性があります。"
 
 #: src/std-types/string.md
 msgid ""
 "When a type implements `Deref<Target = T>`, the compiler will let you "
 "transparently call methods from `T`."
 msgstr ""
+"型が `Deref<Target = T>` を実装している場合、コンパイラにより `T` からメソッ"
+"ドを透過的に呼び出せるようになります。"
 
 #: src/std-types/string.md
 msgid ""
 "We haven't discussed the `Deref` trait yet, so at this point this mostly "
 "explains the structure of the sidebar in the documentation."
 msgstr ""
+"`Deref` トレイトについてはまだ説明していないため、現時点では主にドキュメント"
+"のサイドバーの構造について説明しています。"
 
 #: src/std-types/string.md
 msgid ""
 "`String` implements `Deref<Target = str>` which transparently gives it "
 "access to `str`'s methods."
 msgstr ""
+"`String` は `Deref<Target = str>` を実装し、`str` のメソッドへのアクセスを透"
+"過的に許可します。"
 
 #: src/std-types/string.md
 msgid "Write and compare `let s3 = s1.deref();` and `let s3 = &*s1;`."
-msgstr ""
+msgstr "`let s3 = s1.deref();` と `let s3 = &*s1;` を記述して比較します。"
 
 #: src/std-types/string.md
 msgid ""
@@ -6591,52 +6857,61 @@ msgid ""
 "operations you see supported on vectors are also supported on `String`, but "
 "with some extra guarantees."
 msgstr ""
+"`String` はバイトのベクターのラッパーとして実装されます。ベクターでサポートさ"
+"れているオペレーションの多くは `String` でもサポートされていますが、いくつか"
+"の保証が追加されています。"
 
 #: src/std-types/string.md
 msgid "Compare the different ways to index a `String`:"
-msgstr ""
+msgstr "`String` にインデックスを付けるさまざまな方法を比較します。"
 
 #: src/std-types/string.md
 msgid ""
 "To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
 "out-of-bounds."
 msgstr ""
+"文字には `s3.chars().nth(i).unwrap()` を使用します。ここで `i` は境界内の場合"
+"や境界外の場合を表します。"
 
 #: src/std-types/string.md
 msgid ""
 "To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
+"部分文字列には `s3[0..4]` を使用します。このスライスは、文字境界にある場合と"
+"ない場合があります。"
 
 #: src/std-types/vec.md
 msgid ""
 "[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
 "resizable heap-allocated buffer:"
 msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) は、サイズ変更可能"
+"な標準のヒープ割り当てバッファです。"
 
 #: src/std-types/vec.md
 msgid "\"v1: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"v1: len = {}, capacity = {}\""
 
 #: src/std-types/vec.md
 msgid "\"v2: len = {}, capacity = {}\""
-msgstr ""
+msgstr "\"v2: len = {}, capacity = {}\""
 
 #: src/std-types/vec.md
 msgid "// Canonical macro to initialize a vector with elements.\n"
-msgstr ""
+msgstr "// 要素でベクターを初期化する正規マクロ。\n"
 
 #: src/std-types/vec.md
 msgid "// Retain only the even elements.\n"
-msgstr ""
+msgstr "// 偶数要素のみを保持します。\n"
 
 #: src/std-types/vec.md
 msgid "\"{v3:?}\""
-msgstr ""
+msgstr "\"{v3:?}\""
 
 #: src/std-types/vec.md
 msgid "// Remove consecutive duplicates.\n"
-msgstr ""
+msgstr "// 連続する重複を削除します。\n"
 
 #: src/std-types/vec.md
 msgid ""
@@ -6644,6 +6919,9 @@ msgid ""
 "struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
+"`Vec` は [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/struct."
+"Vec.html#deref-methods-%5BT%5D) を実装しているため、`Vec` でスライス メソッド"
+"を呼び出すことができます。"
 
 #: src/std-types/vec.md
 msgid ""
@@ -6651,6 +6929,9 @@ msgid ""
 "it contains is stored on the heap. This means the amount of data doesn't "
 "need to be known at compile time. It can grow or shrink at runtime."
 msgstr ""
+"`Vec` は、`String` および `HashMap` とともにコレクションの一種です。含まれて"
+"いるデータはヒープに格納されるため、コンパイル時にデータ量を把握する必要はあ"
+"りません。データ量は実行時に増加または減少する場合があります。"
 
 #: src/std-types/vec.md
 msgid ""
@@ -6658,12 +6939,17 @@ msgid ""
 "explicitly. As always with Rust type inference, the `T` was established "
 "during the first `push` call."
 msgstr ""
+"`Vec<T>` もジェネリック型ですが、`T` を明示的に指定する必要はありません。"
+"Rust の型推論でいつも行われるように、最初の `push` 呼び出しで `T` が確立され"
+"ています。"
 
 #: src/std-types/vec.md
 msgid ""
 "`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
 "supports adding initial elements to the vector."
 msgstr ""
+"`vec![...]` は `Vec::new()` の代わりに使用する正規のマクロで、ベクターへの初"
+"期要素の追加をサポートしています。"
 
 #: src/std-types/vec.md
 msgid ""
@@ -6671,61 +6957,70 @@ msgid ""
 "Alternatively, using `get` will return an `Option`. The `pop` function will "
 "remove the last element."
 msgstr ""
+"ベクターにインデックスを付けるには `[` `]` を使用しますが、境界外の場合はパ"
+"ニックが発生します。または、`get` を使用すると `Option` が返されます。`pop` "
+"関数は最後の要素を削除します。"
 
 #: src/std-types/vec.md
 msgid ""
 "Slices are covered on day 3. For now, students only need to know that a "
 "value of type `Vec` gives access to all of the documented slice methods, too."
 msgstr ""
+"スライスについては 3 日目に説明します。受講者は現時点では、型 `Vec` の値によ"
+"り、ドキュメントに記されたすべてのスライスメソッドにアクセスできることだけを"
+"知っていれば十分です。"
 
 #: src/std-types/hashmap.md
 msgid "Standard hash map with protection against HashDoS attacks:"
-msgstr ""
+msgstr "HashDoS 攻撃から保護する標準のハッシュマップ:"
 
 #: src/std-types/hashmap.md
 msgid "\"Adventures of Huckleberry Finn\""
-msgstr ""
+msgstr "\"Adventures of Huckleberry Finn\""
 
 #: src/std-types/hashmap.md
 msgid "\"Grimms' Fairy Tales\""
-msgstr ""
+msgstr "\"Grimms' Fairy Tales\""
 
 #: src/std-types/hashmap.md
 msgid "\"Pride and Prejudice\""
-msgstr ""
+msgstr "\"Pride and Prejudice\""
 
 #: src/std-types/hashmap.md
 msgid "\"Les Misérables\""
-msgstr ""
+msgstr "\"Les Misérables\""
 
 #: src/std-types/hashmap.md
 msgid "\"We know about {} books, but not Les Misérables.\""
-msgstr ""
+msgstr "\"We know about {} books, but not Les Misérables.\""
 
 #: src/std-types/hashmap.md
 msgid "\"Alice's Adventure in Wonderland\""
-msgstr ""
+msgstr "\"Alice's Adventure in Wonderland\""
 
 #: src/std-types/hashmap.md
 msgid "\"{book}: {count} pages\""
-msgstr ""
+msgstr "\"{book}: {count} pages\""
 
 #: src/std-types/hashmap.md
 msgid "\"{book} is unknown.\""
-msgstr ""
+msgstr "\"{book} is unknown.\""
 
 #: src/std-types/hashmap.md
 msgid "// Use the .entry() method to insert a value if nothing is found.\n"
 msgstr ""
+"// 何も見つからなかった場合は、.entry() メソッドを使用して値を挿入します。\n"
 
 #: src/std-types/hashmap.md
 msgid "\"{page_counts:#?}\""
-msgstr ""
+msgstr "\"{page_counts:#?}\""
 
 #: src/std-types/hashmap.md
 msgid ""
 "`HashMap` is not defined in the prelude and needs to be brought into scope."
 msgstr ""
+"`HashMap` はプレリュードで定義されていないため、スコープに含める必要がありま"
+"す。"
 
 #: src/std-types/hashmap.md
 msgid ""
@@ -6733,18 +7028,21 @@ msgid ""
 "hashmap and if not return an alternative value. The second line will insert "
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
+"次のコード行を試します。最初の行で、書籍がハッシュマップにあるかどうかを確認"
+"し、ない場合は代替値を返します。書籍が見つからなかった場合、2 行目でハッシュ"
+"マップに代替値を挿入します。"
 
 #: src/std-types/hashmap.md
 msgid "\"Harry Potter and the Sorcerer's Stone\""
-msgstr ""
+msgstr "\"Harry Potter and the Sorcerer's Stone\""
 
 #: src/std-types/hashmap.md
 msgid "\"The Hunger Games\""
-msgstr ""
+msgstr "\"The Hunger Games\""
 
 #: src/std-types/hashmap.md
 msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
-msgstr ""
+msgstr "`vec!` とは異なり、標準の `hashmap!` マクロはありません。"
 
 #: src/std-types/hashmap.md
 msgid ""
@@ -6753,12 +7051,18 @@ msgid ""
 "From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
 "us to easily initialize a hash map from a literal array:"
 msgstr ""
+"しかし、Rust 1.56 以降では、HashMap は [`From<[(K, V); N]>`](https://doc."
+"rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K,"
+"+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E) を実装しています。これによ"
+"り、リテラル配列からハッシュマップを簡単に初期化できます。"
 
 #: src/std-types/hashmap.md
 msgid ""
 "Alternatively HashMap can be built from any `Iterator` which yields key-"
 "value tuples."
 msgstr ""
+"別の方法として、HashMap は、Key-Value タプルを生成する任意の `Iterator` から"
+"作成することもできます。"
 
 #: src/std-types/hashmap.md
 msgid ""
@@ -6766,12 +7070,18 @@ msgid ""
 "examples easier. Using references in collections can, of course, be done, "
 "but it can lead into complications with the borrow checker."
 msgstr ""
+"ここでは `HashMap<String, i32>` を示していますが、例を簡単にするために "
+"`&str` をキーとして使用しないようにしています。もちろん、コレクション内で参照"
+"を使用することもできますが、それによって借用チェッカーが複雑になる可能性があ"
+"ります。"
 
 #: src/std-types/hashmap.md
 msgid ""
 "Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
+"上記の例から `to_string()` を削除して、まだコンパイルできるかどうかを確認しま"
+"す。どこで問題が発生するでしょうか。"
 
 #: src/std-types/hashmap.md
 msgid ""
@@ -6780,6 +7090,10 @@ msgid ""
 "Rust docs. Show students the docs for this type, and the helpful link back "
 "to the `keys` method."
 msgstr ""
+"この型には、`std::collections::hash_map::Keys` などの「メソッド固有の」戻り値"
+"の型がいくつかあります。これらの型は、Rust ドキュメントの検索でよく使用されま"
+"す。この型のドキュメントと、`keys` メソッドに戻るのに役立つリンクを受講者に示"
+"します。"
 
 #: src/std-types/exercise.md
 msgid ""
@@ -6788,6 +7102,10 @@ msgid ""
 "stable/std/collections/struct.HashMap.html) to keep track of which values "
 "have been seen and how many times each one has appeared."
 msgstr ""
+"この演習では、非常にシンプルなデータ構造を汎用的なものにします。[`std::"
+"collections::HashMap`](https://doc.rust-lang.org/stable/std/collections/"
+"struct.HashMap.html) を使用して、どの値が確認され、各値が何回出現したかを追跡"
+"します。"
 
 #: src/std-types/exercise.md
 msgid ""
@@ -6795,6 +7113,9 @@ msgid ""
 "values. Make the struct and its methods generic over the type of value being "
 "tracked, that way `Counter` can track any type of value."
 msgstr ""
+"`Counter` の初期バージョンは、`u32` の値でのみ機能するようにハードコードされ"
+"ています。追跡する値の型に対して構造体とそのメソッドをジェネリック化します。"
+"これにより、`Counter` であらゆる型の値を追跡できます。"
 
 #: src/std-types/exercise.md
 msgid ""
@@ -6802,101 +7123,109 @@ msgid ""
 "stable/std/collections/struct.HashMap.html#method.entry) method to halve the "
 "number of hash lookups required to implement the `count` method."
 msgstr ""
+"早めに終わった場合は、[`entry`](https://doc.rust-lang.org/stable/std/"
+"collections/struct.HashMap.html#method.entry) メソッドを使用して、`count` メ"
+"ソッドの実装に必要なハッシュ ルックアップの回数を半分にしてみましょう。"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid ""
 "/// Counter counts the number of times each value of type T has been seen.\n"
-msgstr ""
+msgstr "/// カウンタは型 T の各値が確認された回数をカウントします。\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Create a new Counter.\n"
-msgstr ""
+msgstr "/// 新しいカウンタを作成します。\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Count an occurrence of the given value.\n"
-msgstr ""
+msgstr "/// 指定された値の発生をカウントします。\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "/// Return the number of times the given value has been seen.\n"
-msgstr ""
+msgstr "/// 指定された値が確認された回数を返します。\n"
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"saw {} values equal to {}\""
-msgstr ""
+msgstr "\"saw {} values equal to {}\""
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"apple\""
-msgstr ""
+msgstr "\"apple\""
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"orange\""
-msgstr ""
+msgstr "\"orange\""
 
 #: src/std-types/exercise.md src/std-types/solution.md
 msgid "\"got {} apples\""
-msgstr ""
+msgstr "\"got {} apples\""
 
 #: src/std-traits.md
 msgid "[Comparisons](./std-traits/comparisons.md) (10 minutes)"
-msgstr ""
+msgstr "[比較](./std-lets/comparisons.md)（10 分）"
 
 #: src/std-traits.md
 msgid "[Operators](./std-traits/operators.md) (10 minutes)"
-msgstr ""
+msgstr "[演算子](./std-train/operators.md)（10 分）"
 
 #: src/std-traits.md
 msgid "[From and Into](./std-traits/from-and-into.md) (10 minutes)"
-msgstr ""
+msgstr "[From と Into](./std-lets/from-and-into.md)（10 分）"
 
 #: src/std-traits.md
 msgid "[Casting](./std-traits/casting.md) (5 minutes)"
-msgstr ""
+msgstr "[キャスト](./std-train/casting.md)（5 分）"
 
 #: src/std-traits.md
 msgid "[Read and Write](./std-traits/read-and-write.md) (10 minutes)"
-msgstr ""
+msgstr "[読み取りと書き込み](./std-train/read-and-write.md)（10 分）"
 
 #: src/std-traits.md
 msgid "[Default, struct update syntax](./std-traits/default.md) (5 minutes)"
-msgstr ""
+msgstr "[Default、構造体更新記法](./std-lets/default.md)（5 分）"
 
 #: src/std-traits.md
 msgid "[Closures](./std-traits/closures.md) (20 minutes)"
-msgstr ""
+msgstr "[クロージャ](./std-lets/closures.md)（20 分）"
 
 #: src/std-traits.md
 msgid "[Exercise: ROT13](./std-traits/exercise.md) (30 minutes)"
-msgstr ""
+msgstr "[演習: ROT13](./std-train/exercise.md)（30 分）"
 
 #: src/std-traits.md
 msgid "This segment should take about 1 hour and 40 minutes"
-msgstr ""
+msgstr "このセグメントの所要時間は約 1 時間 40 分です"
 
 #: src/std-traits.md
 msgid ""
 "As with the standard-library types, spend time reviewing the documentation "
 "for each trait."
 msgstr ""
+"標準ライブラリ型と同様に、時間をかけて各トレイトのドキュメントを確認します。"
 
 #: src/std-traits.md
 msgid "This section is long. Take a break midway through."
-msgstr ""
+msgstr "このセクションは長いため、途中で休憩を取ってください。"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "These traits support comparisons between values. All traits can be derived "
 "for types containing fields that implement these traits."
 msgstr ""
+"これらのトレイトは値の比較をサポートします。すべてのトレイトは、これらのトレ"
+"イトを実装するフィールドを含む型用に導出できます。"
 
 #: src/std-traits/comparisons.md
 msgid "`PartialEq` and `Eq`"
-msgstr ""
+msgstr "`PartialEq` と `Eq`"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "`PartialEq` is a partial equivalence relation, with required method `eq` and "
 "provided method `ne`. The `==` and `!=` operators will call these methods."
 msgstr ""
+"`PartialEq` は、必須のメソッド `eq` と指定されたメソッド `ne` を持つ部分的な"
+"等価関係です。`==` 演算子と `!=` 演算子は、これらのメソッドを呼び出します。"
 
 #: src/std-traits/comparisons.md
 msgid ""
@@ -6904,51 +7233,62 @@ msgid ""
 "and implies `PartialEq`. Functions that require full equivalence will use "
 "`Eq` as a trait bound."
 msgstr ""
+"`Eq` は完全な等価関係（反射的、対称的、推移的）であり、`PartialEq` を意味しま"
+"す。完全な等価関係を必要とする関数は、トレイト境界として `Eq` を使用します。"
 
 #: src/std-traits/comparisons.md
 msgid "`PartialOrd` and `Ord`"
-msgstr ""
+msgstr "`PartialOrd` と `Ord`"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "`PartialOrd` defines a partial ordering, with a `partial_cmp` method. It is "
 "used to implement the `<`, `<=`, `>=`, and `>` operators."
 msgstr ""
+"`PartialOrd` は `partial_cmp` メソッドを使って部分的な順序を定義します。これ"
+"は、`<`、`<=`、`>=`、`>` 演算子を実装するために使用されます。"
 
 #: src/std-traits/comparisons.md
 msgid "`Ord` is a total ordering, with `cmp` returning `Ordering`."
-msgstr ""
+msgstr "`Ord` は全順序を示し、`cmp` は `Ordering` を返します。"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "`PartialEq` can be implemented between different types, but `Eq` cannot, "
 "because it is reflexive:"
 msgstr ""
+"`PartialEq` は異なる型の間で実装できますが、`Eq` は反射的であるため、実装でき"
+"ません。"
 
 #: src/std-traits/comparisons.md
 msgid ""
 "In practice, it's common to derive these traits, but uncommon to implement "
 "them."
 msgstr ""
+"実際には、これらのトレイトを導出することは一般的ですが、実装するのは一般的で"
+"はありません。"
 
 #: src/std-traits/operators.md
 msgid ""
 "Operator overloading is implemented via traits in [`std::ops`](https://doc."
 "rust-lang.org/std/ops/index.html):"
 msgstr ""
+"演算子のオーバーロードは、[`std::ops`](https://doc.rust-lang.org/std/ops/"
+"index.html) 内のトレイトを介して実装されます。"
 
 #: src/std-traits/operators.md
 msgid "\"{:?} + {:?} = {:?}\""
-msgstr ""
+msgstr "\"{:?} + {:?} = {:?}\""
 
 #: src/std-traits/operators.md src/memory-management/drop.md
 msgid "Discussion points:"
-msgstr ""
+msgstr "議論のポイント:"
 
 #: src/std-traits/operators.md
 msgid ""
 "You could implement `Add` for `&Point`. In which situations is that useful?"
 msgstr ""
+"`&Point` に `Add` を実装できます。これはどのような状況で役に立ちますか？"
 
 #: src/std-traits/operators.md
 msgid ""
@@ -6956,12 +7296,17 @@ msgid ""
 "the operator is not `Copy`, you should consider overloading the operator for "
 "`&T` as well. This avoids unnecessary cloning on the call site."
 msgstr ""
+"回答: `Add:add` は `self` を使用します。演算子をオーバーロードする型 `T` が "
+"`Copy` でない場合は、`&T` の演算子もオーバーロードすることを検討する必要があ"
+"ります。これにより、呼び出し箇所での不要なクローン作成を回避できます。"
 
 #: src/std-traits/operators.md
 msgid ""
 "Why is `Output` an associated type? Could it be made a type parameter of the "
 "method?"
 msgstr ""
+"`Output` が関連型であるのはなぜですか？これをメソッドの型パラメータにできるで"
+"しょうか？"
 
 #: src/std-traits/operators.md
 msgid ""
@@ -6969,12 +7314,16 @@ msgid ""
 "associated types (like `Output`) are controlled by the implementer of a "
 "trait."
 msgstr ""
+"短い回答: 関数型のパラメータは呼び出し元によって制御されますが、関連型"
+"（`Output` など）はトレイトの実装者によって制御されます。"
 
 #: src/std-traits/operators.md
 msgid ""
 "You could implement `Add` for two different types, e.g. `impl Add<(i32, "
 "i32)> for Point` would add a tuple to a `Point`."
 msgstr ""
+"2 種類の型に対して `Add` を実装できます。たとえば、`impl Add<(i32, i32)> for "
+"Point` は `Point` にタプルを追加します。"
 
 #: src/std-traits/from-and-into.md
 msgid ""
@@ -6982,10 +7331,13 @@ msgid ""
 "html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
 "facilitate type conversions:"
 msgstr ""
+"型は、型変換を容易にする [`From`](https://doc.rust-lang.org/std/convert/"
+"trait.From.html) と [`Into`](https://doc.rust-lang.org/std/convert/trait."
+"Into.html) を実装しています。"
 
 #: src/std-traits/from-and-into.md
 msgid "\"{s}, {addr}, {one}, {bigger}\""
-msgstr ""
+msgstr "\"{s}, {addr}, {one}, {bigger}\""
 
 #: src/std-traits/from-and-into.md
 msgid ""
@@ -6993,12 +7345,17 @@ msgid ""
 "automatically implemented when [`From`](https://doc.rust-lang.org/std/"
 "convert/trait.From.html) is implemented:"
 msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) が実装される"
+"と、[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) が自動的"
+"に実装されます。"
 
 #: src/std-traits/from-and-into.md
 msgid ""
 "That's why it is common to only implement `From`, as your type will get "
 "`Into` implementation too."
 msgstr ""
+"このように `Into` も実装されるため、型には `From` のみを実装するのが一般的で"
+"す。"
 
 #: src/std-traits/from-and-into.md
 msgid ""
@@ -7007,24 +7364,30 @@ msgid ""
 "Your function will accept types that implement `From` and those that _only_ "
 "implement `Into`."
 msgstr ""
+"「`String` に変換できるすべて」のような関数引数の入力型を宣言する場合、この"
+"ルールは逆となり、`Into`を使用する必要があります。関数は、`From` を実装する型"
+"と、`Into` _のみ_ を実装する型を受け入れます。"
 
 #: src/std-traits/casting.md
 msgid ""
 "Rust has no _implicit_ type conversions, but does support explicit casts "
 "with `as`. These generally follow C semantics where those are defined."
 msgstr ""
+"Rust には _暗黙的_ な型変換はありませんが、`as` による明示的なキャストはサ"
+"ポートされています。これらのキャストは通常、それらが定義されている C セマン"
+"ティクスに従います。"
 
 #: src/std-traits/casting.md
 msgid "\"as u16: {}\""
-msgstr ""
+msgstr "\"as u16: {}\""
 
 #: src/std-traits/casting.md
 msgid "\"as i16: {}\""
-msgstr ""
+msgstr "\"as i16: {}\""
 
 #: src/std-traits/casting.md
 msgid "\"as u8: {}\""
-msgstr ""
+msgstr "\"as u8: {}\""
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7032,6 +7395,10 @@ msgid ""
 "platforms. This might not match your intuition for changing sign or casting "
 "to a smaller type -- check the docs, and comment for clarity."
 msgstr ""
+"`as` の結果は Rust で _常に_ 定義され、プラットフォーム間で一貫しています。こ"
+"れは、正負の符号を変えたり、より小さな型にキャストしたりする際に得られる直感"
+"に反しているかもしれません。ドキュメントを確認し、明確にするためにコメントを"
+"記述してください。"
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7042,6 +7409,11 @@ msgid ""
 "selecting the bottom 32 bits of a `u64` with `as u32`, regardless of what "
 "was in the high bits)."
 msgstr ""
+"`as` を使用したキャストは比較的扱いにくく、誤って使用することが少なくありませ"
+"ん。また、将来のメンテナンス作業で、使用される型や型の値の範囲が変更された際"
+"に、わかりにくいバグが発生する可能性があります。キャストは、無条件の切り捨て"
+"を示すことを目的としている場合にのみ、最適に使用されます（たとえば、上位ビッ"
+"トの内容に関係なく、`as u32` で `u64` の下位 32 ビットを選択する場合）。"
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7050,10 +7422,15 @@ msgid ""
 "casts, `TryFrom` and `TryInto` are available when you want to handle casts "
 "that fit differently from those that don't."
 msgstr ""
+"絶対に正しいキャスト（例: `u32` から `u64` へのキャスト）では、キャストが実際"
+"に完璧であることを確認するために、`as` ではなく `From` または `Into` を使用す"
+"ることをおすすめします。正しくない可能性があるキャストについては、絶対に正し"
+"いキャストとは異なる方法でそれらを処理したい場合に、`TryFrom` と `TryInto` を"
+"使用できます。"
 
 #: src/std-traits/casting.md
 msgid "Consider taking a break after this slide."
-msgstr ""
+msgstr "このスライドの後で休憩を取ることを検討してください。"
 
 #: src/std-traits/casting.md
 msgid ""
@@ -7061,10 +7438,15 @@ msgid ""
 "be lost is generally discouraged, or at least deserves an explanatory "
 "comment."
 msgstr ""
+"`as` は C++ の静的キャストに似ています。データが失われる可能性がある状況で "
+"`as` を使用することは、一般的に推奨されません。使用する場合は、少なくとも説明"
+"のコメントを記述することをおすすめします。"
 
 #: src/std-traits/casting.md
 msgid "This is common in casting integers to `usize` for use as an index."
 msgstr ""
+"これは、整数を`usize` にキャストしてインデックスとして使用する場合に一般的で"
+"す。"
 
 #: src/std-traits/read-and-write.md
 msgid ""
@@ -7072,98 +7454,111 @@ msgid ""
 "[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
 "abstract over `u8` sources:"
 msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) と [`BufRead`]"
+"(https://doc.rust-lang.org/std/io/trait.BufRead.html) を使用することで、`u8` "
+"ソースを抽象化できます。"
 
 #: src/std-traits/read-and-write.md
 msgid "b\"foo\\nbar\\nbaz\\n\""
-msgstr ""
+msgstr "b\"foo\\nbar\\nbaz\\n\""
 
 #: src/std-traits/read-and-write.md
 msgid "\"lines in slice: {}\""
-msgstr ""
+msgstr "\"lines in slice: {}\""
 
 #: src/std-traits/read-and-write.md
 msgid "\"lines in file: {}\""
-msgstr ""
+msgstr "\"lines in file: {}\""
 
 #: src/std-traits/read-and-write.md
 msgid ""
 "Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
 "you abstract over `u8` sinks:"
 msgstr ""
+"同様に、[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) を使用す"
+"ると、`u8` シンクを抽象化できます。"
 
 #: src/std-traits/read-and-write.md
 msgid "\"\\n\""
-msgstr ""
+msgstr "\"\\n\""
 
 #: src/std-traits/read-and-write.md src/slices-and-lifetimes/str.md
 msgid "\"World\""
-msgstr ""
+msgstr "\"World\""
 
 #: src/std-traits/read-and-write.md
 msgid "\"Logged: {:?}\""
-msgstr ""
+msgstr "\"Logged: {:?}\""
 
 #: src/std-traits/default.md
 msgid "The `Default` Trait"
-msgstr ""
+msgstr "`Default` トレイト"
 
 #: src/std-traits/default.md
 msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
 "produces a default value for a type."
 msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) トレイ"
+"トは、型のデフォルト値を生成します。"
 
 #: src/std-traits/default.md
 msgid "\"John Smith\""
-msgstr ""
+msgstr "\"John Smith\""
 
 #: src/std-traits/default.md
 msgid "\"{default_struct:#?}\""
-msgstr ""
+msgstr "\"{default_struct:#?}\""
 
 #: src/std-traits/default.md
 msgid "\"Y is set!\""
-msgstr ""
+msgstr "\"Y is set!\""
 
 #: src/std-traits/default.md
 msgid "\"{almost_default_struct:#?}\""
-msgstr ""
+msgstr "\"{almost_default_struct:#?}\""
 
 #: src/std-traits/default.md src/slices-and-lifetimes/exercise.md
 #: src/slices-and-lifetimes/solution.md
 msgid "\"{:#?}\""
-msgstr ""
+msgstr "\"{:#?}\""
 
 #: src/std-traits/default.md
 msgid ""
 "It can be implemented directly or it can be derived via `#[derive(Default)]`."
-msgstr ""
+msgstr "直接実装することも、`#[derive(Default)]` で導出することもできます。"
 
 #: src/std-traits/default.md
 msgid ""
 "A derived implementation will produce a value where all fields are set to "
 "their default values."
 msgstr ""
+"導出による実装では、すべてのフィールドがデフォルト値に設定された値が生成され"
+"ます。"
 
 #: src/std-traits/default.md
 msgid "This means all types in the struct must implement `Default` too."
-msgstr ""
+msgstr "つまり、構造体内のすべての型にも `Default` を実装する必要があります。"
 
 #: src/std-traits/default.md
 msgid ""
 "Standard Rust types often implement `Default` with reasonable values (e.g. "
 "`0`, `\"\"`, etc)."
 msgstr ""
+"標準の Rust 型は多くの場合、妥当な値（`0`、`\"\"` など）の `Default` を実装し"
+"ます。"
 
 #: src/std-traits/default.md
 msgid "The partial struct initialization works nicely with default."
-msgstr ""
+msgstr "部分的な構造体の初期化は、デフォルトで適切に機能します。"
 
 #: src/std-traits/default.md
 msgid ""
 "The Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
+"Rust 標準ライブラリは、型が `Default` を実装できることを認識しており、それを"
+"使用するコンビニエンス メソッドを提供しています。"
 
 #: src/std-traits/default.md
 msgid ""
@@ -7171,6 +7566,9 @@ msgid ""
 "book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
 "with-struct-update-syntax)."
 msgstr ""
+"`..` 構文は、[構造体更新記法](https://doc.rust-lang.org/book/ch05-01-"
+"defining-structs.html#creating-instances-from-other-instances-with-struct-"
+"update-syntax)と呼ばれています。"
 
 #: src/std-traits/closures.md
 msgid ""
@@ -7179,22 +7577,27 @@ msgid ""
 "html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
+"クロージャやラムダ式には、名前を付けることができない型があります。ただし、こ"
+"れらは特別な [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、"
+"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html)、[`FnOnce`]"
+"(https://doc.rust-lang.org/std/ops/trait.FnOnce.html) トレイトを備えていま"
+"す。"
 
 #: src/std-traits/closures.md
 msgid "\"Calling function on {input}\""
-msgstr ""
+msgstr "\"Calling function on {input}\""
 
 #: src/std-traits/closures.md
 msgid "\"add_3: {}\""
-msgstr ""
+msgstr "\"add_3: {}\""
 
 #: src/std-traits/closures.md
 msgid "\"accumulate: {}\""
-msgstr ""
+msgstr "\"accumulate: {}\""
 
 #: src/std-traits/closures.md
 msgid "\"multiply_sum: {}\""
-msgstr ""
+msgstr "\"multiply_sum: {}\""
 
 #: src/std-traits/closures.md
 msgid ""
@@ -7202,18 +7605,24 @@ msgid ""
 "perhaps captures nothing at all. It can be called multiple times "
 "concurrently."
 msgstr ""
+"`Fn`（例: `add_3`）は、キャプチャした値を使用も変更もしないか、または何もキャ"
+"プチャしない場合があります。これは同時に複数回呼び出すことができます。"
 
 #: src/std-traits/closures.md
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
 "multiple times, but not concurrently."
 msgstr ""
+"`FnMut`（例: `accumulate`）は、キャプチャした値を変更することがあります。複数"
+"回呼び出すことはできますが、同時に呼び出すことはできません。"
 
 #: src/std-traits/closures.md
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
 "might consume captured values."
 msgstr ""
+"`FnOnce`（例: `multiply_sum`）がある場合は、1 回だけ呼び出すことができます。"
+"これは、キャプチャした値を使用する場合があります。"
 
 #: src/std-traits/closures.md
 msgid ""
@@ -7221,6 +7630,9 @@ msgid ""
 "I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
 "use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
+"`FnMut` は `FnOnce` のサブタイプで、`Fn` は `FnMut` と `FnOnce` のサブタイプ"
+"です。つまり、`FnOnce` が呼び出される場合は常に `FnMut` を使用でき、`FnMut` "
+"または `FnOnce` が呼び出される場合は常に `Fn` を使用できます。"
 
 #: src/std-traits/closures.md
 msgid ""
@@ -7228,32 +7640,41 @@ msgid ""
 "you can (i.e. you call it once), or `FnMut` else, and last `Fn`. This allows "
 "the most flexibility for the caller."
 msgstr ""
+"クロージャを受け取る関数を定義する場合、可能であれば（1 回だけ呼び出す）"
+"`FnOnce` を使用し、次に `FnMut`、最後に `Fn` を使用するようにします。これによ"
+"り、呼び出し元に最も柔軟に対応できます。"
 
 #: src/std-traits/closures.md
 msgid ""
 "In contrast, when you have a closure, the most flexible you can have is `Fn` "
 "(it can be passed everywhere), then `FnMut`, and lastly `FnOnce`."
 msgstr ""
+"一方、クロージャがある場合、最も柔軟性の高い方法は、まず `Fn`（どこでも渡すこ"
+"とができるため）、次に `FnMut`、最後に `FnOnce` を使用することです。"
 
 #: src/std-traits/closures.md
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
 "`multiply_sum`), depending on what the closure captures."
 msgstr ""
+"コンパイラは、クロージャがキャプチャする内容に応じて、`Copy`（例: `add_3`）"
+"と `Clone`（例: `multiply_sum`）も推測します。"
 
 #: src/std-traits/closures.md
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
 "keyword makes them capture by value."
 msgstr ""
+"デフォルトでは、可能であれば、クロージャは参照によってキャプチャします。"
+"`move` キーワードを使用すると、クロージャは値によってキャプチャします。"
 
 #: src/std-traits/closures.md
 msgid "\"Hi\""
-msgstr ""
+msgstr "\"Hi\""
 
 #: src/std-traits/closures.md
 msgid "\"there\""
-msgstr ""
+msgstr "\"there\""
 
 #: src/std-traits/exercise.md
 msgid ""
@@ -7262,28 +7683,34 @@ msgid ""
 "implement the missing bits. Only rotate ASCII alphabetic characters, to "
 "ensure the result is still valid UTF-8."
 msgstr ""
+"この例では、古典的な [「ROT13」暗号](https://en.wikipedia.org/wiki/ROT13)を実"
+"装します。このコードをプレイグラウンドにコピーし、欠落しているビットを実装し"
+"てください。結果が有効な UTF-8 のままになるように、ASCII アルファベット文字の"
+"みをローテーションします。"
 
 #: src/std-traits/exercise.md
 msgid "// Implement the `Read` trait for `RotDecoder`.\n"
-msgstr ""
+msgstr "// `RotDecoder` の `Read` トレイトを実装します。\n"
 
 #: src/std-traits/exercise.md src/std-traits/solution.md
 msgid "\"Gb trg gb gur bgure fvqr!\""
-msgstr ""
+msgstr "\"Gb trg gb gur bgure fvqr!\""
 
 #: src/std-traits/exercise.md src/std-traits/solution.md
 msgid "\"To get to the other side!\""
-msgstr ""
+msgstr "\"To get to the other side!\""
 
 #: src/std-traits/exercise.md
 msgid ""
 "What happens if you chain two `RotDecoder` instances together, each rotating "
 "by 13 characters?"
 msgstr ""
+"それぞれが 13 文字ずつローテーションされる 2 つの `RotDecoder` インスタンスを"
+"連結するとどうなるでしょうか。"
 
 #: src/std-traits/solution.md
 msgid "'A'"
-msgstr ""
+msgstr "'A'"
 
 #: src/welcome-day-3.md
 msgid "Welcome to Day 3"


### PR DESCRIPTION
This PR merges the Japanese (ja) v.2 translation back to main.
This requires just a syntactical review, as the partial PRs into this branch were reviewed already.

You can skim this PR with the [GitHub CLI](https://cli.github.com/):

gh pr diff 2103 | bat -l patch

#1463 #652