### PR TITLE
Remove error handling from protobuf exercise

### DIFF
--- a/src/lifetimes/exercise.md
+++ b/src/lifetimes/exercise.md
@@ -42,7 +42,7 @@ a message into a series of calls to those callbacks.
 What remains for you is to implement the `parse_field` function and the
 `ProtoMessage` trait for `Person` and `PhoneNumber`.
 
-<!-- compile_fail because `mdbook test` does not allow use of `thiserror` -->
+<!-- compile_fail because the stubbed out code has type inference errors. -->
 
 ```rust,editable,compile_fail
 {{#include exercise.rs:preliminaries }}
@@ -62,3 +62,13 @@ What remains for you is to implement the `parse_field` function and the
 
 {{#include exercise.rs:main }}
 ```
+
+<details>
+
+- In this exercise there are various cases where protobuf parsing might fail,
+  e.g. if you try to parse an `i32` when there are fewer than 4 bytes left in
+  the data buffer. In normal Rust code we'd handle this with the `Result` enum,
+  but for simplicity in this exercise we panic if any errors are encountered. On
+  day 4 we'll cover error handling in Rust in more detail.
+
+</details>

--- a/src/lifetimes/solution.md
+++ b/src/lifetimes/solution.md
@@ -1,7 +1,5 @@
 # Solution
 
-<!-- compile_fail because `mdbook test` does not allow use of `thiserror` -->
-
-```rust,editable,compile_fail
+```rust,editable
 {{#include exercise.rs:solution}}
 ```


### PR DESCRIPTION
The protobuf exercise is one of the more complicated exercises, and it comes before the section on error handling in Rust. I think that makes the error handling within the exercise more confusing for students, and adds to the cognitive burden for doing the exercise. As a potential way to address this, this PR removes the `Result`-based error handling in the exercise and replaces it with panics. This makes the code less idiomatic in Rust, but potentially more friendly to students because they don't need to worry about `Result` or error handling.

That said, I'm not entirely sure this is actually an improvement. The simpler thing might be to briefly describe the `?` operator to students so that they know they can use `?` to unwrap errors when calling functions like `parse_varint`. I'm not sure what the best approach is, so I'm open to suggestions here.