### PR TITLE
Adjust timing of standard library slides

### DIFF
--- a/src/std-traits/closures.md
+++ b/src/std-traits/closures.md
@@ -1,5 +1,5 @@
 ---
-minutes: 20
+minutes: 10
 ---
 
 # Closures

--- a/src/std-traits/comparisons.md
+++ b/src/std-traits/comparisons.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Comparisons

--- a/src/std-traits/from-and-into.md
+++ b/src/std-traits/from-and-into.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # `From` and `Into`

--- a/src/std-traits/operators.md
+++ b/src/std-traits/operators.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Operators

--- a/src/std-traits/read-and-write.md
+++ b/src/std-traits/read-and-write.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # `Read` and `Write`

--- a/src/std-types/hashmap.md
+++ b/src/std-types/hashmap.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # `HashMap`

--- a/src/std-types/result.md
+++ b/src/std-types/result.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # Result

--- a/src/std-types/string.md
+++ b/src/std-types/string.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # String

--- a/src/std-types/vec.md
+++ b/src/std-types/vec.md
@@ -1,5 +1,5 @@
 ---
-minutes: 10
+minutes: 5
 ---
 
 # `Vec`


### PR DESCRIPTION
Reduce the timings of the standard library slides to make the timing more accurate to how much time is spent in classes. This was a lingering issue from moving the generics section on day 3 to the afternoon, so day 3 afternoon has been showing up in PRs as taking too long.