### PR TITLE
fa: refresh translation for Jun 2024

### DIFF
--- a/po/fa.po
+++ b/po/fa.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: 2024-01-24T13:24:49+01:00\n"
+"POT-Creation-Date: 2024-06-07T18:15:11+03:30\n"
 "PO-Revision-Date: 2023-08-08 21:41+0330\n"
 "Last-Translator: danny <danykhosravi@gmail.com>\n"
 "Language-Team: Persian\n"
@@ -20,15 +20,15 @@ msgstr "به Comprehensive Rust خوش آمدید 🦀"
 msgid "Running the Course"
 msgstr "اجرای دوره"
 
-#: src/SUMMARY.md src/running-the-course/course-structure.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "مباحث دوره"
 
-#: src/SUMMARY.md src/running-the-course/keyboard-shortcuts.md
+#: src/SUMMARY.md src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "میان‌برهای صفحه کلید"
 
-#: src/SUMMARY.md src/running-the-course/translations.md
+#: src/SUMMARY.md src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "ترجمه"
 
@@ -52,100 +52,127 @@ msgstr "اجرای cargo روی ماشین local"
 msgid "Day 1: Morning"
 msgstr "روز اول: صبح"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:15
+#: src/running-the-course/course-structure.md:34
+#: src/running-the-course/course-structure.md:52
+#: src/running-the-course/course-structure.md:69 src/welcome-day-1.md
+#: src/welcome-day-2.md src/welcome-day-3.md src/welcome-day-4.md
+#: src/concurrency/welcome-async.md
 msgid "Welcome"
 msgstr "خوش آمدید"
 
-#: src/SUMMARY.md src/hello-world.md src/hello-world/hello-world.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:16
+#: src/welcome-day-1.md src/hello-world.md src/types-and-values.md
+#: src/types-and-values/hello-world.md:1
 #, fuzzy
 msgid "Hello, World"
 msgstr "سلام دنیا"
 
-#: src/SUMMARY.md src/hello-world/what-is-rust.md
+#: src/SUMMARY.md src/hello-world.md src/hello-world/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "زبان Rust چیست؟"
 
-#: src/SUMMARY.md src/hello-world/benefits.md
+#: src/SUMMARY.md src/hello-world.md src/hello-world/benefits.md:1
 msgid "Benefits of Rust"
 msgstr ""
 
-#: src/SUMMARY.md src/hello-world/playground.md
+#: src/SUMMARY.md src/hello-world.md src/hello-world/playground.md:1
 msgid "Playground"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:17
+#: src/welcome-day-1.md src/types-and-values.md
 msgid "Types and Values"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/variables.md
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/variables.md:1
 msgid "Variables"
 msgstr "متغیرها"
 
-#: src/SUMMARY.md src/types-and-values/values.md
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/values.md:1
 msgid "Values"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/arithmetic.md
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/arithmetic.md:1
 msgid "Arithmetic"
 msgstr ""
 
-#: src/SUMMARY.md src/types-and-values/strings.md
-msgid "Strings"
-msgstr "رشته‌ها"
-
-#: src/SUMMARY.md src/types-and-values/inference.md
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/inference.md:1
 msgid "Type Inference"
 msgstr "تعیین تایپ ضمنی"
 
-#: src/SUMMARY.md src/types-and-values/exercise.md
+#: src/SUMMARY.md src/types-and-values.md src/types-and-values/exercise.md:1
 #, fuzzy
 msgid "Exercise: Fibonacci"
 msgstr "تمرین: عبارت را بسنجید"
 
-#: src/SUMMARY.md src/types-and-values/solution.md
-#: src/control-flow-basics/solution.md src/tuples-and-arrays/solution.md
-#: src/references/solution.md src/user-defined-types/solution.md
-#: src/pattern-matching/solution.md src/methods-and-traits/solution.md
-#: src/generics/solution.md src/std-types/solution.md
-#: src/std-traits/solution.md src/memory-management/solution.md
-#: src/smart-pointers/solution.md src/borrowing/solution.md
-#: src/slices-and-lifetimes/solution.md src/iterators/solution.md
-#: src/modules/solution.md src/testing/solution.md
-#: src/error-handling/solution.md src/unsafe-rust/solution.md
+#: src/SUMMARY.md src/types-and-values/solution.md:1
+#: src/control-flow-basics/solution.md:1 src/tuples-and-arrays/solution.md:1
+#: src/references/solution.md:1 src/user-defined-types/solution.md:1
+#: src/pattern-matching/solution.md:1 src/methods-and-traits/solution.md:1
+#: src/generics/solution.md:1 src/std-types/solution.md:1
+#: src/std-traits/solution.md:1 src/memory-management/solution.md:1
+#: src/smart-pointers/solution.md:1 src/borrowing/solution.md:1
+#: src/lifetimes/solution.md:1 src/iterators/solution.md:1
+#: src/modules/solution.md:1 src/testing/solution.md:1
+#: src/error-handling/solution.md:1 src/unsafe-rust/solution.md:1
 #, fuzzy
 msgid "Solution"
 msgstr "راه حل‌ها"
 
-#: src/SUMMARY.md src/control-flow-basics.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:18
+#: src/welcome-day-1.md src/control-flow-basics.md
 #, fuzzy
 msgid "Control Flow Basics"
 msgstr "کنترل جریان"
 
-#: src/SUMMARY.md src/control-flow-basics/conditionals.md
-msgid "Conditionals"
-msgstr ""
+#: src/SUMMARY.md
+#, fuzzy
+msgid "`if` Expressions"
+msgstr "عبارات `if`"
 
-#: src/SUMMARY.md src/control-flow-basics/loops.md
+#: src/SUMMARY.md src/control-flow-basics.md src/control-flow-basics/loops.md:1
 msgid "Loops"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/break-continue.md
+#: src/SUMMARY.md src/control-flow-basics/loops/for.md:1
+#, fuzzy
+msgid "`for`"
+msgstr "حلقه‌های `for`"
+
+#: src/SUMMARY.md src/control-flow-basics/loops/loop.md:1
+msgid "`loop`"
+msgstr ""
+
+#: src/SUMMARY.md src/control-flow-basics/break-continue.md:1
 msgid "`break` and `continue`"
 msgstr "`break` و `continue`"
 
-#: src/SUMMARY.md src/control-flow-basics/blocks-and-scopes.md
+#: src/SUMMARY.md src/control-flow-basics/break-continue/labels.md:1
+msgid "Labels"
+msgstr ""
+
+#: src/SUMMARY.md src/control-flow-basics.md
+#: src/control-flow-basics/blocks-and-scopes.md:1
 msgid "Blocks and Scopes"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/functions.md
+#: src/SUMMARY.md src/control-flow-basics/blocks-and-scopes/scopes.md:1
+msgid "Scopes and Shadowing"
+msgstr "محدوده‌ها و سایه‌گذاری"
+
+#: src/SUMMARY.md src/control-flow-basics.md
+#: src/control-flow-basics/functions.md:1
 msgid "Functions"
 msgstr "توابع"
 
-#: src/SUMMARY.md src/control-flow-basics/macros.md
+#: src/SUMMARY.md src/control-flow-basics.md
+#: src/control-flow-basics/macros.md:1
 msgid "Macros"
 msgstr ""
 
-#: src/SUMMARY.md src/control-flow-basics/exercise.md
+#: src/SUMMARY.md src/control-flow-basics.md
+#: src/control-flow-basics/exercise.md:1
 msgid "Exercise: Collatz Sequence"
 msgstr ""
 
@@ -153,76 +180,97 @@ msgstr ""
 msgid "Day 1: Afternoon"
 msgstr "روز ۱: بعد از ظهر"
 
-#: src/SUMMARY.md src/tuples-and-arrays.md
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:25
+#: src/welcome-day-1-afternoon.md src/tuples-and-arrays.md
 msgid "Tuples and Arrays"
 msgstr ""
 
-#: src/SUMMARY.md src/tuples-and-arrays/iteration.md
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/arrays.md:1
+msgid "Arrays"
+msgstr "آرایه‌ها"
+
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/tuples.md:1
+msgid "Tuples"
+msgstr "تاپل‌ها"
+
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/iteration.md:1
 #, fuzzy
 msgid "Array Iteration"
 msgstr "تکرار کننده"
 
-#: src/SUMMARY.md src/tuples-and-arrays/match.md src/pattern-matching.md
-msgid "Pattern Matching"
-msgstr "تطبیق الگو"
-
-#: src/SUMMARY.md src/tuples-and-arrays/destructuring.md
-#: src/pattern-matching/destructuring.md
+#: src/SUMMARY.md src/tuples-and-arrays.md
+#: src/tuples-and-arrays/destructuring.md:1
 #, fuzzy
-msgid "Destructuring"
+msgid "Patterns and Destructuring"
 msgstr "تخریب Enumها"
 
-#: src/SUMMARY.md src/tuples-and-arrays/exercise.md
+#: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/exercise.md:1
 msgid "Exercise: Nested Arrays"
 msgstr ""
 
-#: src/SUMMARY.md src/references.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:26
+#: src/welcome-day-1-afternoon.md src/references.md
 msgid "References"
 msgstr "مراجع"
 
-#: src/SUMMARY.md src/references/shared.md
+#: src/SUMMARY.md src/references.md src/references/shared.md:1
 #, fuzzy
 msgid "Shared References"
 msgstr "مراجع"
 
-#: src/SUMMARY.md src/references/exclusive.md
+#: src/SUMMARY.md src/references.md src/references/exclusive.md:1
 #, fuzzy
 msgid "Exclusive References"
 msgstr "ارجاعات تعلیق شده"
 
-#: src/SUMMARY.md src/references/exercise.md
+#: src/SUMMARY.md
+#, fuzzy
+msgid "Slices: `&[T]`"
+msgstr "برش‌ها"
+
+#: src/SUMMARY.md src/references.md src/references/strings.md:5
+msgid "Strings"
+msgstr "رشته‌ها"
+
+#: src/SUMMARY.md src/references.md src/references/exercise.md:1
 msgid "Exercise: Geometry"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:27
+#: src/welcome-day-1-afternoon.md src/user-defined-types.md
 msgid "User-Defined Types"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/named-structs.md
+#: src/SUMMARY.md src/user-defined-types.md
+#: src/user-defined-types/named-structs.md:1
 #, fuzzy
 msgid "Named Structs"
 msgstr "ساختارها"
 
-#: src/SUMMARY.md src/user-defined-types/tuple-structs.md
+#: src/SUMMARY.md src/user-defined-types.md
+#: src/user-defined-types/tuple-structs.md:5
 msgid "Tuple Structs"
 msgstr "ساختار‌های چند‌گانه (Tuple Structs)"
 
-#: src/SUMMARY.md src/user-defined-types/enums.md
-#: src/pattern-matching/destructuring.md
+#: src/SUMMARY.md src/user-defined-types.md src/user-defined-types/enums.md:1
+#: src/pattern-matching/destructuring-enums.md:1
 msgid "Enums"
 msgstr "Enums"
 
-#: src/SUMMARY.md src/user-defined-types/static-and-const.md
-#, fuzzy
-msgid "Static and Const"
-msgstr "نمادهای ایستا و ثابت"
+#: src/SUMMARY.md src/user-defined-types.md
+msgid "Static"
+msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/aliases.md
+#: src/SUMMARY.md
+msgid "Const"
+msgstr ""
+
+#: src/SUMMARY.md src/user-defined-types.md src/user-defined-types/aliases.md:1
 msgid "Type Aliases"
 msgstr ""
 
-#: src/SUMMARY.md src/user-defined-types/exercise.md
+#: src/SUMMARY.md src/user-defined-types.md
+#: src/user-defined-types/exercise.md:1
 #, fuzzy
 msgid "Exercise: Elevator Events"
 msgstr "تمرین: عبارت را بسنجید"
@@ -231,80 +279,123 @@ msgstr "تمرین: عبارت را بسنجید"
 msgid "Day 2: Morning"
 msgstr "روز دوم: صبح"
 
-#: src/SUMMARY.md src/pattern-matching/let-control-flow.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:35
+#: src/welcome-day-2.md src/pattern-matching.md
+msgid "Pattern Matching"
+msgstr "تطبیق الگو"
+
+#: src/SUMMARY.md src/pattern-matching.md src/pattern-matching/match.md:1
+msgid "Matching Values"
+msgstr ""
+
+#: src/SUMMARY.md src/pattern-matching.md
+msgid "Destructuring Structs"
+msgstr "تخریب ساختارها"
+
+#: src/SUMMARY.md src/pattern-matching.md
+#, fuzzy
+msgid "Destructuring Enums"
+msgstr "تخریب Enumها"
+
+#: src/SUMMARY.md src/pattern-matching.md
+#: src/pattern-matching/let-control-flow.md:1
 #, fuzzy
 msgid "Let Control Flow"
 msgstr "کنترل جریان"
 
-#: src/SUMMARY.md src/pattern-matching/exercise.md
+#: src/SUMMARY.md src/pattern-matching.md src/pattern-matching/exercise.md:1
 msgid "Exercise: Expression Evaluation"
 msgstr "تمرین: عبارت را بسنجید"
 
-#: src/SUMMARY.md src/methods-and-traits.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:36
+#: src/welcome-day-2.md src/methods-and-traits.md
 #, fuzzy
 msgid "Methods and Traits"
 msgstr "Read and Write"
 
-#: src/SUMMARY.md src/methods-and-traits/methods.md
+#: src/SUMMARY.md src/methods-and-traits.md src/methods-and-traits/methods.md:1
 msgid "Methods"
 msgstr "متدها"
 
-#: src/SUMMARY.md src/methods-and-traits/traits.md
+#: src/SUMMARY.md src/methods-and-traits.md src/methods-and-traits/traits.md:1
 msgid "Traits"
 msgstr "صفت‌ها"
 
-#: src/SUMMARY.md src/methods-and-traits/deriving.md
+#: src/SUMMARY.md src/methods-and-traits/traits/implementing.md:1
+#, fuzzy
+msgid "Implementing Traits"
+msgstr "پیاده سازی صفات (Traits) ناامن"
+
+#: src/SUMMARY.md src/methods-and-traits/traits/supertraits.md:1
+msgid "Supertraits"
+msgstr ""
+
+#: src/SUMMARY.md src/methods-and-traits/traits/associated-types.md:1
+#, fuzzy
+msgid "Associated Types"
+msgstr "تایپ‌های عددی"
+
+#: src/SUMMARY.md src/methods-and-traits.md
+#: src/methods-and-traits/deriving.md:1
 #, fuzzy
 msgid "Deriving"
 msgstr "صفات استنتاجی (Deriving Traits)"
 
-#: src/SUMMARY.md src/methods-and-traits/trait-objects.md
-msgid "Trait Objects"
-msgstr "آبجکت‌های موصوفی (Trait Objects)"
-
-#: src/SUMMARY.md src/methods-and-traits/exercise.md
+#: src/SUMMARY.md src/methods-and-traits.md
 msgid "Exercise: Generic Logger"
-msgstr ""
-
-#: src/SUMMARY.md src/generics.md
-msgid "Generics"
-msgstr "جنریک‌ها"
-
-#: src/SUMMARY.md src/generics/generic-functions.md
-#, fuzzy
-msgid "Generic Functions"
-msgstr "توابع خارجی  (Extern Functions)"
-
-#: src/SUMMARY.md src/generics/generic-data.md
-msgid "Generic Data Types"
-msgstr "انواع داده‌ها جنریک (Generic Data Types)"
-
-#: src/SUMMARY.md src/generics/trait-bounds.md
-msgid "Trait Bounds"
-msgstr "صفات مرزی (Trait Bounds)"
-
-#: src/SUMMARY.md src/generics/impl-trait.md
-msgid "`impl Trait`"
-msgstr ""
-
-#: src/SUMMARY.md src/generics/exercise.md
-msgid "Exercise: Generic `min`"
 msgstr ""
 
 #: src/SUMMARY.md
 msgid "Day 2: Afternoon"
 msgstr "روز دوم: عصر"
 
-#: src/SUMMARY.md src/std-types.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:43
+#: src/welcome-day-2-afternoon.md src/generics.md
+msgid "Generics"
+msgstr "جنریک‌ها"
+
+#: src/SUMMARY.md src/generics.md src/generics/generic-functions.md:1
+#, fuzzy
+msgid "Generic Functions"
+msgstr "توابع خارجی  (Extern Functions)"
+
+#: src/SUMMARY.md src/generics.md src/generics/generic-data.md:1
+msgid "Generic Data Types"
+msgstr "انواع داده‌ها جنریک (Generic Data Types)"
+
+#: src/SUMMARY.md src/generics/generic-traits.md:1
+#, fuzzy
+msgid "Generic Traits"
+msgstr "جنریک‌ها"
+
+#: src/SUMMARY.md src/generics.md src/generics/trait-bounds.md:1
+msgid "Trait Bounds"
+msgstr "صفات مرزی (Trait Bounds)"
+
+#: src/SUMMARY.md src/generics/impl-trait.md:1
+msgid "`impl Trait`"
+msgstr ""
+
+#: src/SUMMARY.md src/generics/dyn-trait.md:1
+#, fuzzy
+msgid "`dyn Trait`"
+msgstr "صفات Async"
+
+#: src/SUMMARY.md src/generics/exercise.md:1
+msgid "Exercise: Generic `min`"
+msgstr ""
+
+#: src/SUMMARY.md src/running-the-course/course-structure.md:44
+#: src/welcome-day-2-afternoon.md src/std-types.md
 #, fuzzy
 msgid "Standard Library Types"
 msgstr "کتابخانه‌های استاندارد"
 
-#: src/SUMMARY.md src/std-types/std.md
+#: src/SUMMARY.md src/std-types.md src/std-types/std.md:1
 msgid "Standard Library"
 msgstr "کتابخانه‌های استاندارد"
 
-#: src/SUMMARY.md src/std-types/docs.md
+#: src/SUMMARY.md src/std-types.md src/std-types/docs.md:1
 #, fuzzy
 msgid "Documentation"
 msgstr "تست‌ سندها"
@@ -317,48 +408,51 @@ msgstr ""
 msgid "`Result`"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
+#: src/SUMMARY.md src/android/aidl/types/primitives.md:14
+#: src/android/interoperability/cpp/type-mapping.md:5
 #, fuzzy
 msgid "`String`"
 msgstr "String"
 
-#: src/SUMMARY.md src/std-types/vec.md
+#: src/SUMMARY.md src/std-types/vec.md:1
 msgid "`Vec`"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types/hashmap.md src/bare-metal/no_std.md
+#: src/SUMMARY.md src/std-types/hashmap.md:1 src/bare-metal/no_std.md
 msgid "`HashMap`"
 msgstr ""
 
-#: src/SUMMARY.md src/std-types/exercise.md
+#: src/SUMMARY.md src/std-types.md src/std-types/exercise.md:1
 #, fuzzy
 msgid "Exercise: Counter"
 msgstr "تمرین‌ها"
 
-#: src/SUMMARY.md src/std-traits.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:45
+#: src/welcome-day-2-afternoon.md src/std-traits.md
 #, fuzzy
 msgid "Standard Library Traits"
 msgstr "کتابخانه‌های استاندارد"
 
-#: src/SUMMARY.md src/std-traits/comparisons.md src/async.md
+#: src/SUMMARY.md src/std-traits.md src/std-traits/comparisons.md:1
+#: src/concurrency/welcome-async.md
 msgid "Comparisons"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/operators.md
+#: src/SUMMARY.md src/std-traits.md src/std-traits/operators.md:1
 #, fuzzy
 msgid "Operators"
 msgstr "تکرار کننده"
 
-#: src/SUMMARY.md src/std-traits/from-and-into.md
+#: src/SUMMARY.md src/std-traits/from-and-into.md:1
 msgid "`From` and `Into`"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/casting.md
+#: src/SUMMARY.md src/std-traits.md src/std-traits/casting.md:1
 #, fuzzy
 msgid "Casting"
 msgstr "تست‌کردن"
 
-#: src/SUMMARY.md src/std-traits/read-and-write.md
+#: src/SUMMARY.md src/std-traits/read-and-write.md:1
 msgid "`Read` and `Write`"
 msgstr ""
 
@@ -366,11 +460,11 @@ msgstr ""
 msgid "`Default`, struct update syntax"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/closures.md
+#: src/SUMMARY.md src/std-traits.md src/std-traits/closures.md:1
 msgid "Closures"
 msgstr ""
 
-#: src/SUMMARY.md src/std-traits/exercise.md
+#: src/SUMMARY.md src/std-traits.md src/std-traits/exercise.md:1
 #, fuzzy
 msgid "Exercise: ROT13"
 msgstr "تمرین‌ها"
@@ -379,24 +473,26 @@ msgstr "تمرین‌ها"
 msgid "Day 3: Morning"
 msgstr "روز سوم: صبح"
 
-#: src/SUMMARY.md src/memory-management.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:53
+#: src/welcome-day-3.md src/memory-management.md
 msgid "Memory Management"
 msgstr "مدیریت حافظه"
 
-#: src/SUMMARY.md src/memory-management/review.md
+#: src/SUMMARY.md src/memory-management.md src/memory-management/review.md:1
 msgid "Review of Program Memory"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/approaches.md
+#: src/SUMMARY.md src/memory-management.md
+#: src/memory-management/approaches.md:1
 #, fuzzy
 msgid "Approaches to Memory Management"
 msgstr "مدیریت حافظه خودکار"
 
-#: src/SUMMARY.md src/memory-management/ownership.md
+#: src/SUMMARY.md src/memory-management.md src/memory-management/ownership.md:1
 msgid "Ownership"
 msgstr "مالکیت"
 
-#: src/SUMMARY.md src/memory-management/move.md
+#: src/SUMMARY.md src/memory-management.md src/memory-management/move.md:1
 msgid "Move Semantics"
 msgstr "مفاهیم جابه‌جایی"
 
@@ -404,7 +500,8 @@ msgstr "مفاهیم جابه‌جایی"
 msgid "`Clone`"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/copy-types.md
+#: src/SUMMARY.md src/memory-management.md
+#: src/memory-management/copy-types.md:1
 #, fuzzy
 msgid "Copy Types"
 msgstr "تایپ‌های مرکب"
@@ -414,24 +511,30 @@ msgstr "تایپ‌های مرکب"
 msgid "`Drop`"
 msgstr "رها کردن"
 
-#: src/SUMMARY.md src/memory-management/exercise.md
+#: src/SUMMARY.md src/memory-management.md src/memory-management/exercise.md:1
 msgid "Exercise: Builder Type"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:54
+#: src/welcome-day-3.md src/smart-pointers.md
 msgid "Smart Pointers"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers/box.md
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/SUMMARY.md src/smart-pointers/box.md:1
+#: src/android/interoperability/cpp/type-mapping.md:9
 msgid "`Box<T>`"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers/rc.md
+#: src/SUMMARY.md src/smart-pointers/rc.md:1
 msgid "`Rc`"
 msgstr ""
 
-#: src/SUMMARY.md src/smart-pointers/exercise.md
+#: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/trait-objects.md:1
+#, fuzzy
+msgid "Owned Trait Objects"
+msgstr "آبجکت‌های موصوفی (Trait Objects)"
+
+#: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/exercise.md:1
 msgid "Exercise: Binary Tree"
 msgstr ""
 
@@ -439,61 +542,57 @@ msgstr ""
 msgid "Day 3: Afternoon"
 msgstr "روز سوم: عصر"
 
-#: src/SUMMARY.md src/borrowing.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:61
+#: src/welcome-day-3-afternoon.md src/borrowing.md
 msgid "Borrowing"
 msgstr "قرض گرفتن"
 
-#: src/SUMMARY.md src/borrowing/shared.md
+#: src/SUMMARY.md src/borrowing.md src/borrowing/shared.md:1
 #, fuzzy
 msgid "Borrowing a Value"
 msgstr "قرض گرفتن"
 
-#: src/SUMMARY.md src/borrowing/borrowck.md
+#: src/SUMMARY.md src/borrowing.md src/borrowing/borrowck.md:1
 #, fuzzy
 msgid "Borrow Checking"
 msgstr "قرض گرفتن"
 
-#: src/SUMMARY.md src/borrowing/interior-mutability.md
+#: src/SUMMARY.md src/borrowing.md src/borrowing/examples.md:1
+msgid "Borrow Errors"
+msgstr ""
+
+#: src/SUMMARY.md src/borrowing.md src/borrowing/interior-mutability.md:1
 #, fuzzy
 msgid "Interior Mutability"
 msgstr "قابلیت همکاری"
 
-#: src/SUMMARY.md src/borrowing/exercise.md
+#: src/SUMMARY.md src/borrowing.md src/borrowing/exercise.md:1
 #, fuzzy
 msgid "Exercise: Health Statistics"
 msgstr "آمارهای سلامتی"
 
-#: src/SUMMARY.md src/slices-and-lifetimes.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:62
+#: src/welcome-day-3-afternoon.md src/lifetimes.md
 #, fuzzy
-msgid "Slices and Lifetimes"
+msgid "Lifetimes"
 msgstr "چرخه حیات"
 
-#: src/SUMMARY.md
-#, fuzzy
-msgid "Slices: `&[T]`"
-msgstr "برش‌ها"
-
-#: src/SUMMARY.md src/slices-and-lifetimes/str.md
-#, fuzzy
-msgid "String References"
-msgstr "ارجاعات تعلیق شده"
-
-#: src/SUMMARY.md src/slices-and-lifetimes/lifetime-annotations.md
+#: src/SUMMARY.md src/lifetimes.md src/lifetimes/lifetime-annotations.md:1
 #, fuzzy
 msgid "Lifetime Annotations"
 msgstr "طول عمر در فراخوانی‌ توابع"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/lifetimes.md
 #, fuzzy
 msgid "Lifetime Elision"
 msgstr "چرخه حیات"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/lifetimes.md
 #, fuzzy
 msgid "Struct Lifetimes"
 msgstr "چرخه حیات"
 
-#: src/SUMMARY.md src/slices-and-lifetimes/exercise.md
+#: src/SUMMARY.md src/lifetimes.md src/lifetimes/exercise.md:1
 msgid "Exercise: Protobuf Parsing"
 msgstr ""
 
@@ -502,15 +601,16 @@ msgstr ""
 msgid "Day 4: Morning"
 msgstr "روز اول: صبح"
 
-#: src/SUMMARY.md src/iterators.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:70
+#: src/welcome-day-4.md src/iterators.md
 msgid "Iterators"
 msgstr ""
 
-#: src/SUMMARY.md src/iterators/iterator.md src/bare-metal/no_std.md
+#: src/SUMMARY.md src/iterators/iterator.md:1 src/bare-metal/no_std.md
 msgid "`Iterator`"
 msgstr ""
 
-#: src/SUMMARY.md src/iterators/intoiterator.md
+#: src/SUMMARY.md src/iterators/intoiterator.md:1
 msgid "`IntoIterator`"
 msgstr ""
 
@@ -519,19 +619,20 @@ msgstr ""
 msgid "`FromIterator`"
 msgstr "FromIterator"
 
-#: src/SUMMARY.md src/iterators/exercise.md
+#: src/SUMMARY.md src/iterators.md src/iterators/exercise.md:1
 msgid "Exercise: Iterator Method Chaining"
 msgstr ""
 
-#: src/SUMMARY.md src/modules.md src/modules/modules.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:71
+#: src/welcome-day-4.md src/modules.md src/modules/modules.md:1
 msgid "Modules"
 msgstr "ماژول‌ها"
 
-#: src/SUMMARY.md src/modules/filesystem.md
+#: src/SUMMARY.md src/modules.md src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "سلسله‌ مراتب فایل‌سیستم"
 
-#: src/SUMMARY.md src/modules/visibility.md
+#: src/SUMMARY.md src/modules.md src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "قابلیت دید"
 
@@ -539,40 +640,29 @@ msgstr "قابلیت دید"
 msgid "`use`, `super`, `self`"
 msgstr ""
 
-#: src/SUMMARY.md src/modules/exercise.md
+#: src/SUMMARY.md src/modules.md src/modules/exercise.md:1
 msgid "Exercise: Modules for a GUI Library"
 msgstr ""
 
-#: src/SUMMARY.md src/testing.md src/chromium/testing.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:72
+#: src/welcome-day-4.md src/testing.md src/chromium/testing.md
 msgid "Testing"
 msgstr "تست‌کردن"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/testing.md
 msgid "Test Modules"
 msgstr "تست‌ ماژول‌ها"
 
-#: src/SUMMARY.md src/testing/other.md
+#: src/SUMMARY.md src/testing.md src/testing/other.md:1
 #, fuzzy
 msgid "Other Types of Tests"
 msgstr "منابع دیگر"
 
-#: src/SUMMARY.md src/testing/useful-crates.md
-msgid "Useful Crates"
-msgstr "جعبه‌های (Crates) کاربردی"
-
-#: src/SUMMARY.md src/testing/googletest.md
-msgid "GoogleTest"
-msgstr ""
-
-#: src/SUMMARY.md src/testing/mocking.md
-msgid "Mocking"
-msgstr ""
-
-#: src/SUMMARY.md src/testing/lints.md
+#: src/SUMMARY.md src/testing.md src/testing/lints.md:1
 msgid "Compiler Lints and Clippy"
 msgstr ""
 
-#: src/SUMMARY.md src/testing/exercise.md
+#: src/SUMMARY.md src/testing.md src/testing/exercise.md:1
 #, fuzzy
 msgid "Exercise: Luhn Algorithm"
 msgstr "الگوریتم  Luhn"
@@ -582,20 +672,21 @@ msgstr "الگوریتم  Luhn"
 msgid "Day 4: Afternoon"
 msgstr "روز ۱: بعد از ظهر"
 
-#: src/SUMMARY.md src/error-handling.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:79
+#: src/welcome-day-4-afternoon.md src/error-handling.md
 msgid "Error Handling"
 msgstr "مدیریت خطا (Error Handling)"
 
-#: src/SUMMARY.md src/error-handling/panics.md
+#: src/SUMMARY.md src/error-handling.md src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "پانیک‌ها"
 
-#: src/SUMMARY.md src/error-handling/try.md
+#: src/SUMMARY.md src/error-handling.md src/error-handling/try.md:1
 #, fuzzy
 msgid "Try Operator"
 msgstr "تکرار کننده"
 
-#: src/SUMMARY.md src/error-handling/try-conversions.md
+#: src/SUMMARY.md src/error-handling.md src/error-handling/try-conversions.md:1
 #, fuzzy
 msgid "Try Conversions"
 msgstr "تبدیل‌های غیر صریح"
@@ -605,7 +696,7 @@ msgstr "تبدیل‌های غیر صریح"
 msgid "`Error` Trait"
 msgstr "صفت‌های بیشتر"
 
-#: src/SUMMARY.md src/error-handling/thiserror-and-anyhow.md
+#: src/SUMMARY.md src/error-handling/thiserror-and-anyhow.md:1
 msgid "`thiserror` and `anyhow`"
 msgstr ""
 
@@ -613,38 +704,40 @@ msgstr ""
 msgid "Exercise: Rewriting with `Result`"
 msgstr ""
 
-#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unsafe.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:80
+#: src/welcome-day-4-afternoon.md src/unsafe-rust.md
+#: src/unsafe-rust/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Rust ناایمن"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/unsafe-rust.md
 #, fuzzy
 msgid "Unsafe"
 msgstr "Rust ناایمن"
 
-#: src/SUMMARY.md src/unsafe-rust/dereferencing.md
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/dereferencing.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "عدم ارجاع به اشاره گرهای خام"
 
-#: src/SUMMARY.md src/unsafe-rust/mutable-static.md
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/mutable-static.md:1
 msgid "Mutable Static Variables"
 msgstr "متغیرهای ثابت قابل تغییر"
 
-#: src/SUMMARY.md src/unsafe-rust/unions.md
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unions.md:1
 msgid "Unions"
 msgstr "نوع داده چندگانه"
 
-#: src/SUMMARY.md src/unsafe-rust/unsafe-functions.md
+#: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/unsafe-functions.md:1
 #, fuzzy
 msgid "Unsafe Functions"
 msgstr "فراخوانی متدهای ناامن"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/unsafe-rust.md
 #, fuzzy
 msgid "Unsafe Traits"
 msgstr "پیاده سازی صفات (Traits) ناامن"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/unsafe-rust.md
 #, fuzzy
 msgid "Exercise: FFI Wrapper"
 msgstr "امن بودن FFI Wrapper"
@@ -673,19 +766,28 @@ msgstr "کتابخانه"
 msgid "AIDL"
 msgstr "AIDL"
 
+#: src/SUMMARY.md src/android/aidl/birthday-service.md:1
+msgid "Birthday Service Tutorial"
+msgstr ""
+
 #: src/SUMMARY.md
 msgid "Interface"
 msgstr "رابط (Interface)"
 
 #: src/SUMMARY.md
-msgid "Implementation"
-msgstr "پیاده سازی"
+msgid "Service API"
+msgstr ""
+
+#: src/SUMMARY.md
+#, fuzzy
+msgid "Service"
+msgstr "سرور"
 
 #: src/SUMMARY.md
 msgid "Server"
 msgstr "سرور"
 
-#: src/SUMMARY.md src/android/aidl/deploy.md
+#: src/SUMMARY.md src/android/aidl/example-service/deploy.md:1
 msgid "Deploy"
 msgstr "دیپلوی"
 
@@ -693,11 +795,52 @@ msgstr "دیپلوی"
 msgid "Client"
 msgstr "کاربر"
 
-#: src/SUMMARY.md src/android/aidl/changing.md
+#: src/SUMMARY.md src/android/aidl/example-service/changing-definition.md:1
 msgid "Changing API"
 msgstr "تغییر دادن API"
 
-#: src/SUMMARY.md src/android/logging.md src/bare-metal/aps/logging.md
+#: src/SUMMARY.md
+#, fuzzy
+msgid "Updating Implementations"
+msgstr "پیاده سازی"
+
+#: src/SUMMARY.md
+#, fuzzy
+msgid "AIDL Types"
+msgstr "انواع"
+
+#: src/SUMMARY.md src/android/aidl/types/primitives.md:1
+msgid "Primitive Types"
+msgstr ""
+
+#: src/SUMMARY.md src/android/aidl/types/arrays.md:1
+#, fuzzy
+msgid "Array Types"
+msgstr "آرایه‌ها"
+
+#: src/SUMMARY.md src/android/aidl/types/objects.md:1
+#, fuzzy
+msgid "Sending Objects"
+msgstr "آبجکت‌های موصوفی (Trait Objects)"
+
+#: src/SUMMARY.md src/android/aidl/types/parcelables.md:1
+#, fuzzy
+msgid "Parcelables"
+msgstr "متغیرها"
+
+#: src/SUMMARY.md src/android/aidl/types/file-descriptor.md:1
+msgid "Sending Files"
+msgstr ""
+
+#: src/SUMMARY.md src/android/testing/googletest.md:1
+msgid "GoogleTest"
+msgstr ""
+
+#: src/SUMMARY.md src/android/testing/mocking.md:1
+msgid "Mocking"
+msgstr ""
+
+#: src/SUMMARY.md src/android/logging.md src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "لاگ"
 
@@ -717,11 +860,11 @@ msgstr "فراخوانی C با Bindgen"
 msgid "Calling Rust from C"
 msgstr "فراخوانی Rust از C"
 
-#: src/SUMMARY.md src/android/interoperability/cpp.md
+#: src/SUMMARY.md src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "با <span dir=ltr>C++</span>"
 
-#: src/SUMMARY.md src/android/interoperability/cpp/bridge.md
+#: src/SUMMARY.md src/android/interoperability/cpp/bridge.md:1
 #, fuzzy
 msgid "The Bridge Module"
 msgstr "تست‌ ماژول‌ها"
@@ -731,7 +874,7 @@ msgstr "تست‌ ماژول‌ها"
 msgid "Rust Bridge"
 msgstr "Rust در اندروید"
 
-#: src/SUMMARY.md src/android/interoperability/cpp/generated-cpp.md
+#: src/SUMMARY.md src/android/interoperability/cpp/generated-cpp.md:1
 msgid "Generated C++"
 msgstr ""
 
@@ -739,26 +882,26 @@ msgstr ""
 msgid "C++ Bridge"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/shared-types.md
+#: src/SUMMARY.md src/android/interoperability/cpp/shared-types.md:1
 #, fuzzy
 msgid "Shared Types"
 msgstr "تایپ‌های عددی"
 
-#: src/SUMMARY.md src/android/interoperability/cpp/shared-enums.md
+#: src/SUMMARY.md src/android/interoperability/cpp/shared-enums.md:1
 msgid "Shared Enums"
 msgstr ""
 
-#: src/SUMMARY.md src/android/interoperability/cpp/rust-result.md
+#: src/SUMMARY.md src/android/interoperability/cpp/rust-result.md:1
 #, fuzzy
 msgid "Rust Error Handling"
 msgstr "مدیریت خطا (Error Handling)"
 
-#: src/SUMMARY.md src/android/interoperability/cpp/cpp-exception.md
+#: src/SUMMARY.md src/android/interoperability/cpp/cpp-exception.md:1
 #, fuzzy
 msgid "C++ Error Handling"
 msgstr "مدیریت خطا (Error Handling)"
 
-#: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
+#: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md:1
 msgid "Additional Types"
 msgstr ""
 
@@ -778,9 +921,12 @@ msgstr ""
 msgid "With Java"
 msgstr "با جاوا"
 
-#: src/SUMMARY.md src/exercises/android/morning.md
-#: src/exercises/bare-metal/morning.md src/exercises/bare-metal/afternoon.md
-#: src/exercises/concurrency/morning.md src/exercises/concurrency/afternoon.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:155
+#: src/running-the-course/course-structure.md:165
+#: src/exercises/android/morning.md src/exercises/bare-metal/morning.md
+#: src/exercises/bare-metal/afternoon.md src/concurrency/welcome.md
+#: src/concurrency/sync-exercises.md src/concurrency/welcome-async.md
+#: src/concurrency/async-exercises.md
 msgid "Exercises"
 msgstr "تمرین‌ها"
 
@@ -801,28 +947,28 @@ msgstr ""
 msgid "Unsafe Code"
 msgstr "Rust ناایمن"
 
-#: src/SUMMARY.md src/chromium/build-rules/depending.md
+#: src/SUMMARY.md src/chromium/build-rules/depending.md:1
 msgid "Depending on Rust Code from Chromium C++"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/build-rules/vscode.md
+#: src/SUMMARY.md src/chromium/build-rules/vscode.md:1
 msgid "Visual Studio Code"
 msgstr ""
 
-#: src/SUMMARY.md src/exercises/chromium/third-party.md
+#: src/SUMMARY.md src/exercises/chromium/third-party.md:1
 #, fuzzy
 msgid "Exercise"
 msgstr "تمرین‌ها"
 
-#: src/SUMMARY.md src/chromium/testing/rust-gtest-interop.md
+#: src/SUMMARY.md src/chromium/testing/rust-gtest-interop.md:1
 msgid "`rust_gtest_interop` Library"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/testing/build-gn.md
+#: src/SUMMARY.md src/chromium/testing/build-gn.md:1
 msgid "GN Rules for Rust Tests"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/testing/chromium-import-macro.md
+#: src/SUMMARY.md src/chromium/testing/chromium-import-macro.md:1
 msgid "`chromium::import!` Macro"
 msgstr ""
 
@@ -831,16 +977,17 @@ msgstr ""
 msgid "Interoperability with C++"
 msgstr "قابلیت همکاری"
 
-#: src/SUMMARY.md src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/SUMMARY.md src/chromium/interoperability-with-cpp/example-bindings.md:1
 #, fuzzy
 msgid "Example Bindings"
 msgstr "مثال‌ها"
 
-#: src/SUMMARY.md src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/SUMMARY.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:1
 msgid "Limitations of CXX"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/interoperability-with-cpp/error-handling.md
+#: src/SUMMARY.md src/chromium/interoperability-with-cpp/error-handling.md:1
 #, fuzzy
 msgid "CXX Error Handling"
 msgstr "مدیریت خطا (Error Handling)"
@@ -868,35 +1015,37 @@ msgid "Configuring Cargo.toml"
 msgstr ""
 
 #: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:1
 msgid "Configuring `gnrt_config.toml`"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:1
 msgid "Downloading Crates"
 msgstr ""
 
 #: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:1
 msgid "Generating `gn` Build Rules"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:1
 msgid "Resolving Problems"
 msgstr ""
 
 #: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:1
 msgid "Build Scripts Which Generate Code"
 msgstr ""
 
 #: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:1
 msgid "Build Scripts Which Build C++ or Take Arbitrary Actions"
 msgstr ""
 
 #: src/SUMMARY.md
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:1
 msgid "Depending on a Crate"
 msgstr ""
 
@@ -908,7 +1057,8 @@ msgstr ""
 msgid "Checking into Chromium Source Code"
 msgstr ""
 
-#: src/SUMMARY.md src/chromium/adding-third-party-crates/keeping-up-to-date.md
+#: src/SUMMARY.md
+#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:1
 msgid "Keeping Crates Up to Date"
 msgstr ""
 
@@ -933,7 +1083,7 @@ msgstr ""
 msgid "A Minimal Example"
 msgstr "یک مثال ساده"
 
-#: src/SUMMARY.md src/bare-metal/no_std.md src/bare-metal/alloc.md
+#: src/SUMMARY.md src/bare-metal/no_std.md src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -941,7 +1091,7 @@ msgstr ""
 msgid "Microcontrollers"
 msgstr "میکروکنترلرها"
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/mmio.md
+#: src/SUMMARY.md src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "Raw MMIO"
 
@@ -961,16 +1111,16 @@ msgstr "Board Support Crates"
 msgid "The Type State Pattern"
 msgstr "انواع State Pattern"
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/embedded-hal.md
+#: src/SUMMARY.md src/bare-metal/microcontrollers/embedded-hal.md:1
 msgid "`embedded-hal`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/probe-rs.md
+#: src/SUMMARY.md src/bare-metal/microcontrollers/probe-rs.md:1
 #, fuzzy
 msgid "`probe-rs` and `cargo-embed`"
 msgstr "probe-rs, cargo-embed"
 
-#: src/SUMMARY.md src/bare-metal/microcontrollers/debugging.md
+#: src/SUMMARY.md src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "اشکال یابی (Debugging)"
 
@@ -978,12 +1128,15 @@ msgstr "اشکال یابی (Debugging)"
 msgid "Other Projects"
 msgstr "باقی پروژه‌ها"
 
-#: src/SUMMARY.md src/exercises/bare-metal/compass.md
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/SUMMARY.md src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "قطب‌نما"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/concurrency/sync-exercises.md
+#: src/concurrency/sync-exercises/solutions.md:1
+#: src/concurrency/async-exercises.md
+#: src/concurrency/async-exercises/solutions.md:1
 msgid "Solutions"
 msgstr "راه حل‌ها"
 
@@ -995,7 +1148,7 @@ msgstr "با Bare Metal:  عصر"
 msgid "Application Processors"
 msgstr "پردازنده‌های برنامه"
 
-#: src/SUMMARY.md src/bare-metal/aps/entry-point.md
+#: src/SUMMARY.md src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr "آماده شدن برای Rust"
 
@@ -1019,7 +1172,7 @@ msgstr "صفت‌های بیشتر"
 msgid "A Better UART Driver"
 msgstr "یک درایور بهتر UART"
 
-#: src/SUMMARY.md src/bare-metal/aps/better-uart/bitflags.md
+#: src/SUMMARY.md src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "پرچم‌های بیتی (Bitflags)"
 
@@ -1027,7 +1180,7 @@ msgstr "پرچم‌های بیتی (Bitflags)"
 msgid "Multiple Registers"
 msgstr "رجیستر‌های چندگانه"
 
-#: src/SUMMARY.md src/bare-metal/aps/better-uart/driver.md
+#: src/SUMMARY.md src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "درایور"
 
@@ -1035,27 +1188,31 @@ msgstr "درایور"
 msgid "Using It"
 msgstr "استفاده از آن"
 
-#: src/SUMMARY.md src/bare-metal/aps/exceptions.md
+#: src/SUMMARY.md src/bare-metal/aps/exceptions.md:1
 msgid "Exceptions"
 msgstr "استثناها"
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/zerocopy.md
+#: src/SUMMARY.md
+msgid "Useful Crates"
+msgstr "جعبه‌های (Crates) کاربردی"
+
+#: src/SUMMARY.md src/bare-metal/useful-crates/zerocopy.md:1
 msgid "`zerocopy`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/aarch64-paging.md
+#: src/SUMMARY.md src/bare-metal/useful-crates/aarch64-paging.md:1
 msgid "`aarch64-paging`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/SUMMARY.md src/bare-metal/useful-crates/buddy_system_allocator.md:1
 msgid "`buddy_system_allocator`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/tinyvec.md
+#: src/SUMMARY.md src/bare-metal/useful-crates/tinyvec.md:1
 msgid "`tinyvec`"
 msgstr ""
 
-#: src/SUMMARY.md src/bare-metal/useful-crates/spin.md
+#: src/SUMMARY.md src/bare-metal/useful-crates/spin.md:1
 msgid "`spin`"
 msgstr ""
 
@@ -1072,23 +1229,39 @@ msgstr "درایور RTC"
 msgid "Concurrency: Morning"
 msgstr "همزمانی: صبح"
 
-#: src/SUMMARY.md src/concurrency/threads.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:151
+#: src/concurrency/welcome.md src/concurrency/threads.md
 msgid "Threads"
 msgstr "تردها"
 
-#: src/SUMMARY.md src/concurrency/scoped-threads.md
+#: src/SUMMARY.md src/concurrency/threads.md src/concurrency/threads/plain.md:1
+#, fuzzy
+msgid "Plain Threads"
+msgstr "تردها"
+
+#: src/SUMMARY.md src/concurrency/threads.md
+#: src/concurrency/threads/scoped.md:1
 msgid "Scoped Threads"
 msgstr "محدوده تردها"
 
-#: src/SUMMARY.md src/concurrency/channels.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:152
+#: src/concurrency/welcome.md src/concurrency/channels.md
 msgid "Channels"
 msgstr "کانال‌ها"
 
-#: src/SUMMARY.md src/concurrency/channels/unbounded.md
+#: src/SUMMARY.md src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md:1
+#, fuzzy
+msgid "Senders and Receivers"
+msgstr "متد دریافتی"
+
+#: src/SUMMARY.md src/concurrency/channels.md
+#: src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "کانال‌های نامحدود"
 
-#: src/SUMMARY.md src/concurrency/channels/bounded.md
+#: src/SUMMARY.md src/concurrency/channels.md
+#: src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "کانال‌های محدود"
 
@@ -1096,42 +1269,53 @@ msgstr "کانال‌های محدود"
 msgid "`Send` and `Sync`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/send-sync/send.md
+#: src/SUMMARY.md src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:1
+#, fuzzy
+msgid "Marker Traits"
+msgstr "صفت‌های بیشتر"
+
+#: src/SUMMARY.md src/concurrency/send-sync/send.md:1
 msgid "`Send`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/send-sync/sync.md
+#: src/SUMMARY.md src/concurrency/send-sync/sync.md:1
 msgid "`Sync`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/send-sync/examples.md
+#: src/SUMMARY.md src/concurrency/send-sync.md
+#: src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "مثال‌ها"
 
-#: src/SUMMARY.md src/concurrency/shared_state.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:154
+#: src/concurrency/welcome.md src/concurrency/shared-state.md
 msgid "Shared State"
 msgstr "ناحیه‌های مشترک"
 
-#: src/SUMMARY.md src/concurrency/shared_state/arc.md
+#: src/SUMMARY.md src/concurrency/shared-state/arc.md:1
 msgid "`Arc`"
 msgstr ""
 
-#: src/SUMMARY.md src/concurrency/shared_state/mutex.md
+#: src/SUMMARY.md src/concurrency/shared-state/mutex.md:1
 msgid "`Mutex`"
 msgstr ""
 
-#: src/SUMMARY.md src/memory-management/review.md
-#: src/error-handling/try-conversions.md
-#: src/concurrency/shared_state/example.md
+#: src/SUMMARY.md src/memory-management/review.md:16
+#: src/error-handling/try-conversions.md:23 src/concurrency/shared-state.md
+#: src/concurrency/shared-state/example.md:1
 msgid "Example"
 msgstr "مثال"
 
-#: src/SUMMARY.md src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/SUMMARY.md src/concurrency/sync-exercises.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:1
+#: src/concurrency/sync-exercises/solutions.md:3
+#: src/concurrency/async-exercises.md
 msgid "Dining Philosophers"
 msgstr "فلسفه Dining"
 
-#: src/SUMMARY.md src/exercises/concurrency/link-checker.md
+#: src/SUMMARY.md src/concurrency/sync-exercises.md
+#: src/concurrency/sync-exercises/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "جستجوگر پیوند چند تِردی"
 
@@ -1139,69 +1323,80 @@ msgstr "جستجوگر پیوند چند تِردی"
 msgid "Concurrency: Afternoon"
 msgstr "همزمانی: عصر"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:162
+#: src/concurrency/welcome-async.md src/concurrency/async.md
 msgid "Async Basics"
 msgstr "مبانی Async"
 
-#: src/SUMMARY.md src/async/async-await.md
+#: src/SUMMARY.md src/concurrency/async/async-await.md:1
 msgid "`async`/`await`"
 msgstr ""
 
-#: src/SUMMARY.md src/async/futures.md
+#: src/SUMMARY.md src/concurrency/async.md src/concurrency/async/futures.md:1
 msgid "Futures"
 msgstr "Futures"
 
-#: src/SUMMARY.md src/async/runtimes.md
+#: src/SUMMARY.md src/concurrency/async.md src/concurrency/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "Runtimes"
 
-#: src/SUMMARY.md src/async/runtimes/tokio.md
+#: src/SUMMARY.md src/concurrency/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md src/exercises/concurrency/link-checker.md src/async/tasks.md
-#: src/exercises/concurrency/chat-app.md
+#: src/SUMMARY.md src/concurrency/sync-exercises/link-checker.md:119
+#: src/concurrency/async.md src/concurrency/async/tasks.md:1
+#: src/concurrency/async-exercises/chat-app.md:143
 msgid "Tasks"
 msgstr "Task"
 
-#: src/SUMMARY.md src/async/channels.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:163
+#: src/concurrency/welcome-async.md src/concurrency/async-control-flow.md
+#, fuzzy
+msgid "Channels and Control Flow"
+msgstr "کنترل جریان پیشرفته"
+
+#: src/SUMMARY.md src/concurrency/async-control-flow.md
+#: src/concurrency/async-control-flow/channels.md:1
 msgid "Async Channels"
 msgstr "کانال‌های Async"
 
-#: src/SUMMARY.md
-msgid "Control Flow"
-msgstr "کنترل جریان"
-
-#: src/SUMMARY.md src/async/control-flow/join.md
+#: src/SUMMARY.md src/concurrency/async-control-flow.md
+#: src/concurrency/async-control-flow/join.md:1
 msgid "Join"
 msgstr "Join"
 
-#: src/SUMMARY.md src/async/control-flow/select.md
+#: src/SUMMARY.md src/concurrency/async-control-flow.md
+#: src/concurrency/async-control-flow/select.md:1
 msgid "Select"
 msgstr "Select"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/running-the-course/course-structure.md:164
+#: src/concurrency/welcome-async.md src/concurrency/async-pitfalls.md
 msgid "Pitfalls"
 msgstr "مشکل‌ها"
 
-#: src/SUMMARY.md
+#: src/SUMMARY.md src/concurrency/async-pitfalls.md
 msgid "Blocking the Executor"
 msgstr "مسدود کردن Executor"
 
-#: src/SUMMARY.md src/async/pitfalls/pin.md
+#: src/SUMMARY.md src/concurrency/async-pitfalls/pin.md:1
 msgid "`Pin`"
 msgstr ""
 
-#: src/SUMMARY.md src/async/pitfalls/async-traits.md
+#: src/SUMMARY.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "صفات Async"
 
-#: src/SUMMARY.md src/async/pitfalls/cancellation.md
+#: src/SUMMARY.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-pitfalls/cancellation.md:1
 msgid "Cancellation"
 msgstr "لغو"
 
-#: src/SUMMARY.md src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/SUMMARY.md src/concurrency/async-exercises.md
+#: src/concurrency/async-exercises/chat-app.md:1
+#: src/concurrency/async-exercises/solutions.md:102
 msgid "Broadcast Chat Application"
 msgstr "پخش برنامه چت"
 
@@ -1213,6 +1408,7 @@ msgstr "کلمات آخر"
 msgid "Thanks!"
 msgstr "سپاس!"
 
+#. Please keep { #glossary } untranslated.
 #: src/SUMMARY.md src/glossary.md
 msgid "Glossary"
 msgstr "واژه نامه"
@@ -1228,14 +1424,11 @@ msgstr "اعتبارها"
 #: src/index.md
 #, fuzzy
 msgid ""
-"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
-"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
-"[GitHub contributors](https://img.shields.io/github/contributors/google/"
-"comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
-"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
-"com/google/comprehensive-rust/stargazers)"
+"![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square) ![GitHub contributors]"
+"(https://img.shields.io/github/contributors/google/comprehensive-rust?"
+"style=flat-square) ![GitHub stars](https://img.shields.io/github/stars/"
+"google/comprehensive-rust?style=flat-square)"
 msgstr ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
@@ -1254,14 +1447,19 @@ msgstr ""
 "پیشرفته  مانند جنریک و مدیریت خطاها."
 
 #: src/index.md
+#, fuzzy
 msgid ""
-"The latest version of the course can be found at <https://google.github.io/"
-"comprehensive-rust/>. If you are reading somewhere else, please check there "
+"The latest version of the course can be found at https://google.github.io/"
+"comprehensive-rust/. If you are reading somewhere else, please check there "
 "for updates."
 msgstr ""
 "آخرین نسخه از دوره را میتوان در <https://google.github.io/comprehensive-rust/"
 "> پیدا کنید. اگر از جای دیگری میخوانید, لطفا برای بروز رسانی‌ها منبع اصلی را "
 "نیز بررسی کنید."
+
+#: src/index.md
+msgid "The course is also available as a PDF."
+msgstr ""
 
 #: src/index.md
 msgid ""
@@ -1297,9 +1495,10 @@ msgstr ""
 "با تکیه بر این، از شما دعوت می شود تا به یک یا چند موضوع تخصصی بپردازید:"
 
 #: src/index.md
+#, fuzzy
 msgid ""
-"[Android](android.md): a half-day course on using Rust for Android platform "
-"development (AOSP). This includes interoperability with C, C++, and Java."
+"Android: a half-day course on using Rust for Android platform development "
+"(AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
 "[Android](android.md): دوره نیم روزه استفاده از Rust برای پلتفرم "
 "اندرویدتوسعه (AOSP). این شامل قابلیت همکاری با C، <span dir=ltr>C++</span> و "
@@ -1308,30 +1507,30 @@ msgstr ""
 #: src/index.md
 #, fuzzy
 msgid ""
-"[Chromium](chromium.md): a half-day course on using Rust within Chromium "
-"based browsers. This includes interoperability with C++ and how to include "
-"third-party crates in Chromium."
+"Chromium: a half-day course on using Rust within Chromium based browsers. "
+"This includes interoperability with C++ and how to include third-party "
+"crates in Chromium."
 msgstr ""
 "[Android](android.md): دوره نیم روزه استفاده از Rust برای پلتفرم "
 "اندرویدتوسعه (AOSP). این شامل قابلیت همکاری با C، <span dir=ltr>C++</span> و "
 "جاوا می شود."
 
 #: src/index.md
+#, fuzzy
 msgid ""
-"[Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-metal "
-"(embedded) development. Both microcontrollers and application processors are "
-"covered."
+"Bare-metal: a whole-day class on using Rust for bare-metal (embedded) "
+"development. Both microcontrollers and application processors are covered."
 msgstr ""
 "[Bare-metal](bare-metal.md): یک دوره یک روزه درباره استفاده از راست برای "
 "توسعه bare-metal(embedded). هر دوی میکروکنترلر‌ها و هم پردازشگر هایی با "
 "کارایی خاص پوشش داده میشود."
 
 #: src/index.md
+#, fuzzy
 msgid ""
-"[Concurrency](concurrency.md): a whole-day class on concurrency in Rust. We "
-"cover both classical concurrency (preemptively scheduling using threads and "
-"mutexes) and async/await concurrency (cooperative multitasking using "
-"futures)."
+"Concurrency: a whole-day class on concurrency in Rust. We cover both "
+"classical concurrency (preemptively scheduling using threads and mutexes) "
+"and async/await concurrency (cooperative multitasking using futures)."
 msgstr ""
 "[Concurrency](concurrency.md): یک دوره یک روزه درباره همروندی (Concurrency) "
 "در Rust. ما هر دو همزمانی کلاسیک (برنامه ریزی پیشگیرانه با استفاده از نخ ها "
@@ -1351,10 +1550,10 @@ msgstr ""
 "چندتا از اهداف خارج از این دوره عبارتند از:"
 
 #: src/index.md
+#, fuzzy
 msgid ""
-"Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
-"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
-"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learning how to develop macros: please see Chapter 19.5 in the Rust Book and "
+"Rust by Example instead."
 msgstr ""
 "برای آموزش چگونه‌گی توسعه Macro ها: لطفا [Chapter 19.5 in the Rust Book]"
 "(https://doc.rust-lang.org/book/ch19-06-macros.html) و [Rust by Example]"
@@ -1393,7 +1592,7 @@ msgstr ""
 "اطلاعات بیشتری را ارائه دهیم.. این می تواند نکات کلیدی باشد که مدرس باید "
 "پوشش دهد و همچنین پاسخ به سوالات رایجی که در کلاس مطرح می شود."
 
-#: src/running-the-course.md src/running-the-course/course-structure.md
+#: src/running-the-course.md src/running-the-course/course-structure.md:3
 msgid "This page is for the course instructor."
 msgstr "این صفحه برای مدرس دوره است."
 
@@ -1469,13 +1668,13 @@ msgstr ""
 "نخواهد بود."
 
 #: src/running-the-course.md
+#, fuzzy
 msgid ""
 "On the day of your course, show up to the room a little early to set things "
 "up. We recommend presenting directly using `mdbook serve` running on your "
-"laptop (see the [installation instructions](https://github.com/google/"
-"comprehensive-rust#building)). This ensures optimal performance with no lag "
-"as you change pages. Using your laptop will also allow you to fix typos as "
-"you or the course participants spot them."
+"laptop (see the installation instructions). This ensures optimal performance "
+"with no lag as you change pages. Using your laptop will also allow you to "
+"fix typos as you or the course participants spot them."
 msgstr ""
 "در روز برگزاری دوره، کمی زودتر به کلاس بیایید تا همه چیز را آماده کنید. ما "
 "توصیه می کنیم مستقیماً با استفاده از `mdbook serve`را در لپتاپ خود اجرا کنید. "
@@ -1511,12 +1710,11 @@ msgstr ""
 "اندازه که برای ما لذت‌بخش بوده، لذت‌بخش باشد!"
 
 #: src/running-the-course.md
+#, fuzzy
 msgid ""
-"Please [provide feedback](https://github.com/google/comprehensive-rust/"
-"discussions/86) afterwards so that we can keep improving the course. We "
-"would love to hear what worked well for you and what can be made better. "
-"Your students are also very welcome to [send us feedback](https://github.com/"
-"google/comprehensive-rust/discussions/100)!"
+"Please provide feedback afterwards so that we can keep improving the course. "
+"We would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to send us feedback!"
 msgstr ""
 "لطفاً [بازخورد خود را ارائه دهید](https://github.com/google/comprehensive-"
 "rust/discussions/86) تا در آینده بتوانیم به بهبود دوره ادامه دهیم. ما دوست "
@@ -1524,161 +1722,192 @@ msgstr ""
 "شما دانش‌آموزان نیز بسیار خوش آمدید  [برای ما بازخورد ارسال کنید](https://"
 "github.com/google/comprehensive-rust/discussions/100) !"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:5
 msgid "Rust Fundamentals"
 msgstr "مبانی Rust"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:7
 #, fuzzy
 msgid ""
-"The first four days make up [Rust Fundamentals](../welcome-day-1.md). The "
-"days are fast paced and we cover a lot of ground!"
+"The first four days make up Rust Fundamentals. The days are fast paced and "
+"we cover a lot of ground!"
 msgstr ""
 "سه روز اول دوره را [مبانی Rust ](../welcome-day-1.md)تشکیل میدهند. این این "
 "سه روز با سرعت بالایی پیش می‌روند و ما موارد زیادی را پوشش می‌دهیم:"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:10
+#: src/running-the-course/course-structure.md:146
 #, fuzzy
 msgid "Course schedule:"
 msgstr "مباحث دوره"
 
-#: src/running-the-course/course-structure.md
-msgid "Day 1 Morning (3 hours, including breaks)"
+#: src/running-the-course/course-structure.md:11
+msgid "Day 1 Morning (2 hours and 5 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-1.md) (5 minutes)"
+#: src/running-the-course/course-structure.md:13
+#: src/running-the-course/course-structure.md:23
+#: src/running-the-course/course-structure.md:32
+#: src/running-the-course/course-structure.md:41
+#: src/running-the-course/course-structure.md:50
+#: src/running-the-course/course-structure.md:59
+#: src/running-the-course/course-structure.md:67
+#: src/running-the-course/course-structure.md:77
+#: src/running-the-course/course-structure.md:149
+#: src/running-the-course/course-structure.md:160 src/welcome-day-1.md
+#: src/welcome-day-1-afternoon.md src/welcome-day-2.md
+#: src/welcome-day-2-afternoon.md src/welcome-day-3.md
+#: src/welcome-day-3-afternoon.md src/welcome-day-4.md
+#: src/welcome-day-4-afternoon.md src/concurrency/welcome.md
+#: src/concurrency/welcome-async.md
+msgid "Segment"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Hello, World](../hello-world.md) (20 minutes)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "[Types and Values](../types-and-values.md) (1 hour and 5 minutes)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "[Control Flow Basics](../control-flow-basics.md) (1 hour)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "Day 1 Afternoon (2 hours and 55 minutes, including breaks)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "[Tuples and Arrays](../tuples-and-arrays.md) (1 hour)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "[References](../references.md) (50 minutes)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "[User-Defined Types](../user-defined-types.md) (50 minutes)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "Day 2 Morning (3 hours and 5 minutes, including breaks)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-2.md) (3 minutes)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:13
+#: src/running-the-course/course-structure.md:23
+#: src/running-the-course/course-structure.md:32
+#: src/running-the-course/course-structure.md:41
+#: src/running-the-course/course-structure.md:50
+#: src/running-the-course/course-structure.md:59
+#: src/running-the-course/course-structure.md:67
+#: src/running-the-course/course-structure.md:77
+#: src/running-the-course/course-structure.md:149
+#: src/running-the-course/course-structure.md:160 src/welcome-day-1.md
+#: src/hello-world.md src/types-and-values.md src/control-flow-basics.md
+#: src/welcome-day-1-afternoon.md src/tuples-and-arrays.md src/references.md
+#: src/user-defined-types.md src/welcome-day-2.md src/pattern-matching.md
+#: src/methods-and-traits.md src/welcome-day-2-afternoon.md src/generics.md
+#: src/std-types.md src/std-traits.md src/welcome-day-3.md
+#: src/memory-management.md src/smart-pointers.md
+#: src/welcome-day-3-afternoon.md src/borrowing.md src/lifetimes.md
+#: src/welcome-day-4.md src/iterators.md src/modules.md src/testing.md
+#: src/welcome-day-4-afternoon.md src/error-handling.md src/unsafe-rust.md
+#: src/concurrency/welcome.md src/concurrency/threads.md
+#: src/concurrency/channels.md src/concurrency/send-sync.md
+#: src/concurrency/shared-state.md src/concurrency/sync-exercises.md
+#: src/concurrency/welcome-async.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-exercises.md
 #, fuzzy
-msgid "[Pattern Matching](../pattern-matching.md) (50 minutes)"
-msgstr ""
-"به [تطبیق الگو](../pattern-matching.md) مراجعه کنید تا در مورد الگوها در "
-"Rust اطلاعات بیشتری کسب کنید."
+msgid "Duration"
+msgstr "پیاده سازی"
 
-#: src/running-the-course/course-structure.md
-msgid "[Methods and Traits](../methods-and-traits.md) (55 minutes)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "[Generics](../generics.md) (45 minutes)"
-msgstr ""
-
-#: src/running-the-course/course-structure.md
-msgid "Day 2 Afternoon (3 hours, including breaks)"
+#: src/running-the-course/course-structure.md:15 src/welcome-day-1.md
+#: src/types-and-values.md src/control-flow-basics.md src/tuples-and-arrays.md
+#: src/user-defined-types.md src/generics.md src/std-types.md src/std-traits.md
+#: src/memory-management.md src/smart-pointers.md src/lifetimes.md
+#: src/iterators.md src/modules.md src/testing.md src/error-handling.md
+#: src/unsafe-rust.md src/concurrency/shared-state.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
+msgid "5 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Standard Library Types](../std-types.md) (1 hour and 10 minutes)"
+#: src/running-the-course/course-structure.md:16
+#: src/running-the-course/course-structure.md:153 src/welcome-day-1.md
+#: src/types-and-values.md src/control-flow-basics.md src/tuples-and-arrays.md
+#: src/references.md src/user-defined-types.md src/methods-and-traits.md
+#: src/modules.md src/concurrency/welcome.md src/concurrency/threads.md
+#: src/concurrency/shared-state.md
+msgid "15 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Standard Library Traits](../std-traits.md) (1 hour and 40 minutes)"
+#: src/running-the-course/course-structure.md:17
+#: src/running-the-course/course-structure.md:18
+#: src/running-the-course/course-structure.md:71 src/welcome-day-1.md
+#: src/welcome-day-4.md
+msgid "40 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "Day 3 Morning (2 hours and 15 minutes, including breaks)"
+#: src/running-the-course/course-structure.md:21
+msgid "Day 1 Afternoon (2 hours and 35 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-3.md) (3 minutes)"
+#: src/running-the-course/course-structure.md:25 src/welcome-day-1-afternoon.md
+msgid "35 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Memory Management](../memory-management.md) (1 hour and 10 minutes)"
+#: src/running-the-course/course-structure.md:26
+#: src/running-the-course/course-structure.md:54
+#: src/running-the-course/course-structure.md:61
+#: src/running-the-course/course-structure.md:79
+#: src/running-the-course/course-structure.md:164
+#: src/welcome-day-1-afternoon.md src/welcome-day-3.md
+#: src/welcome-day-3-afternoon.md src/welcome-day-4-afternoon.md
+#: src/concurrency/welcome-async.md
+msgid "55 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Smart Pointers](../smart-pointers.md) (45 minutes)"
+#: src/running-the-course/course-structure.md:27
+#: src/running-the-course/course-structure.md:36
+#: src/running-the-course/course-structure.md:62 src/welcome-day-1-afternoon.md
+#: src/welcome-day-2.md src/welcome-day-3-afternoon.md
+msgid "50 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "Day 3 Afternoon (2 hours and 20 minutes, including breaks)"
+#: src/running-the-course/course-structure.md:30
+msgid "Day 2 Morning (2 hours and 10 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Borrowing](../borrowing.md) (1 hour)"
+#: src/running-the-course/course-structure.md:34
+#: src/running-the-course/course-structure.md:52
+#: src/running-the-course/course-structure.md:69 src/hello-world.md
+#: src/types-and-values.md src/control-flow-basics.md src/tuples-and-arrays.md
+#: src/welcome-day-2.md src/methods-and-traits.md src/std-types.md
+#: src/welcome-day-3.md src/borrowing.md src/welcome-day-4.md src/modules.md
+#: src/testing.md src/error-handling.md
+msgid "3 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid ""
-"[Slices and Lifetimes](../slices-and-lifetimes.md) (1 hour and 10 minutes)"
+#: src/running-the-course/course-structure.md:35
+#: src/running-the-course/course-structure.md:53 src/welcome-day-2.md
+#: src/welcome-day-3.md
+msgid "1 hour"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "Day 4 Morning (3 hours and 5 minutes, including breaks)"
+#: src/running-the-course/course-structure.md:39
+msgid "Day 2 Afternoon (4 hours and 5 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Welcome](../welcome-day-4.md) (3 minutes)"
+#: src/running-the-course/course-structure.md:43
+#: src/running-the-course/course-structure.md:70
+#: src/running-the-course/course-structure.md:72 src/welcome-day-2-afternoon.md
+#: src/welcome-day-4.md
+msgid "45 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Iterators](../iterators.md) (45 minutes)"
+#: src/running-the-course/course-structure.md:44 src/welcome-day-2-afternoon.md
+msgid "1 hour and 20 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Modules](../modules.md) (40 minutes)"
+#: src/running-the-course/course-structure.md:45 src/welcome-day-2-afternoon.md
+msgid "1 hour and 40 minutes"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Testing](../testing.md) (1 hour and 5 minutes)"
+#: src/running-the-course/course-structure.md:48
+msgid "Day 3 Morning (2 hours and 20 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "Day 4 Afternoon (2 hours, including breaks)"
+#: src/running-the-course/course-structure.md:57
+msgid "Day 3 Afternoon (1 hour and 55 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Error Handling](../error-handling.md) (45 minutes)"
+#: src/running-the-course/course-structure.md:65
+msgid "Day 4 Morning (2 hours and 40 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
-msgid "[Unsafe Rust](../unsafe-rust.md) (1 hour and 5 minutes)"
+#: src/running-the-course/course-structure.md:75
+msgid "Day 4 Afternoon (2 hours and 10 minutes, including breaks)"
 msgstr ""
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:80 src/welcome-day-4-afternoon.md
+msgid "1 hour and 5 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:85
 msgid "Deep Dives"
 msgstr "عمیق تر شدن"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:87
 #, fuzzy
 msgid ""
 "In addition to the 4-day class on Rust Fundamentals, we cover some more "
@@ -1687,27 +1916,27 @@ msgstr ""
 "علاوه بر کلاس 3 روزه Rust Fundamentals، موضوعات تخصصی تری را نیز پوشش می "
 "دهیم:"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:90
 msgid "Rust in Android"
 msgstr "Rust در اندروید"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:92
+#, fuzzy
 msgid ""
-"The [Rust in Android](../android.md) deep dive is a half-day course on using "
-"Rust for Android platform development. This includes interoperability with "
-"C, C++, and Java."
+"The Rust in Android deep dive is a half-day course on using Rust for Android "
+"platform development. This includes interoperability with C, C++, and Java."
 msgstr ""
 "در [Rust در اندروید](../android.md) توی دوره  یک دوره نیم روزه در مورد "
 "استفاده از  Rust برای توسعه پلتفرم اندروید عمیق می‌شیم. این شامل قابلیت تعامل "
 "با C، <span dir=ltr>C++</span> و جاوا می‌شود."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:96
+#, fuzzy
 msgid ""
-"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
-"download/downloading). Make a checkout of the [course repository](https://"
-"github.com/google/comprehensive-rust) on the same machine and move the `src/"
-"android/` directory into the root of your AOSP checkout. This will ensure "
-"that the Android build system sees the `Android.bp` files in `src/android/`."
+"You will need an AOSP checkout. Make a checkout of the course repository on "
+"the same machine and move the `src/android/` directory into the root of your "
+"AOSP checkout. This will ensure that the Android build system sees the "
+"`Android.bp` files in `src/android/`."
 msgstr ""
 "شما نیاز دارید که یک نسخه از [مخزن ASOP](https://source.android.com/docs/"
 "setup/download/downloading) بگیرید, همچنین یک نسخه از [مخزن دوره](https://"
@@ -1715,7 +1944,7 @@ msgstr ""
 "android/`مخزن ASOP قرار دهید. با این کار طمینان حاصل می‌کنید که سیستم build "
 "اندروید فایل های `Android.bp` را در `src/android/` می‌بینید."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:101
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
 "all Android examples using `src/android/build_all.sh`. Read the script to "
@@ -1726,65 +1955,67 @@ msgstr ""
 "بسازید.  اسکریپت را بخوانید تا دستوراتی را که اجرا می‌کند ببینید و مطمئن شوید "
 "که وقتی آنها را  اجرا می‌کنید به درستی کار می‌کنند."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:108
 #, fuzzy
 msgid "Rust in Chromium"
 msgstr "Rust در اندروید"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:110
 msgid ""
-"The [Rust in Chromium](../chromium.md) deep dive is a half-day course on "
-"using Rust as part of the Chromium browser. It includes using Rust in "
-"Chromium's `gn` build system, bringing in third-party libraries (\"crates\") "
-"and C++ interoperability."
+"The Rust in Chromium deep dive is a half-day course on using Rust as part of "
+"the Chromium browser. It includes using Rust in Chromium's `gn` build "
+"system, bringing in third-party libraries (\"crates\") and C++ "
+"interoperability."
 msgstr ""
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:115
 msgid ""
 "You will need to be able to build Chromium --- a debug, component build is "
-"[recommended](../chromium/setup.md) for speed but any build will work. "
-"Ensure that you can run the Chromium browser that you've built."
+"recommended for speed but any build will work. Ensure that you can run the "
+"Chromium browser that you've built."
 msgstr ""
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:119
 msgid "Bare-Metal Rust"
 msgstr "Rust بر روی سخت افزار بدون سیستم عامل"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:121
+#, fuzzy
 msgid ""
-"The [Bare-Metal Rust](../bare-metal.md) deep dive is a full day class on "
-"using Rust for bare-metal (embedded) development. Both microcontrollers and "
-"application processors are covered."
+"The Bare-Metal Rust deep dive is a full day class on using Rust for bare-"
+"metal (embedded) development. Both microcontrollers and application "
+"processors are covered."
 msgstr ""
 "دوره آموزشی [Rust بر روی سخت افزار بدون سیستم عامل](../bare-metal.md) یک "
 "دوره یک روزه با تمرکز بر استفاده ازRust برای توسعه بر روی سخت افزار بدون "
 "سیستم عامل (embedded) است.  این دوره هم میکروکنترلرها و هم پردازشگر هایی با "
 "کارایی خاص را پوشش می دهد. "
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:125
+#, fuzzy
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC micro:bit]"
-"(https://microbit.org/) v2 development board ahead of time. Everybody will "
-"need to install a number of packages as described on the [welcome page](../"
-"bare-metal.md)."
+"For the microcontroller part, you will need to buy the BBC micro:bit v2 "
+"development board ahead of time. Everybody will need to install a number of "
+"packages as described on the welcome page."
 msgstr ""
 "برای قسمت میکروکنترلر، باید برد توسعه [BBCmicro:bit](https://microbit.org/)  "
 "v2 را   خریداری کنید. همه باید تعدادی بسته را همانطور که در [welcome page]"
 "(../bare-metal.md) توضیح داده شده نصب کنند."
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:130
 msgid "Concurrency in Rust"
 msgstr "همزمانی در Rust"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:132
+#, fuzzy
 msgid ""
-"The [Concurrency in Rust](../concurrency.md) deep dive is a full day class "
-"on classical as well as `async`/`await` concurrency."
+"The Concurrency in Rust deep dive is a full day class on classical as well "
+"as `async`/`await` concurrency."
 msgstr ""
 "دوره [همزمانی در Rust ](../concurrency.md) یک روزه با تمرکز بر همزمانی  "
 "کلاسیک و همچنین همزمانی `async`/`await` است. "
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:135
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
 "to go. You can then copy/paste the examples into `src/main.rs` to experiment "
@@ -1794,11 +2025,48 @@ msgstr ""
 "باشند. سپس می‌توانید نمونه‌ها را در `src/main.rs‍` کپی/پیست کنید تا با آنها "
 "آزمایش کنید:"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:147
+msgid "Morning (3 hours and 20 minutes, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:151
+#: src/running-the-course/course-structure.md:154
+#: src/running-the-course/course-structure.md:162 src/pattern-matching.md
+#: src/std-traits.md src/smart-pointers.md src/lifetimes.md src/iterators.md
+#: src/testing.md src/error-handling.md src/unsafe-rust.md
+#: src/concurrency/welcome.md src/concurrency/sync-exercises.md
+#: src/concurrency/welcome-async.md src/concurrency/async-exercises.md
+msgid "30 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:152
+#: src/running-the-course/course-structure.md:163 src/methods-and-traits.md
+#: src/std-types.md src/std-traits.md src/memory-management.md src/borrowing.md
+#: src/concurrency/welcome.md src/concurrency/sync-exercises.md
+#: src/concurrency/welcome-async.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-exercises.md
+msgid "20 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:153 src/concurrency/welcome.md
+msgid "Send and Sync"
+msgstr "ارسال و همگام سازی"
+
+#: src/running-the-course/course-structure.md:155
+#: src/running-the-course/course-structure.md:165 src/concurrency/welcome.md
+#: src/concurrency/welcome-async.md
+msgid "1 hour and 10 minutes"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:158
+msgid "Afternoon (3 hours and 20 minutes, including breaks)"
+msgstr ""
+
+#: src/running-the-course/course-structure.md:170
 msgid "Format"
 msgstr "فرمت"
 
-#: src/running-the-course/course-structure.md
+#: src/running-the-course/course-structure.md:172
 msgid ""
 "The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
@@ -1806,43 +2074,31 @@ msgstr ""
 "این دوره قرار است بسیار تعاملی باشد و توصیه می کنیم اجازه دهید حس کنجکاوی "
 "Rust را هدایت کنند!"
 
-#: src/running-the-course/keyboard-shortcuts.md
+#: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "چندین میانبر صفحه کلید مفید در mdBook وجود دارد:"
 
-#: src/running-the-course/keyboard-shortcuts.md
-msgid "Arrow-Left"
-msgstr "Arrow-Left"
-
-#: src/running-the-course/keyboard-shortcuts.md
-msgid ": Navigate to the previous page."
+#: src/running-the-course/keyboard-shortcuts.md:5
+#, fuzzy
+msgid "<kbd>Arrow-Left</kbd>: Navigate to the previous page."
 msgstr ": به صفحه قبلی هدایت می کند"
 
-#: src/running-the-course/keyboard-shortcuts.md
-msgid "Arrow-Right"
-msgstr "Arrow-Right"
-
-#: src/running-the-course/keyboard-shortcuts.md
-msgid ": Navigate to the next page."
+#: src/running-the-course/keyboard-shortcuts.md:6
+#, fuzzy
+msgid "<kbd>Arrow-Right</kbd>: Navigate to the next page."
 msgstr "به صفحه بعدی هدایت می کند"
 
-#: src/running-the-course/keyboard-shortcuts.md src/cargo/code-samples.md
-msgid "Ctrl + Enter"
-msgstr "Ctrl + Enter"
-
-#: src/running-the-course/keyboard-shortcuts.md
-msgid ": Execute the code sample that has focus."
+#: src/running-the-course/keyboard-shortcuts.md:7
+#, fuzzy
+msgid "<kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus."
 msgstr "اجرای نمونه کدی که بر روی آن قرار گرفته است."
 
-#: src/running-the-course/keyboard-shortcuts.md
-msgid "s"
-msgstr "s"
-
-#: src/running-the-course/keyboard-shortcuts.md
-msgid ": Activate the search bar."
+#: src/running-the-course/keyboard-shortcuts.md:8
+#, fuzzy
+msgid "<kbd>s</kbd>: Activate the search bar."
 msgstr "نوار جستجو را فعال می کند."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:3
 msgid ""
 "The course has been translated into other languages by a set of wonderful "
 "volunteers:"
@@ -1850,77 +2106,43 @@ msgstr ""
 "این دوره توسط مجموعه ای از داوطلبان فوق العاده به زبان های دیگر ترجمه شده "
 "است:"
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:6
 msgid ""
-"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
-"by [@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
-"com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes), and "
-"[@henrif75](https://github.com/henrif75)."
+"Brazilian Portuguese by @rastringer, @hugojacob, @joaovicmendes, and "
+"@henrif75."
 msgstr ""
-"[پرتغالی برزیلی](https://google.github.io/comprehensive-rust/pt-BR/) توسط "
-"[@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
-"com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes) و  "
-"[@henrif75](https://github.com/henrif75)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:8
 msgid ""
-"[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-CN/) "
-"by [@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
-"wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
-"kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
-"github.com/superwhd), [@SketchK](https://github.com/SketchK), and [@nodmp]"
-"(https://github.com/nodmp)."
+"Chinese (Simplified) by @suetfei, @wnghl, @anlunx, @kongy, @noahdragon, "
+"@superwhd, @SketchK, and @nodmp."
 msgstr ""
-"[چینی (ساده‌شده)](https://google.github.io/comprehensive-rust/zh-CN/) توسط "
-"[@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/wnghl), "
-"[@anlunx](https://github.com/anlunx), [@kongy](https://github.com/kongy), "
-"[@noahdragon](https://github.com/noahdragon), [@superwhd](https://github.com/"
-"superwhd), [@SketchK](https://github.com/SketchK) و [@nodmp](https://github."
-"com/nodmp)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:10
 msgid ""
-"[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-TW/) "
-"by [@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
-"victorhsieh), [@mingyc](https://github.com/mingyc), [@kuanhungchen](https://"
-"github.com/kuanhungchen), and [@johnathan79717](https://github.com/"
-"johnathan79717)."
+"Chinese (Traditional) by @hueich, @victorhsieh, @mingyc, @kuanhungchen, and "
+"@johnathan79717."
 msgstr ""
-"[چینی (سنتی)](https://google.github.io/comprehensive-rust/zh-TW/) توسط "
-"[@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
-"victorhsieh), [@mingyc](https://github.com/mingyc), [@kuanhungchen](https://"
-"github.com/kuanhungchen) و [@johnathan79717](https://github.com/"
-"johnathan79717)."
 
-#: src/running-the-course/translations.md
-msgid ""
-"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
-"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), and "
-"[@jooyunghan](https://github.com/jooyunghan)."
+#: src/running-the-course/translations.md:12
+msgid "Korean by @keispace, @jiyongp, @jooyunghan, and @namhyung."
 msgstr ""
-"[کره ای](https://google.github.io/comprehensive-rust/ko/) توسط [@keispace]"
-"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) و "
-"[@jooyunghan](https://github.com/jooyunghan)."
 
-#: src/running-the-course/translations.md
-msgid ""
-"[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
-"(https://github.com/deavid)."
+#: src/running-the-course/translations.md:13
+msgid "Spanish by @deavid."
 msgstr ""
-"[Spanish](https://google.github.io/comprehensive-rust/es/) توسط [@deavid]"
-"(https://github.com/deavid)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:15
 msgid ""
 "Use the language picker in the top-right corner to switch between languages."
 msgstr ""
 "از انتخابگر زبان در گوشه بالا سمت راست برای جابه‌جایی بین زبان‌ها استفاده کنید."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:17
 msgid "Incomplete Translations"
 msgstr "ترجمه‌های ناقص"
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:19
 msgid ""
 "There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
@@ -1928,46 +2150,31 @@ msgstr ""
 "تعداد زیادی ترجمه در حال انجام وجود دارد. ما به آخرین ترجمه های به روز شده "
 "پیوند می دهیم:"
 
-#: src/running-the-course/translations.md
-msgid ""
-"[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
-"(https://github.com/raselmandol)."
+#: src/running-the-course/translations.md:22
+msgid "Bengali by @raselmandol."
 msgstr ""
-"[بنگالی](https://google.github.io/comprehensive-rust/bn/) توسط [@raselmandol]"
-"(https://github.com/raselmandol)."
 
-#: src/running-the-course/translations.md
-msgid ""
-"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
-"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+#: src/running-the-course/translations.md:23
+msgid "French by @KookaS, @vcaen and @AdrienBaudemont."
 msgstr ""
-"[فرانسویی](https://google.github.io/comprehensive-rust/fr/) توسط [@KookaS]"
-"(https://github.com/KookaS) و [@vcaen](https://github.com/vcaen)."
 
-#: src/running-the-course/translations.md
-msgid ""
-"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
-"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+#: src/running-the-course/translations.md:24
+msgid "German by @Throvn and @ronaldfw."
 msgstr ""
-"[آلمانی](https://google.github.io/comprehensive-rust/de/) توسط [@Throvn]"
-"(https://github.com/Throvn) و [@ronaldfw](https://github.com/ronaldfw)."
 
-#: src/running-the-course/translations.md
-msgid ""
-"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
-"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
-"momotaro1105)."
+#: src/running-the-course/translations.md:25
+msgid "Japanese by @CoinEZ-JPN and @momotaro1105."
 msgstr ""
-"[ژاپنی](https://google.github.io/comprehensive-rust/ja/) توسط [@CoinEZ-JPN]"
-"(https://github.com/CoinEZ) و [@momotaro1105](https://github.com/"
-"momotaro1105)."
 
-#: src/running-the-course/translations.md
+#: src/running-the-course/translations.md:26
+msgid "Italian by @henrythebuilder and @detro."
+msgstr ""
+
+#: src/running-the-course/translations.md:28
+#, fuzzy
 msgid ""
-"If you want to help with this effort, please see [our instructions](https://"
-"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
-"get going. Translations are coordinated on the [issue tracker](https://"
-"github.com/google/comprehensive-rust/issues/282)."
+"If you want to help with this effort, please see our instructions for how to "
+"get going. Translations are coordinated on the issue tracker."
 msgstr ""
 "اگر می‌خواهید به این کار کمک کنید، لطفاً [دستورالعمل‌های ما](https://github.com/"
 "google/comprehensive-rust/blob/main/TRANSLATIONS.md) را برای چگونگی ادامه "
@@ -1975,12 +2182,12 @@ msgstr ""
 "comprehensive-rust/issues/282) هماهنگ و کنترل می شوند."
 
 #: src/cargo.md
+#, fuzzy
 msgid ""
-"When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
-"and run Rust applications. Here we want to give a brief overview of what "
-"Cargo is and how it fits into the wider ecosystem and how it fits into this "
-"training."
+"When you start reading about Rust, you will soon meet Cargo, the standard "
+"tool used in the Rust ecosystem to build and run Rust applications. Here we "
+"want to give a brief overview of what Cargo is and how it fits into the "
+"wider ecosystem and how it fits into this training."
 msgstr ""
 "وقتی شروع به خواندن درباره Rust می کنید، خیلی سریع با [Cargo](https://doc."
 "rust-lang.org/cargo/) ، ابزار استانداردی که در اکوسیستم Rust برای ساخت و "
@@ -1993,7 +2200,8 @@ msgid "Installation"
 msgstr "راهنمای نصب"
 
 #: src/cargo.md
-msgid "**Please follow the instructions on <https://rustup.rs/>.**"
+#, fuzzy
+msgid "**Please follow the instructions on https://rustup.rs/.**"
 msgstr "**لطفا دستورالعمل را اجرا کنید <https://rustup.rs/>.**"
 
 #: src/cargo.md
@@ -2007,14 +2215,13 @@ msgstr ""
 "توانید از آن برای نصب نسخه های مختلف کامپایلر استفاده کنید."
 
 #: src/cargo.md
+#, fuzzy
 msgid ""
 "After installing Rust, you should configure your editor or IDE to work with "
-"Rust. Most editors do this by talking to [rust-analyzer](https://rust-"
-"analyzer.github.io/), which provides auto-completion and jump-to-definition "
-"functionality for [VS Code](https://code.visualstudio.com/), [Emacs](https://"
-"rust-analyzer.github.io/manual.html#emacs), [Vim/Neovim](https://rust-"
-"analyzer.github.io/manual.html#vimneovim), and many others. There is also a "
-"different IDE available called [RustRover](https://www.jetbrains.com/rust/)."
+"Rust. Most editors do this by talking to rust-analyzer, which provides auto-"
+"completion and jump-to-definition functionality for VS Code, Emacs, Vim/"
+"Neovim, and many others. There is also a different IDE available called "
+"RustRover."
 msgstr ""
 "پس از نصب Rust، باید ویرایشگر یا IDE خود را برای کار با Rust پیکربندی کنید. "
 "اکثر ویرایشگرها این کار را با ارتباط گرفتن با [rust-analyzer](https://rust-"
@@ -2025,28 +2232,28 @@ msgstr ""
 "متفاوت به نام [RustRover](https://www.jetbrains.com/rust/) در دسترس است."
 
 #: src/cargo.md
+#, fuzzy
 msgid ""
-"On Debian/Ubuntu, you can also install Cargo, the Rust source and the [Rust "
-"formatter](https://github.com/rust-lang/rustfmt) via `apt`. However, this "
-"gets you an outdated rust version and may lead to unexpected behavior. The "
-"command would be:"
+"On Debian/Ubuntu, you can also install Cargo, the Rust source and the Rust "
+"formatter via `apt`. However, this gets you an outdated rust version and may "
+"lead to unexpected behavior. The command would be:"
 msgstr ""
 "در دبیان/اوبونتو، می‌توانید Cargo و  Rust و [Rust formatter](https://github."
 "com/rust-lang/rustfmt) را نیز از طریق `apt` نصب کنید. با این حال، این به شما "
 "یک نسخه   قدیمی Rust  را جهت نصب می دهد و ممکن است منجر به رفتار غیرمنتظره "
 "برنامه شود. command مورد نظر این خواهد بود:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:1
 msgid "The Rust Ecosystem"
 msgstr "اکوسیستم رراست"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:3
 msgid ""
 "The Rust ecosystem consists of a number of tools, of which the main ones are:"
 msgstr ""
 "اکوسیستم Rust از تعدادی ابزار تشکیل شده است که مهمترین آنها عبارتند از:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:5
 msgid ""
 "`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
 "intermediate formats."
@@ -2054,19 +2261,20 @@ msgstr ""
 "`rustc`: کامپایلر Rust که فایل‌های `.rs` را به باینری و سایر فرمت‌های میانی "
 "تبدیل می‌کند. "
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:8
+#, fuzzy
 msgid ""
 "`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
-"download dependencies, usually hosted on <https://crates.io>, and it will "
-"pass them to `rustc` when building your project. Cargo also comes with a "
-"built-in test runner which is used to execute unit tests."
+"download dependencies, usually hosted on https://crates.io, and it will pass "
+"them to `rustc` when building your project. Cargo also comes with a built-in "
+"test runner which is used to execute unit tests."
 msgstr ""
 "`cargo`: مدیر وابستگی Rust و build tool آن است. Cargo می داند که چگونه "
 "وابستگی ها را که معمولاً در <https://crates.io> میزبانی می شوند دانلود کند و "
 "هنگام ساخت پروژه آنها را به `rustc` منتقل می‌کند. Cargo همچنین دارای یک "
 "دستگاه تست داخلی است که برای اجرای unit test استفاده می شود."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:13
 #, fuzzy
 msgid ""
 "`rustup`: the Rust toolchain installer and updater. This tool is used to "
@@ -2081,15 +2289,14 @@ msgstr ""
 "Rust  را دانلود کند. همچنین می‌توانید چندین نسخه Rust را به‌طور هم‌زمان نصب "
 "کنید و `rustup` به شما امکان می‌دهد در صورت نیاز بین آنها جابه‌جا شوید."
 
-#: src/cargo/rust-ecosystem.md src/hello-world/hello-world.md
-#: src/tuples-and-arrays/tuples-and-arrays.md src/references/exclusive.md
-#: src/pattern-matching/destructuring.md src/memory-management/move.md
-#: src/error-handling/try.md src/android/setup.md src/concurrency/threads.md
-#: src/async/async-await.md
+#: src/cargo/rust-ecosystem.md:21 src/types-and-values/hello-world.md:26
+#: src/references/exclusive.md:20 src/memory-management/move.md:153
+#: src/error-handling/try.md:53 src/android/setup.md
+#: src/concurrency/async/async-await.md:26
 msgid "Key points:"
 msgstr "نکات کلیدی:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:23
 msgid ""
 "Rust has a rapid release schedule with a new release coming out every six "
 "weeks. New releases maintain backwards compatibility with old releases --- "
@@ -2099,12 +2306,12 @@ msgstr ""
 "منتشر می شود. نسخه‌های جدید سازگاری با نسخه‌های قدیمی را حفظ می‌کنند --- به "
 "علاوه قابلیت‌های جدید را فعال می‌کنند."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:27
 msgid ""
 "There are three release channels: \"stable\", \"beta\", and \"nightly\"."
 msgstr "سه کانال انتشار وجود دارد: \"stable\"، \"beta\"، و \"nightly\"."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:29
 msgid ""
 "New features are being tested on \"nightly\", \"beta\" is what becomes "
 "\"stable\" every six weeks."
@@ -2112,29 +2319,31 @@ msgstr ""
 "ویژگی های جدید در \"nightly\" آزمایش می شوند ، \"beta\" چیزی است که هر شش "
 "هفته \"stable\" می شود."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:32
+#, fuzzy
 msgid ""
-"Dependencies can also be resolved from alternative [registries](https://doc."
-"rust-lang.org/cargo/reference/registries.html), git, folders, and more."
+"Dependencies can also be resolved from alternative registries, git, folders, "
+"and more."
 msgstr ""
 "همچنین می‌توان وابستگی‌ها را از  [registries](https://doc.rust-lang.org/cargo/"
 "reference/registries.html)،  پوشه‌ها و git و موارد دیگر برطرف کرد."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:35
+#, fuzzy
 msgid ""
-"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
-"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+"Rust also has editions: the current edition is Rust 2021. Previous editions "
+"were Rust 2015 and Rust 2018."
 msgstr ""
 "Rust همچنین نسخه [editions](https://doc.rust-lang.org/edition-guide/) دارد: "
 "نسخه فعلی Rust 2021 است. نسخه های قبلی Rust 2015 و Rust 2018 بودند."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:38
 msgid ""
 "The editions are allowed to make backwards incompatible changes to the "
 "language."
 msgstr "نسخه ها مجاز به ایجاد تغییرات backwards incompatible  در زبان هستند."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:41
 msgid ""
 "To prevent breaking code, editions are opt-in: you select the edition for "
 "your crate via the `Cargo.toml` file."
@@ -2142,7 +2351,7 @@ msgstr ""
 "برای جلوگیری از breaking code، نسخه‌ها اختیاری انتخاب می‌شوند که: شما نسخه‌ "
 "مورد نظر  برای crate خود از طریق فایل `Cargo.toml` انتخاب می‌کنید."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:44
 msgid ""
 "To avoid splitting the ecosystem, Rust compilers can mix code written for "
 "different editions."
@@ -2150,7 +2359,7 @@ msgstr ""
 "برای جلوگیری از شکاف در اکوسیستم، کامپایلرهای Rust می توانند کدهای نوشته شده "
 "برای نسخه های مختلف را ترکیب کنند."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:47
 msgid ""
 "Mention that it is quite rare to ever use the compiler directly not through "
 "`cargo` (most users never do)."
@@ -2158,7 +2367,7 @@ msgstr ""
 "لازم به ذکر است که استفاده از کامپایلر به طور مستقیم و نه از طریق `cargo` "
 "بسیار غیرمعمول است (اکثر کاربران هرگز این کار را نمی کنند)."
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:50
 #, fuzzy
 msgid ""
 "It might be worth alluding that Cargo itself is an extremely powerful and "
@@ -2169,54 +2378,47 @@ msgstr ""
 "قابلیت دارای بسیاری از ویژگی های پیشرفته زیر است و محدود به همین موارد "
 "نمی‌شود:"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:53
 msgid "Project/package structure"
 msgstr "ساختار پروژه/بسته"
 
-#: src/cargo/rust-ecosystem.md
-msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+#: src/cargo/rust-ecosystem.md:54
+msgid "workspaces"
 msgstr ""
-"[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:55
 msgid "Dev Dependencies and Runtime Dependency management/caching"
 msgstr "وابستگی های Dev و وابستگی‌های   Runtime  Management/Caching."
 
-#: src/cargo/rust-ecosystem.md
-msgid ""
-"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
-"html)"
+#: src/cargo/rust-ecosystem.md:56
+msgid "build scripting"
 msgstr ""
-"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
-"html)"
 
-#: src/cargo/rust-ecosystem.md
-msgid ""
-"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
-"html)"
-msgstr ""
-"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
-"html)"
+#: src/cargo/rust-ecosystem.md:57
+#, fuzzy
+msgid "global installation"
+msgstr "راهنمای نصب"
 
-#: src/cargo/rust-ecosystem.md
+#: src/cargo/rust-ecosystem.md:58
+#, fuzzy
 msgid ""
-"It is also extensible with sub command plugins as well (such as [cargo "
-"clippy](https://github.com/rust-lang/rust-clippy))."
+"It is also extensible with sub command plugins as well (such as cargo "
+"clippy)."
 msgstr ""
 "همچنین با command plugin فرعی (مانند [cargo clippy](https://github.com/rust-"
 "lang/rust-clippy)) قابل توسعه است."
 
-#: src/cargo/rust-ecosystem.md
-msgid ""
-"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+#: src/cargo/rust-ecosystem.md:60
+#, fuzzy
+msgid "Read more from the official Cargo Book"
 msgstr ""
 "در [official Cargo Book](https://doc.rust-lang.org/cargo/) بیشتر بخوانید."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:1
 msgid "Code Samples in This Training"
 msgstr "نمونه کد در این آموزش"
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:3
 msgid ""
 "For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
@@ -2226,7 +2428,7 @@ msgstr ""
 "مرورگر شما اجرا کرد، بررسی می کنیم. این کار راه اندازی را بسیار ساده تر می "
 "کند و تجربه ای ثابت را برای همه تضمین می کند."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
 "the exercises. On the last day, we will do a larger exercise which shows you "
@@ -2236,23 +2438,22 @@ msgstr ""
 "کند. در روز آخر، تمرین بزرگتری را انجام خواهیم داد که به شما نشان می دهد "
 "چگونه با وابستگی ها کار کنید و برای این کار شما به Cargo نیاز دارید."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
 msgstr "بلوک های کد در این دوره کاملاً تعاملی(interactive) هستند:"
 
-#: src/cargo/code-samples.md src/cargo/running-locally.md
+#: src/cargo/code-samples.md:15 src/cargo/running-locally.md:46
 msgid "\"Edit me!\""
 msgstr ""
 
-#: src/cargo/code-samples.md
-msgid "You can use "
-msgstr "همان طور که مشاهده می‌کنید"
-
-#: src/cargo/code-samples.md
-msgid " to execute the code when focus is in the text box."
+#: src/cargo/code-samples.md:19
+#, fuzzy
+msgid ""
+"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in the "
+"text box."
 msgstr "برای اجرای کد زمانی که focus در text box است."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:24
 msgid ""
 "Most code samples are editable like shown above. A few code samples are not "
 "editable for various reasons:"
@@ -2260,7 +2461,7 @@ msgstr ""
 "اکثر نمونه های کد مانند نشان داده شده در بالا قابل ویرایش هستند. چند نمونه "
 "کد به دلایل مختلف قابل ویرایش نیستند:"
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:27
 msgid ""
 "The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
 "open it in the real Playground to demonstrate unit tests."
@@ -2268,7 +2469,7 @@ msgstr ""
 "همینطورembedded playground نمی توانند unit tests را اجرا کنند. کد را کپی "
 "کنید و آن را در Playground واقعی باز کنید تا unit tests د را نشان دهید."
 
-#: src/cargo/code-samples.md
+#: src/cargo/code-samples.md:30
 msgid ""
 "The embedded playgrounds lose their state the moment you navigate away from "
 "the page! This is the reason that the students should solve the exercises "
@@ -2278,17 +2479,17 @@ msgstr ""
 "خود را از دست می دهند! به همین دلیل است که دانش آموزان باید تمرینات را با "
 "استفاده از local Rust installation یا از طریق زPlayground حل کنند."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:1
 msgid "Running Code Locally with Cargo"
 msgstr "اجرای کد به صورت Locally با Cargo"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:3
+#, fuzzy
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need to first install Rust. Do this by following the [instructions in the "
-"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
-"should give you a working `rustc` and `cargo`. At the time of writing, the "
-"latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the instructions in the "
+"Rust Book. This should give you a working `rustc` and `cargo`. At the time "
+"of writing, the latest stable Rust release has these version numbers:"
 msgstr ""
 "اگر می خواهید کد را روی سیستم خود آزمایش کنید، ابتدا باید Rust را نصب کنید. "
 "این کار را با دنبال کردن [instructions in the Rust Book](https://doc.rust-"
@@ -2296,7 +2497,7 @@ msgstr ""
 "`rustc` و `cargo` کاربردی بدهد. در زمان نگارش، آخرین نسخه پایدار Rust دارای "
 "این version numberها است:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:16
 msgid ""
 "You can use any later version too since Rust maintains backwards "
 "compatibility."
@@ -2304,7 +2505,7 @@ msgstr ""
 "شما همچنین می توانید از هر نسخه بعدی استفاده کنید، زیرا Rust سازگاری با نسخه "
 "های قبلی را حفظ می‌کند."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:18
 msgid ""
 "With this in place, follow these steps to build a Rust binary from one of "
 "the examples in this training:"
@@ -2312,26 +2513,26 @@ msgstr ""
 "با این کار، این مراحل را دنبال کنید تا از یکی از مثال‌های این آموزش، یک "
 "باینری Rust بسازید:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:21
 msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr ""
 "روی دکمه \"کپی در کلیپ بورد\" در نمونه ای که می خواهید کپی کنید؛ کلیک کنید."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:23
 msgid ""
 "Use `cargo new exercise` to create a new `exercise/` directory for your code:"
 msgstr ""
 "از `cargo new exercise` برای ایجاد دایرکتوری `excerise/` جدید برای کد خود "
 "استفاده کنید:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:30
 msgid ""
 "Navigate into `exercise/` and use `cargo run` to build and run your binary:"
 msgstr ""
 "به `exercise/` بروید و از `cargo run` برای ساخت و اجرای باینری خود استفاده "
 "کنید:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:41
 msgid ""
 "Replace the boiler-plate code in `src/main.rs` with your own code. For "
 "example, using the example on the previous page, make `src/main.rs` look like"
@@ -2339,11 +2540,11 @@ msgstr ""
 "کد صفحه دیگر را در `src/main.rs` با کد خود جایگزین کنید. برای مثال، با "
 "استفاده از مثال در صفحه قبل، `src/main.rs` را شبیه به آن کنید."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:50
 msgid "Use `cargo run` to build and run your updated binary:"
 msgstr "برای ساختن و اجرای باینری به روز شده خود از `cargo run` استفاده کنید:"
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:60
 msgid ""
 "Use `cargo check` to quickly check your project for errors, use `cargo "
 "build` to compile it without running it. You will find the output in `target/"
@@ -2355,7 +2556,7 @@ msgstr ""
 "debug/` برای ساخت اشکال زدایی معمولی خواهید یافت. برای تولید نسخه بهینه سازی "
 "شده در `target/release/` از `cargo build --release` استفاده کنید."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:65
 msgid ""
 "You can add dependencies for your project by editing `Cargo.toml`. When you "
 "run `cargo` commands, it will automatically download and compile missing "
@@ -2365,7 +2566,7 @@ msgstr ""
 "هنگامی که دستورات `cargo` را اجرا می کنید، به طور خودکار وابستگی های مورد "
 "نیاز را برای شما دانلود و کامپایل می‌کند."
 
-#: src/cargo/running-locally.md
+#: src/cargo/running-locally.md:73
 msgid ""
 "Try to encourage the class participants to install Cargo and use a local "
 "editor. It will make their life easier since they will have a normal "
@@ -2413,35 +2614,15 @@ msgid "Pattern matching: destructuring enums, structs, and arrays."
 msgstr "تطابق الگو: تجزیه و تحلیل enums, structs و آرایه‌ها."
 
 #: src/welcome-day-1.md src/welcome-day-2.md src/welcome-day-3.md
-#: src/welcome-day-4.md
+#: src/welcome-day-4.md src/concurrency/welcome.md
+#: src/concurrency/welcome-async.md
 msgid "Schedule"
 msgstr ""
 
-#: src/welcome-day-1.md src/welcome-day-1-afternoon.md src/welcome-day-2.md
-#: src/welcome-day-2-afternoon.md src/welcome-day-3.md
-#: src/welcome-day-3-afternoon.md src/welcome-day-4.md
-#: src/welcome-day-4-afternoon.md
-msgid "In this session:"
-msgstr ""
-
 #: src/welcome-day-1.md
-msgid "[Welcome](./welcome-day-1.md) (5 minutes)"
-msgstr ""
-
-#: src/welcome-day-1.md
-msgid "[Hello, World](./hello-world.md) (20 minutes)"
-msgstr ""
-
-#: src/welcome-day-1.md
-msgid "[Types and Values](./types-and-values.md) (1 hour and 5 minutes)"
-msgstr ""
-
-#: src/welcome-day-1.md
-msgid "[Control Flow Basics](./control-flow-basics.md) (1 hour)"
-msgstr ""
-
-#: src/welcome-day-1.md src/welcome-day-2-afternoon.md
-msgid "Including 10 minute breaks, this session should take about 3 hours"
+msgid ""
+"Including 10 minute breaks, this session should take about 2 hours and 5 "
+"minutes. It contains:"
 msgstr ""
 
 #: src/welcome-day-1.md
@@ -2506,314 +2687,212 @@ msgid ""
 "schedule. Feel free to be flexible and adjust as necessary!"
 msgstr ""
 
+#: src/hello-world.md src/concurrency/send-sync.md
+msgid "This segment should take about 15 minutes. It contains:"
+msgstr ""
+
 #: src/hello-world.md src/types-and-values.md src/control-flow-basics.md
 #: src/tuples-and-arrays.md src/references.md src/user-defined-types.md
 #: src/pattern-matching.md src/methods-and-traits.md src/generics.md
 #: src/std-types.md src/std-traits.md src/memory-management.md
-#: src/smart-pointers.md src/borrowing.md src/slices-and-lifetimes.md
-#: src/iterators.md src/modules.md src/testing.md src/error-handling.md
-#: src/unsafe-rust.md
-msgid "In this segment:"
+#: src/smart-pointers.md src/borrowing.md src/lifetimes.md src/iterators.md
+#: src/modules.md src/testing.md src/error-handling.md src/unsafe-rust.md
+#: src/concurrency/threads.md src/concurrency/channels.md
+#: src/concurrency/send-sync.md src/concurrency/shared-state.md
+#: src/concurrency/sync-exercises.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
+#: src/concurrency/async-exercises.md
+msgid "Slide"
 msgstr ""
 
-#: src/hello-world.md
-msgid "[What is Rust?](./hello-world/what-is-rust.md) (10 minutes)"
+#: src/hello-world.md src/references.md src/user-defined-types.md
+#: src/pattern-matching.md src/methods-and-traits.md src/generics.md
+#: src/std-types.md src/std-traits.md src/memory-management.md
+#: src/smart-pointers.md src/borrowing.md src/lifetimes.md src/modules.md
+#: src/unsafe-rust.md src/concurrency/channels.md src/concurrency/send-sync.md
+#: src/concurrency/shared-state.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md src/concurrency/async-pitfalls.md
+msgid "10 minutes"
 msgstr ""
 
-#: src/hello-world.md
-msgid "[Hello, World](./hello-world/hello-world.md) (5 minutes)"
+#: src/hello-world.md src/control-flow-basics.md src/user-defined-types.md
+#: src/memory-management.md src/concurrency/channels.md
+#: src/concurrency/send-sync.md
+msgid "2 minutes"
 msgstr ""
 
-#: src/hello-world.md
-msgid "[Benefits of Rust](./hello-world/benefits.md) (3 minutes)"
+#: src/hello-world/what-is-rust.md:3
+msgid "Rust is a new programming language which had its 1.0 release in 2015:"
 msgstr ""
 
-#: src/hello-world.md
-msgid "[Playground](./hello-world/playground.md) (2 minutes)"
-msgstr ""
-
-#: src/hello-world.md
-msgid "This segment should take about 20 minutes"
-msgstr ""
-
-#: src/hello-world/what-is-rust.md
-msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015]"
-"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
-msgstr ""
-
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:5
 msgid "Rust is a statically compiled language in a similar role as C++"
 msgstr ""
 "زبان Rust, یک زبان کامپایل شده ایستا است که نقشی مشابه <span dir=ltr>C++</"
 "span> دارد."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:6
 msgid "`rustc` uses LLVM as its backend."
 msgstr "`rustc` از `LLVM` به عنوان بک‌اند خود استفاده می‌کند."
 
-#: src/hello-world/what-is-rust.md
-msgid ""
-"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
-"nightly/rustc/platform-support.html):"
+#: src/hello-world/what-is-rust.md:7
+msgid "Rust supports many platforms and architectures:"
 msgstr ""
-" راست از بسیاری از [بسترها و معماری‌ها](https://doc.rust-lang.org/nightly/"
-"rustc/platform-support.html) پشتیبانی می کند :"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:9
 msgid "x86, ARM, WebAssembly, ..."
 msgstr "<span dir=ltr>x86, ARM, WebAssembly, ...</span>"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:10
 msgid "Linux, Mac, Windows, ..."
 msgstr "<span dir=ltr>Linux, Mac, Windows, ...</span>"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:11
 msgid "Rust is used for a wide range of devices:"
 msgstr ":راست برای طیف گسترده‌ای از دستگاه‌ها استفاده می‌شود"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:12
 msgid "firmware and boot loaders,"
 msgstr "میان‌افزار (firmware) و بوت‌لودرها (boot loaders)"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:13
 msgid "smart displays,"
 msgstr "نمایشگر‌های هوشمند"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:14
 msgid "mobile phones,"
 msgstr "تلفن‌های همراه"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:15
 msgid "desktops,"
 msgstr "رایانه‌های رومیزی"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:16
 msgid "servers."
 msgstr "سرورها"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust در همان حوزه <span dir=ltr>C++</span> قرار می‌گیرد:"
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:23
 msgid "High flexibility."
 msgstr ""
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:24
 msgid "High level of control."
 msgstr ""
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:25
 msgid ""
 "Can be scaled down to very constrained devices such as microcontrollers."
 msgstr "می‌تواند به دستگاه‌های بسیار محدود مانند میکروکنترلرها مقیاس‌بندی شود."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:26
 msgid "Has no runtime or garbage collection."
 msgstr " فاقد ران‌تایم (runtime)  یا جمع‌آوری زباله (garbage collection) است."
 
-#: src/hello-world/what-is-rust.md
+#: src/hello-world/what-is-rust.md:27
 msgid "Focuses on reliability and safety without sacrificing performance."
 msgstr "بر قابلیت اطمینان و ایمنی بدون قربانی کردن عملکرد تمرکز دارد."
 
-#: src/hello-world/hello-world.md
-msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World "
-"program:"
-msgstr ""
-"بیایید به ساده ترین برنامه Rust ممکن یعنی یک برنامه Hello World کلاسیک "
-"بپردازیم:"
-
-#: src/hello-world/hello-world.md
-msgid "\"Hello 🌍!\""
-msgstr ""
-
-#: src/hello-world/hello-world.md
-msgid "What you see:"
-msgstr "آنچه شما می‌بینید:"
-
-#: src/hello-world/hello-world.md
-msgid "Functions are introduced with `fn`."
-msgstr " توابع با `fn` معرفی می‌شوند."
-
-#: src/hello-world/hello-world.md
-msgid "Blocks are delimited by curly braces like in C and C++."
-msgstr ""
-"بلوک‌ها با پرانتزهای باز و بسته مانند C و <span dir=ltr>C++</span> محدود "
-"می‌شوند."
-
-#: src/hello-world/hello-world.md
-msgid "The `main` function is the entry point of the program."
-msgstr "تابع `main` نقطه ورود برنامه است."
-
-#: src/hello-world/hello-world.md
-msgid "Rust has hygienic macros, `println!` is an example of this."
-msgstr ""
-"زبان Rust دارای ماکروهای hygienic است، <span dir=ltr>`println!`</span> یک "
-"نمونه از این است."
-
-#: src/hello-world/hello-world.md
-msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
-msgstr ""
-"رشته‌های Rust دارای انکودینگ UTF-8 هستند و می‌توانند شامل هر کاراکتر یونیکد "
-"باشند."
-
-#: src/hello-world/hello-world.md
-#, fuzzy
-msgid ""
-"This slide tries to make the students comfortable with Rust code. They will "
-"see a ton of it over the next four days so we start small with something "
-"familiar."
-msgstr ""
-"این اسلاید سعی می کند دانشجویان با کد Rust احساس راحتی کنند. آنها در سه روز "
-"آینده خیلی از این کدها خواهند دید، بنابراین با یک چیز آشنا شروع می کنیم.."
-
-#: src/hello-world/hello-world.md
-msgid ""
-"Rust is very much like other languages in the C/C++/Java tradition. It is "
-"imperative and it doesn't try to reinvent things unless absolutely necessary."
-msgstr ""
-"زبان Rust, زبان بسیار شبیه به سایر زبان‌های خانواده C/<span dir=ltr>C++</"
-"span>/Java است.یک زبان امری است (imperative) و سعی نمی‌کند چیزی را مگر اینکه "
-"کاملاً ضروری باشد، دوباره اختراع کند."
-
-#: src/hello-world/hello-world.md
-msgid "Rust is modern with full support for things like Unicode."
-msgstr "زبان Rust, یک زبان مدرن با پشتیبانی کامل از چیزهایی مانند یونیکد است."
-
-#: src/hello-world/hello-world.md
-#, fuzzy
-msgid ""
-"Rust uses macros for situations where you want to have a variable number of "
-"arguments (no function [overloading](../control-flow-basics/functions.md))."
-msgstr ""
-"Rust از ماکروها برای موقعیت‌هایی استفاده می‌کند که می‌خواهید تعداد متغیری از  "
-"آرگومان‌ها داشته باشید (بدون [اورلودینگ](basic-syntax/functions-interlude.md) "
-"تابع)."
-
-#: src/hello-world/hello-world.md
-msgid ""
-"Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from the scope they are used in. Rust macros are actually only [partially "
-"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
-"html)."
-msgstr ""
-"«هاجنیک» (`hygienic‍`) بودن ماکرو به این معنی است که آنها به طور تصادفی "
-"شناسه‌ها را از اسکوپ‌ای که در آن استفاده می‌شوند، ضبط نمی‌کنند. ماکروهای Rust در "
-"واقع فقط [تا حدی هاجنیک](https://veykril.github.io/tlborm/decl-macros/"
-"minutiae/hygiene.html هستند."
-
-#: src/hello-world/hello-world.md
-msgid ""
-"Rust is multi-paradigm. For example, it has powerful [object-oriented "
-"programming features](https://doc.rust-lang.org/book/ch17-00-oop.html), and, "
-"while it is not a functional language, it includes a range of [functional "
-"concepts](https://doc.rust-lang.org/book/ch13-00-functional-features.html)."
-msgstr ""
-"زبان Rust, یک زبان چند پارادایمی است. به عنوان مثال، دارای ویژگی‌های قدرتمند "
-"[برنامه نویسی شی‌گرا](https://doc.rust-lang.org/book/ch17-00-oop.html) است و "
-"در حالی که یک زبان فانکشنال(`functional‍`) نیست، شامل طیف وسیعی از [مفاهیم "
-"فانکشنال](https://doc.rust-lang.org/book/ch13-00-functional-features.html) "
-"است."
-
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "برخی از نقاط قوت منحصر به فرد زبان Rust:"
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:5
 msgid ""
 "_Compile time memory safety_ - whole classes of memory bugs are prevented at "
 "compile time"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:7
 msgid "No uninitialized variables."
 msgstr "هیچ متغیر مقدار‌دهی نشده‌ای (`uninitialized`) وجود ندارد."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:8
 msgid "No double-frees."
 msgstr "هیچ آزادسازی دوباره‌ای وجود ندارد."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:9
 msgid "No use-after-free."
 msgstr "هیچ استفاده‌ای پس از آزادسازی وجود ندارد."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:10
 msgid "No `NULL` pointers."
 msgstr "هیچ اشاره‌گر `NULL` وجود ندارد."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:11
 msgid "No forgotten locked mutexes."
 msgstr "هیچ موتکس قفل شدهِ فراموش شده‌ای وجود ندارد."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:12
 msgid "No data races between threads."
 msgstr " هیچ وضعیت رقابتی (`data races`) بین رشته‌ها وجود ندارد."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:13
 msgid "No iterator invalidation."
 msgstr "تکرارکننده‌ها (`iterators`) هیچگاه نامعتبر نمی‌شوند.."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:15
 msgid ""
 "_No undefined runtime behavior_ - what a Rust statement does is never left "
 "unspecified"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:17
 msgid "Array access is bounds checked."
 msgstr "دسترسی به آرایه با بررسی محدوده چک می‌شود."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:18
 msgid "Integer overflow is defined (panic or wrap-around)."
 msgstr "سرریز عدد صحیح تعریف شده است (پانیک یا `wrap-around`)."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:20
 msgid ""
 "_Modern language features_ - as expressive and ergonomic as higher-level "
 "languages"
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:22
 msgid "Enums and pattern matching."
 msgstr "Enumها و تطابق الگوها."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:23
 msgid "Generics."
 msgstr "جنریک‌ها."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:24
 msgid "No overhead FFI."
 msgstr "FFI بدون سربار"
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:25
 msgid "Zero-cost abstractions."
 msgstr "انتزاع‌هایی بدون هزینه"
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:26
 msgid "Great compiler errors."
 msgstr "خطاهای کامپایل عالیست."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:27
 msgid "Built-in dependency manager."
 msgstr "مدیر وابستگی درون-ساختی"
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:28
 msgid "Built-in support for testing."
 msgstr "پشتیبانی درون-ساختی از تست نویسی"
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:29
 msgid "Excellent Language Server Protocol support."
 msgstr "پشتیبانی عالی از LSP‌."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:34
 msgid ""
 "Do not spend much time here. All of these points will be covered in more "
 "depth later."
 msgstr ""
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:37
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
 "Depending on the answer you can highlight different features of Rust:"
@@ -2821,7 +2900,7 @@ msgstr ""
 "حتما از کلاس بپرسید که با چه زبان‌هایی تجربه دارند. بسته به پاسخ، می توانید "
 "ویژگی‌های مختلف Rust را برجسته کنید::"
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:40
 msgid ""
 "Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
 "via the borrow checker. You get performance like in C and C++, but you don't "
@@ -2834,7 +2913,7 @@ msgstr ""
 "دارید اما مشکلات عدم ایمنی حافظه را ندارید. علاوه بر این، شما یک زبان مدرن "
 "با ساختارهایی مانند تطابق الگو و مدیریت وابستگی داخلی دریافت می‌کنید."
 
-#: src/hello-world/benefits.md
+#: src/hello-world/benefits.md:45
 msgid ""
 "Experience with Java, Go, Python, JavaScript...: You get the same memory "
 "safety as in those languages, plus a similar high-level language feeling. In "
@@ -2847,34 +2926,33 @@ msgstr ""
 "جمع‌آوری زباله) و همچنین دسترسی به سخت‌افزار سطح پایین (در صورت نیاز) دریافت "
 "می‌کنید."
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:3
 msgid ""
-"The [Rust Playground](https://play.rust-lang.org/) provides an easy way to "
-"run short Rust programs, and is the basis for the examples and exercises in "
-"this course. Try running the \"hello-world\" program it starts with. It "
-"comes with a few handy features:"
+"The Rust Playground provides an easy way to run short Rust programs, and is "
+"the basis for the examples and exercises in this course. Try running the "
+"\"hello-world\" program it starts with. It comes with a few handy features:"
 msgstr ""
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:8
 msgid ""
 "Under \"Tools\", use the `rustfmt` option to format your code in the "
 "\"standard\" way."
 msgstr ""
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:11
 msgid ""
 "Rust has two main \"profiles\" for generating code: Debug (extra runtime "
 "checks, less optimization) and Release (fewer runtime checks, lots of "
 "optimization). These are accessible under \"Debug\" at the top."
 msgstr ""
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:15
 msgid ""
 "If you're interested, use \"ASM\" under \"...\" to see the generated "
 "assembly code."
 msgstr ""
 
-#: src/hello-world/playground.md
+#: src/hello-world/playground.md:21
 msgid ""
 "As students head into the break, encourage them to open up the playground "
 "and experiment a little. Encourage them to keep the tab open and try things "
@@ -2883,35 +2961,111 @@ msgid ""
 "assembly."
 msgstr ""
 
-#: src/types-and-values.md
-msgid "[Variables](./types-and-values/variables.md) (5 minutes)"
+#: src/types-and-values.md src/control-flow-basics.md src/modules.md
+msgid "This segment should take about 40 minutes. It contains:"
 msgstr ""
 
-#: src/types-and-values.md
-msgid "[Values](./types-and-values/values.md) (10 minutes)"
+#: src/types-and-values/hello-world.md:3
+msgid ""
+"Let us jump into the simplest possible Rust program, a classic Hello World "
+"program:"
+msgstr ""
+"بیایید به ساده ترین برنامه Rust ممکن یعنی یک برنامه Hello World کلاسیک "
+"بپردازیم:"
+
+#: src/types-and-values/hello-world.md:8
+msgid "\"Hello 🌍!\""
 msgstr ""
 
-#: src/types-and-values.md
-msgid "[Arithmetic](./types-and-values/arithmetic.md) (5 minutes)"
-msgstr ""
+#: src/types-and-values/hello-world.md:12
+msgid "What you see:"
+msgstr "آنچه شما می‌بینید:"
 
-#: src/types-and-values.md
-msgid "[Strings](./types-and-values/strings.md) (10 minutes)"
-msgstr ""
+#: src/types-and-values/hello-world.md:14
+msgid "Functions are introduced with `fn`."
+msgstr " توابع با `fn` معرفی می‌شوند."
 
-#: src/types-and-values.md
-msgid "[Type Inference](./types-and-values/inference.md) (5 minutes)"
+#: src/types-and-values/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
 msgstr ""
+"بلوک‌ها با پرانتزهای باز و بسته مانند C و <span dir=ltr>C++</span> محدود "
+"می‌شوند."
 
-#: src/types-and-values.md
-msgid "[Exercise: Fibonacci](./types-and-values/exercise.md) (30 minutes)"
+#: src/types-and-values/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "تابع `main` نقطه ورود برنامه است."
+
+#: src/types-and-values/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr ""
+"زبان Rust دارای ماکروهای hygienic است، <span dir=ltr>`println!`</span> یک "
+"نمونه از این است."
 
-#: src/types-and-values.md src/testing.md src/unsafe-rust.md
-msgid "This segment should take about 1 hour and 5 minutes"
+#: src/types-and-values/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
+"رشته‌های Rust دارای انکودینگ UTF-8 هستند و می‌توانند شامل هر کاراکتر یونیکد "
+"باشند."
 
-#: src/types-and-values/variables.md
+#: src/types-and-values/hello-world.md:23
+#, fuzzy
+msgid ""
+"This slide tries to make the students comfortable with Rust code. They will "
+"see a ton of it over the next four days so we start small with something "
+"familiar."
+msgstr ""
+"این اسلاید سعی می کند دانشجویان با کد Rust احساس راحتی کنند. آنها در سه روز "
+"آینده خیلی از این کدها خواهند دید، بنابراین با یک چیز آشنا شروع می کنیم.."
+
+#: src/types-and-values/hello-world.md:28
+msgid ""
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative and it doesn't try to reinvent things unless absolutely necessary."
+msgstr ""
+"زبان Rust, زبان بسیار شبیه به سایر زبان‌های خانواده C/<span dir=ltr>C++</"
+"span>/Java است.یک زبان امری است (imperative) و سعی نمی‌کند چیزی را مگر اینکه "
+"کاملاً ضروری باشد، دوباره اختراع کند."
+
+#: src/types-and-values/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "زبان Rust, یک زبان مدرن با پشتیبانی کامل از چیزهایی مانند یونیکد است."
+
+#: src/types-and-values/hello-world.md:33
+#, fuzzy
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function overloading)."
+msgstr ""
+"Rust از ماکروها برای موقعیت‌هایی استفاده می‌کند که می‌خواهید تعداد متغیری از  "
+"آرگومان‌ها داشته باشید (بدون [اورلودینگ](basic-syntax/functions-interlude.md) "
+"تابع)."
+
+#: src/types-and-values/hello-world.md:36
+#, fuzzy
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only partially "
+"hygienic."
+msgstr ""
+"«هاجنیک» (`hygienic‍`) بودن ماکرو به این معنی است که آنها به طور تصادفی "
+"شناسه‌ها را از اسکوپ‌ای که در آن استفاده می‌شوند، ضبط نمی‌کنند. ماکروهای Rust در "
+"واقع فقط [تا حدی هاجنیک](https://veykril.github.io/tlborm/decl-macros/"
+"minutiae/hygiene.html هستند."
+
+#: src/types-and-values/hello-world.md:40
+#, fuzzy
+msgid ""
+"Rust is multi-paradigm. For example, it has powerful object-oriented "
+"programming features, and, while it is not a functional language, it "
+"includes a range of functional concepts."
+msgstr ""
+"زبان Rust, یک زبان چند پارادایمی است. به عنوان مثال، دارای ویژگی‌های قدرتمند "
+"[برنامه نویسی شی‌گرا](https://doc.rust-lang.org/book/ch17-00-oop.html) است و "
+"در حالی که یک زبان فانکشنال(`functional‍`) نیست، شامل طیف وسیعی از [مفاهیم "
+"فانکشنال](https://doc.rust-lang.org/book/ch13-00-functional-features.html) "
+"است."
+
+#: src/types-and-values/variables.md:3
 #, fuzzy
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are made with "
@@ -2920,137 +3074,133 @@ msgstr ""
 "زبان Rust از طریق سیستم تایپ استاتیک, ایمینی نوع را فراهم می‌کند. به صورت "
 "پیشفرض تعریف متغییر ها از نوع «غیر قابل تغییر» (immutable) است:"
 
-#: src/types-and-values/variables.md src/control-flow-basics/loops.md
-#: src/control-flow-basics/break-continue.md
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/types-and-values/variables.md:9 src/control-flow-basics/loops/for.md:9
+#: src/control-flow-basics/blocks-and-scopes.md:17
 msgid "\"x: {x}\""
 msgstr ""
 
-#: src/types-and-values/variables.md
-msgid ""
-"// x = 20;\n"
-"    // println!(\"x: {x}\");\n"
+#: src/types-and-values/variables.md:10
+msgid "// x = 20; // println!(\"x: {x}\");"
 msgstr ""
 
-#: src/types-and-values/variables.md
+#: src/types-and-values/variables.md:18
 msgid ""
 "Uncomment the `x = 20` to demonstrate that variables are immutable by "
 "default. Add the `mut` keyword to allow changes."
 msgstr ""
 
-#: src/types-and-values/variables.md
+#: src/types-and-values/variables.md:21
 msgid ""
 "The `i32` here is the type of the variable. This must be known at compile "
 "time, but type inference (covered later) allows the programmer to omit it in "
 "many cases."
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:3
 msgid ""
 "Here are some basic built-in types, and the syntax for literal values of "
 "each type."
 msgstr ""
 
-#: src/types-and-values/values.md src/tuples-and-arrays/tuples-and-arrays.md
-#: src/unsafe-rust/exercise.md
+#: src/types-and-values/values.md:6 src/unsafe-rust/exercise.md:16
 msgid "Types"
 msgstr "انواع"
 
-#: src/types-and-values/values.md src/tuples-and-arrays/tuples-and-arrays.md
+#: src/types-and-values/values.md:6
 msgid "Literals"
 msgstr "مقادیر ثابت"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:8
 msgid "Signed integers"
 msgstr "اعداد صحیح علامت‌دار"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:8
 msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
 msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:8
 msgid "`-10`, `0`, `1_000`, `123_i64`"
 msgstr ""
 "<span dir=ltr><code class=hljs>-10</code>, <code class=hljs>0</code>, <code "
 "class=hljs>1_000</code>, <code class=hljs>123_i64</code></span>"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:9
 msgid "Unsigned integers"
 msgstr "اعداد صحیح مثبت"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:9
 msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
 msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:9
 msgid "`0`, `123`, `10_u16`"
 msgstr ""
 "<span dir=ltr><code class=hljs>0</code>, <code class=hljs>123</code>, <code "
 "class=hljs>10_u16</code></span>"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:10
 msgid "Floating point numbers"
 msgstr "اعداد با ممیز شناور"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:10
 msgid "`f32`, `f64`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:10
 msgid "`3.14`, `-10.0e20`, `2_f32`"
 msgstr ""
 "<span dir=ltr><code class=hljs>3.14</code>, <code class=hljs>-10.0e20</"
 "code>, <code class=hljs>2_f32</code></span>"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:11
 msgid "Unicode scalar values"
 msgstr "مقادیر عددی یونیکد"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:11 src/android/aidl/types/primitives.md:9
 msgid "`char`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:11
 msgid "`'a'`, `'α'`, `'∞'`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:12
 msgid "Booleans"
 msgstr "بولین‌ها"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:12 src/android/aidl/types/primitives.md:7
 msgid "`bool`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:12
 msgid "`true`, `false`"
 msgstr ""
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:14
 msgid "The types have widths as follows:"
 msgstr "اندازه تایپ‌ها به شرح زیر است:"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:16
 msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
 msgstr "`iN`, `uN`و `fN` به اندازه _N_ حافظه اشغال می‌کنند.,"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:17
 msgid "`isize` and `usize` are the width of a pointer,"
 msgstr "`isize` و `usize` به اندازه یک اشاره‌گر حافظه اشغال می‌کنند,"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:18
 msgid "`char` is 32 bits wide,"
 msgstr "`char` به اندازه 32 بیت حافظه اشغال می‌کنند.,"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:19
 msgid "`bool` is 8 bits wide."
 msgstr "`bool` به اندازه 8 بیت حافظه اشغال می‌کنند."
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:24
 msgid "There are a few syntaxes which are not shown above:"
 msgstr "موارد اندکی وجود دارند که در بالا نشان داده نشده است:"
 
-#: src/types-and-values/values.md
+#: src/types-and-values/values.md:26
 msgid ""
 "All underscores in numbers can be left out, they are for legibility only. So "
 "`1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written "
@@ -3061,29 +3211,29 @@ msgstr ""
 "(یا <span dir=ltr>`10_00`</span>) نوشته شود و <span dir=ltr>`123_i64`</span> "
 "می‌تواند به صورت <span dir=ltr>`123i64`</span> نوشته شود.»"
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:9
 msgid "\"result: {}\""
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:16
 msgid ""
 "This is the first time we've seen a function other than `main`, but the "
 "meaning should be clear: it takes three integers, and returns an integer. "
 "Functions will be covered in more detail later."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:20
 msgid "Arithmetic is very similar to other languages, with similar precedence."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:22
 msgid ""
 "What about integer overflow? In C and C++ overflow of _signed_ integers is "
 "actually undefined, and might do different things on different platforms or "
 "compilers. In Rust, it's defined."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:26
 msgid ""
 "Change the `i32`'s to `i16` to see an integer overflow, which panics "
 "(checked) in a debug build and wraps in a release build. There are other "
@@ -3092,97 +3242,17 @@ msgid ""
 "a)`."
 msgstr ""
 
-#: src/types-and-values/arithmetic.md
+#: src/types-and-values/arithmetic.md:31
 msgid ""
 "In fact, the compiler will detect overflow of constant expressions, which is "
 "why the example requires a separate function."
 msgstr ""
 
-#: src/types-and-values/strings.md
-msgid ""
-"Rust has two types to represent strings, both of which will be covered in "
-"more depth later. Both _always_ store UTF-8 encoded strings."
-msgstr ""
-
-#: src/types-and-values/strings.md
-#, fuzzy
-msgid "`String` - a modifiable, owned string."
-msgstr "`String` یک بافر رشته‌ای قابل تغییر است."
-
-#: src/types-and-values/strings.md
-msgid "`&str` - a read-only string. String literals have this type."
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid "\"Greetings\""
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid "\"🪐\""
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid "\", \""
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid "\"final sentence: {}\""
-msgstr ""
-
-#: src/types-and-values/strings.md src/async/control-flow/join.md
-msgid "\"{:?}\""
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid "//println!(\"{:?}\", &sentence[12..13]);\n"
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid ""
-"This slide introduces strings. Everything here will be covered in more depth "
-"later, but this is enough for subsequent slides and exercises to use strings."
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid "Invalid UTF-8 in a string is UB, and this not allowed in safe Rust."
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid ""
-"`String` is a user-defined type with a constructor (`::new()`) and methods "
-"like `s.push_str(..)`."
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid ""
-"The `&` in `&str` indicates that this is a reference. We will cover "
-"references later, so for now just think of `&str` as a unit meaning \"a read-"
-"only string\"."
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid ""
-"The commented-out line is indexing into the string by byte position. "
-"`12..13` does not end on a character boundary, so the program panics. Adjust "
-"it to a range that does, based on the error message."
-msgstr ""
-
-#: src/types-and-values/strings.md
-msgid ""
-"Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
-"amount of `#` on either side of the quotes:"
-msgstr ""
-"رشته‌های خام به شما امکان می دهند یک مقدار <span dir=ltr><code "
-"class=hljs>&str</code></span> با غیرفعال کردن فرارها ایجاد کنید:  `r\"\\n\" "
-"== \"\\\\n\"`.شما می‌توانید با استفاده از تعداد برابر `#` در دو طرف دابل‌کوت "
-"دابل‌کوت‌ها، دابل‌کوت‌ها را جاسازی کنید:"
-
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
 msgstr "زبان Rust برای تعیین نوع متغیر به نحوه استفاده از آن نگاه می‌کند:"
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:29
 msgid ""
 "This slide demonstrates how the Rust compiler infers types based on "
 "constraints given by variable declarations and usages."
@@ -3190,7 +3260,7 @@ msgstr ""
 "این اسلاید نشان می‌دهد که چگونه کامپایلر Rust با توجه به اعلان‌ها و استفاده‌های "
 "متغیر، انواع را استنتاج می‌کند. "
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:32
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
 "of some sort of dynamic \"any type\" that can hold any data. The machine "
@@ -3204,132 +3274,89 @@ msgstr ""
 "اعلام میکنیم و کد های ماشین آنها دقیقا یکسان هستند. فقط با استفاده از  تعیین "
 "تایپ ضمنی میتوانید کد ها رو به صورت مختصرتر بنویسیم. "
 
-#: src/types-and-values/inference.md
+#: src/types-and-values/inference.md:37
 msgid ""
 "When nothing constrains the type of an integer literal, Rust defaults to "
 "`i32`. This sometimes appears as `{integer}` in error messages. Similarly, "
 "floating-point literals default to `f64`."
 msgstr ""
 
-#: src/types-and-values/inference.md
-msgid "// ERROR: no implementation for `{float} == {integer}`\n"
+#: src/types-and-values/inference.md:46
+msgid "// ERROR: no implementation for `{float} == {integer}`"
 msgstr ""
 
-#: src/types-and-values/exercise.md
+#: src/types-and-values/exercise.md:3
 msgid ""
-"The first and second Fibonacci numbers are both `1`. For n>2, the n'th "
-"Fibonacci number is calculated recursively as the sum of the n-1'th and "
-"n-2'th Fibonacci numbers."
+"The Fibonacci sequence begins with `[0,1]`. For n>1, the n'th Fibonacci "
+"number is calculated recursively as the sum of the n-1'th and n-2'th "
+"Fibonacci numbers."
 msgstr ""
 
-#: src/types-and-values/exercise.md
+#: src/types-and-values/exercise.md:6
 msgid ""
 "Write a function `fib(n)` that calculates the n'th Fibonacci number. When "
 "will this function panic?"
 msgstr ""
 
-#: src/types-and-values/exercise.md
-msgid "// The base case.\n"
+#: src/types-and-values/exercise.md:12
+msgid "// The base case."
 msgstr ""
 
-#: src/types-and-values/exercise.md src/control-flow-basics/exercise.md
+#: src/types-and-values/exercise.md:13 src/types-and-values/exercise.md:16
+#: src/control-flow-basics/exercise.md:27
+#: src/control-flow-basics/exercise.md:31
 #, fuzzy
 msgid "\"Implement this\""
 msgstr "پیاده سازی"
 
-#: src/types-and-values/exercise.md
-msgid "// The recursive case.\n"
+#: src/types-and-values/exercise.md:15
+msgid "// The recursive case."
 msgstr ""
 
-#: src/types-and-values/exercise.md src/types-and-values/solution.md
-msgid "\"fib(n) = {}\""
-msgstr ""
-
-#: src/control-flow-basics.md
-msgid "[Conditionals](./control-flow-basics/conditionals.md) (5 minutes)"
+#: src/types-and-values/exercise.md:22 src/types-and-values/solution.md:14
+msgid "\"fib({n}) = {}\""
 msgstr ""
 
 #: src/control-flow-basics.md
-msgid "[Loops](./control-flow-basics/loops.md) (5 minutes)"
-msgstr ""
-
-#: src/control-flow-basics.md
-msgid ""
-"[break and continue](./control-flow-basics/break-continue.md) (5 minutes)"
-msgstr ""
-
-#: src/control-flow-basics.md
-msgid ""
-"[Blocks and Scopes](./control-flow-basics/blocks-and-scopes.md) (10 minutes)"
-msgstr ""
-
-#: src/control-flow-basics.md
-msgid "[Functions](./control-flow-basics/functions.md) (3 minutes)"
-msgstr ""
-
-#: src/control-flow-basics.md
-msgid "[Macros](./control-flow-basics/macros.md) (2 minutes)"
-msgstr ""
-
-#: src/control-flow-basics.md
-msgid ""
-"[Exercise: Collatz Sequence](./control-flow-basics/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/control-flow-basics.md src/tuples-and-arrays.md src/borrowing.md
-msgid "This segment should take about 1 hour"
-msgstr ""
-
-#: src/control-flow-basics/conditionals.md
-msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
-msgstr "بسیاری از دستور زبان Rust مشابه زبان‌های C، C++ یا Java خواهد بود:"
-
-#: src/control-flow-basics/conditionals.md
 #, fuzzy
-msgid "Blocks are delimited by curly braces."
-msgstr "بلاک‌ها و اسکوپ‌ها با پرانتزهای باز و بسته مشخص می‌شوند."
+msgid "if Expressions"
+msgstr "عبارت if"
 
-#: src/control-flow-basics/conditionals.md
-msgid ""
-"Line comments are started with `//`, block comments are delimited by `/* ... "
-"*/`."
+#: src/control-flow-basics.md src/pattern-matching.md src/concurrency/async.md
+#: src/concurrency/async-control-flow.md
+msgid "4 minutes"
 msgstr ""
-"کامنت‌های تک خطی با ‍`//` شروع می‌شوند و کامنت‌های چند خطی با `/* ... */` مشخص "
-"می‌شوند."
 
-#: src/control-flow-basics/conditionals.md
-msgid "Keywords like `if` and `while` work the same."
-msgstr "کلمات کلیدی مانند `if `و `while` به همان صورت عمل می‌کنند."
+#: src/control-flow-basics.md
+#, fuzzy
+msgid "break and continue"
+msgstr "`break` و `continue`"
 
-#: src/control-flow-basics/conditionals.md
-msgid "Variable assignment is done with `=`, comparison is done with `==`."
-msgstr "انتساب متغیر با `=` انجام می‌شود، مقایسه با `==` انجام می‌شود."
-
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:1
 msgid "`if` expressions"
 msgstr "عبارات `if`"
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:3
+#, fuzzy
 msgid ""
-"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
-"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
+"You use `if` expressions exactly like `if` statements in other languages:"
 msgstr ""
 "شما [عبارت `if`](https://doc.rust-lang.org/reference/expressions/if-expr."
 "html#if-expressions) رو به مانند دیگر زبان‌ها استفاده می‌کنید:"
 
-#: src/control-flow-basics/conditionals.md
-msgid "\"small\""
+#: src/control-flow-basics/if.md:11
+msgid "\"zero!\""
 msgstr ""
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:13
 msgid "\"biggish\""
 msgstr ""
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:15
 msgid "\"huge\""
 msgstr ""
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:20
 msgid ""
 "In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
@@ -3337,15 +3364,19 @@ msgstr ""
 "در کنار این موضوع, می‌توانید از if به عنوان یک عبارت با قابلیت بازگشت مقدار "
 "هم استفاده کنید. آخرین عبارت توی هر بلاک  if اون مقدار و نوع بازگشتی است:"
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:26
+msgid "\"small\""
+msgstr ""
+
+#: src/control-flow-basics/if.md:26
 msgid "\"large\""
 msgstr ""
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:27
 msgid "\"number size: {}\""
 msgstr ""
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:34
 #, fuzzy
 msgid ""
 "Because `if` is an expression and must have a particular type, both of its "
@@ -3356,97 +3387,94 @@ msgstr ""
 "و `else`) باید از نوع یکسانی را باز گردانند.  در نظر بگیرید که اگر بعد از "
 "`x / 2` در مثال دوم `;` اضافه کنید، چه اتفاقی می افتد. "
 
-#: src/control-flow-basics/conditionals.md
+#: src/control-flow-basics/if.md:38
 msgid ""
 "When `if` is used in an expression, the expression must have a `;` to "
 "separate it from the next statement. Remove the `;` before `println!` to see "
 "the compiler error."
 msgstr ""
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:3
 msgid "There are three looping keywords in Rust: `while`, `loop`, and `for`:"
 msgstr ""
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:5
 #, fuzzy
 msgid "`while`"
 msgstr "حلقه‌های `while`"
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:7
 #, fuzzy
 msgid ""
-"The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops) works much like in other languages, executing the "
-"loop body as long as the condition is true."
+"The `while` keyword works much like in other languages, executing the loop "
+"body as long as the condition is true."
 msgstr ""
 "[کلمه‌کلیدی`while` ](https://doc.rust-lang.org/reference/expressions/loop-"
 "expr.html#predicate-loops) بسیار شبیه به سایر زبان‌ها عمل می‌کند:"
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops.md:18
 msgid "\"Final x: {x}\""
 msgstr ""
 
-#: src/control-flow-basics/loops.md
-#, fuzzy
-msgid "`for`"
-msgstr "حلقه‌های `for`"
-
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops/for.md:3
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) iterates "
-"over ranges of values:"
+"The `for` loop iterates over ranges of values or the items in a collection:"
 msgstr ""
 
-#: src/control-flow-basics/loops.md
-msgid "`loop`"
+#: src/control-flow-basics/loops/for.md:13
+msgid "\"elem: {elem}\""
 msgstr ""
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops/for.md:20
 msgid ""
-"The [`loop` statement](https://doc.rust-lang.org/std/keyword.loop.html) just "
-"loops forever, until a `break`."
+"Under the hood `for` loops use a concept called \"iterators\" to handle "
+"iterating over different kinds of ranges/collections. Iterators will be "
+"discussed in more detail later."
 msgstr ""
 
-#: src/control-flow-basics/loops.md
+#: src/control-flow-basics/loops/for.md:23
+msgid ""
+"Note that the first `for` loop only iterates to `4`. Show the `1..=5` syntax "
+"for an inclusive range."
+msgstr ""
+
+#: src/control-flow-basics/loops/loop.md:3
+msgid "The `loop` statement just loops forever, until a `break`."
+msgstr ""
+
+#: src/control-flow-basics/loops/loop.md:11
 msgid "\"{i}\""
 msgstr ""
 
-#: src/control-flow-basics/loops.md
-msgid ""
-"We will discuss iteration later; for now, just stick to range expressions."
-msgstr ""
-
-#: src/control-flow-basics/loops.md
-msgid ""
-"Note that the `for` loop only iterates to `4`. Show the `1..=5` syntax for "
-"an inclusive range."
-msgstr ""
-
-#: src/control-flow-basics/break-continue.md
+#: src/control-flow-basics/break-continue.md:3
 #, fuzzy
-msgid ""
-"If you want to exit any kind of loop early, use [`break`](https://doc.rust-"
-"lang.org/reference/expressions/loop-expr.html#break-expressions). For "
-"`loop`, this can take an optional expression that becomes the value of the "
-"`loop` expression."
-msgstr ""
-"اگر می‌خواهید زودتر از یک حلقه خارج شوید، از [`break`](https://doc.rust-lang."
-"org/reference/expressions/loop-expr.html#break-expressions) استفاده کنید,"
-
-#: src/control-flow-basics/break-continue.md
-msgid ""
-"If you want to immediately start the next iteration use [`continue`](https://"
-"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+msgid "If you want to immediately start the next iteration use `continue`."
 msgstr ""
 "اگر می‌خواهید بلافاصله تکرار بعدی را شروع کنید، از [`continue`](https://doc."
 "rust-lang.org/reference/expressions/loop-expr.html#continue-expressions) "
 "استفاده کنید."
 
-#: src/control-flow-basics/break-continue.md
-msgid "\"{result}\""
+#: src/control-flow-basics/break-continue.md:6
+#, fuzzy
+msgid ""
+"If you want to exit any kind of loop early, use `break`. For `loop`, this "
+"can take an optional expression that becomes the value of the `loop` "
+"expression."
+msgstr ""
+"اگر می‌خواهید زودتر از یک حلقه خارج شوید، از [`break`](https://doc.rust-lang."
+"org/reference/expressions/loop-expr.html#break-expressions) استفاده کنید,"
+
+#: src/control-flow-basics/break-continue.md:22 src/std-traits/exercise.md:23
+#: src/std-traits/solution.md:29 src/smart-pointers/trait-objects.md:95
+#: src/smart-pointers/trait-objects.md:96
+#: src/borrowing/interior-mutability.md:47 src/modules/exercise.md:136
+#: src/modules/solution.md:78 src/android/build-rules/library.md:44
+#: src/android/interoperability/cpp/rust-bridge.md:17
+#: src/concurrency/async-pitfalls/cancellation.md:59
+msgid "\"{}\""
 msgstr ""
 
-#: src/control-flow-basics/break-continue.md
+#: src/control-flow-basics/break-continue/labels.md:3
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
 "used to break out of nested loops:"
@@ -3454,16 +3482,11 @@ msgstr ""
 "کلیدواژه‌های `continue` و `break` هر دو می‌توانند به صورت اختیاری یک آرگومان "
 "برچسب (label) بگیرند که میتوان برای  خروج از حلقه‌های تو در تو استفاده می‌کرد:"
 
-#: src/control-flow-basics/break-continue.md
-msgid "\"x: {x}, i: {i}\""
+#: src/control-flow-basics/break-continue/labels.md:19
+msgid "\"elements searched: {elements_searched}\""
 msgstr ""
 
-#: src/control-flow-basics/break-continue.md
-msgid ""
-"In this case we break the outer loop after 3 iterations of the inner loop."
-msgstr "در این مورد، پس از 3 تکرار حلقه `inner`، از حلقه `outer` خارج می‌شویم."
-
-#: src/control-flow-basics/break-continue.md
+#: src/control-flow-basics/break-continue/labels.md:25
 msgid ""
 "Note that `loop` is the only looping construct which returns a non-trivial "
 "value. This is because it's guaranteed to be entered at least once (unlike "
@@ -3473,11 +3496,11 @@ msgstr ""
 "را برمی‌گرداند. این به دلیل این است که  تضمین می‌شود حداقل یک بار وارد آن شود "
 "(برخلاف حلقه‌های `while` و `for`)."
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:3
 msgid "Blocks"
 msgstr "بلوک‌ها"
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:5
 #, fuzzy
 msgid ""
 "A block in Rust contains a sequence of expressions, enclosed by braces `{}`. "
@@ -3487,54 +3510,17 @@ msgstr ""
 "یک بلاک در Rust میتواند حاوی چندین عبارات باشد. هر بلاک دارای یک مقدار  و یک "
 "نوع بازگشتی است که مربوط به آخرین عبارت در ان بلاک می‌باشد:"
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:14
 msgid "\"y: {y}\""
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:21
 msgid ""
 "If the last expression ends with `;`, then the resulting value and type is "
 "`()`."
 msgstr "اگر آخرین عبارت با `;` پایان یابد، مقدار و نوع بازگشتی `()` است."
 
-#: src/control-flow-basics/blocks-and-scopes.md
-msgid "Scopes and Shadowing"
-msgstr "محدوده‌ها و سایه‌گذاری"
-
-#: src/control-flow-basics/blocks-and-scopes.md
-msgid "A variable's scope is limited to the enclosing block."
-msgstr ""
-
-#: src/control-flow-basics/blocks-and-scopes.md
-msgid ""
-"You can shadow variables, both those from outer scopes and variables from "
-"the same scope:"
-msgstr ""
-"شما می توانید متغیرها را سایه بزنید، هم آنهایی که از اسکوپ‌های بیرونی هستند و "
-"هم متغیرهایی که از اسکوپ یکسان هستند:"
-
-#: src/control-flow-basics/blocks-and-scopes.md
-msgid "\"before: {a}\""
-msgstr ""
-
-#: src/control-flow-basics/blocks-and-scopes.md src/std-traits/from-and-into.md
-#: src/slices-and-lifetimes/solution.md
-msgid "\"hello\""
-msgstr ""
-
-#: src/control-flow-basics/blocks-and-scopes.md
-msgid "\"inner scope: {a}\""
-msgstr ""
-
-#: src/control-flow-basics/blocks-and-scopes.md
-msgid "\"shadowed in inner scope: {a}\""
-msgstr ""
-
-#: src/control-flow-basics/blocks-and-scopes.md
-msgid "\"after: {a}\""
-msgstr ""
-
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes.md:26
 msgid ""
 "You can show how the value of the block changes by changing the last line in "
 "the block. For instance, adding/removing a semicolon or using a `return`."
@@ -3543,13 +3529,48 @@ msgstr ""
 "می‌کند. به عنوان مثال با اضافه کردن یا  حذف کردن یک `;` یا با استفاده از کلید "
 "واژه `return` تغییرات را اعمال کنید."
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:3
+msgid "A variable's scope is limited to the enclosing block."
+msgstr ""
+
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:5
+msgid ""
+"You can shadow variables, both those from outer scopes and variables from "
+"the same scope:"
+msgstr ""
+"شما می توانید متغیرها را سایه بزنید، هم آنهایی که از اسکوپ‌های بیرونی هستند و "
+"هم متغیرهایی که از اسکوپ یکسان هستند:"
+
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:11
+msgid "\"before: {a}\""
+msgstr ""
+
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:13
+#: src/generics/exercise.md:18 src/generics/solution.md:20
+#: src/std-traits/from-and-into.md:7 src/std-traits/from-and-into.md:19
+#: src/lifetimes/solution.md:225
+msgid "\"hello\""
+msgstr ""
+
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:14
+msgid "\"inner scope: {a}\""
+msgstr ""
+
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:17
+msgid "\"shadowed in inner scope: {a}\""
+msgstr ""
+
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:20
+msgid "\"after: {a}\""
+msgstr ""
+
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:26
 msgid ""
 "Show that a variable's scope is limited by adding a `b` in the inner block "
 "in the last example, and then trying to access it outside that block."
 msgstr ""
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:28
 #, fuzzy
 msgid ""
 "Shadowing is different from mutation, because after shadowing both "
@@ -3560,12 +3581,12 @@ msgstr ""
 "های حافظه هر دو متغیر همزمان وجود دارند. هر دو تحت یک نام در دسترس هستند، "
 "بسته به اینکه در کجا در کد از آن استفاده می کنید."
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:31
 #, fuzzy
 msgid "A shadowing variable can have a different type."
 msgstr "یک متغیر سایه‌دار می تواند انواع داده‌ای متفاوتی داشته باشد."
 
-#: src/control-flow-basics/blocks-and-scopes.md
+#: src/control-flow-basics/blocks-and-scopes/scopes.md:32
 msgid ""
 "Shadowing looks obscure at first, but is convenient for holding on to values "
 "after `.unwrap()`."
@@ -3573,7 +3594,7 @@ msgstr ""
 "سایه زدن در ابتدا مبهم به نظر می رسد، اما برای نگه داشتن مقادیر پس از  <span "
 "dir=ltr>`.unwrap()`</span> مناسب است."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:22
 msgid ""
 "Declaration parameters are followed by a type (the reverse of some "
 "programming languages), then a return type."
@@ -3581,7 +3602,7 @@ msgstr ""
 "بعد اعلان تابع پارامترهای ورودی و نوع آن و سپس یک نوع برگشتی هستند (برخلاف "
 "برخی از زبان‌های برنامه‌نویسی)."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:24
 #, fuzzy
 msgid ""
 "The last expression in a function body (or any block) becomes the return "
@@ -3593,7 +3614,7 @@ msgstr ""
 "گرفته می‌شود. به همین سادگی <span dir=ltr>`;`</span> را  میتوان در انتهای "
 "عبارت حذف کنید."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:28
 msgid ""
 "Some functions have no return value, and return the 'unit type', `()`. The "
 "compiler will infer this if the `-> ()` return type is omitted."
@@ -3602,242 +3623,145 @@ msgstr ""
 "را برمی‌گردانند. اگر <span dir=ltr>`-> ()`</span> از بخش نوع برگشتی حذف شود، "
 "کامپایلر این را استنتاج خواهد کرد که هیچ نوع برگشتی وجود ندارد."
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:30
 #, fuzzy
 msgid ""
 "Overloading is not supported -- each function has a single implementation."
 msgstr "هر تابع فقط یک پیاده سازی دارد:"
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:31
 msgid ""
 "Always takes a fixed number of parameters. Default arguments are not "
 "supported. Macros can be used to support variadic functions."
 msgstr ""
 
-#: src/control-flow-basics/functions.md
+#: src/control-flow-basics/functions.md:33
 #, fuzzy
 msgid ""
 "Always takes a single set of parameter types. These types can be generic, "
 "which will be covered later."
 msgstr "همیشه یک مجموعه واحد از انواع آرگومان‌ها را می‌گیرد."
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:3
 msgid ""
 "Macros are expanded into Rust code during compilation, and can take a "
 "variable number of arguments. They are distinguished by a `!` at the end. "
 "The Rust standard library includes an assortment of useful macros."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:7
 msgid ""
 "`println!(format, ..)` prints a line to standard output, applying formatting "
-"described in [`std::fmt`](https://doc.rust-lang.org/std/fmt/index.html)."
+"described in `std::fmt`."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:9
 msgid ""
 "`format!(format, ..)` works just like `println!` but returns the result as a "
 "string."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:11
 msgid "`dbg!(expression)` logs the value of the expression and returns it."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:12
 msgid ""
 "`todo!()` marks a bit of code as not-yet-implemented. If executed, it will "
 "panic."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:14
 msgid ""
 "`unreachable!()` marks a bit of code as unreachable. If executed, it will "
 "panic."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:32
 msgid "\"{n}! = {}\""
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:39
 msgid ""
 "The takeaway from this section is that these common conveniences exist, and "
 "how to use them. Why they are defined as macros, and what they expand to, is "
 "not especially critical."
 msgstr ""
 
-#: src/control-flow-basics/macros.md
+#: src/control-flow-basics/macros.md:43
 msgid ""
 "The course does not cover defining macros, but a later section will describe "
 "use of derive macros."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:3
 msgid ""
-"The [Collatz Sequence](https://en.wikipedia.org/wiki/Collatz_conjecture) is "
-"defined as follows, for an arbitrary n"
+"The Collatz Sequence is defined as follows, for an arbitrary n<sub>1</sub> "
+"greater than zero:"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "1"
+#: src/control-flow-basics/exercise.md:6
+msgid ""
+"If _n<sub>i</sub>_ is 1, then the sequence terminates at _n<sub>i</sub>_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid " greater than zero:"
+#: src/control-flow-basics/exercise.md:7
+msgid "If _n<sub>i</sub>_ is even, then _n<sub>i+1</sub> = n<sub>i</sub> / 2_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "If _n"
+#: src/control-flow-basics/exercise.md:8
+msgid ""
+"If _n<sub>i</sub>_ is odd, then _n<sub>i+1</sub> = 3 * n<sub>i</sub> + 1_."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "i"
+#: src/control-flow-basics/exercise.md:10
+msgid "For example, beginning with _n<sub>1</sub>_ = 3:"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "_ is 1, then the sequence terminates at _n"
+#: src/control-flow-basics/exercise.md:12
+msgid "3 is odd, so _n<sub>2</sub>_ = 3 * 3 + 1 = 10;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "_."
+#: src/control-flow-basics/exercise.md:13
+msgid "10 is even, so _n<sub>3</sub>_ = 10 / 2 = 5;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "_ is even, then _n"
+#: src/control-flow-basics/exercise.md:14
+msgid "5 is odd, so _n<sub>4</sub>_ = 3 * 5 + 1 = 16;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "i+1"
+#: src/control-flow-basics/exercise.md:15
+msgid "16 is even, so _n<sub>5</sub>_ = 16 / 2 = 8;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid " = n"
+#: src/control-flow-basics/exercise.md:16
+msgid "8 is even, so _n<sub>6</sub>_ = 8 / 2 = 4;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid " / 2_."
+#: src/control-flow-basics/exercise.md:17
+msgid "4 is even, so _n<sub>7</sub>_ = 4 / 2 = 2;"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid "_ is odd, then _n"
+#: src/control-flow-basics/exercise.md:18
+msgid "2 is even, so _n<sub>8</sub>_ = 1; and"
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
-msgid " = 3 * n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid " + 1_."
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "For example, beginning with _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 3:"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "3 is odd, so _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "2"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 3 * 3 + 1 = 10;"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "10 is even, so _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
-msgid "3"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 10 / 2 = 5;"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "5 is odd, so _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
-msgid "4"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 3 * 5 + 1 = 16;"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "16 is even, so _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "5"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 16 / 2 = 8;"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "8 is even, so _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
-msgid "6"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 8 / 2 = 4;"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "4 is even, so _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "7"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 4 / 2 = 2;"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "2 is even, so _n"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md src/bare-metal/aps/better-uart.md
-msgid "8"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
-msgid "_ = 1; and"
-msgstr ""
-
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:19
 msgid "the sequence terminates."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md
+#: src/control-flow-basics/exercise.md:21
 msgid ""
 "Write a function to calculate the length of the collatz sequence for a given "
 "initial `n`."
 msgstr ""
 
-#: src/control-flow-basics/exercise.md src/control-flow-basics/solution.md
-msgid "/// Determine the length of the collatz sequence beginning at `n`.\n"
+#: src/control-flow-basics/exercise.md:25 src/control-flow-basics/solution.md:4
+msgid "/// Determine the length of the collatz sequence beginning at `n`."
 msgstr ""
 
-#: src/control-flow-basics/solution.md src/concurrency/scoped-threads.md
+#: src/control-flow-basics/solution.md:20 src/concurrency/threads/scoped.md:11
+#: src/concurrency/threads/scoped.md:30
 msgid "\"Length: {}\""
 msgstr ""
 
@@ -3848,96 +3772,16 @@ msgid "Welcome Back"
 msgstr "خوش آمدید"
 
 #: src/welcome-day-1-afternoon.md
-msgid "[Tuples and Arrays](./tuples-and-arrays.md) (1 hour)"
-msgstr ""
-
-#: src/welcome-day-1-afternoon.md
-msgid "[References](./references.md) (50 minutes)"
-msgstr ""
-
-#: src/welcome-day-1-afternoon.md
-msgid "[User-Defined Types](./user-defined-types.md) (50 minutes)"
-msgstr ""
-
-#: src/welcome-day-1-afternoon.md
 msgid ""
-"Including 10 minute breaks, this session should take about 2 hours and 55 "
-"minutes"
+"Including 10 minute breaks, this session should take about 2 hours and 35 "
+"minutes. It contains:"
 msgstr ""
 
 #: src/tuples-and-arrays.md
-msgid ""
-"[Tuples and Arrays](./tuples-and-arrays/tuples-and-arrays.md) (10 minutes)"
+msgid "This segment should take about 35 minutes. It contains:"
 msgstr ""
 
-#: src/tuples-and-arrays.md
-msgid "[Array Iteration](./tuples-and-arrays/iteration.md) (3 minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays.md
-msgid "[Pattern Matching](./tuples-and-arrays/match.md) (10 minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays.md
-msgid "[Destructuring](./tuples-and-arrays/destructuring.md) (5 minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays.md
-msgid "[Exercise: Nested Arrays](./tuples-and-arrays/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid ""
-"Tuples and arrays are the first \"compound\" types we have seen. All "
-"elements of an array have the same type, while tuples can accommodate "
-"different types. Both types have a size fixed at compile time."
-msgstr ""
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-#: src/tuples-and-arrays/destructuring.md
-msgid "Arrays"
-msgstr "آرایه‌ها"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "`[T; N]`"
-msgstr "<span dir=ltr><code class=hljs>[T; N]</code></span>"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "`[20, 30, 40]`, `[0; 3]`"
-msgstr ""
-"<span dir=ltr><code class=hljs>[20, 30, 40]</code>, <code class=hljs>[0; 3]</"
-"code></span>"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-#: src/tuples-and-arrays/destructuring.md
-msgid "Tuples"
-msgstr "تاپل‌ها"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "`()`, `(T,)`, `(T1, T2)`, ..."
-msgstr ""
-"<span dir=ltr><code class=hljs>()</code>, <code class=hljs>(T,)</code>, "
-"<code class=hljs>(T1, T2)</code>, …</span>"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
-msgstr ""
-"<span dir=ltr><code class=hljs>()</code>, <code class=hljs>('x',)</code>, "
-"<code class=hljs>('x', 1.2)</code>, …</span>"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "Array assignment and access:"
-msgstr "انتساب و دسترسی به آرایه:"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "Tuple assignment and access:"
-msgstr "انتساب و دسترسی به تاپل:"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "Arrays:"
-msgstr "آرایه‌ها:"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/arrays.md:16
 #, fuzzy
 msgid ""
 "A value of the array type `[T; N]` holds `N` (a compile-time constant) "
@@ -3952,18 +3796,18 @@ msgstr ""
 "dir=ltr>`[u8; 3]`</span> و <span dir=ltr>`[u8; 4]`</span> دو نوع متفاوت در "
 "نظر گرفته می‌شوند."
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/arrays.md:22
 msgid ""
 "Try accessing an out-of-bounds array element. Array accesses are checked at "
 "runtime. Rust can usually optimize these checks away, and they can be "
 "avoided using unsafe Rust."
 msgstr ""
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/arrays.md:26
 msgid "We can use literals to assign values to arrays."
 msgstr "ما می‌توانیم از مقادیر ثابت برای انتساب مقادیر به آرایه‌ها استفاده کنیم."
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/arrays.md:28
 msgid ""
 "The `println!` macro asks for the debug implementation with the `?` format "
 "parameter: `{}` gives the default output, `{:?}` gives the debug output. "
@@ -3978,7 +3822,7 @@ msgstr ""
 "فقط خروجی دیباگ را پیاده سازی می‌کنند. این بدان معناست که ما باید در اینجا از "
 "خروجی دیباگ استفاده کنیم."
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/arrays.md:33
 msgid ""
 "Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
 "easier to read."
@@ -3986,19 +3830,15 @@ msgstr ""
 "اضافه کردن <span dir=ltr>`#`</span>، مانند <span dir=ltr>`{a:#?}`</span>، یک "
 "فرمت «چاپ زیبا» را فراخوانی می‌کند که می‌تواند خواندن آن را آسان تر کند."
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
-msgid "Tuples:"
-msgstr ":تاپل‌ها"
-
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/tuples.md:16
 msgid "Like arrays, tuples have a fixed length."
 msgstr "مانند آرایه‌ها، تاپل‌ها نیز دارای طول ثابت هستند."
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/tuples.md:18
 msgid "Tuples group together values of different types into a compound type."
 msgstr "تاپل‌ها مقادیر انواع مختلف را در یک نوع مرکب کنار هم قرار می‌دهند."
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
+#: src/tuples-and-arrays/tuples.md:20
 msgid ""
 "Fields of a tuple can be accessed by the period and the index of the value, "
 "e.g. `t.0`, `t.1`."
@@ -4006,282 +3846,82 @@ msgstr ""
 "می‌توان به فیلدهای یک تاپل با استفاده از نقطه و شماره اندیس مقدار، مانند "
 "<span dir=ltr>`t.0`</span>، <span dir=ltr>`t.1`</span> دسترسی پیدا کرد."
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
-#, fuzzy
+#: src/tuples-and-arrays/tuples.md:23
 msgid ""
-"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
-"and the only valid value of that type --- that is to say both the type and "
-"its value are expressed as `()`. It is used to indicate, for example, that a "
-"function or expression has no return value, as we'll see in a future slide."
+"The empty tuple `()` is referred to as the \"unit type\" and signifies "
+"absence of a return value, akin to `void` in other languages."
 msgstr ""
-"تاپل خالی <span dir=ltr>`()`</span> همچنین به عنوان «نوع یکه» شناخته می‌شود. "
-"این هم یک نوع است و هم تنها مقدار معتبر آن نوع - یعنی هم نوع و هم مقدار آن "
-"به صورت <span dir=ltr>`()`</span> بیان می‌شوند.رای مثال برای نشان دادن اینکه "
-"یک تابع یا عبارت هیچ مقدار برگشتی ندارد استفاده می‌شود، همانطور که در اسلاید "
-"بعدی خواهیم دید. "
 
-#: src/tuples-and-arrays/tuples-and-arrays.md
-#, fuzzy
-msgid ""
-"You can think of it as `void` that can be familiar to you from other "
-"programming languages."
-msgstr ""
-"می‌توانید آن را به عنوان `void` در نظر بگیرید که ممکن است از سایر زبان‌های "
-"برنامه‌نویسی برایتان آشنا باشد."
-
-#: src/tuples-and-arrays/iteration.md
+#: src/tuples-and-arrays/iteration.md:3
 msgid "The `for` statement supports iterating over arrays (but not tuples)."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md
+#: src/tuples-and-arrays/iteration.md:19
 msgid ""
 "This functionality uses the `IntoIterator` trait, but we haven't covered "
 "that yet."
 msgstr ""
 
-#: src/tuples-and-arrays/iteration.md
+#: src/tuples-and-arrays/iteration.md:22
 msgid ""
 "The `assert_ne!` macro is new here. There are also `assert_eq!` and `assert!"
 "` macros. These are always checked while, debug-only variants like "
 "`debug_assert!` compile to nothing in release builds."
 msgstr ""
 
-#: src/tuples-and-arrays/match.md
+#: src/tuples-and-arrays/destructuring.md:3
 msgid ""
-"The `match` keyword lets you match a value against one or more _patterns_. "
-"The comparisons are done from top to bottom and the first match wins."
-msgstr ""
-"کلمه کلیدی `match` به شما امکان می دهد یک مقدار را در برابر _یک یا چند الگو_ "
-"مطابقت دهید. مقایسه‌ها از بالا به پایین انجام می‌شوند و اولین تطبیق انتخاب "
-"می‌شود."
-
-#: src/tuples-and-arrays/match.md
-msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
-msgstr ""
-"الگوها می توانند مقادیر ساده ای باشند، شبیه به `switch` در C و <span "
-"dir=ltr>C++</span>:"
-
-#: src/tuples-and-arrays/match.md
-msgid "'x'"
+"When working with tuples and other structured values it's common to want to "
+"extract the inner values into local variables. This can be done manually by "
+"directly accessing the inner values:"
 msgstr ""
 
-#: src/tuples-and-arrays/match.md
-msgid "'q'"
+#: src/tuples-and-arrays/destructuring.md:11
+#: src/tuples-and-arrays/destructuring.md:21
+msgid "\"left: {left}, right: {right}\""
 msgstr ""
 
-#: src/tuples-and-arrays/match.md
-msgid "\"Quitting\""
-msgstr ""
-
-#: src/tuples-and-arrays/match.md src/std-traits/solution.md
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "'a'"
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
-msgid "'s'"
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
-msgid "'w'"
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
-msgid "'d'"
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
-msgid "\"Moving around\""
-msgstr ""
-
-#: src/tuples-and-arrays/match.md src/error-handling/exercise.md
-#: src/error-handling/solution.md
-msgid "'0'"
-msgstr ""
-
-#: src/tuples-and-arrays/match.md src/error-handling/exercise.md
-#: src/error-handling/solution.md
-msgid "'9'"
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
-msgid "\"Number input\""
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
-msgid "\"Lowercase: {key}\""
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
-msgid "\"Something else\""
-msgstr ""
-
-#: src/tuples-and-arrays/match.md
+#: src/tuples-and-arrays/destructuring.md:15
 msgid ""
-"The `_` pattern is a wildcard pattern which matches any value. The "
-"expressions _must_ be irrefutable, meaning that it covers every possibility, "
-"so `_` is often used as the final catch-all case."
+"However, Rust also supports using pattern matching to destructure a larger "
+"value into its constituent parts:"
 msgstr ""
 
-#: src/tuples-and-arrays/match.md
-#, fuzzy
+#: src/tuples-and-arrays/destructuring.md:28
 msgid ""
-"Match can be used as an expression. Just like `if`, each match arm must have "
-"the same type. The type is the last expression of the block, if any. In the "
-"example above, the type is `()`."
+"The patterns used here are \"irrefutable\", meaning that the compiler can "
+"statically verify that the value on the right of `=` has the same structure "
+"as the pattern."
 msgstr ""
-"مثل دستور `if let`، باید همه شاخه تطبیق باید از نوع یکسانی را داشته باشند. "
-"نوع عبارت در آخر بلوک تعیین می‌شود، البته اگر وجود داشته باشد. در مثال بالا، "
-"نوع `()` است."
 
-#: src/tuples-and-arrays/match.md
+#: src/tuples-and-arrays/destructuring.md:31
 msgid ""
-"A variable in the pattern (`key` in this example) will create a binding that "
-"can be used within the match arm."
+"A variable name is an irrefutable pattern that always matches any value, "
+"hence why we can also use `let` to declare a single variable."
 msgstr ""
 
-#: src/tuples-and-arrays/match.md
-msgid "A match guard causes the arm to match only if the condition is true."
-msgstr ""
-
-#: src/tuples-and-arrays/match.md src/user-defined-types/named-structs.md
-#: src/user-defined-types/enums.md src/methods-and-traits/methods.md
-msgid "Key Points:"
-msgstr "نکات کلیدی:"
-
-#: src/tuples-and-arrays/match.md
+#: src/tuples-and-arrays/destructuring.md:33
 msgid ""
-"You might point out how some specific characters are being used when in a "
-"pattern"
+"Rust also supports using patterns in conditionals, allowing for equality "
+"comparison and destructuring to happen at the same time. This form of "
+"pattern matching will be discussed in more detail later."
 msgstr ""
-"بهتر است که اشاره کنید چطوری میتوان از کاراکترهای خاص در الگو استفاده کرد:"
 
-#: src/tuples-and-arrays/match.md
-msgid "`|` as an `or`"
-msgstr "`|` به عنوان `or`"
-
-#: src/tuples-and-arrays/match.md
-msgid "`..` can expand as much as it needs to be"
-msgstr "`..` برای تعیین همه محدوده یا تا جایی که میتوان گسترش یابد"
-
-#: src/tuples-and-arrays/match.md
-msgid "`1..=5` represents an inclusive range"
-msgstr ""
-"<span dir=ltr><code class=hljs>1..=5</code></span> نمایانگر یک محدوده خاص "
-"است."
-
-#: src/tuples-and-arrays/match.md
-msgid "`_` is a wild card"
-msgstr "`_` یک wildcard (هر حالتی) است."
-
-#: src/tuples-and-arrays/match.md
+#: src/tuples-and-arrays/destructuring.md:36
 msgid ""
-"Match guards as a separate syntax feature are important and necessary when "
-"we wish to concisely express more complex ideas than patterns alone would "
-"allow."
-msgstr ""
-"گارد های تطبیق  به عنوان یک ویژگی سینتکس جداگانه دسته بندی می‌شوند, زمانی مهم "
-"و ضروری هستند که بخواهیم ایده های پیچیده تر از الگوهای ساده بیان کنیم."
-
-#: src/tuples-and-arrays/match.md
-msgid ""
-"They are not the same as separate `if` expression inside of the match arm. "
-"An `if` expression inside of the branch block (after `=>`) happens after the "
-"match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms of the original `match` expression being considered."
-msgstr ""
-"آنها با عبارت `if` جداگانه ای در داخل یک شاخه تطبیق هستند یکسان نیستند. یک "
-"عبارت `if` در داخل بلاک شاخه (پس از <span dir=ltr>`=>`</span>) پس از ورود به "
-"اون شاخه خاص صدا زده میشود. اگر شرط `if` برقرار نباشد کاری به  سایر شاخه های "
-"عبارت `match` اصلی ندارد."
-
-#: src/tuples-and-arrays/match.md
-msgid ""
-"The condition defined in the guard applies to every expression in a pattern "
-"with an `|`."
-msgstr "شرط تعریف شده در guard با کمک `|` به شرط های تطبیق الگو اضافه می‌شود."
-
-#: src/tuples-and-arrays/destructuring.md
-msgid ""
-"Destructuring is a way of extracting data from a data structure by writing a "
-"pattern that is matched up to the data structure, binding variables to "
-"subcomponents of the data structure."
+"Edit the examples above to show the compiler error when the pattern doesn't "
+"match the value being matched on."
 msgstr ""
 
-#: src/tuples-and-arrays/destructuring.md
-#, fuzzy
-msgid "You can destructure tuples and arrays by matching on their elements:"
-msgstr ""
-"می توانید آرایه‌ها، تاپل‌ها و برش‌ها را با تطابق با عناصر آنها destructure کنید."
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"on Y axis\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"on X axis\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"left of Y axis\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"below X axis\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"first quadrant\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"Tell me about {triple:?}\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"First is 0, y = {y}, and z = {z}\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"First is 1 and the rest were ignored\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "\"All elements were ignored\""
-msgstr ""
-
-#: src/tuples-and-arrays/destructuring.md
-#, fuzzy
-msgid "Create a new array pattern using `_` to represent an element."
-msgstr "یک الگوی جدید با استفاده از `_` برای نمایش یک عنصر ایجاد کنید."
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "Add more values to the array."
-msgstr "مقادیر بیشتری را به آرایه اضافه کنید."
-
-#: src/tuples-and-arrays/destructuring.md
-msgid ""
-"Point out that how `..` will expand to account for different number of "
-"elements."
-msgstr ""
-"اشاره کنید که چگونه `..` برای در نظر گرفتن تعداد عناصر مختلف، گسترش خواهد "
-"یافت."
-
-#: src/tuples-and-arrays/destructuring.md
-msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
-msgstr ""
-"مطابقت با انتهای آرایه رو با با الگوهای <span dir=ltr>`[.., b]`</span>  و "
-"<span dir=ltr>`[a@..,b]`</span> را نشان دهید."
-
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:3
 msgid "Arrays can contain other arrays:"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:9
 msgid "What is the type of this variable?"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:11
 #, fuzzy
 msgid ""
 "Use an array such as the above to write a function `transpose` which will "
@@ -4292,74 +3932,66 @@ msgstr ""
 "dir=ltr>`transpose`</span> که یک ماتریس را جابجا می‌کند  (ردیف‌ها را به ستون‌ها "
 "تبدیل می‌کند) استفاده کنید: "
 
-#: src/tuples-and-arrays/exercise.md
-msgid "Hard-code both functions to operate on 3 × 3 matrices."
-msgstr "هر دو تابع را برای کار بر روی ماتریس‌های 3 × 3 هاردکد کنید."
-
-#: src/tuples-and-arrays/exercise.md
+#: src/tuples-and-arrays/exercise.md:22
+#, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the "
-"functions:"
+"Copy the code below to https://play.rust-lang.org/ and implement the "
+"function. This function only operates on 3x3 matrices."
 msgstr ""
 "کد زیر را در <span dir=ltr><https://play.rust-lang.org/></span> کپی کرده و "
 "توابع را پیاده‌سازی کنید:"
 
-#: src/tuples-and-arrays/exercise.md src/borrowing/exercise.md
-#: src/unsafe-rust/exercise.md
-msgid "// TODO: remove this when you're done with your implementation.\n"
+#: src/tuples-and-arrays/exercise.md:26 src/borrowing/exercise.md:14
+#: src/unsafe-rust/exercise.md:51
+msgid "// TODO: remove this when you're done with your implementation."
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
-msgid "// <-- the comment makes rustfmt add a newline\n"
+#: src/tuples-and-arrays/exercise.md:36 src/tuples-and-arrays/exercise.md:44
+#: src/tuples-and-arrays/solution.md:17 src/tuples-and-arrays/solution.md:25
+msgid "//"
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
+#: src/tuples-and-arrays/exercise.md:53 src/tuples-and-arrays/solution.md:34
+msgid "// \\<\\-- the comment makes rustfmt add a newline"
+msgstr ""
+
+#: src/tuples-and-arrays/exercise.md:58 src/tuples-and-arrays/solution.md:39
 msgid "\"matrix: {:#?}\""
 msgstr ""
 
-#: src/tuples-and-arrays/exercise.md src/tuples-and-arrays/solution.md
+#: src/tuples-and-arrays/exercise.md:60 src/tuples-and-arrays/solution.md:41
 msgid "\"transposed: {:#?}\""
 msgstr ""
 
-#: src/tuples-and-arrays/solution.md
-msgid "//\n"
+#: src/references.md src/smart-pointers.md src/borrowing.md
+#: src/error-handling.md src/concurrency/async-pitfalls.md
+msgid "This segment should take about 55 minutes. It contains:"
 msgstr ""
 
 #: src/references.md
-msgid "[Shared References](./references/shared.md) (10 minutes)"
-msgstr ""
+#, fuzzy
+msgid "Slices: &\\[T\\]"
+msgstr "برش‌ها"
 
-#: src/references.md
-msgid "[Exclusive References](./references/exclusive.md) (10 minutes)"
-msgstr ""
-
-#: src/references.md
-msgid "[Exercise: Geometry](./references/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/references.md src/user-defined-types.md src/pattern-matching.md
-msgid "This segment should take about 50 minutes"
-msgstr ""
-
-#: src/references/shared.md
+#: src/references/shared.md:3
 msgid ""
 "A reference provides a way to access another value without taking "
 "responsibility for the value, and is also called \"borrowing\". Shared "
 "references are read-only, and the referenced data cannot change."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:20
 msgid ""
 "A shared reference to a type `T` has type `&T`. A reference value is made "
 "with the `&` operator. The `*` operator \"dereferences\" a reference, "
 "yielding its value."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:24
 msgid "Rust will statically forbid dangling references:"
 msgstr "راست بطور استاتیک مراجع تعلیق شده (dangling) را ممنوع می‌کند:"
 
-#: src/references/shared.md
+#: src/references/shared.md:38
 msgid ""
 "A reference is said to \"borrow\" the value it refers to, and this is a good "
 "model for students not familiar with pointers: code can use the reference to "
@@ -4367,7 +3999,7 @@ msgid ""
 "course will get into more detail on ownership in day 3."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:43
 msgid ""
 "References are implemented as pointers, and a key advantage is that they can "
 "be much smaller than the thing they point to. Students familiar with C or C+"
@@ -4376,23 +4008,23 @@ msgid ""
 "pointers."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:48
 msgid ""
 "Rust does not automatically create references for you - the `&` is always "
 "required."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:51
 #, fuzzy
 msgid ""
 "Rust will auto-dereference in some cases, in particular when invoking "
-"methods (try `r.count_ones()`). There is no need for an `->` operator like "
-"in C++."
+"methods (try `r.is_ascii()`). There is no need for an `->` operator like in "
+"C++."
 msgstr ""
 "راست در برخی موارد به‌طور خودکار از Dereference می‌کند، به‌ویژه هنگام فراخوانی "
 "متدها (<span dir=ltr>`ref_x.count_ones()`</span> را امتحان کنید)."
 
-#: src/references/shared.md
+#: src/references/shared.md:54
 msgid ""
 "In this example, `r` is mutable so that it can be reassigned (`r = &b`). "
 "Note that this re-binds `r`, so that it refers to something else. This is "
@@ -4400,13 +4032,13 @@ msgid ""
 "value."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:58
 msgid ""
 "A shared reference does not allow modifying the value it refers to, even if "
 "that value was mutable. Try `*r = 'X'`."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:61
 msgid ""
 "Rust is tracking the lifetimes of all references to ensure they live long "
 "enough. Dangling references cannot occur in safe Rust. `x_axis` would return "
@@ -4414,19 +4046,19 @@ msgid ""
 "returns, so this will not compile."
 msgstr ""
 
-#: src/references/shared.md
+#: src/references/shared.md:66
 msgid "We will talk more about borrowing when we get to ownership."
 msgstr ""
 "هنگامی که به مالکیت در زبان راست رسیدیم، بیشتر در مورد «قرض دادن» صحبت "
 "خواهیم کرد."
 
-#: src/references/exclusive.md
+#: src/references/exclusive.md:3
 msgid ""
 "Exclusive references, also known as mutable references, allow changing the "
 "value they refer to. They have type `&mut T`."
 msgstr ""
 
-#: src/references/exclusive.md
+#: src/references/exclusive.md:22
 msgid ""
 "\"Exclusive\" means that only this reference can be used to access the "
 "value. No other references (shared or exclusive) can exist at the same time, "
@@ -4435,7 +4067,7 @@ msgid ""
 "alive."
 msgstr ""
 
-#: src/references/exclusive.md
+#: src/references/exclusive.md:27
 #, fuzzy
 msgid ""
 "Be sure to note the difference between `let mut x_coord: &i32` and `let "
@@ -4448,207 +4080,395 @@ msgstr ""
 "یک مرجع قابل تغییر است که می‌تواند به مقادیر مختلفی ارجاع داده شود،  در حالی "
 "که دومی یک مرجع به یک مقدار قابل تغییر را نشان می‌دهد."
 
-#: src/references/exercise.md
+#: src/references/slices.md:1
+msgid "Slices"
+msgstr "برش‌ها"
+
+#: src/references/slices.md:3
+msgid "A slice gives you a view into a larger collection:"
+msgstr "یک برش به شما امکان می‌دهد نما (view) از یک مجموعه بزرگتر داشته باشید:"
+
+#: src/references/slices.md:18
+msgid "Slices borrow data from the sliced type."
+msgstr "برش‌ها داده‌ها را از نوع برش‌شده قرض می‌گیرند."
+
+#: src/references/slices.md:19
+msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
+msgstr ""
+"پرسش: اگر <span dir=ltr>`a[3]`</span> را درست قبل از چاپ <span dir=ltr>`s`</"
+"span> تغییر دهید چه اتفاقی می‌افتد؟"
+
+#: src/references/slices.md:24
+msgid ""
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr ""
+"ما با قرض گرفتن <span dir=ltr>`a`</span> و مشخص کردن شاخص‌های شروع و پایان در "
+"براکت‌ها، برش (slice) ایجاد می‌کنیم."
+
+#: src/references/slices.md:27
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"اگر برش از شاخص ۰ شروع شود، سینتکس راست به ما اجازه می‌دهد شاخص شروع را حذف "
+"کنیم (یعنی عدد صفر را  ننویسیم)، به این معنی که <span dir=ltr>`&a[0..a."
+"len()]`</span>  و <span dir=ltr>`&a[..a.len()]`</span> یکسان  هستند."
+
+#: src/references/slices.md:31
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"در مورد شاخص آخر نیز همینطور است، بنابراین <span dir=ltr>`&a[2..a.len()]`</"
+"span> و <span dir=ltr>`&a[2..]`</span>  یکسان هستند."
+
+#: src/references/slices.md:34
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+"یک روش ساده برای برش کل آرایه، این است که از <span dir=ltr>`&a[..]`</span> "
+"استفاده کنیم."
+
+#: src/references/slices.md:36
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+"<span dir=ltr>`s`</span> یک مرجع به برش i32 است. توجه داشته باشید که نوع "
+"<span dir=ltr>`s`</span> (<span dir=ltr>`&[i32]`</span>) دیگر طول آرایه را "
+"ذکر نمی‌شود. این به ما امکان می‌دهد محاسباتی را روی برش‌هایی با اندازه‌های مختلف "
+"انجام دهیم."
+
+#: src/references/slices.md:40
+#, fuzzy
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice."
+msgstr ""
+"برش‌ها همیشه از یک شیء دیگر قرض می‌گیرند. در این مثال، <span dir=ltr>`a`</"
+"span> باید حداقل به اندازه طول‌عمر برش ما، زنده (در محدوده) باقی بماند. "
+
+#: src/references/slices.md:43
+#, fuzzy
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` at "
+"this point in the execution, but you can read the data from both `a` and `s` "
+"safely. It works before you created the slice, and again after the "
+"`println`, when the slice is no longer used."
+msgstr ""
+"پرسش در مورد تغییر <span dir=ltr>`a[3]`</span> می تواند یک بحث جالب را شروع "
+"کند، اما پاسخ‌اش این است که به دلایل ایمنی حافظه، نمی‌توانید این کار را از "
+"طریق <span dir=ltr>`a`</span> در این مرحله از اجرا انجام دهید، اما می‌توانید "
+"داده‌ها را از هر دو <span dir=ltr>`a`</span> و <span dir=ltr>`s`</span> به "
+"طور ایمن بخوانید. این کار قبل از ایجاد برش و دوباره بعد از <span "
+"dir=ltr>`println!`</span> کار میکند، زمانی که برش دیگر استفاده نمی شود. "
+"جزئیات بیشتری در بخش بررسی‌کننده‌قرض (the borrow checker) توضیح خواهیم داد. "
+
+#: src/references/strings.md:7
+msgid "We can now understand the two string types in Rust:"
+msgstr "حالا می‌توانیم دو نوع رشته‌ای را در راست درک کنیم:"
+
+#: src/references/strings.md:9
+msgid "`&str` is a slice of UTF-8 encoded bytes, similar to `&[u8]`."
+msgstr ""
+
+#: src/references/strings.md:10
+msgid ""
+"`String` is an owned buffer of UTF-8 encoded bytes, similar to `Vec<T>`."
+msgstr ""
+
+#: src/references/strings.md:17 src/std-traits/read-and-write.md:36
+msgid "\"World\""
+msgstr ""
+
+#: src/references/strings.md:18
+msgid "\"s1: {s1}\""
+msgstr ""
+
+#: src/references/strings.md:20
+#, fuzzy
+msgid "\"Hello \""
+msgstr "سلام دنیا"
+
+#: src/references/strings.md:21 src/references/strings.md:23
+#: src/memory-management/move.md:9
+msgid "\"s2: {s2}\""
+msgstr ""
+
+#: src/references/strings.md:26
+msgid "\"s3: {s3}\""
+msgstr ""
+
+#: src/references/strings.md:33
+#, fuzzy
+msgid ""
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data stored in a block of memory. String literals "
+"(`\"Hello\"`), are stored in the program’s binary."
+msgstr ""
+"<span dir=ltr>`&str`</span>  یک برش رشته‌ای را معرفی می‌کند، که یک مرجع "
+"غیرقابل تغییر به داده‌های رشته‌ای رمزشده UTF-8 است که در یک بلوک حافظه ذخیره "
+"شده است. لیترال های رشته‌ای <span dir=ltr>`String`</span>  (`”Hello”`) در "
+"باینری برنامه ذخیره می‌شوند."
+
+#: src/references/strings.md:37
+#, fuzzy
+msgid ""
+"Rust's `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+"در راست نوع ‍<span dir=ltr>`String`</span> یک wrapper بر روی یک بردار از "
+"بایت‌هاست. مانند <span dir=ltr>`Vec<T>`</span>، یک نوع Owned است."
+
+#: src/references/strings.md:40
+#, fuzzy
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()` creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"مانند بسیاری از انواع دیگر، <span dir=ltr>`String::from()`</span> یک رشته از "
+"یک لیترال رشته ایجاد می‌کند. <span dir=ltr>`String::new()`</span> که رشته "
+"خالی جدید ایجاد می‌کند که داده های رشته‌ای می‌توانند با استفاده از متدهای <span "
+"dir=ltr>`push()`</span> و <span dir=ltr>`push_str()`</span> به آن اضافه شوند."
+
+#: src/references/strings.md:44
+#, fuzzy
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It accepts the same format specification as `println!()`."
+msgstr ""
+"ماکرو <span dir=ltr>`format!()`</span> یک راه راحت برای ایجاد یک رشته Owned "
+"از مقادیر پویا است. مثل فرمت قابل پذیرش توسط ماکرو <span dir=ltr>`println!"
+"()`</span> است."
+
+#: src/references/strings.md:47
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection. If you select a byte range that is not aligned to character "
+"boundaries, the expression will panic. The `chars` iterator iterates over "
+"characters and is preferred over trying to get character boundaries right."
+msgstr ""
+
+#: src/references/strings.md:52
+#, fuzzy
+msgid ""
+"For C++ programmers: think of `&str` as `std::string_view` from C++, but the "
+"one that always points to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++ (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"برای برنامه‌نویسان <span dir=ltr>`C++`</span>: <span dir=ltr>`&str`</span>را  "
+"به عنوان <span dir=ltr>`const char*`</span> در <span dir=ltr>`C++`</span> "
+"درنظر بگیرید، اما یک فرق مهم این است که در راست که همیشه به یک رشته معتبر در "
+"حافظه اشاره می کند. راست نوع <span dir=ltr>`String`</span>معادل تقریبی <span "
+"dir=ltr>`std::string`</span> در <span dir=ltr>`C++`</span> است (با این تفاوت "
+"که فقط می‌تواند حاوی بایت‌های رمزشده UTF-8 باشد و هرگز از بهینه‌سازی Small-"
+"String استفاده نمی کند)."
+
+#: src/references/strings.md:57
+#, fuzzy
+msgid "Byte strings literals allow you to create a `&[u8]` value directly:"
+msgstr ""
+"رشته‌های بایت به شما امکان می‌دهند مستقیماً یک مقدار <span dir=ltr>`&[u8]`</"
+"span>  ایجاد کنید:"
+
+#: src/references/strings.md:67
+msgid ""
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
+msgstr ""
+"رشته‌های خام به شما امکان می دهند یک مقدار <span dir=ltr><code "
+"class=hljs>&str</code></span> با غیرفعال کردن فرارها ایجاد کنید:  `r\"\\n\" "
+"== \"\\\\n\"`.شما می‌توانید با استفاده از تعداد برابر `#` در دو طرف دابل‌کوت "
+"دابل‌کوت‌ها، دابل‌کوت‌ها را جاسازی کنید:"
+
+#: src/references/exercise.md:3
 msgid ""
 "We will create a few utility functions for 3-dimensional geometry, "
 "representing a point as `[f64;3]`. It is up to you to determine the function "
 "signatures."
 msgstr ""
 
-#: src/references/exercise.md
+#: src/references/exercise.md:7
 msgid ""
 "// Calculate the magnitude of a vector by summing the squares of its "
-"coordinates\n"
-"// and taking the square root. Use the `sqrt()` method to calculate the "
-"square\n"
-"// root, like `v.sqrt()`.\n"
+"coordinates // and taking the square root. Use the `sqrt()` method to "
+"calculate the square // root, like `v.sqrt()`."
 msgstr ""
 
-#: src/references/exercise.md
+#: src/references/exercise.md:15
 msgid ""
-"// Normalize a vector by calculating its magnitude and dividing all of its\n"
-"// coordinates by that magnitude.\n"
+"// Normalize a vector by calculating its magnitude and dividing all of "
+"its // coordinates by that magnitude."
 msgstr ""
 
-#: src/references/exercise.md
-msgid "// Use the following `main` to test your work.\n"
+#: src/references/exercise.md:23
+msgid "// Use the following `main` to test your work."
 msgstr ""
 
-#: src/references/exercise.md src/references/solution.md
+#: src/references/exercise.md:27 src/references/solution.md:22
 msgid "\"Magnitude of a unit vector: {}\""
 msgstr ""
 
-#: src/references/exercise.md src/references/solution.md
+#: src/references/exercise.md:30 src/references/solution.md:25
 msgid "\"Magnitude of {v:?}: {}\""
 msgstr ""
 
-#: src/references/exercise.md src/references/solution.md
+#: src/references/exercise.md:32 src/references/solution.md:27
 msgid "\"Magnitude of {v:?} after normalization: {}\""
 msgstr ""
 
-#: src/references/solution.md
-msgid "/// Calculate the magnitude of the given vector.\n"
+#: src/references/solution.md:4
+msgid "/// Calculate the magnitude of the given vector."
 msgstr ""
 
-#: src/references/solution.md
+#: src/references/solution.md:12
 msgid ""
-"/// Change the magnitude of the vector to 1.0 without changing its "
-"direction.\n"
+"/// Change the magnitude of the vector to 1.0 without changing its direction."
 msgstr ""
 
-#: src/user-defined-types.md
-msgid "[Named Structs](./user-defined-types/named-structs.md) (10 minutes)"
+#: src/user-defined-types.md src/methods-and-traits.md src/lifetimes.md
+msgid "This segment should take about 50 minutes. It contains:"
 msgstr ""
 
-#: src/user-defined-types.md
-msgid "[Tuple Structs](./user-defined-types/tuple-structs.md) (10 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid "[Enums](./user-defined-types/enums.md) (5 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid ""
-"[Static and Const](./user-defined-types/static-and-const.md) (5 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid "[Type Aliases](./user-defined-types/aliases.md) (2 minutes)"
-msgstr ""
-
-#: src/user-defined-types.md
-msgid ""
-"[Exercise: Elevator Events](./user-defined-types/exercise.md) (15 minutes)"
-msgstr ""
-
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:3
 msgid "Like C and C++, Rust has support for custom structs:"
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:12
 msgid "\"{} is {} years old\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
-#: src/android/interoperability/with-c/bindgen.md
+#: src/user-defined-types/named-structs.md:16
+#: src/android/interoperability/with-c/bindgen.md:87
 msgid "\"Peter\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:22
 msgid "\"Avery\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:27
 msgid "\"Jackie\""
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:35
+#: src/user-defined-types/enums.md:29 src/pattern-matching/match.md:38
+#: src/methods-and-traits/methods.md:69
+msgid "Key Points:"
+msgstr "نکات کلیدی:"
+
+#: src/user-defined-types/named-structs.md:37
 msgid "Structs work like in C or C++."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:38
 msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:39
 msgid "Unlike in C++, there is no inheritance between structs."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:40
 msgid ""
 "This may be a good time to let people know there are different types of "
 "structs."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:42
 msgid ""
 "Zero-sized structs (e.g. `struct Foo;`) might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
 "value itself."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:45
 msgid ""
 "The next slide will introduce Tuple structs, used when the field names are "
 "not important."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:47
 msgid ""
 "If you already have variables with the right names, then you can create the "
 "struct using a shorthand."
 msgstr ""
 
-#: src/user-defined-types/named-structs.md
+#: src/user-defined-types/named-structs.md:49
 msgid ""
 "The syntax `..avery` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:7
 msgid "If the field names are unimportant, you can use a tuple struct:"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:14
 msgid "\"({}, {})\""
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:18
 msgid "This is often used for single-field wrappers (called newtypes):"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:25
 msgid "\"Ask a rocket scientist at NASA\""
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
-#: src/android/interoperability/cpp/cpp-bridge.md
-#: src/bare-metal/microcontrollers/type-state.md
-#: src/async/pitfalls/cancellation.md
-msgid "// ...\n"
+#: src/user-defined-types/tuple-structs.md:29
+#: src/android/interoperability/cpp/cpp-bridge.md:50
+#: src/bare-metal/microcontrollers/type-state.md:14
+#: src/concurrency/async-pitfalls/cancellation.md:99
+#: src/concurrency/async-pitfalls/cancellation.md:102
+msgid "// ..."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:41
 msgid ""
 "Newtypes are a great way to encode additional information about the value in "
 "a primitive type, for example:"
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:43
 msgid "The number is measured in some units: `Newtons` in the example above."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:44
 msgid ""
 "The value passed some validation when it was created, so you no longer have "
 "to validate it again at every use: `PhoneNumber(String)` or `OddNumber(u32)`."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:47
 msgid ""
 "Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
 "single field in the newtype."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:49
 msgid ""
 "Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
 "for instance using booleans as integers."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
+#: src/user-defined-types/tuple-structs.md:51
 msgid "Operator overloading is discussed on Day 3 (generics)."
 msgstr ""
 
-#: src/user-defined-types/tuple-structs.md
-msgid ""
-"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
-"wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
+#: src/user-defined-types/tuple-structs.md:52
+msgid "The example is a subtle reference to the Mars Climate Orbiter failure."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:3
 msgid ""
 "The `enum` keyword allows the creation of a type which has a few different "
 "variants:"
@@ -4656,48 +4476,48 @@ msgstr ""
 "کلمه کلیدی `enum` اجازه ایجاد نوع داده‌ای را می دهد که دارای چندین گونه مختلف "
 "است:"
 
-#: src/user-defined-types/enums.md
-msgid "// Simple variant\n"
+#: src/user-defined-types/enums.md:15
+msgid "// Simple variant"
 msgstr ""
 
-#: src/user-defined-types/enums.md
-msgid "// Tuple variant\n"
+#: src/user-defined-types/enums.md:16
+msgid "// Tuple variant"
 msgstr ""
 
-#: src/user-defined-types/enums.md
-msgid "// Struct variant\n"
+#: src/user-defined-types/enums.md:17
+msgid "// Struct variant"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:22
 msgid "\"On this turn: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:31
 #, fuzzy
 msgid "Enumerations allow you to collect a set of values under one type."
 msgstr ""
 "`Enum`ها به شما امکان می دهند مجموعه‌ای از مقادیر مختلف با نوع‌های مختلف را "
 "تحت یک نوع جمع آوری کنید."
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:32
 msgid ""
 "`Direction` is a type with variants. There are two values of `Direction`: "
 "`Direction::Left` and `Direction::Right`."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:34
 msgid ""
 "`PlayerMove` is a type with three variants. In addition to the payloads, "
 "Rust will store a discriminant so that it knows at runtime which variant is "
 "in a `PlayerMove` value."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:37
 #, fuzzy
 msgid "This might be a good time to compare structs and enums:"
 msgstr "الان زمان خوبی برای مقایسه ساختارها و `Enum`هاست:"
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:38
 #, fuzzy
 msgid ""
 "In both, you can have a simple version without fields (unit struct) or one "
@@ -4706,7 +4526,7 @@ msgstr ""
 "در هر دو، می توانید یک نسخه ساده بدون فیلد (unit struct) یا یکی با انواع "
 "مختلف فیلد (variant payloads) داشته باشید."
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:40
 #, fuzzy
 msgid ""
 "You could even implement the different variants of an enum with separate "
@@ -4717,15 +4537,15 @@ msgstr ""
 "کنید، اما در آن صورت آنها از همان نوعی که در ابتدا تعریف کردید یعنی `Enum` "
 "نخواهند بود."
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:43
 msgid "Rust uses minimal space to store the discriminant."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:44
 msgid "If necessary, it stores an integer of the smallest required size"
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:45
 msgid ""
 "If the allowed variant values do not cover all bit patterns, it will use "
 "invalid bit patterns to encode the discriminant (the \"niche "
@@ -4733,14 +4553,14 @@ msgid ""
 "integer or `NULL` for the `None` variant."
 msgstr ""
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:49
 msgid ""
 "You can control the discriminant if needed (e.g., for compatibility with C):"
 msgstr ""
 "شما می توانید در صورت نیاز (به عنوان مثال، برای سازگاری با C) discriminant "
 "را کنترل کنید:"
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:67
 msgid ""
 "Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
 "bytes."
@@ -4748,13 +4568,14 @@ msgstr ""
 "بدون `repr`، نوع discriminant دو بایت حافظه اشغال میکند، زیرا 10001 در 2 "
 "بایت جا می‌شود."
 
-#: src/user-defined-types/enums.md src/user-defined-types/static-and-const.md
-#: src/memory-management/review.md src/memory-management/move.md
-#: src/smart-pointers/box.md src/borrowing/shared.md
+#: src/user-defined-types/enums.md:70 src/user-defined-types/static.md:27
+#: src/memory-management/review.md:51 src/memory-management/move.md:100
+#: src/memory-management/copy-types.md:57 src/smart-pointers/box.md:85
+#: src/borrowing/shared.md:33
 msgid "More to Explore"
 msgstr "برای کاوش بیشتر"
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:72
 msgid ""
 "Rust has several optimizations it can employ to make enums take up less "
 "space."
@@ -4762,17 +4583,17 @@ msgstr ""
 "زبان Rust دارای چندین بهینه‌سازی دارد که می‌تواند برای کاهش فضای اشغال شده "
 "توسط`Enum`ها استفاده کند."
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:74
+#, fuzzy
 msgid ""
-"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
-"option/#representation), Rust guarantees that `size_of::<T>()` equals "
-"`size_of::<Option<T>>()`."
+"Null pointer optimization: For some types, Rust guarantees that `size_of::"
+"<T>()` equals `size_of::<Option<T>>()`."
 msgstr ""
 "بهینه‌سازی اشاره‌گر `NULL`: برای برخی از انواع، Rust تضمین می‌کند که <span "
 "dir=ltr>`size_of::<T>()`</span>  برابر با <span dir=ltr>`size_of::"
 "<Option<T>>()`</span> است."
 
-#: src/user-defined-types/enums.md
+#: src/user-defined-types/enums.md:78
 msgid ""
 "Example code if you want to show how the bitwise representation _may_ look "
 "like in practice. It's important to note that the compiler provides no "
@@ -4782,51 +4603,11 @@ msgstr ""
 "به نظر برسد. مهم است توجه داشته باشید که کامپایلر هیچ تضمینی در مورد این "
 "نمایش نمی‌دهد، بنابراین این کاملاً ناایمن است."
 
-#: src/user-defined-types/static-and-const.md
-#, fuzzy
-msgid ""
-"Static and constant variables are two different ways to create globally-"
-"scoped values that cannot be moved or reallocated during the execution of "
-"the program."
-msgstr ""
-"متغیرهای `ثابت` و `ایستا` دو روش متفاوت برای ایجاد مقادیر با اسکوپ گلوبال "
-"(قابل دسترس در کل برنامه) هستند که نمی‌توانند در طول اجرای برنامه منتقل یا "
-"دوباره تعریف شوند."
-
-#: src/user-defined-types/static-and-const.md
-msgid "`const`"
-msgstr ""
-
-#: src/user-defined-types/static-and-const.md
-msgid ""
-"Constant variables are evaluated at compile time and their values are "
-"inlined wherever they are used:"
-msgstr ""
-"متغیرهای ثابت در زمان کامپایل ارزیابی می شوند و مقادیر آنها در هر جایی که "
-"استفاده می شوند، درج می شوند:"
-
-#: src/user-defined-types/static-and-const.md
-msgid ""
-"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
-"vs-static.html) these are inlined upon use."
-msgstr ""
-"طبق [کتاب Rust RFC](https://rust-lang.github.io/rfcs/0246-const-vs-static."
-"html)، این موارد هنگام استفاده درج می شوند."
-
-#: src/user-defined-types/static-and-const.md
-msgid ""
-"Only functions marked `const` can be called at compile time to generate "
-"`const` values. `const` functions can however be called at runtime."
-msgstr ""
-"فقط توابعی که با `const` علامت گذاری شده اند می توانند در زمان کامپایل برای "
-"تولید مقادیر `const` فراخوانی شوند. با این حال، توابع `const` را می توان در "
-"زمان اجرا فراخوانی کرد (بر خلاف تعریف متغییری ثابت)"
-
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:1
 msgid "`static`"
 msgstr ""
 
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:3
 msgid ""
 "Static variables will live during the whole execution of the program, and "
 "therefore will not move:"
@@ -4834,23 +4615,22 @@ msgstr ""
 "متغیرهای ایستا در طول عمر کل اجرای برنامه خواهند ماند و بنابراین منتقل "
 "نمی‌شوند:"
 
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:7
 #, fuzzy
 msgid "\"Welcome to RustOS 3.14\""
 msgstr "به روز ۱ خوش آمدید"
 
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:10
 msgid "\"{BANNER}\""
 msgstr ""
 
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:14
 #, fuzzy
 msgid ""
-"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
-"vs-static.html), these are not inlined upon use and have an actual "
-"associated memory location. This is useful for unsafe and embedded code, and "
-"the variable lives through the entirety of the program execution. When a "
-"globally-scoped value does not have a reason to need object identity, "
+"As noted in the Rust RFC Book, these are not inlined upon use and have an "
+"actual associated memory location. This is useful for unsafe and embedded "
+"code, and the variable lives through the entirety of the program execution. "
+"When a globally-scoped value does not have a reason to need object identity, "
 "`const` is generally preferred."
 msgstr ""
 "همانطور که در [کتاب Rust RFC](https://rust-lang.github.io/rfcs/0246-const-vs-"
@@ -4859,21 +4639,14 @@ msgstr ""
 "اجرای برنامه زنده می ماند. هنگامی که یک مقدار با اسکوپ گلوبال نیاز نیست, "
 "استفاده از `const` ترجیح داده می‌شود."
 
-#: src/user-defined-types/static-and-const.md
-msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
-msgstr ""
-"به این نکته اشاره کنید که `const` شبیه `constexpr` در <span dir=ltr>`C++`</"
-"span> عمل می کند."
-
-#: src/user-defined-types/static-and-const.md
-msgid ""
-"`static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++."
+#: src/user-defined-types/static.md:23
+#, fuzzy
+msgid "`static` is similar to mutable global variables in C++."
 msgstr ""
 "از سوی دیگر، `static` بسیار شبیه به یک متغیر سراسری `const` یا `mutable` در "
 "<span dir=ltr>`C++`</span> هستند."
 
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:24
 msgid ""
 "`static` provides object identity: an address in memory and state as "
 "required by types with interior mutability such as `Mutex<T>`."
@@ -4881,80 +4654,11 @@ msgstr ""
 "`static` هویت شی را فراهم می‌کند: آدرسی در حافظه و حالتی که توسط انواع با "
 "تغییرپذیری داخلی مانند <span dir=ltr>`Mutex<T>`</span> را نیاز دارد."
 
-#: src/user-defined-types/static-and-const.md
-msgid ""
-"It isn't super common that one would need a runtime evaluated constant, but "
-"it is helpful and safer than using a static."
-msgstr ""
-"با اینکه خیلی رایج نیست که اگر کسی به یک یک مقدار ثابت  که در زمان اجرا "
-"ارزیابی می‌شود از `const` استفاده کند اما مفید تر و ایمن تر از استفاده "
-"`static`ها هستند."
-
-#: src/user-defined-types/static-and-const.md
-msgid "Properties table:"
-msgstr "جدول خاصیت‌ها:"
-
-#: src/user-defined-types/static-and-const.md
-#: src/chromium/adding-third-party-crates.md
-msgid "Property"
-msgstr "ویژگی"
-
-#: src/user-defined-types/static-and-const.md
-msgid "Static"
-msgstr ""
-
-#: src/user-defined-types/static-and-const.md
-msgid "Constant"
-msgstr ""
-
-#: src/user-defined-types/static-and-const.md
-msgid "Has an address in memory"
-msgstr "دارای یک آدرس واقعی در حافظه"
-
-#: src/user-defined-types/static-and-const.md
-#: src/chromium/adding-third-party-crates/resolving-problems.md
-msgid "Yes"
-msgstr "بلی"
-
-#: src/user-defined-types/static-and-const.md
-msgid "No (inlined)"
-msgstr "خیر (به صورت درون خطی)"
-
-#: src/user-defined-types/static-and-const.md
-msgid "Lives for the entire duration of the program"
-msgstr "در طول‌عمر کل برنامه زنده می‌ماند؟"
-
-#: src/user-defined-types/static-and-const.md
-#: src/chromium/adding-third-party-crates/resolving-problems.md
-msgid "No"
-msgstr "خیر"
-
-#: src/user-defined-types/static-and-const.md
-msgid "Can be mutable"
-msgstr "میتوان قابل تغییر اش کرد"
-
-#: src/user-defined-types/static-and-const.md
-msgid "Yes (unsafe)"
-msgstr "بلی (unsafe)"
-
-#: src/user-defined-types/static-and-const.md
-msgid "Evaluated at compile time"
-msgstr "ارزیابی در زمان کامپایل"
-
-#: src/user-defined-types/static-and-const.md
-msgid "Yes (initialised at compile time)"
-msgstr "بلی (در زمان کامپایل ساخته می‌شود)"
-
-#: src/user-defined-types/static-and-const.md
-msgid "Inlined wherever it is used"
-msgstr "به صورت درون‌خطی هر جا که استفاده میشود قرار میگیرد"
-
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:29
 #, fuzzy
 msgid ""
 "Because `static` variables are accessible from any thread, they must be "
-"`Sync`. Interior mutability is possible through a [`Mutex`](https://doc.rust-"
-"lang.org/std/sync/struct.Mutex.html), atomic or similar."
+"`Sync`. Interior mutability is possible through a `Mutex`, atomic or similar."
 msgstr ""
 "از آنجایی که متغیرهای `static` از هر رشته‌ای (thread) قابل دسترسی هستند، باید "
 "`Sync` باشند. تغییرپذیری داخلی از طریق یک [`Mutex`](https://doc.rust-lang."
@@ -4964,28 +4668,73 @@ msgstr ""
 "دارد. ما در فصل Unsafe Rust به استاتیک های قابل تغییر [mutable statics](../"
 "unsafe/mutable-static-variables.md) نگاه خواهیم کرد."
 
-#: src/user-defined-types/static-and-const.md
+#: src/user-defined-types/static.md:34
 #, fuzzy
 msgid "Thread-local data can be created with the macro `std::thread_local`."
 msgstr ""
 "داده‌های `thread_local` را با ماکروی <span dir=ltr>`std::thread_local`</span> "
 "می‌توان ایجاد کرد."
 
-#: src/user-defined-types/aliases.md
+#: src/user-defined-types/const.md:1
+msgid "`const`"
+msgstr ""
+
+#: src/user-defined-types/const.md:3
+#, fuzzy
+msgid ""
+"Constants are evaluated at compile time and their values are inlined "
+"wherever they are used:"
+msgstr ""
+"متغیرهای ثابت در زمان کامپایل ارزیابی می شوند و مقادیر آنها در هر جایی که "
+"استفاده می شوند، درج می شوند:"
+
+#: src/user-defined-types/const.md:26
+#, fuzzy
+msgid "According to the Rust RFC Book these are inlined upon use."
+msgstr ""
+"طبق [کتاب Rust RFC](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html)، این موارد هنگام استفاده درج می شوند."
+
+#: src/user-defined-types/const.md:28
+msgid ""
+"Only functions marked `const` can be called at compile time to generate "
+"`const` values. `const` functions can however be called at runtime."
+msgstr ""
+"فقط توابعی که با `const` علامت گذاری شده اند می توانند در زمان کامپایل برای "
+"تولید مقادیر `const` فراخوانی شوند. با این حال، توابع `const` را می توان در "
+"زمان اجرا فراخوانی کرد (بر خلاف تعریف متغییری ثابت)"
+
+#: src/user-defined-types/const.md:33
+#, fuzzy
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`"
+msgstr ""
+"به این نکته اشاره کنید که `const` شبیه `constexpr` در <span dir=ltr>`C++`</"
+"span> عمل می کند."
+
+#: src/user-defined-types/const.md:34
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+"با اینکه خیلی رایج نیست که اگر کسی به یک یک مقدار ثابت  که در زمان اجرا "
+"ارزیابی می‌شود از `const` استفاده کند اما مفید تر و ایمن تر از استفاده "
+"`static`ها هستند."
+
+#: src/user-defined-types/aliases.md:3
 msgid ""
 "A type alias creates a name for another type. The two types can be used "
 "interchangeably."
 msgstr ""
 
-#: src/user-defined-types/aliases.md
-msgid "// Aliases are more useful with long, complex types:\n"
+#: src/user-defined-types/aliases.md:13
+msgid "// Aliases are more useful with long, complex types:"
 msgstr ""
 
-#: src/user-defined-types/aliases.md
+#: src/user-defined-types/aliases.md:23
 msgid "C programmers will recognize this as similar to a `typedef`."
 msgstr ""
 
-#: src/user-defined-types/exercise.md
+#: src/user-defined-types/exercise.md:3
 msgid ""
 "We will create a data structure to represent an event in an elevator control "
 "system. It is up to you to define the types and functions to construct "
@@ -4993,102 +4742,100 @@ msgid ""
 "with `{:?}`."
 msgstr ""
 
-#: src/user-defined-types/exercise.md
+#: src/user-defined-types/exercise.md:7
 msgid ""
 "This exercise only requires creating and populating data structures so that "
 "`main` runs without errors. The next part of the course will cover getting "
 "data out of these structures."
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:12 src/user-defined-types/solution.md:4
+msgid "/// An event in the elevator system that the controller must react to."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:15
+msgid "// TODO: add required variants"
+msgstr ""
+
+#: src/user-defined-types/exercise.md:17 src/user-defined-types/solution.md:22
+msgid "/// A direction of travel."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:24 src/user-defined-types/solution.md:39
+msgid "/// The car has arrived on the given floor."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:29 src/user-defined-types/solution.md:44
+msgid "/// The car doors have opened."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:34 src/user-defined-types/solution.md:49
+msgid "/// The car doors have closed."
+msgstr ""
+
+#: src/user-defined-types/exercise.md:39 src/user-defined-types/solution.md:54
 msgid ""
-"/// An event in the elevator system that the controller must react to.\n"
+"/// A directional button was pressed in an elevator lobby on the given floor."
 msgstr ""
 
-#: src/user-defined-types/exercise.md
-msgid "// TODO: add required variants\n"
+#: src/user-defined-types/exercise.md:44 src/user-defined-types/solution.md:59
+msgid "/// A floor button was pressed in the elevator car."
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
-msgid "/// A direction of travel.\n"
-msgstr ""
-
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
-msgid "/// The car has arrived on the given floor.\n"
-msgstr ""
-
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
-msgid "/// The car doors have opened.\n"
-msgstr ""
-
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
-msgid "/// The car doors have closed.\n"
-msgstr ""
-
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
-msgid ""
-"/// A directional button was pressed in an elevator lobby on the given "
-"floor.\n"
-msgstr ""
-
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
-msgid "/// A floor button was pressed in the elevator car.\n"
-msgstr ""
-
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:52 src/user-defined-types/solution.md:67
 msgid "\"A ground floor passenger has pressed the up button: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:55 src/user-defined-types/solution.md:70
 msgid "\"The car has arrived on the ground floor: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:56 src/user-defined-types/solution.md:71
 msgid "\"The car door opened: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:58 src/user-defined-types/solution.md:73
 msgid "\"A passenger has pressed the 3rd floor button: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:61 src/user-defined-types/solution.md:76
 msgid "\"The car door closed: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/exercise.md src/user-defined-types/solution.md
+#: src/user-defined-types/exercise.md:62 src/user-defined-types/solution.md:77
 msgid "\"The car has arrived on the 3rd floor: {:?}\""
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// A button was pressed.\n"
+#: src/user-defined-types/solution.md:7
+msgid "/// A button was pressed."
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// The car has arrived at the given floor.\n"
+#: src/user-defined-types/solution.md:10
+msgid "/// The car has arrived at the given floor."
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// The car's doors have opened.\n"
+#: src/user-defined-types/solution.md:13
+msgid "/// The car's doors have opened."
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// The car's doors have closed.\n"
+#: src/user-defined-types/solution.md:16
+msgid "/// The car's doors have closed."
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// A floor is represented as an integer.\n"
+#: src/user-defined-types/solution.md:19
+msgid "/// A floor is represented as an integer."
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// A user-accessible button.\n"
+#: src/user-defined-types/solution.md:29
+msgid "/// A user-accessible button."
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// A button in the elevator lobby on the given floor.\n"
+#: src/user-defined-types/solution.md:33
+msgid "/// A button in the elevator lobby on the given floor."
 msgstr ""
 
-#: src/user-defined-types/solution.md
-msgid "/// A floor button within the car.\n"
+#: src/user-defined-types/solution.md:36
+msgid "/// A floor button within the car."
 msgstr ""
 
 #: src/welcome-day-2.md
@@ -5126,106 +4873,201 @@ msgid ""
 "Standard library types and traits: a tour of Rust's rich standard library."
 msgstr ""
 
-#: src/welcome-day-2.md
-msgid "[Welcome](./welcome-day-2.md) (3 minutes)"
+#: src/welcome-day-2.md src/welcome-day-4-afternoon.md
+msgid ""
+"Including 10 minute breaks, this session should take about 2 hours and 10 "
+"minutes. It contains:"
 msgstr ""
 
-#: src/welcome-day-2.md
+#: src/pattern-matching.md src/memory-management.md
+msgid "This segment should take about 1 hour. It contains:"
+msgstr ""
+
+#: src/pattern-matching/match.md:3
+msgid ""
+"The `match` keyword lets you match a value against one or more _patterns_. "
+"The comparisons are done from top to bottom and the first match wins."
+msgstr ""
+"کلمه کلیدی `match` به شما امکان می دهد یک مقدار را در برابر _یک یا چند الگو_ "
+"مطابقت دهید. مقایسه‌ها از بالا به پایین انجام می‌شوند و اولین تطبیق انتخاب "
+"می‌شود."
+
+#: src/pattern-matching/match.md:6
+msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
+msgstr ""
+"الگوها می توانند مقادیر ساده ای باشند، شبیه به `switch` در C و <span "
+"dir=ltr>C++</span>:"
+
+#: src/pattern-matching/match.md:11
+msgid "'x'"
+msgstr ""
+
+#: src/pattern-matching/match.md:13
+msgid "'q'"
+msgstr ""
+
+#: src/pattern-matching/match.md:13
+msgid "\"Quitting\""
+msgstr ""
+
+#: src/pattern-matching/match.md:14 src/generics/exercise.md:15
+#: src/generics/solution.md:17 src/std-traits/solution.md:16
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:75
+#: src/error-handling/solution.md:60 src/error-handling/solution.md:75
+msgid "'a'"
+msgstr ""
+
+#: src/pattern-matching/match.md:14
+msgid "'s'"
+msgstr ""
+
+#: src/pattern-matching/match.md:14
+msgid "'w'"
+msgstr ""
+
+#: src/pattern-matching/match.md:14
+msgid "'d'"
+msgstr ""
+
+#: src/pattern-matching/match.md:14
+msgid "\"Moving around\""
+msgstr ""
+
+#: src/pattern-matching/match.md:15 src/error-handling/exercise.md:51
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:74
+#: src/error-handling/solution.md:51 src/error-handling/solution.md:60
+#: src/error-handling/solution.md:74
+msgid "'0'"
+msgstr ""
+
+#: src/pattern-matching/match.md:15 src/error-handling/exercise.md:51
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:74
+#: src/error-handling/solution.md:51 src/error-handling/solution.md:60
+#: src/error-handling/solution.md:74
+msgid "'9'"
+msgstr ""
+
+#: src/pattern-matching/match.md:15
+msgid "\"Number input\""
+msgstr ""
+
+#: src/pattern-matching/match.md:16
+msgid "\"Lowercase: {key}\""
+msgstr ""
+
+#: src/pattern-matching/match.md:17
+msgid "\"Something else\""
+msgstr ""
+
+#: src/pattern-matching/match.md:22
+msgid ""
+"The `_` pattern is a wildcard pattern which matches any value. The "
+"expressions _must_ be exhaustive, meaning that it covers every possibility, "
+"so `_` is often used as the final catch-all case."
+msgstr ""
+
+#: src/pattern-matching/match.md:26
 #, fuzzy
-msgid "[Pattern Matching](./pattern-matching.md) (50 minutes)"
-msgstr ""
-"به [تطبیق الگو](../pattern-matching.md) مراجعه کنید تا در مورد الگوها در "
-"Rust اطلاعات بیشتری کسب کنید."
-
-#: src/welcome-day-2.md
-msgid "[Methods and Traits](./methods-and-traits.md) (55 minutes)"
-msgstr ""
-
-#: src/welcome-day-2.md
-msgid "[Generics](./generics.md) (45 minutes)"
-msgstr ""
-
-#: src/welcome-day-2.md src/welcome-day-4.md
 msgid ""
-"Including 10 minute breaks, this session should take about 3 hours and 5 "
-"minutes"
+"Match can be used as an expression. Just like `if`, each match arm must have "
+"the same type. The type is the last expression of the block, if any. In the "
+"example above, the type is `()`."
 msgstr ""
+"مثل دستور `if let`، باید همه شاخه تطبیق باید از نوع یکسانی را داشته باشند. "
+"نوع عبارت در آخر بلوک تعیین می‌شود، البته اگر وجود داشته باشد. در مثال بالا، "
+"نوع `()` است."
 
-#: src/pattern-matching.md
-msgid "[Destructuring](./pattern-matching/destructuring.md) (10 minutes)"
-msgstr ""
-
-#: src/pattern-matching.md
-msgid "[Let Control Flow](./pattern-matching/let-control-flow.md) (10 minutes)"
-msgstr ""
-
-#: src/pattern-matching.md
+#: src/pattern-matching/match.md:30
 msgid ""
-"[Exercise: Expression Evaluation](./pattern-matching/exercise.md) (30 "
-"minutes)"
+"A variable in the pattern (`key` in this example) will create a binding that "
+"can be used within the match arm."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
-msgid "Like tuples, structs and enums can also be destructured by matching:"
+#: src/pattern-matching/match.md:33
+msgid "A match guard causes the arm to match only if the condition is true."
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/match.md:40
+msgid ""
+"You might point out how some specific characters are being used when in a "
+"pattern"
+msgstr ""
+"بهتر است که اشاره کنید چطوری میتوان از کاراکترهای خاص در الگو استفاده کرد:"
+
+#: src/pattern-matching/match.md:42
+msgid "`|` as an `or`"
+msgstr "`|` به عنوان `or`"
+
+#: src/pattern-matching/match.md:43
+msgid "`..` can expand as much as it needs to be"
+msgstr "`..` برای تعیین همه محدوده یا تا جایی که میتوان گسترش یابد"
+
+#: src/pattern-matching/match.md:44
+msgid "`1..=5` represents an inclusive range"
+msgstr ""
+"<span dir=ltr><code class=hljs>1..=5</code></span> نمایانگر یک محدوده خاص "
+"است."
+
+#: src/pattern-matching/match.md:45
+msgid "`_` is a wild card"
+msgstr "`_` یک wildcard (هر حالتی) است."
+
+#: src/pattern-matching/match.md:47
+msgid ""
+"Match guards as a separate syntax feature are important and necessary when "
+"we wish to concisely express more complex ideas than patterns alone would "
+"allow."
+msgstr ""
+"گارد های تطبیق  به عنوان یک ویژگی سینتکس جداگانه دسته بندی می‌شوند, زمانی مهم "
+"و ضروری هستند که بخواهیم ایده های پیچیده تر از الگوهای ساده بیان کنیم."
+
+#: src/pattern-matching/match.md:49
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
+"An `if` expression inside of the branch block (after `=>`) happens after the "
+"match arm is selected. Failing the `if` condition inside of that block won't "
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+"آنها با عبارت `if` جداگانه ای در داخل یک شاخه تطبیق هستند یکسان نیستند. یک "
+"عبارت `if` در داخل بلاک شاخه (پس از <span dir=ltr>`=>`</span>) پس از ورود به "
+"اون شاخه خاص صدا زده میشود. اگر شرط `if` برقرار نباشد کاری به  سایر شاخه های "
+"عبارت `match` اصلی ندارد."
+
+#: src/pattern-matching/match.md:53
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr "شرط تعریف شده در guard با کمک `|` به شرط های تطبیق الگو اضافه می‌شود."
+
+#: src/pattern-matching/destructuring-structs.md:1
 msgid "Structs"
 msgstr "ساختارها"
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:3
+msgid "Like tuples, Struct can also be destructured by matching:"
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:15
 msgid "\"x.0 = 1, b = {b}, y = {y}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:16
 msgid "\"y = 2, x = {i:?}\""
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:17
 msgid "\"y = {y}, other fields were ignored\""
 msgstr ""
 
-#: src/pattern-matching/destructuring.md
-msgid ""
-"Patterns can also be used to bind variables to parts of your values. This is "
-"how you inspect the structure of your types. Let us start with a simple "
-"`enum` type:"
-msgstr ""
-"الگوها همچنین می توانند برای انتساب متغیرها استفاده شوند.به این ترتیب ساختار "
-"انواع (Types) خود را بررسی می‌کنید. اجازه دهید با یک نوع `enum` ساده شروع "
-"کنیم:"
-
-#: src/pattern-matching/destructuring.md
-msgid "\"cannot divide {n} into two equal parts\""
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
-msgid "\"{n} divided in two is {half}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
-msgid "\"sorry, an error happened: {msg}\""
-msgstr ""
-
-#: src/pattern-matching/destructuring.md
-msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the first "
-"arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm, `msg` is bound to the error message."
-msgstr ""
-"در اینجا ما از شاخه‌ها برای `destructure` کردن مقدار `Result` استفاده "
-"کرده‌ایم. در شاخه اول، `half` به مقداری داخل نوع `Ok` متصل می شود. در شاخه "
-"دوم، `msg` به نوع`Err` متصل می‌شود."
-
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:25
 msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr "تغییر مقادیر لیترال در foo برای مطابقت با سایر الگوها."
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:26
 msgid "Add a new field to `Foo` and make changes to the pattern as needed."
 msgstr "اضافه کردن یک فیلد جدید به Foo و ایجاد تغییرات مورد نیاز."
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-structs.md:27
 msgid ""
 "The distinction between a capture and a constant expression can be hard to "
 "spot. Try changing the `2` in the second arm to a variable, and see that it "
@@ -5235,14 +5077,50 @@ msgstr ""
 "‍`2` را در شاخه دوم به یک متغیر تغییر دهید و خواهید دید که  کار نمی‌کند. آن را "
 "به یک `const` تغییر دهید و خواهید دید که دوباره کار می‌کند."
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:3
+msgid "Like tuples, enums can also be destructured by matching:"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:5
+msgid ""
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
+msgstr ""
+"الگوها همچنین می توانند برای انتساب متغیرها استفاده شوند.به این ترتیب ساختار "
+"انواع (Types) خود را بررسی می‌کنید. اجازه دهید با یک نوع `enum` ساده شروع "
+"کنیم:"
+
+#: src/pattern-matching/destructuring-enums.md:18
+msgid "\"cannot divide {n} into two equal parts\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:25
+msgid "\"{n} divided in two is {half}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:26
+msgid "\"sorry, an error happened: {msg}\""
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:31
+msgid ""
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm, `msg` is bound to the error message."
+msgstr ""
+"در اینجا ما از شاخه‌ها برای `destructure` کردن مقدار `Result` استفاده "
+"کرده‌ایم. در شاخه اول، `half` به مقداری داخل نوع `Ok` متصل می شود. در شاخه "
+"دوم، `msg` به نوع`Err` متصل می‌شود."
+
+#: src/pattern-matching/destructuring-enums.md:38
 msgid ""
 "The `if`/`else` expression is returning an enum that is later unpacked with "
 "a `match`."
 msgstr ""
 "عبارت `if`/`else` یک `enum` را برمی گرداند که بعداً با `match` باز می شود."
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:40
 msgid ""
 "You can try adding a third variant to the enum definition and displaying the "
 "errors when running the code. Point out the places where your code is now "
@@ -5252,7 +5130,7 @@ msgstr ""
 "خطاها هنگام اجرای کد، را تست کنید. مکان هایی را که کد شما اکنون ناقص است و "
 "نحوه تلاش کامپایلر برای ارائه نکاتی به شما را نشان دهید."
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:43
 #, fuzzy
 msgid ""
 "The values in the enum variants can only be accessed after being pattern "
@@ -5262,7 +5140,7 @@ msgstr ""
 "فیلدهای موجود با استفاده  بازوی `match` پس از <span dir=ltr>`=>`</span>  "
 "متصل می کند."
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:45
 #, fuzzy
 msgid ""
 "Demonstrate what happens when the search is inexhaustive. Note the advantage "
@@ -5271,100 +5149,100 @@ msgstr ""
 "این اتفاق را زمانی که الگوهای جستجو کامل نیستند نشان دهید. به مزیت کامپایلر "
 "Rust که با تایید زمانی که همه موارد رسیدگی می‌شوند، اشاره کنید."
 
-#: src/pattern-matching/destructuring.md
+#: src/pattern-matching/destructuring-enums.md:47
 msgid ""
 "Save the result of `divide_in_two` in the `result` variable and `match` it "
 "in a loop. That won't compile because `msg` is consumed when matched. To fix "
 "it, match `&result` instead of `result`. That will make `msg` a reference so "
-"it won't be consumed. This [\"match ergonomics\"](https://rust-lang.github."
-"io/rfcs/2005-match-ergonomics.html) appeared in Rust 2018. If you want to "
-"support older Rust, replace `msg` with `ref msg` in the pattern."
+"it won't be consumed. This \"match ergonomics\" appeared in Rust 2018. If "
+"you want to support older Rust, replace `msg` with `ref msg` in the pattern."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:3
 msgid ""
 "Rust has a few control flow constructs which differ from other languages. "
 "They are used for pattern matching:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:6
+#: src/pattern-matching/let-control-flow.md:10
 msgid "`if let` expressions"
 msgstr "عبارت `if let`"
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:7
+#: src/pattern-matching/let-control-flow.md:32
+#, fuzzy
+msgid "`let else` expressions"
+msgstr "عبارت `while let`"
+
+#: src/pattern-matching/let-control-flow.md:8
 msgid "`while let` expressions"
 msgstr "عبارت `while let`"
 
-#: src/pattern-matching/let-control-flow.md
-msgid "`match` expressions"
-msgstr "عبارت `match`"
-
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:12
+#, fuzzy
 msgid ""
-"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
-"expr.html#if-let-expressions) lets you execute different code depending on "
-"whether a value matches a pattern:"
+"The `if let` expression lets you execute different code depending on whether "
+"a value matches a pattern:"
 msgstr ""
 "[عبارت `if let`](https://doc.rust-lang.org/reference/expressions/if-expr."
 "html#if-let-expressions)  به شما امکان می‌دهد بسته به اینکه آیا یک مقدار با "
 "یک الگو مطابقت دارد، کدهای مختلفی را اجرا کنید:"
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:22
 msgid "\"slept for {:?}\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
-#, fuzzy
-msgid "`let else` expressions"
-msgstr "عبارت `while let`"
-
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:34
 msgid ""
 "For the common case of matching a pattern and returning from the function, "
-"use [`let else`](https://doc.rust-lang.org/rust-by-example/flow_control/"
-"let_else.html). The \"else\" case must diverge (`return`, `break`, or panic "
+"use `let else`. The \"else\" case must diverge (`return`, `break`, or panic "
 "- anything but falling off the end of the block)."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:44
+#: src/pattern-matching/let-control-flow.md:107
 msgid "\"got None\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:50
+#: src/pattern-matching/let-control-flow.md:111
 msgid "\"got empty string\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:56
+#: src/pattern-matching/let-control-flow.md:115
 msgid "\"not a hex digit\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md src/pattern-matching/solution.md
+#: src/pattern-matching/let-control-flow.md:61
+#: src/pattern-matching/solution.md:113
 msgid "\"result: {:?}\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md src/generics/trait-bounds.md
-#: src/smart-pointers/solution.md src/testing/googletest.md
-#: src/testing/solution.md
+#: src/pattern-matching/let-control-flow.md:61 src/generics/trait-bounds.md:16
+#: src/smart-pointers/solution.md:87 src/smart-pointers/solution.md:90
+#: src/testing/solution.md:83 src/android/testing.md
+#: src/android/testing/googletest.md:11 src/android/testing/googletest.md:12
 msgid "\"foo\""
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:65
+#, fuzzy
 msgid ""
-"Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
-"repeatedly tests a value against a pattern:"
+"Like with `if let`, there is a `while let` variant which repeatedly tests a "
+"value against a pattern:"
 msgstr ""
 "مانند `if let`، یک دستور [`while let`](https://doc.rust-lang.org/reference/"
 "expressions/loop-expr.html#predicate-pattern-loops) وجود دارد که مقادیر "
 "مقابل الگو به طور مکرر (تکرار شونده‌ای) بررسی می‌کند:"
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:81
 #, fuzzy
 msgid ""
-"Here [`String::pop`](https://doc.rust-lang.org/stable/std/string/struct."
-"String.html#method.pop) returns `Some(c)` until the string is empty, after "
-"which it will return `None`. The `while let` lets us keep iterating through "
-"all items."
+"Here `String::pop` returns `Some(c)` until the string is empty, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 "در اینجا، پیماینده (iterator) توسط <span dir=ltr>`v.into_iter()`</span> یک "
 "مقدار را برمیگرداند, یک <span dir=ltr>`Option<i32>`</span> را در هر فراخوانی "
@@ -5373,11 +5251,11 @@ msgstr ""
 "span> را برمی گرداند و پس از آن None را برمی گرداند. `while let` به ما امکان "
 "می دهد همه مارد را به صورت کامل پیمایش کنیم."
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:89
 msgid "if-let"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:91
 msgid ""
 "Unlike `match`, `if let` does not have to cover all branches. This can make "
 "it more concise than `match`."
@@ -5386,40 +5264,40 @@ msgstr ""
 "پشتیبانی نمیکند. اگر می‌خواهید همه حالت را پوشش دهید از دستور `match` استفاده "
 "کنید."
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:93
 msgid "A common usage is handling `Some` values when working with `Option`."
 msgstr ""
 "یک استفاده رایج از دستور `if let`، رسیدگی به مقادیر `Some` هنگام کار با "
 "`Option` است:"
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:94
 msgid ""
 "Unlike `match`, `if let` does not support guard clauses for pattern matching."
 msgstr ""
 "برخلاف دستور `match` دستور `if let`  از <span dir=ltr>`=>`</span> برای تطبیق "
 "الگو استفاده نمیکند."
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:96
 msgid "let-else"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:98
 msgid ""
 "`if-let`s can pile up, as shown. The `let-else` construct supports "
 "flattening this nested code. Rewrite the awkward version for students, so "
 "they can see the transformation."
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:102
 msgid "The rewritten version is:"
 msgstr ""
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:122
 #, fuzzy
 msgid "while-let"
 msgstr "حلقه `while let`"
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:124
 msgid ""
 "Point out that the `while let` loop will keep going as long as the value "
 "matches the pattern."
@@ -5427,7 +5305,7 @@ msgstr ""
 "توجه داشته باشید که حلقه `while let` تا زمانی که مقادیر مقابل الگو طبیق "
 "داشته باشد (شرط برقرار باشد)، ادامه خواهد داشت."
 
-#: src/pattern-matching/let-control-flow.md
+#: src/pattern-matching/let-control-flow.md:126
 #, fuzzy
 msgid ""
 "You could rewrite the `while let` loop as an infinite loop with an if "
@@ -5439,12 +5317,12 @@ msgstr ""
 "span> وجود ندارد، قطع می‌شود. `while let` مثل آب خوردن سناریو بالا رو برای "
 "شما فراهم می‌کند."
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:3
 #, fuzzy
 msgid "Let's write a simple recursive evaluator for arithmetic expressions."
 msgstr "بیایید یک ارزیاب بازگشتی ساده برای عبارات حسابی بنویسیم."
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:5
 #, fuzzy
 msgid ""
 "The `Box` type here is a smart pointer, and will be covered in detail later "
@@ -5458,20 +5336,19 @@ msgstr ""
 "از عملگر `deref` برای «خارج کردن» آن استفاده کنید: <span "
 "dir=ltr>`eval(*boxed_expr)`</span>"
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:10
 #, fuzzy
 msgid ""
 "Some expressions cannot be evaluated and will return an error. The standard "
-"[`Result<Value, String>`](https://doc.rust-lang.org/std/result/enum.Result."
-"html) type is an enum that represents either a successful value "
-"(`Ok(Value)`) or an error (`Err(String)`). We will cover this type in detail "
-"later."
+"`Result<Value, String>` type is an enum that represents either a successful "
+"value (`Ok(Value)`) or an error (`Err(String)`). We will cover this type in "
+"detail later."
 msgstr ""
 "برخی از عبارات قابل ارزیابی نیستند و خطایی را برمی‌گردانند. نوع `Res` "
 "نشان‌دهنده یک مقدار موفقیت‌آمیز یا یک خطا با پیام است. این بسیار شبیه به "
 "`Result` کتابخانه استاندارد است که بعداً خواهیم دید."
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:15
 #, fuzzy
 msgid ""
 "Copy and paste the code into the Rust playground, and begin implementing "
@@ -5483,7 +5360,7 @@ msgstr ""
 "محصول نهایی باید تست‌ها را پشت سر بگذارد. ممکن است مفید باشد از <span "
 "dir=ltr>`todo!()`</span> استفاده کنید و تست‌ها را یکی یکی پاس دهید."
 
-#: src/pattern-matching/exercise.md
+#: src/pattern-matching/exercise.md:26
 #, fuzzy
 msgid ""
 "If you finish early, try writing a test that results in division by zero or "
@@ -5493,116 +5370,92 @@ msgstr ""
 "overflow) شود. چگونه می توانید این مشکل را با <span dir=ltr>`Res::Err`</"
 "span>  به جای `panic` برطرف کنید؟"
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
-msgid "/// An operation to perform on two subexpressions.\n"
+#: src/pattern-matching/exercise.md:30 src/pattern-matching/solution.md:4
+msgid "/// An operation to perform on two subexpressions."
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
-msgid "/// An expression, in tree form.\n"
+#: src/pattern-matching/exercise.md:38 src/pattern-matching/solution.md:12
+msgid "/// An expression, in tree form."
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
-msgid "/// An operation on two subexpressions.\n"
+#: src/pattern-matching/exercise.md:42 src/pattern-matching/solution.md:16
+msgid "/// An operation on two subexpressions."
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
-msgid "/// A literal value\n"
+#: src/pattern-matching/exercise.md:45 src/pattern-matching/solution.md:19
+msgid "/// A literal value"
 msgstr ""
 
-#: src/pattern-matching/exercise.md src/pattern-matching/solution.md
+#: src/pattern-matching/exercise.md:104 src/pattern-matching/solution.md:40
+#: src/pattern-matching/solution.md:102
 msgid "\"division by zero\""
 msgstr ""
 
-#: src/pattern-matching/solution.md
+#: src/pattern-matching/solution.md:112
 msgid "\"expr: {:?}\""
 msgstr ""
 
-#: src/methods-and-traits.md
-msgid "[Methods](./methods-and-traits/methods.md) (10 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid "[Traits](./methods-and-traits/traits.md) (10 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid "[Deriving](./methods-and-traits/deriving.md) (5 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid "[Trait Objects](./methods-and-traits/trait-objects.md) (10 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid ""
-"[Exercise: Generic Logger](./methods-and-traits/exercise.md) (20 minutes)"
-msgstr ""
-
-#: src/methods-and-traits.md
-msgid "This segment should take about 55 minutes"
-msgstr ""
-
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:3
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
 "an `impl` block:"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
-msgid "// No receiver, a static method\n"
+#: src/methods-and-traits/methods.md:14
+msgid "// No receiver, a static method"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
-msgid "// Exclusive borrowed read-write access to self\n"
+#: src/methods-and-traits/methods.md:19
+msgid "// Exclusive borrowed read-write access to self"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
-msgid "// Shared and read-only borrowed access to self\n"
+#: src/methods-and-traits/methods.md:24
+msgid "// Shared and read-only borrowed access to self"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:26
 msgid "\"Recorded {} laps for {}:\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:28
 msgid "\"Lap {idx}: {lap} sec\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
-msgid "// Exclusive ownership of self\n"
+#: src/methods-and-traits/methods.md:32
+msgid "// Exclusive ownership of self"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:35
 msgid "\"Race {} is finished, total lap time: {}\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:40
 msgid "\"Monaco Grand Prix\""
 msgstr ""
 
-#: src/methods-and-traits/methods.md
-msgid "// race.add_lap(42);\n"
+#: src/methods-and-traits/methods.md:47
+msgid "// race.add_lap(42);"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:51
 msgid ""
 "The `self` arguments specify the \"receiver\" - the object the method acts "
 "on. There are several common receivers for a method:"
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:54
 msgid ""
 "`&self`: borrows the object from the caller using a shared and immutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:56
 msgid ""
 "`&mut self`: borrows the object from the caller using a unique and mutable "
 "reference. The object can be used again afterwards."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:58
 msgid ""
 "`self`: takes ownership of the object and moves it away from the caller. The "
 "method becomes the owner of the object. The object will be dropped "
@@ -5610,263 +5463,211 @@ msgid ""
 "transmitted. Complete ownership does not automatically mean mutability."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:62
 msgid "`mut self`: same as above, but the method can mutate the object."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:63
 msgid ""
 "No receiver: this becomes a static method on the struct. Typically used to "
 "create constructors which are called `new` by convention."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:71
 msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:72
 msgid ""
 "Methods are called on an instance of a type (such as a struct or enum), the "
 "first parameter represents the instance as `self`."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:74
 msgid ""
 "Developers may choose to use methods to take advantage of method receiver "
 "syntax and to help keep them more organized. By using methods we can keep "
 "all the implementation code in one predictable place."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:77
 msgid "Point out the use of the keyword `self`, a method receiver."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:78
 msgid ""
 "Show that it is an abbreviated term for `self: Self` and perhaps show how "
 "the struct name could also be used."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:80
 msgid ""
 "Explain that `Self` is a type alias for the type the `impl` block is in and "
 "can be used elsewhere in the block."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:82
 msgid ""
 "Note how `self` is used like other structs and dot notation can be used to "
 "refer to individual fields."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:84
 msgid ""
 "This might be a good time to demonstrate how the `&self` differs from `self` "
 "by trying to run `finish` twice."
 msgstr ""
 
-#: src/methods-and-traits/methods.md
+#: src/methods-and-traits/methods.md:86
 msgid ""
-"Beyond variants on `self`, there are also [special wrapper types](https://"
-"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
-"receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also special wrapper types allowed to "
+"be receiver types, such as `Box<Self>`."
 msgstr ""
 
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:3
 msgid ""
 "Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
-#: src/methods-and-traits/traits.md
-msgid "\"Oh you're a cutie! What's your name? {}\""
+#: src/methods-and-traits/traits.md:7
+msgid "/// Return a sentence from this pet."
 msgstr ""
 
-#: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
-msgid "\"Woof, my name is {}!\""
+#: src/methods-and-traits/traits.md:10
+msgid "/// Print a string to the terminal greeting this pet."
 msgstr ""
 
-#: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
-msgid "\"Miau!\""
-msgstr ""
-
-#: src/methods-and-traits/traits.md src/methods-and-traits/trait-objects.md
-msgid "\"Fido\""
-msgstr ""
-
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:18
 msgid ""
 "A trait defines a number of methods that types must have in order to "
 "implement the trait."
 msgstr ""
 
-#: src/methods-and-traits/traits.md
-msgid "Traits are implemented in an `impl <trait> for <type> { .. }` block."
-msgstr ""
-
-#: src/methods-and-traits/traits.md
+#: src/methods-and-traits/traits.md:21
 msgid ""
-"Traits may specify pre-implemented (provided) methods and methods that users "
-"are required to implement themselves. Provided methods can rely on required "
-"methods. In this case, `greet` is provided, and relies on `talk`."
+"In the \"Generics\" segment, next, we will see how to build functionality "
+"that is generic over all types implementing a trait."
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/traits/implementing.md:8
+msgid "\"Oh you're a cutie! What's your name? {}\""
+msgstr ""
+
+#: src/methods-and-traits/traits/implementing.md:19
+#: src/generics/dyn-trait.md:21 src/smart-pointers/trait-objects.md:22
+msgid "\"Woof, my name is {}!\""
+msgstr ""
+
+#: src/methods-and-traits/traits/implementing.md:24
+#: src/generics/dyn-trait.md:43 src/smart-pointers/trait-objects.md:35
+msgid "\"Fido\""
+msgstr ""
+
+#: src/methods-and-traits/traits/implementing.md:31
+msgid ""
+"To implement `Trait` for `Type`, you use an `impl Trait for Type { .. }` "
+"block."
+msgstr ""
+
+#: src/methods-and-traits/traits/implementing.md:34
+msgid ""
+"Unlike Go interfaces, just having matching methods is not enough: a `Cat` "
+"type with a `talk()` method would not automatically satisfy `Pet` unless it "
+"is in an `impl Pet` block."
+msgstr ""
+
+#: src/methods-and-traits/traits/implementing.md:38
+msgid ""
+"Traits may provide default implementations of some methods. Default "
+"implementations can rely on all the methods of the trait. In this case, "
+"`greet` is provided, and relies on `talk`."
+msgstr ""
+
+#: src/methods-and-traits/traits/supertraits.md:3
+msgid ""
+"A trait can require that types implementing it also implement other traits, "
+"called _supertraits_. Here, any type implementing `Pet` must implement "
+"`Animal`."
+msgstr ""
+
+#: src/methods-and-traits/traits/supertraits.md:30
+#: src/concurrency/async-control-flow/select.md:44
+msgid "\"Rex\""
+msgstr ""
+
+#: src/methods-and-traits/traits/supertraits.md:31
+msgid "\"{} has {} legs\""
+msgstr ""
+
+#: src/methods-and-traits/traits/supertraits.md:37
+msgid ""
+"This is sometimes called \"trait inheritance\" but students should not "
+"expect this to behave like OO inheritance. It just specifies an additional "
+"requirement on implementations of a trait."
+msgstr ""
+
+#: src/methods-and-traits/traits/associated-types.md:3
+msgid ""
+"Associated types are placeholder types which are supplied by the trait "
+"implementation."
+msgstr ""
+
+#: src/methods-and-traits/traits/associated-types.md:25
+#: src/concurrency/async-control-flow/join.md:30
+msgid "\"{:?}\""
+msgstr ""
+
+#: src/methods-and-traits/traits/associated-types.md:31
+msgid ""
+"Associated types are sometimes also called \"output types\". The key "
+"observation is that the implementer, not the caller, chooses this type."
+msgstr ""
+
+#: src/methods-and-traits/traits/associated-types.md:34
+msgid ""
+"Many standard library traits have associated types, including arithmetic "
+"operators and `Iterator`."
+msgstr ""
+
+#: src/methods-and-traits/deriving.md:3
 msgid ""
 "Supported traits can be automatically implemented for your custom types, as "
 "follows:"
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
-msgid "// Default trait adds `default` constructor.\n"
+#: src/methods-and-traits/deriving.md:15
+msgid "// Default trait adds `default` constructor."
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
-msgid "// Clone trait adds `clone` method.\n"
+#: src/methods-and-traits/deriving.md:16
+msgid "// Clone trait adds `clone` method."
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:17
 msgid "\"EldurScrollz\""
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
-msgid "// Debug trait adds support for printing with `{:?}`.\n"
+#: src/methods-and-traits/deriving.md:18
+msgid "// Debug trait adds support for printing with `{:?}`."
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:19
 msgid "\"{:?} vs. {:?}\""
 msgstr ""
 
-#: src/methods-and-traits/deriving.md
+#: src/methods-and-traits/deriving.md:26
 msgid ""
 "Derivation is implemented with macros, and many crates provide useful derive "
 "macros to add useful functionality. For example, `serde` can derive "
 "serialization support for a struct using `#[derive(Serialize)]`."
 msgstr ""
 
-#: src/methods-and-traits/trait-objects.md
-msgid ""
-"Trait objects allow for values of different types, for instance in a "
-"collection:"
-msgstr ""
+#: src/methods-and-traits/exercise.md:1
+#, fuzzy
+msgid "Exercise: Logger Trait"
+msgstr "تمرین‌ها"
 
-#: src/methods-and-traits/trait-objects.md
-msgid "\"Hello, who are you? {}\""
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid "Memory layout after allocating `pets`:"
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid ""
-"```bob\n"
-" Stack                             Heap\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
-"- -.\n"
-":                           :     :                                             :\n"
-":    pets                   :     :                     +----+----+----+----"
-"+   :\n"
-":   +-----------+-------+   :     :   +-----+-----+  .->| F  | i  | d  | o  "
-"|   :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |  |  +----+----+----+----"
-"+   :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+  "
-"`---------.                :\n"
-":   | capacity  |     2 |   :     :     | |   | |    data      "
-"|                :\n"
-":   +-----------+-------+   :     :     | |   | |   +-------+--|-------"
-"+        :\n"
-":                           :     :     | |   | '-->| name  |  o, 4, 4 "
-"|        :\n"
-":                           :     :     | |   |     | age   |        5 "
-"|        :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |     +-------+----------"
-"+        :\n"
-"                                  :     | |   "
-"|                                 :\n"
-"                                  :     | |   |      "
-"vtable                     :\n"
-"                                  :     | |   |     +----------------------"
-"+    :\n"
-"                                  :     | |   '---->| \"<Dog as Pet>::talk\" "
-"|    :\n"
-"                                  :     | |         +----------------------"
-"+    :\n"
-"                                  :     | "
-"|                                     :\n"
-"                                  :     | |    "
-"data                             :\n"
-"                                  :     | |   +-------+-------"
-"+                 :\n"
-"                                  :     | '-->| lives |     9 "
-"|                 :\n"
-"                                  :     |     +-------+-------"
-"+                 :\n"
-"                                  :     "
-"|                                       :\n"
-"                                  :     |      "
-"vtable                           :\n"
-"                                  :     |     +----------------------"
-"+          :\n"
-"                                  :     '---->| \"<Cat as Pet>::talk\" "
-"|          :\n"
-"                                  :           +----------------------"
-"+          :\n"
-"                                  :                                             :\n"
-"                                  '- - - - - - - - - - - - - - - - - - - - - "
-"- -'\n"
-"```"
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid ""
-"Types that implement a given trait may be of different sizes. This makes it "
-"impossible to have things like `Vec<dyn Pet>` in the example above."
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid ""
-"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
-"implements `Pet`."
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid ""
-"In the example, `pets` is allocated on the stack and the vector data is on "
-"the heap. The two vector elements are _fat pointers_:"
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid ""
-"A fat pointer is a double-width pointer. It has two components: a pointer to "
-"the actual object and a pointer to the [virtual method table](https://en."
-"wikipedia.org/wiki/Virtual_method_table) (vtable) for the `Pet` "
-"implementation of that particular object."
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid ""
-"The data for the `Dog` named Fido is the `name` and `age` fields. The `Cat` "
-"has a `lives` field."
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md
-msgid "Compare these outputs in the above example:"
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md src/std-traits/closures.md
-msgid "\"{} {}\""
-msgstr ""
-
-#: src/methods-and-traits/trait-objects.md src/std-traits/exercise.md
-#: src/std-traits/solution.md src/modules/exercise.md src/modules/solution.md
-#: src/android/build-rules/library.md
-#: src/android/interoperability/cpp/rust-bridge.md
-#: src/async/pitfalls/cancellation.md
-msgid "\"{}\""
-msgstr ""
-
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:3
 msgid ""
 "Let's design a simple logging utility, using a trait `Logger` with a `log` "
 "method. Code which might log its progress can then take an `&impl Logger`. "
@@ -5874,101 +5675,101 @@ msgid ""
 "production build it would send messages to a log server."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:8
 msgid ""
 "However, the `StderrLogger` given below logs all messages, regardless of "
 "verbosity. Your task is to write a `VerbosityFilter` type that will ignore "
 "messages above a maximum verbosity."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
+#: src/methods-and-traits/exercise.md:12
 msgid ""
 "This is a common pattern: a struct wrapping a trait implementation and "
 "implementing that same trait, adding behavior in the process. What other "
 "kinds of wrappers might be useful in a logging utility?"
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
-msgid "/// Log a message at the given verbosity level.\n"
+#: src/methods-and-traits/exercise.md:20 src/methods-and-traits/solution.md:7
+msgid "/// Log a message at the given verbosity level."
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
+#: src/methods-and-traits/exercise.md:28 src/methods-and-traits/solution.md:15
 msgid "\"verbosity={verbosity}: {message}\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
+#: src/methods-and-traits/exercise.md:33 src/methods-and-traits/solution.md:20
 msgid "\"FYI\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md src/methods-and-traits/solution.md
+#: src/methods-and-traits/exercise.md:34 src/methods-and-traits/solution.md:21
 msgid "\"Uhoh\""
 msgstr ""
 
-#: src/methods-and-traits/exercise.md
-msgid "// TODO: Define and implement `VerbosityFilter`.\n"
+#: src/methods-and-traits/exercise.md:36
+msgid "// TODO: Define and implement `VerbosityFilter`."
 msgstr ""
 
-#: src/methods-and-traits/solution.md
-msgid "/// Only log messages up to the given verbosity level.\n"
+#: src/methods-and-traits/solution.md:23
+msgid "/// Only log messages up to the given verbosity level."
 msgstr ""
 
-#: src/generics.md
-msgid "[Generic Functions](./generics/generic-functions.md) (5 minutes)"
+#: src/welcome-day-2-afternoon.md
+msgid ""
+"Including 10 minute breaks, this session should take about 4 hours and 5 "
+"minutes. It contains:"
 msgstr ""
 
-#: src/generics.md
-msgid "[Generic Data Types](./generics/generic-data.md) (15 minutes)"
-msgstr ""
-
-#: src/generics.md
-msgid "[Trait Bounds](./generics/trait-bounds.md) (10 minutes)"
-msgstr ""
-
-#: src/generics.md
-msgid "[impl Trait](./generics/impl-trait.md) (5 minutes)"
+#: src/generics.md src/iterators.md src/testing.md
+msgid "This segment should take about 45 minutes. It contains:"
 msgstr ""
 
 #: src/generics.md
-msgid "[Exercise: Generic min](./generics/exercise.md) (10 minutes)"
-msgstr ""
+msgid "impl Trait"
+msgstr "صفات impl  (impl Trait)"
 
-#: src/generics.md src/smart-pointers.md src/iterators.md src/error-handling.md
-msgid "This segment should take about 45 minutes"
-msgstr ""
+#: src/generics.md
+#, fuzzy
+msgid "dyn Trait"
+msgstr "صفات Async"
 
-#: src/generics/generic-functions.md
+#: src/generics.md
+#, fuzzy
+msgid "Exercise: Generic min"
+msgstr "تمرین‌ها"
+
+#: src/generics/generic-functions.md:3
 msgid ""
 "Rust supports generics, which lets you abstract algorithms or data "
 "structures (such as sorting or a binary tree) over the types used or stored."
 msgstr ""
 
-#: src/generics/generic-functions.md
-msgid "/// Pick `even` or `odd` depending on the value of `n`.\n"
+#: src/generics/generic-functions.md:7
+msgid "/// Pick `even` or `odd` depending on the value of `n`."
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:17
 msgid "\"picked a number: {:?}\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:18
 msgid "\"picked a tuple: {:?}\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:18
 msgid "\"dog\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:18
 msgid "\"cat\""
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:25
 msgid ""
 "Rust infers a type for T based on the types of the arguments and return "
 "value."
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:27
 msgid ""
 "This is similar to C++ templates, but Rust partially compiles the generic "
 "function immediately, so that function must be valid for all types matching "
@@ -5977,156 +5778,198 @@ msgid ""
 "still considers it invalid. C++ would let you do this."
 msgstr ""
 
-#: src/generics/generic-functions.md
+#: src/generics/generic-functions.md:33
 msgid ""
 "Generic code is turned into non-generic code based on the call sites. This "
 "is a zero-cost abstraction: you get exactly the same result as if you had "
 "hand-coded the data structures without the abstraction."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:3
 msgid "You can use generics to abstract over the concrete field type:"
 msgstr ""
 
-#: src/generics/generic-data.md
-msgid "// fn set_x(&mut self, x: T)\n"
-msgstr ""
-
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:25
 msgid "\"{integer:?} and {float:?}\""
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:26
 msgid "\"coords: {:?}\""
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:33
 msgid ""
 "_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
 "redundant?"
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:35
 msgid ""
 "This is because it is a generic implementation section for generic type. "
 "They are independently generic."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:37
 msgid "It means these methods are defined for any `T`."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:38
 msgid "It is possible to write `impl Point<u32> { .. }`."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:39
 msgid ""
 "`Point` is still generic and you can use `Point<f64>`, but methods in this "
 "block will only be available for `Point<u32>`."
 msgstr ""
 
-#: src/generics/generic-data.md
+#: src/generics/generic-data.md:42
 msgid ""
 "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`. Update the "
 "code to allow points that have elements of different types, by using two "
 "type variables, e.g., `T` and `U`."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/generic-traits.md:3
+msgid ""
+"Traits can also be generic, just like types and functions. A trait's "
+"parameters get concrete types when it is used."
+msgstr ""
+
+#: src/generics/generic-traits.md:12
+msgid "\"Converted from integer: {from}\""
+msgstr ""
+
+#: src/generics/generic-traits.md:18
+msgid "\"Converted from bool: {from}\""
+msgstr ""
+
+#: src/generics/generic-traits.md:25
+msgid "\"{from_int:?}, {from_bool:?}\""
+msgstr ""
+
+#: src/generics/generic-traits.md:31
+msgid ""
+"The `From` trait will be covered later in the course, but its definition in "
+"the `std` docs is simple."
+msgstr ""
+
+#: src/generics/generic-traits.md:35
+msgid ""
+"Implementations of the trait do not need to cover all possible type "
+"parameters. Here, `Foo::From(\"hello\")` would not compile because there is "
+"no `From<&str>` implementation for `Foo`."
+msgstr ""
+
+#: src/generics/generic-traits.md:39
+msgid ""
+"Generic traits take types as \"input\", while associated types are a kind of "
+"\"output\" type. A trait can have multiple implementations for different "
+"input types."
+msgstr ""
+
+#: src/generics/generic-traits.md:43
+msgid ""
+"In fact, Rust requires that at most one implementation of a trait match for "
+"any type T. Unlike some other languages, Rust has no heuristic for choosing "
+"the \"most specific\" match. There is work on adding this support, called "
+"specialization."
+msgstr ""
+
+#: src/generics/trait-bounds.md:3
 msgid ""
 "When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
 msgstr ""
 
-#: src/generics/trait-bounds.md
-msgid "// struct NotClonable;\n"
+#: src/generics/trait-bounds.md:12
+msgid "// struct NotClonable;"
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:18
 msgid "\"{pair:?}\""
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:25
 msgid "Try making a `NonClonable` and passing it to `duplicate`."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:27
 msgid "When multiple traits are necessary, use `+` to join them."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:29
 msgid "Show a `where` clause, students will encounter it when reading code."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:40
 msgid "It declutters the function signature if you have many parameters."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:41
 msgid "It has additional features making it more powerful."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:42
 msgid ""
 "If someone asks, the extra feature is that the type on the left of \":\" can "
 "be arbitrary, like `Option<T>`."
 msgstr ""
 
-#: src/generics/trait-bounds.md
+#: src/generics/trait-bounds.md:45
 msgid ""
 "Note that Rust does not (yet) support specialization. For example, given the "
 "original `duplicate`, it is invalid to add a specialized `duplicate(a: u32)`."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:3
 msgid ""
 "Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:7
 msgid ""
-"// Syntactic sugar for:\n"
-"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
+"// Syntactic sugar for: //   fn add_42_millions\\<T: Into<i32>\\>(x: T) -> "
+"i32 {"
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:19
 msgid "\"{many}\""
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:21
 msgid "\"{many_more}\""
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:23
 msgid "\"debuggable: {debuggable:?}\""
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:30
 msgid ""
 "`impl Trait` allows you to work with types which you cannot name. The "
 "meaning of `impl Trait` is a bit different in the different positions."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:33
 msgid ""
 "For a parameter, `impl Trait` is like an anonymous generic parameter with a "
 "trait bound."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:36
 msgid ""
 "For a return type, it means that the return type is some concrete type that "
 "implements the trait, without naming the type. This can be useful when you "
 "don't want to expose the concrete type in a public API."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:40
 msgid ""
 "Inference is hard in return position. A function returning `impl Foo` picks "
 "the concrete type it returns, without writing it out in the source. A "
@@ -6136,77 +5979,141 @@ msgid ""
 "<Vec<_>>()`."
 msgstr ""
 
-#: src/generics/impl-trait.md
+#: src/generics/impl-trait.md:47
 msgid ""
 "What is the type of `debuggable`? Try `let debuggable: () = ..` to see what "
 "the error message shows."
 msgstr ""
 
-#: src/generics/exercise.md
+#: src/generics/dyn-trait.md:3
+msgid ""
+"In addition to using traits for static dispatch via generics, Rust also "
+"supports using them for type-erased, dynamic dispatch via trait objects:"
+msgstr ""
+
+#: src/generics/dyn-trait.md:27 src/smart-pointers/trait-objects.md:28
+msgid "\"Miau!\""
+msgstr ""
+
+#: src/generics/dyn-trait.md:30
+msgid "// Uses generics and static dispatch."
+msgstr ""
+
+#: src/generics/dyn-trait.md:33 src/generics/dyn-trait.md:38
+#: src/smart-pointers/trait-objects.md:38
+msgid "\"Hello, who are you? {}\""
+msgstr ""
+
+#: src/generics/dyn-trait.md:35
+msgid "// Uses type-erasure and dynamic dispatch."
+msgstr ""
+
+#: src/generics/dyn-trait.md:56
+msgid ""
+"Generics, including `impl Trait`, use monomorphization to create a "
+"specialized instance of the function for each different type that the "
+"generic is instantiated with. This means that calling a trait method from "
+"within a generic function still uses static dispatch, as the compiler has "
+"full type information and can resolve which type's trait implementation to "
+"use."
+msgstr ""
+
+#: src/generics/dyn-trait.md:62
+msgid ""
+"When using `dyn Trait`, it instead uses dynamic dispatch through a virtual "
+"method table (vtable). This means that there's a single version of `fn "
+"dynamic` that is used regardless of what type of `Pet` is passed in."
+msgstr ""
+
+#: src/generics/dyn-trait.md:67
+msgid ""
+"When using `dyn Trait`, the trait object needs to be behind some kind of "
+"indirection. In this case it's a reference, though smart pointer types like "
+"`Box` can also be used (this will be demonstrated on day 3)."
+msgstr ""
+
+#: src/generics/dyn-trait.md:71
+msgid ""
+"At runtime, a `&dyn Pet` is represented as a \"fat pointer\", i.e. a pair of "
+"two pointers: One pointer points to the concrete object that implements "
+"`Pet`, and the other points to the vtable for the trait implementation for "
+"that type. When calling the `talk` method on `&dyn Pet` the compiler looks "
+"up the function pointer for `talk` in the vtable and then invokes the "
+"function, passing the pointer to the `Dog` or `Cat` into that function. The "
+"compiler doesn't need to know the concrete type of the `Pet` in order to do "
+"this."
+msgstr ""
+
+#: src/generics/dyn-trait.md:79
+msgid ""
+"A `dyn Trait` is considered to be \"type-erased\", because we no longer have "
+"compile-time knowledge of what the concrete type is."
+msgstr ""
+
+#: src/generics/exercise.md:3
 msgid ""
 "In this short exercise, you will implement a generic `min` function that "
-"determines the minimum of two values, using a `LessThan` trait."
+"determines the minimum of two values, using the `Ord` trait."
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
-msgid "/// Return true if self is less than other.\n"
+#: src/generics/exercise.md:8
+msgid "// TODO: implement the `min` function used in `main`."
 msgstr ""
 
-#: src/generics/exercise.md
-msgid "// TODO: implement the `min` function used in `main`.\n"
+#: src/generics/exercise.md:15 src/generics/solution.md:17
+#: src/error-handling/exercise.md:60 src/error-handling/exercise.md:75
+#: src/error-handling/solution.md:60 src/error-handling/solution.md:75
+msgid "'z'"
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
-msgid "\"Shapiro\""
+#: src/generics/exercise.md:16 src/generics/solution.md:18
+msgid "'7'"
 msgstr ""
 
-#: src/generics/exercise.md src/generics/solution.md
-msgid "\"Baumann\""
+#: src/generics/exercise.md:16 src/generics/solution.md:18
+msgid "'1'"
 msgstr ""
 
-#: src/welcome-day-2-afternoon.md
-msgid "[Standard Library Types](./std-types.md) (1 hour and 10 minutes)"
+#: src/generics/exercise.md:18 src/generics/solution.md:20
+msgid "\"goodbye\""
 msgstr ""
 
-#: src/welcome-day-2-afternoon.md
-msgid "[Standard Library Traits](./std-traits.md) (1 hour and 40 minutes)"
+#: src/generics/exercise.md:19 src/generics/solution.md:21
+msgid "\"bat\""
 msgstr ""
 
-#: src/std-types.md
-msgid "[Standard Library](./std-types/std.md) (3 minutes)"
+#: src/generics/exercise.md:19 src/generics/solution.md:21
+msgid "\"armadillo\""
 msgstr ""
 
-#: src/std-types.md
-msgid "[Documentation](./std-types/docs.md) (5 minutes)"
-msgstr ""
-
-#: src/std-types.md
-msgid "[Option](./std-types/option.md) (10 minutes)"
+#: src/generics/exercise.md:26
+msgid "Show students the `Ord` trait and `Ordering` enum."
 msgstr ""
 
 #: src/std-types.md
-msgid "[Result](./std-types/result.md) (10 minutes)"
+msgid "This segment should take about 1 hour and 20 minutes. It contains:"
 msgstr ""
+
+#: src/std-types.md src/std-types/option.md:1
+#, fuzzy
+msgid "Option"
+msgstr "استثناها"
+
+#: src/std-types.md src/std-types/result.md:1
+msgid "Result"
+msgstr ""
+
+#: src/std-types.md src/std-types/string.md:1
+msgid "String"
+msgstr "String"
 
 #: src/std-types.md
-msgid "[String](./std-types/string.md) (10 minutes)"
-msgstr ""
+msgid "Vec"
+msgstr "Vec"
 
 #: src/std-types.md
-msgid "[Vec](./std-types/vec.md) (10 minutes)"
-msgstr ""
-
-#: src/std-types.md
-msgid "[HashMap](./std-types/hashmap.md) (10 minutes)"
-msgstr ""
-
-#: src/std-types.md
-msgid "[Exercise: Counter](./std-types/exercise.md) (10 minutes)"
-msgstr ""
-
-#: src/std-types.md src/memory-management.md src/slices-and-lifetimes.md
-msgid "This segment should take about 1 hour and 10 minutes"
-msgstr ""
+msgid "HashMap"
+msgstr "HashMap"
 
 #: src/std-types.md
 msgid ""
@@ -6214,80 +6121,67 @@ msgid ""
 "documentation pages, highlighting some of the more common methods."
 msgstr ""
 
-#: src/std-types/std.md
+#: src/std-types/std.md:3
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
 "types used by Rust libraries and programs. This way, two libraries can work "
 "together smoothly because they both use the same `String` type."
 msgstr ""
 
-#: src/std-types/std.md
+#: src/std-types/std.md:7
 msgid ""
 "In fact, Rust contains several layers of the Standard Library: `core`, "
 "`alloc` and `std`."
 msgstr ""
 
-#: src/std-types/std.md
+#: src/std-types/std.md:10
 msgid ""
 "`core` includes the most basic types and functions that don't depend on "
 "`libc`, allocator or even the presence of an operating system."
 msgstr ""
 
-#: src/std-types/std.md
+#: src/std-types/std.md:12
 msgid ""
 "`alloc` includes types which require a global heap allocator, such as `Vec`, "
 "`Box` and `Arc`."
 msgstr ""
 
-#: src/std-types/std.md
+#: src/std-types/std.md:14
 msgid ""
 "Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:3
 msgid "Rust comes with extensive documentation. For example:"
 msgstr ""
 
-#: src/std-types/docs.md
-#, fuzzy
-msgid ""
-"All of the details about [loops](https://doc.rust-lang.org/stable/reference/"
-"expressions/loop-expr.html)."
-msgstr ""
-"اگر می‌خواهید زودتر از یک حلقه خارج شوید، از [`break`](https://doc.rust-lang."
-"org/reference/expressions/loop-expr.html#break-expressions) استفاده کنید,"
-
-#: src/std-types/docs.md
-msgid ""
-"Primitive types like [`u8`](https://doc.rust-lang.org/stable/std/primitive."
-"u8.html)."
+#: src/std-types/docs.md:5
+msgid "All of the details about loops."
 msgstr ""
 
-#: src/std-types/docs.md
-msgid ""
-"Standard library types like [`Option`](https://doc.rust-lang.org/stable/std/"
-"option/enum.Option.html) or [`BinaryHeap`](https://doc.rust-lang.org/stable/"
-"std/collections/struct.BinaryHeap.html)."
+#: src/std-types/docs.md:7
+msgid "Primitive types like `u8`."
 msgstr ""
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:9
+msgid "Standard library types like `Option` or `BinaryHeap`."
+msgstr ""
+
+#: src/std-types/docs.md:13
 msgid "In fact, you can document your own code:"
 msgstr ""
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:16
 msgid ""
 "/// Determine whether the first argument is divisible by the second "
-"argument.\n"
-"///\n"
-"/// If the second argument is zero, the result is false.\n"
+"argument. /// /// If the second argument is zero, the result is false."
 msgstr ""
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:27
 #, fuzzy
 msgid ""
 "The contents are treated as Markdown. All published Rust library crates are "
-"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
-"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
+"automatically documented at `docs.rs` using the rustdoc tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
 "محتوا کامنت شده به عنوان `Markdown` در نظر گرفته می‌شود. تمام جعبه‌هایی "
@@ -6297,92 +6191,81 @@ msgstr ""
 "یک API با استفاده از این الگو مستند شود. همچنین میتوان قطعه کدهایی شامل نحوه "
 "استفاده را مستند کرد و به عنوان تست‌های واحد (unit tests) استفاده خواهند شد."
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:32
 msgid ""
 "To document an item from inside the item (such as inside a module), use `//!"
 "` or `/*! .. */`, called \"inner doc comments\":"
 msgstr ""
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:36
 msgid ""
-"//! This module contains functionality relating to divisibility of "
-"integers.\n"
+"//! This module contains functionality relating to divisibility of integers."
 msgstr ""
 
-#: src/std-types/docs.md
+#: src/std-types/docs.md:42
 #, fuzzy
 msgid ""
-"Show students the generated docs for the `rand` crate at <https://docs.rs/"
-"rand>."
+"Show students the generated docs for the `rand` crate at https://docs.rs/"
+"rand."
 msgstr ""
 "دانشجویان را با مستندات تولید شده برای جعبه `rand` در [`docs.rs/rand`]"
 "(https://docs.rs/rand)  آشنا کنید."
 
-#: src/std-types/option.md
-#, fuzzy
-msgid "Option"
-msgstr "استثناها"
-
-#: src/std-types/option.md
+#: src/std-types/option.md:3
 msgid ""
 "We have already seen some use of `Option<T>`. It stores either a value of "
-"type `T` or nothing. For example, [`String::find`](https://doc.rust-lang.org/"
-"stable/std/string/struct.String.html#method.find) returns an `Option<usize>`."
+"type `T` or nothing. For example, `String::find` returns an `Option<usize>`."
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:10
 msgid "\"Löwe 老虎 Léopard Gepardi\""
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:11
 msgid "'é'"
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:12 src/std-types/option.md:15
 msgid "\"find returned {position:?}\""
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:14
 msgid "'Z'"
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:16
 msgid "\"Character not found\""
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:23
 msgid "`Option` is widely used, not just in the standard library."
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:24
 msgid ""
 "`unwrap` will return the value in an `Option`, or panic. `expect` is similar "
 "but takes an error message."
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:26
 msgid ""
 "You can panic on None, but you can't \"accidentally\" forget to check for "
 "None."
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:28
 msgid ""
 "It's common to `unwrap`/`expect` all over the place when hacking something "
 "together, but production code typically handles `None` in a nicer fashion."
 msgstr ""
 
-#: src/std-types/option.md
+#: src/std-types/option.md:30
 msgid ""
 "The niche optimization means that `Option<T>` often has the same size in "
 "memory as `T`."
 msgstr ""
 
-#: src/std-types/result.md
-msgid "Result"
-msgstr ""
-
-#: src/std-types/result.md
+#: src/std-types/result.md:3
 msgid ""
 "`Result` is similar to `Option`, but indicates the success or failure of an "
 "operation, each with a different type. This is similar to the `Res` defined "
@@ -6390,23 +6273,23 @@ msgid ""
 "the `Ok` variant and `E` appears in the `Err` variant."
 msgstr ""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:13
 msgid "\"diary.txt\""
 msgstr ""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:18
 msgid "\"Dear diary: {contents} ({bytes} bytes)\""
 msgstr ""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:20
 msgid "\"Could not read file content\""
 msgstr ""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:24
 msgid "\"The diary could not be opened: {err}\""
 msgstr ""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:33
 msgid ""
 "As with `Option`, the successful value sits inside of `Result`, forcing the "
 "developer to explicitly extract it. This encourages error checking. In the "
@@ -6414,299 +6297,296 @@ msgid ""
 "called, and this is a signal of the developer intent too."
 msgstr ""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:37
 msgid ""
 "`Result` documentation is a recommended read. Not during the course, but it "
 "is worth mentioning. It contains a lot of convenience methods and functions "
 "that help functional-style programming."
 msgstr ""
 
-#: src/std-types/result.md
+#: src/std-types/result.md:40
 msgid ""
 "`Result` is the standard type to implement error handling as we will see on "
-"Day 3."
+"Day 4."
 msgstr ""
 
-#: src/std-types/string.md
-msgid "String"
-msgstr "String"
+#: src/std-types/string.md:3
+#, fuzzy
+msgid "`String` is a growable UTF-8 encoded string:"
+msgstr "`String` یک بافر رشته‌ای قابل تغییر است."
 
-#: src/std-types/string.md
-msgid ""
-"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
-"standard heap-allocated growable UTF-8 string buffer:"
-msgstr ""
-
-#: src/std-types/string.md src/std-traits/read-and-write.md
-#: src/memory-management/review.md src/testing/unit-tests.md
-#: src/concurrency/scoped-threads.md
+#: src/std-types/string.md:8 src/std-traits/read-and-write.md:35
+#: src/memory-management/review.md:23 src/memory-management/review.md:58
+#: src/testing/unit-tests.md:32 src/testing/unit-tests.md:37
+#: src/concurrency/threads/scoped.md:9 src/concurrency/threads/scoped.md:26
 msgid "\"Hello\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:9
 msgid "\"s1: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:13
 msgid "'!'"
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:14
 msgid "\"s2: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:16
 msgid "\"🇨🇭\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:17
 msgid "\"s3: len = {}, number of chars = {}\""
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:21
 msgid ""
-"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
-"string/struct.String.html#deref-methods-str), which means that you can call "
-"all `str` methods on a `String`."
+"`String` implements `Deref<Target = str>`, which means that you can call all "
+"`str` methods on a `String`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:30
 msgid ""
 "`String::new` returns a new empty string, use `String::with_capacity` when "
 "you know how much data you want to push to the string."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:32
 msgid ""
 "`String::len` returns the size of the `String` in bytes (which can be "
 "different from its length in characters)."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:34
 msgid ""
 "`String::chars` returns an iterator over the actual characters. Note that a "
 "`char` can be different from what a human will consider a \"character\" due "
-"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html)."
+"to grapheme clusters."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:37
 msgid ""
 "When people refer to strings they could either be talking about `&str` or "
 "`String`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:39
 msgid ""
 "When a type implements `Deref<Target = T>`, the compiler will let you "
 "transparently call methods from `T`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:41
 msgid ""
 "We haven't discussed the `Deref` trait yet, so at this point this mostly "
 "explains the structure of the sidebar in the documentation."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:43
 msgid ""
 "`String` implements `Deref<Target = str>` which transparently gives it "
 "access to `str`'s methods."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:45
 msgid "Write and compare `let s3 = s1.deref();` and `let s3 = &*s1;`."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:46
 msgid ""
 "`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
 "with some extra guarantees."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:49
 msgid "Compare the different ways to index a `String`:"
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:50
 msgid ""
 "To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
 "out-of-bounds."
 msgstr ""
 
-#: src/std-types/string.md
+#: src/std-types/string.md:52
 msgid ""
 "To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/string.md:54
 msgid ""
-"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
-"resizable heap-allocated buffer:"
+"Many types can be converted to a string with the `to_string` method. This "
+"trait is automatically implemented for all types that implement `Display`, "
+"so anything that can be formatted can also be converted to a string."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:3
+msgid "`Vec` is the standard resizable heap-allocated buffer:"
+msgstr ""
+
+#: src/std-types/vec.md:9
 msgid "\"v1: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:14
 msgid "\"v2: len = {}, capacity = {}\""
 msgstr ""
 
-#: src/std-types/vec.md
-msgid "// Canonical macro to initialize a vector with elements.\n"
+#: src/std-types/vec.md:16
+msgid "// Canonical macro to initialize a vector with elements."
 msgstr ""
 
-#: src/std-types/vec.md
-msgid "// Retain only the even elements.\n"
+#: src/std-types/vec.md:19
+msgid "// Retain only the even elements."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:21 src/std-types/vec.md:25
 msgid "\"{v3:?}\""
 msgstr ""
 
-#: src/std-types/vec.md
-msgid "// Remove consecutive duplicates.\n"
+#: src/std-types/vec.md:23
+msgid "// Remove consecutive duplicates."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
-"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
+"`Vec` implements `Deref<Target = [T]>`, which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:38
 msgid ""
 "`Vec` is a type of collection, along with `String` and `HashMap`. The data "
 "it contains is stored on the heap. This means the amount of data doesn't "
 "need to be known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:41
 msgid ""
 "Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
 "explicitly. As always with Rust type inference, the `T` was established "
 "during the first `push` call."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:44
 msgid ""
 "`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
 "supports adding initial elements to the vector."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:46
 msgid ""
 "To index the vector you use `[` `]`, but they will panic if out of bounds. "
 "Alternatively, using `get` will return an `Option`. The `pop` function will "
 "remove the last element."
 msgstr ""
 
-#: src/std-types/vec.md
+#: src/std-types/vec.md:49
 msgid ""
 "Slices are covered on day 3. For now, students only need to know that a "
 "value of type `Vec` gives access to all of the documented slice methods, too."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:3
 msgid "Standard hash map with protection against HashDoS attacks:"
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:10
 msgid "\"Adventures of Huckleberry Finn\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:11
 msgid "\"Grimms' Fairy Tales\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:12 src/std-types/hashmap.md:21
+#: src/std-types/hashmap.md:29
 msgid "\"Pride and Prejudice\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:14
 msgid "\"Les Misérables\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:16
 msgid "\"We know about {} books, but not Les Misérables.\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:21 src/std-types/hashmap.md:29
 msgid "\"Alice's Adventure in Wonderland\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:23
 msgid "\"{book}: {count} pages\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:24
 msgid "\"{book} is unknown.\""
 msgstr ""
 
-#: src/std-types/hashmap.md
-msgid "// Use the .entry() method to insert a value if nothing is found.\n"
+#: src/std-types/hashmap.md:28
+msgid "// Use the .entry() method to insert a value if nothing is found."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:34
 msgid "\"{page_counts:#?}\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:41
 msgid ""
 "`HashMap` is not defined in the prelude and needs to be brought into scope."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:42
 msgid ""
 "Try the following lines of code. The first line will see if a book is in the "
 "hashmap and if not return an alternative value. The second line will insert "
 "the alternative value in the hashmap if the book is not found."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:48 src/std-types/hashmap.md:60
 msgid "\"Harry Potter and the Sorcerer's Stone\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:51 src/std-types/hashmap.md:61
 msgid "\"The Hunger Games\""
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:54
 msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:55
 msgid ""
-"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
-"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
-"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
-"us to easily initialize a hash map from a literal array:"
+"Although, since Rust 1.56, HashMap implements `From<[(K, V); N]>`, which "
+"allows us to easily initialize a hash map from a literal array:"
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:65
 msgid ""
 "Alternatively HashMap can be built from any `Iterator` which yields key-"
 "value tuples."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:67
 msgid ""
 "We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
 "examples easier. Using references in collections can, of course, be done, "
 "but it can lead into complications with the borrow checker."
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:70
 msgid ""
 "Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
-#: src/std-types/hashmap.md
+#: src/std-types/hashmap.md:73
 msgid ""
 "This type has several \"method-specific\" return types, such as `std::"
 "collections::hash_map::Keys`. These types often appear in searches of the "
@@ -6714,95 +6594,76 @@ msgid ""
 "to the `keys` method."
 msgstr ""
 
-#: src/std-types/exercise.md
+#: src/std-types/exercise.md:3
 msgid ""
 "In this exercise you will take a very simple data structure and make it "
-"generic. It uses a [`std::collections::HashMap`](https://doc.rust-lang.org/"
-"stable/std/collections/struct.HashMap.html) to keep track of which values "
+"generic. It uses a `std::collections::HashMap` to keep track of which values "
 "have been seen and how many times each one has appeared."
 msgstr ""
 
-#: src/std-types/exercise.md
+#: src/std-types/exercise.md:9
 msgid ""
 "The initial version of `Counter` is hard coded to only work for `u32` "
 "values. Make the struct and its methods generic over the type of value being "
 "tracked, that way `Counter` can track any type of value."
 msgstr ""
 
-#: src/std-types/exercise.md
+#: src/std-types/exercise.md:13
 msgid ""
-"If you finish early, try using the [`entry`](https://doc.rust-lang.org/"
-"stable/std/collections/struct.HashMap.html#method.entry) method to halve the "
-"number of hash lookups required to implement the `count` method."
+"If you finish early, try using the `entry` method to halve the number of "
+"hash lookups required to implement the `count` method."
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:20 src/std-types/solution.md:6
 msgid ""
-"/// Counter counts the number of times each value of type T has been seen.\n"
+"/// Counter counts the number of times each value of type T has been seen."
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
-msgid "/// Create a new Counter.\n"
+#: src/std-types/exercise.md:27 src/std-types/solution.md:13
+msgid "/// Create a new Counter."
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
-msgid "/// Count an occurrence of the given value.\n"
+#: src/std-types/exercise.md:34 src/std-types/solution.md:18
+msgid "/// Count an occurrence of the given value."
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
-msgid "/// Return the number of times the given value has been seen.\n"
+#: src/std-types/exercise.md:43 src/std-types/solution.md:23
+msgid "/// Return the number of times the given value has been seen."
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:59 src/std-types/solution.md:39
 msgid "\"saw {} values equal to {}\""
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:63 src/std-types/exercise.md:65
+#: src/std-types/exercise.md:66 src/std-types/solution.md:43
+#: src/std-types/solution.md:45 src/std-types/solution.md:46
 msgid "\"apple\""
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:64 src/std-types/solution.md:44
 msgid "\"orange\""
 msgstr ""
 
-#: src/std-types/exercise.md src/std-types/solution.md
+#: src/std-types/exercise.md:66 src/std-types/solution.md:46
 msgid "\"got {} apples\""
 msgstr ""
 
 #: src/std-traits.md
-msgid "[Comparisons](./std-traits/comparisons.md) (10 minutes)"
+msgid "This segment should take about 1 hour and 40 minutes. It contains:"
 msgstr ""
 
 #: src/std-traits.md
-msgid "[Operators](./std-traits/operators.md) (10 minutes)"
-msgstr ""
+msgid "From and Into"
+msgstr "From و Into"
 
 #: src/std-traits.md
-msgid "[From and Into](./std-traits/from-and-into.md) (10 minutes)"
-msgstr ""
+#, fuzzy
+msgid "Read and Write"
+msgstr "Read and Write"
 
 #: src/std-traits.md
-msgid "[Casting](./std-traits/casting.md) (5 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Read and Write](./std-traits/read-and-write.md) (10 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Default, struct update syntax](./std-traits/default.md) (5 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Closures](./std-traits/closures.md) (20 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "[Exercise: ROT13](./std-traits/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/std-traits.md
-msgid "This segment should take about 1 hour and 40 minutes"
+msgid "Default, struct update syntax"
 msgstr ""
 
 #: src/std-traits.md
@@ -6815,125 +6676,117 @@ msgstr ""
 msgid "This section is long. Take a break midway through."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:3
 msgid ""
 "These traits support comparisons between values. All traits can be derived "
 "for types containing fields that implement these traits."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:6
 msgid "`PartialEq` and `Eq`"
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:8
 msgid ""
 "`PartialEq` is a partial equivalence relation, with required method `eq` and "
 "provided method `ne`. The `==` and `!=` operators will call these methods."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:23
 msgid ""
 "`Eq` is a full equivalence relation (reflexive, symmetric, and transitive) "
 "and implies `PartialEq`. Functions that require full equivalence will use "
 "`Eq` as a trait bound."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:27
 msgid "`PartialOrd` and `Ord`"
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:29
 msgid ""
 "`PartialOrd` defines a partial ordering, with a `partial_cmp` method. It is "
 "used to implement the `<`, `<=`, `>=`, and `>` operators."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:49
 msgid "`Ord` is a total ordering, with `cmp` returning `Ordering`."
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:54
 msgid ""
 "`PartialEq` can be implemented between different types, but `Eq` cannot, "
 "because it is reflexive:"
 msgstr ""
 
-#: src/std-traits/comparisons.md
+#: src/std-traits/comparisons.md:69
 msgid ""
 "In practice, it's common to derive these traits, but uncommon to implement "
 "them."
 msgstr ""
 
-#: src/std-traits/operators.md
-msgid ""
-"Operator overloading is implemented via traits in [`std::ops`](https://doc."
-"rust-lang.org/std/ops/index.html):"
+#: src/std-traits/operators.md:3
+msgid "Operator overloading is implemented via traits in `std::ops`:"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:23
 msgid "\"{:?} + {:?} = {:?}\""
 msgstr ""
 
-#: src/std-traits/operators.md src/memory-management/drop.md
+#: src/std-traits/operators.md:30 src/memory-management/drop.md:48
 msgid "Discussion points:"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:32
 msgid ""
 "You could implement `Add` for `&Point`. In which situations is that useful?"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:33
 msgid ""
 "Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
 "the operator is not `Copy`, you should consider overloading the operator for "
 "`&T` as well. This avoids unnecessary cloning on the call site."
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:36
 msgid ""
 "Why is `Output` an associated type? Could it be made a type parameter of the "
 "method?"
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:38
 msgid ""
 "Short answer: Function type parameters are controlled by the caller, but "
 "associated types (like `Output`) are controlled by the implementer of a "
 "trait."
 msgstr ""
 
-#: src/std-traits/operators.md
+#: src/std-traits/operators.md:41
 msgid ""
 "You could implement `Add` for two different types, e.g. `impl Add<(i32, "
 "i32)> for Point` would add a tuple to a `Point`."
 msgstr ""
 
-#: src/std-traits/from-and-into.md
-msgid ""
-"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
-"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
-"facilitate type conversions:"
+#: src/std-traits/from-and-into.md:3
+msgid "Types implement `From` and `Into` to facilitate type conversions:"
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:11 src/std-traits/from-and-into.md:23
 msgid "\"{s}, {addr}, {one}, {bigger}\""
 msgstr ""
 
-#: src/std-traits/from-and-into.md
-msgid ""
-"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
-"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
-"convert/trait.From.html) is implemented:"
+#: src/std-traits/from-and-into.md:15
+msgid "`Into` is automatically implemented when `From` is implemented:"
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:30
 msgid ""
 "That's why it is common to only implement `From`, as your type will get "
 "`Into` implementation too."
 msgstr ""
 
-#: src/std-traits/from-and-into.md
+#: src/std-traits/from-and-into.md:32
 msgid ""
 "When declaring a function argument input type like \"anything that can be "
 "converted into a `String`\", the rule is opposite, you should use `Into`. "
@@ -6941,32 +6794,32 @@ msgid ""
 "implement `Into`."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:3
 msgid ""
 "Rust has no _implicit_ type conversions, but does support explicit casts "
 "with `as`. These generally follow C semantics where those are defined."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:9
 msgid "\"as u16: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:10
 msgid "\"as i16: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:11
 msgid "\"as u8: {}\""
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:15
 msgid ""
 "The results of `as` are _always_ defined in Rust and consistent across "
 "platforms. This might not match your intuition for changing sign or casting "
 "to a smaller type -- check the docs, and comment for clarity."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:19
 msgid ""
 "Casting with `as` is a relatively sharp tool that is easy to use "
 "incorrectly, and can be a source of subtle bugs as future maintenance work "
@@ -6976,7 +6829,7 @@ msgid ""
 "was in the high bits)."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:25
 msgid ""
 "For infallible casts (e.g. `u32` to `u64`), prefer using `From` or `Into` "
 "over `as` to confirm that the cast is in fact infallible. For fallible "
@@ -6984,238 +6837,227 @@ msgid ""
 "that fit differently from those that don't."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:33
 msgid "Consider taking a break after this slide."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:35
 msgid ""
 "`as` is similar to a C++ static cast. Use of `as` in cases where data might "
 "be lost is generally discouraged, or at least deserves an explanatory "
 "comment."
 msgstr ""
 
-#: src/std-traits/casting.md
+#: src/std-traits/casting.md:38
 msgid "This is common in casting integers to `usize` for use as an index."
 msgstr ""
 
-#: src/std-traits/read-and-write.md
-msgid ""
-"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
-"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
-"abstract over `u8` sources:"
+#: src/std-traits/read-and-write.md:3
+msgid "Using `Read` and `BufRead`, you can abstract over `u8` sources:"
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:14
 msgid "b\"foo\\nbar\\nbaz\\n\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:15
 msgid "\"lines in slice: {}\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:18
 msgid "\"lines in file: {}\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md
-msgid ""
-"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
-"you abstract over `u8` sinks:"
+#: src/std-traits/read-and-write.md:23
+msgid "Similarly, `Write` lets you abstract over `u8` sinks:"
 msgstr ""
 
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:30
 msgid "\"\\n\""
 msgstr ""
 
-#: src/std-traits/read-and-write.md src/slices-and-lifetimes/str.md
-msgid "\"World\""
-msgstr ""
-
-#: src/std-traits/read-and-write.md
+#: src/std-traits/read-and-write.md:37
 msgid "\"Logged: {:?}\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:1
 msgid "The `Default` Trait"
 msgstr ""
 
-#: src/std-traits/default.md
-msgid ""
-"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
-"produces a default value for a type."
+#: src/std-traits/default.md:3
+msgid "`Default` trait produces a default value for a type."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:18
 msgid "\"John Smith\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:24
 msgid "\"{default_struct:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:27
 msgid "\"Y is set!\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:28
 msgid "\"{almost_default_struct:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md src/slices-and-lifetimes/exercise.md
-#: src/slices-and-lifetimes/solution.md
+#: src/std-traits/default.md:31 src/lifetimes/exercise.md:211
+#: src/lifetimes/solution.md:214
 msgid "\"{:#?}\""
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:38
 msgid ""
 "It can be implemented directly or it can be derived via `#[derive(Default)]`."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:39
 msgid ""
 "A derived implementation will produce a value where all fields are set to "
 "their default values."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:41
 msgid "This means all types in the struct must implement `Default` too."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:42
 msgid ""
 "Standard Rust types often implement `Default` with reasonable values (e.g. "
 "`0`, `\"\"`, etc)."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:44
 msgid "The partial struct initialization works nicely with default."
 msgstr ""
 
-#: src/std-traits/default.md
+#: src/std-traits/default.md:45
 msgid ""
 "The Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
 
-#: src/std-traits/default.md
-msgid ""
-"The `..` syntax is called [struct update syntax](https://doc.rust-lang.org/"
-"book/ch05-01-defining-structs.html#creating-instances-from-other-instances-"
-"with-struct-update-syntax)."
+#: src/std-traits/default.md:47
+msgid "The `..` syntax is called struct update syntax."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:3
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
-"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
+"they implement special `Fn`, `FnMut`, and `FnOnce` traits:"
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:10
 #, fuzzy
 msgid "\"Calling function on {input}\""
 msgstr "فراخوانی متدهای ناامن"
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:16 src/std-traits/closures.md:17
 msgid "\"add_3: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:24 src/std-traits/closures.md:25
 msgid "\"accumulate: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:28
 msgid "\"multiply_sum: {}\""
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:35
 msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
 "perhaps captures nothing at all. It can be called multiple times "
 "concurrently."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:38
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
 "multiple times, but not concurrently."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:41
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
 "might consume captured values."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:44
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
 "I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
 "use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:48
 msgid ""
 "When you define a function that takes a closure, you should take `FnOnce` if "
 "you can (i.e. you call it once), or `FnMut` else, and last `Fn`. This allows "
 "the most flexibility for the caller."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:52
 msgid ""
 "In contrast, when you have a closure, the most flexible you can have is `Fn` "
 "(it can be passed everywhere), then `FnMut`, and lastly `FnOnce`."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:55
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
 "`multiply_sum`), depending on what the closure captures."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:58
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
 "keyword makes them capture by value."
 msgstr ""
 
-#: src/std-traits/closures.md
+#: src/std-traits/closures.md:63 src/smart-pointers/trait-objects.md:93
+#: src/smart-pointers/trait-objects.md:94
+msgid "\"{} {}\""
+msgstr ""
+
+#: src/std-traits/closures.md:67
 msgid "\"Hi\""
 msgstr ""
 
-#: src/std-traits/closures.md
-msgid "\"there\""
+#: src/std-traits/closures.md:68
+msgid "\"Greg\""
 msgstr ""
 
-#: src/std-traits/exercise.md
+#: src/std-traits/exercise.md:3
 msgid ""
-"In this example, you will implement the classic [\"ROT13\" cipher](https://"
-"en.wikipedia.org/wiki/ROT13). Copy this code to the playground, and "
-"implement the missing bits. Only rotate ASCII alphabetic characters, to "
-"ensure the result is still valid UTF-8."
+"In this example, you will implement the classic \"ROT13\" cipher. Copy this "
+"code to the playground, and implement the missing bits. Only rotate ASCII "
+"alphabetic characters, to ensure the result is still valid UTF-8."
 msgstr ""
 
-#: src/std-traits/exercise.md
-msgid "// Implement the `Read` trait for `RotDecoder`.\n"
+#: src/std-traits/exercise.md:15
+msgid "// Implement the `Read` trait for `RotDecoder`."
 msgstr ""
 
-#: src/std-traits/exercise.md src/std-traits/solution.md
+#: src/std-traits/exercise.md:20 src/std-traits/exercise.md:33
+#: src/std-traits/solution.md:26 src/std-traits/solution.md:39
 msgid "\"Gb trg gb gur bgure fvqr!\""
 msgstr ""
 
-#: src/std-traits/exercise.md src/std-traits/solution.md
+#: src/std-traits/exercise.md:36 src/std-traits/solution.md:42
 msgid "\"To get to the other side!\""
 msgstr ""
 
-#: src/std-traits/exercise.md
+#: src/std-traits/exercise.md:55
 msgid ""
 "What happens if you chain two `RotDecoder` instances together, each rotating "
 "by 13 characters?"
 msgstr ""
 
-#: src/std-traits/solution.md
+#: src/std-traits/solution.md:16
 msgid "'A'"
 msgstr ""
 
@@ -7238,102 +7080,65 @@ msgid "Smart pointers: standard library pointer types."
 msgstr ""
 
 #: src/welcome-day-3.md
-msgid "[Welcome](./welcome-day-3.md) (3 minutes)"
-msgstr ""
-
-#: src/welcome-day-3.md
-msgid "[Memory Management](./memory-management.md) (1 hour and 10 minutes)"
-msgstr ""
-
-#: src/welcome-day-3.md
-msgid "[Smart Pointers](./smart-pointers.md) (45 minutes)"
-msgstr ""
-
-#: src/welcome-day-3.md
 msgid ""
-"Including 10 minute breaks, this session should take about 2 hours and 15 "
-"minutes"
+"Including 10 minute breaks, this session should take about 2 hours and 20 "
+"minutes. It contains:"
+msgstr ""
+
+#: src/memory-management.md src/memory-management/clone.md:1
+msgid "Clone"
 msgstr ""
 
 #: src/memory-management.md
-msgid "[Review of Program Memory](./memory-management/review.md) (5 minutes)"
-msgstr ""
+#, fuzzy
+msgid "Drop"
+msgstr "رها کردن"
 
-#: src/memory-management.md
-msgid ""
-"[Approaches to Memory Management](./memory-management/approaches.md) (10 "
-"minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Ownership](./memory-management/ownership.md) (5 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Move Semantics](./memory-management/move.md) (10 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Clone](./memory-management/clone.md) (2 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Copy Types](./memory-management/copy-types.md) (5 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Drop](./memory-management/drop.md) (10 minutes)"
-msgstr ""
-
-#: src/memory-management.md
-msgid "[Exercise: Builder Type](./memory-management/exercise.md) (20 minutes)"
-msgstr ""
-
-#: src/memory-management/review.md
+#: src/memory-management/review.md:3
 msgid "Programs allocate memory in two ways:"
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:5
 msgid "Stack: Continuous area of memory for local variables."
 msgstr ""
 "پشته: مقادیر پشت سر هم در حافظه که برای متغییر محلی (داخل یک تابع) استفاده "
 "میشود."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:6
 msgid "Values have fixed sizes known at compile time."
 msgstr ""
 "مقادیر دارای سایز یکسان در طول کل پشته هستند که در زمان کامپایل تعیین می‌شود."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:7
 msgid "Extremely fast: just move a stack pointer."
 msgstr "بسیار سریع: فقط کافیه یک اشاره‌گر را جا به جا کنیم."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:8
 msgid "Easy to manage: follows function calls."
 msgstr "مدیریت آسان: از فراخوانی توابع پیروی میکنند."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:9
 msgid "Great memory locality."
 msgstr "بهره‌وری عالی از حافظه"
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:11
 msgid "Heap: Storage of values outside of function calls."
 msgstr ""
 "انباشت: حافظه از از مقادیر که خارج از جایی که فراخوانی میشود وجود دارد."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:12
 msgid "Values have dynamic sizes determined at runtime."
 msgstr "مقادیر سایز‌های مختلفی دارند که در زمان اجرا تعیین می‌شوند."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:13
 msgid "Slightly slower than the stack: some book-keeping needed."
 msgstr "به طور محسوسی کندتر از پشته است: نیاز به یک چی-کجاست دارد."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:14
 msgid "No guarantee of memory locality."
 msgstr "هیچ تضمینی برای بهره‌وری بالا از حافظه ندارد"
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:18
 msgid ""
 "Creating a `String` puts fixed-sized metadata on the stack and dynamically "
 "sized data, the actual string, on the heap:"
@@ -7341,7 +7146,7 @@ msgstr ""
 "یک `String` بسازید که متادیتا با سایزثابت را روی استک قرار دهد و متن اصلی "
 "سایزپویا را در انباشت قرار دهد."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:44
 msgid ""
 "Mention that a `String` is backed by a `Vec`, so it has a capacity and "
 "length and can grow if mutable via reallocation on the heap."
@@ -7349,12 +7154,12 @@ msgstr ""
 "اشاره کنید که یک `String` بر پایه `Vec` است، بنابراین دارای ظرفیت و طول است "
 "و می تواند در صورت قابل تغییر بودن از طریق تخصیص مجدد در انباش بزرگتر کند."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:47
+#, fuzzy
 msgid ""
 "If students ask about it, you can mention that the underlying memory is heap "
-"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
-"struct.System.html) and custom allocators can be implemented using the "
-"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+"allocated using the System Allocator and custom allocators can be "
+"implemented using the Allocator API"
 msgstr ""
 "اگر دانشجویان در مورد آن بپرسند، می توانید اشاره کنید که حافظه زیربنایی "
 "انباشت (heap) است که با استفاده از [System Allocator](https://doc.rust-lang."
@@ -7362,7 +7167,7 @@ msgstr ""
 "را می‌توان با استفاده از [Allocator API](https://doc.rust-lang.org/std/alloc/"
 "index.html) اجرا کرد."
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:53
 msgid ""
 "We can inspect the memory layout with `unsafe` Rust. However, you should "
 "point out that this is rightfully unsafe!"
@@ -7370,50 +7175,48 @@ msgstr ""
 "می‌توان با استفاده از `unsafe` در زبان راست چیدمان حافظه را بررسی کنیم. البته "
 "که به این موضوع که این کار خیلی ناایمن است هم اشاره کنید."
 
-#: src/memory-management/review.md src/testing/unit-tests.md
+#: src/memory-management/review.md:59 src/testing/unit-tests.md:15
 msgid "' '"
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:60
 msgid "\"world\""
 msgstr ""
 
-#: src/memory-management/review.md
+#: src/memory-management/review.md:61
 msgid ""
-"// DON'T DO THIS AT HOME! For educational purposes only.\n"
-"    // String provides no guarantees about its layout, so this could lead "
-"to\n"
-"    // undefined behavior.\n"
+"// DON'T DO THIS AT HOME! For educational purposes only. // String provides "
+"no guarantees about its layout, so this could lead to // undefined behavior."
 msgstr ""
 
-#: src/memory-management/review.md
-msgid "\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\""
+#: src/memory-management/review.md:66
+msgid "\"capacity = {capacity}, ptr = {ptr:#x}, len = {len}\""
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr "به طور سنتی، زبان‌ها به دو دسته کلی تقسیم می شوند:"
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:5
 msgid "Full control via manual memory management: C, C++, Pascal, ..."
 msgstr ""
 "کنترل کامل از طریق مدیریت دستی حافظه: <span dir=ltr>C، C++</span> ، "
 "پاسکال، ..."
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:6
 msgid "Programmer decides when to allocate or free heap memory."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:7
 msgid ""
 "Programmer must determine whether a pointer still points to valid memory."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:8
 msgid "Studies show, programmers make mistakes."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:9
 msgid ""
 "Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
@@ -7421,45 +7224,45 @@ msgstr ""
 "ایمنی کامل از طریق مدیریت حافظه خودکار در زمان اجرا: جاوا، پایتون، Go، "
 "Haskell، ..."
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:11
 msgid ""
 "A runtime system ensures that memory is not freed until it can no longer be "
 "referenced."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:13
 msgid ""
 "Typically implemented with reference counting, garbage collection, or RAII."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:15
 msgid "Rust offers a new mix:"
 msgstr "زبان Rust یک ترکیبی از هر را ارائه میدهد:"
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:17
 msgid ""
 "Full control _and_ safety via compile time enforcement of correct memory "
 "management."
 msgstr "مدیریت کامل و ایمنی حافظه با مدیریت درست حافظه در زمان کامپایل"
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:20
 msgid "It does this with an explicit ownership concept."
 msgstr "این کار رو با کمک مفهوم مالکیت صریح انجام میدهد."
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:25
 msgid ""
 "This slide is intended to help students coming from other languages to put "
 "Rust in context."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:28
 msgid ""
 "C must manage heap manually with `malloc` and `free`. Common errors include "
 "forgetting to call `free`, calling it multiple times for the same pointer, "
 "or dereferencing a pointer after the memory it points to has been freed."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:32
 msgid ""
 "C++ has tools like smart pointers (`unique_ptr`, `shared_ptr`) that take "
 "advantage of language guarantees about calling destructors to ensure memory "
@@ -7467,7 +7270,7 @@ msgid ""
 "tools and create similar bugs to C."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:37
 msgid ""
 "Java, Go, and Python rely on the garbage collector to identify memory that "
 "is no longer reachable and discard it. This guarantees that any pointer can "
@@ -7475,7 +7278,7 @@ msgid ""
 "GC has a runtime cost and is difficult to tune properly."
 msgstr ""
 
-#: src/memory-management/approaches.md
+#: src/memory-management/approaches.md:42
 msgid ""
 "Rust's ownership and borrowing model can, in many cases, get the performance "
 "of C, with alloc and free operations precisely where they are required -- "
@@ -7485,7 +7288,7 @@ msgid ""
 "(not covered in this class)."
 msgstr ""
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:3
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
 "to use a variable outside its scope:"
@@ -7493,91 +7296,87 @@ msgstr ""
 "همه انتساب متغیر دارای یک *اسکوپ* هستند که در آن معتبر هستند و استفاده از یک "
 "متغیر خارج از اسکوپ آن خطا است."
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:20
 #, fuzzy
 msgid ""
 "We say that the variable _owns_ the value. Every Rust value has precisely "
 "one owner at all times."
 msgstr "ما می‌گوییم که متغیر *مالکیت* یک مقدار است."
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:23
 #, fuzzy
 msgid ""
 "At the end of the scope, the variable is _dropped_ and the data is freed. A "
 "destructor can run here to free up resources."
 msgstr "در پایان اسکوپ، متغیر حذف می‌شود و داده‌ها آزاد می‌شوند."
 
-#: src/memory-management/ownership.md
+#: src/memory-management/ownership.md:29
 msgid ""
 "Students familiar with garbage-collection implementations will know that a "
 "garbage collector starts with a set of \"roots\" to find all reachable "
 "memory. Rust's \"single owner\" principle is a similar idea."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:3
 msgid "An assignment will transfer _ownership_ between variables:"
 msgstr "انتساب, *مالکیت* را بین متغیرها منتقل می‌کند:"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:7
 #, fuzzy
 msgid "\"Hello!\""
 msgstr "سلام دنیا"
 
-#: src/memory-management/move.md src/slices-and-lifetimes/str.md
-msgid "\"s2: {s2}\""
+#: src/memory-management/move.md:10
+msgid "// println!(\"s1: {s1}\");"
 msgstr ""
 
-#: src/memory-management/move.md
-msgid "// println!(\"s1: {s1}\");\n"
-msgstr ""
-
-#: src/memory-management/move.md
+#: src/memory-management/move.md:14
 msgid "The assignment of `s1` to `s2` transfers ownership."
 msgstr "انتساب `s1`به `s2` مالکیت را منتقل می‌کند."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:15
 msgid "When `s1` goes out of scope, nothing happens: it does not own anything."
 msgstr ""
 "زمانی که دیگر در اسکوپ `s1` نیستیم,  هیچ اتفاقی نمی‌افتد: چون `s1` مالک چیزی "
 "نیست."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:16
 msgid "When `s2` goes out of scope, the string data is freed."
 msgstr "زمانی که دیگر در اسکوپ `s2` نیستیم, داده‌های رشته آزاد می‌شوند."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:18
 msgid "Before move to `s2`:"
 msgstr "قبل از انتقال به `s2` :"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:35
 msgid "After move to `s2`:"
 msgstr "بعد از انتقال به `s2` :"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:37
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
-":                           :     :                           :\n"
-":    s1 \"(inaccessible)\"    :     :                           :\n"
-":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
-":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
-":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
-":   | capacity  |     4 |   :  |  :                           :\n"
-":   +-----------+-------+   :  |  :                           :\n"
-":                           :  |  `- - - - - - - - - - - - - -'\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - -.\n"
+":                           :     :                                     :\n"
+":    s1 \"(inaccessible)\"    :     :                                     :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| H  | e  | l  | l  | o  | !  |   :\n"
+":   | len       |     6 |   :  |  :   +----+----+----+----+----+----+   :\n"
+":   | capacity  |     6 |   :  |  :                                     :\n"
+":   +-----------+-------+   :  |  :                                     :\n"
+":                           :  |  `- - - - - - - - - - - - - - - - - - -'\n"
 ":    s2                     :  |\n"
 ":   +-----------+-------+   :  |\n"
 ":   | ptr       |   o---+---+--'\n"
-":   | len       |     4 |   :\n"
-":   | capacity  |     4 |   :\n"
+":   | len       |     6 |   :\n"
+":   | capacity  |     6 |   :\n"
 ":   +-----------+-------+   :\n"
 ":                           :\n"
 "`- - - - - - - - - - - - - -'\n"
 "```"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:58
 msgid ""
 "When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
@@ -7585,20 +7384,21 @@ msgstr ""
 "هنگامی که یک مقدار را به یک تابع منتقل می‌کنید، مقدار به آرگمان تابع اختصاص "
 "داده می‌شود. به این شکل مالکیت را منتقل می‌کند:"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:63 src/memory-management/clone.md:8
 msgid "\"Hello {name}\""
 msgstr ""
 
-#: src/memory-management/move.md src/android/interoperability/java.md
+#: src/memory-management/move.md:67 src/memory-management/clone.md:12
+#: src/android/interoperability/java.md:57
 #, fuzzy
 msgid "\"Alice\""
 msgstr "برش‌ها"
 
-#: src/memory-management/move.md
-msgid "// say_hello(name);\n"
+#: src/memory-management/move.md:69
+msgid "// say_hello(name);"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:76
 msgid ""
 "Mention that this is the opposite of the defaults in C++, which copies by "
 "value unless you use `std::move` (and the move constructor is defined!)."
@@ -7607,7 +7407,7 @@ msgstr ""
 "است که در ان مقدار کپی میشود مگر که از <span dir=ltr>`std::move`</span> "
 "استفاده کنیم ( تا یک مقدار را جا به جا کنیم!)"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:79
 msgid ""
 "It is only the ownership that moves. Whether any machine code is generated "
 "to manipulate the data itself is a matter of optimization, and such copies "
@@ -7617,22 +7417,22 @@ msgstr ""
 "خود داده‌ها تولید می‌شود یا خیر، موضوعی برای بهینه‌سازی است و چنین کپی‌هایی "
 "به‌طور تهاجمی (aggressively) بهینه‌سازی می‌شوند."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:83
 msgid ""
 "Simple values (such as integers) can be marked `Copy` (see later slides)."
 msgstr ""
 "مقادیر ساده (مانند اعداد صحیح) را می‌توان `Copy` کرد (اسلایدهای بعدی را "
 "ببینید)."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:85
 msgid "In Rust, clones are explicit (by using `clone`)."
 msgstr "در Rust، کلون‌ها واضح بیان می‌شوند (با استفاده از `clone`)."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:87
 msgid "In the `say_hello` example:"
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:89
 msgid ""
 "With the first call to `say_hello`, `main` gives up ownership of `name`. "
 "Afterwards, `name` cannot be used anymore within `main`."
@@ -7640,7 +7440,7 @@ msgstr ""
 "با اولین فراخوانی `say_hello`، تابع `main` مالکیت `name` را انتقال می‌دهد. پس "
 "از آن، `name` دیگر نمی‌تواند در `main` استفاده شود."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:91
 msgid ""
 "The heap memory allocated for `name` will be freed at the end of the "
 "`say_hello` function."
@@ -7648,7 +7448,7 @@ msgstr ""
 "حافظه انباشت اختصاص داده شده برای `name` در انتهای تابع `say_hello` آزاد "
 "خواهد شد."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:93
 msgid ""
 "`main` can retain ownership if it passes `name` as a reference (`&name`) and "
 "if `say_hello` accepts a reference as a parameter."
@@ -7657,7 +7457,7 @@ msgstr ""
 "(<span dir=ltr>`&name`</span>) منتقل کند و صد البته که `say_hello` یک مرجع "
 "را به عنوان پارامتر باید بپذیرد."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:95
 msgid ""
 "Alternatively, `main` can pass a clone of `name` in the first call (`name."
 "clone()`)."
@@ -7665,7 +7465,7 @@ msgstr ""
 "به عنوان گزینه دیگر، `main` می‌تواند یک کلون از `name` را در فراخوانی اولیه "
 "تابع ای که در نظر داریم (<span dir=ltr>`name.clone()`</span>) منتقل کند."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:97
 msgid ""
 "Rust makes it harder than C++ to inadvertently create copies by making move "
 "semantics the default, and by forcing programmers to make clones explicit."
@@ -7674,44 +7474,44 @@ msgstr ""
 "زیر به صورت پیش‌فرض از مفهوم «انتقال» استفاده میکنیم و برنامه نویس مجبور است "
 "هر جا که لازم هست به صورت صریح کلون را ایجاد کند."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:102
 msgid "Defensive Copies in Modern C++"
 msgstr "کپی‌های تدافعی در <span dir=ltr>C++</span> مدرن"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:104
 msgid "Modern C++ solves this differently:"
 msgstr "<span dir=ltr>C++</span> مدرن این مشکل را به شیوه متفاوتی حل می‌کند:"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:107
 msgid "\"Cpp\""
 msgstr ""
 
-#: src/memory-management/move.md
-msgid "// Duplicate the data in s1.\n"
+#: src/memory-management/move.md:108
+msgid "// Duplicate the data in s1."
 msgstr ""
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:111
 msgid ""
 "The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
 "داده‌های انباشت از داده‌های `s1`  یک کپی برابر اصل برای  `s2` گرفته می‌شود که "
 "این کپی به صورت مستقل است."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:112
 msgid "When `s1` and `s2` go out of scope, they each free their own memory."
 msgstr ""
 "حالا هر موقع `s1` یا `s2` از اسکوپ موردنظرشون خارج شوند هر کدام به صورت "
 "جداگانه‌ای حافظه خود را آزاد میکنند."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:114
 msgid "Before copy-assignment:"
 msgstr "قبل از انتساب همراه کپی:"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:130
 msgid "After copy-assignment:"
 msgstr "بعد از انتساب همراه کپی:"
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:155
 msgid ""
 "C++ has made a slightly different choice than Rust. Because `=` copies data, "
 "the string data has to be cloned. Otherwise we would get a double-free when "
@@ -7722,13 +7522,13 @@ msgstr ""
 "این صورت، هر موقع از اسکوپ یکی از آنها خارج شویم امکان به وجود آمدن اشتباه "
 "آزادسازی مجدد حافظه رخ دهد."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:159
+#, fuzzy
 msgid ""
-"C++ also has [`std::move`](https://en.cppreference.com/w/cpp/utility/move), "
-"which is used to indicate when a value may be moved from. If the example had "
-"been `s2 = std::move(s1)`, no heap allocation would take place. After the "
-"move, `s1` would be in a valid but unspecified state. Unlike Rust, the "
-"programmer is allowed to keep using `s1`."
+"C++ also has `std::move`, which is used to indicate when a value may be "
+"moved from. If the example had been `s2 = std::move(s1)`, no heap allocation "
+"would take place. After the move, `s1` would be in a valid but unspecified "
+"state. Unlike Rust, the programmer is allowed to keep using `s1`."
 msgstr ""
 "البته که زبان <span dir=ltr>C++</span> دارای  [<span dir=ltr>`std::move`</"
 "span>](https://en.cppreference.com/w/cpp/utility/move)  است که برای انتقال "
@@ -7737,7 +7537,7 @@ msgstr ""
 "نامشخص قرار میگرفت و برخلاف زبان Rust, توی زبان <span dir=ltr>C++</span> "
 "برنامه‌نویس مجاز است که دوباره از `s1` استفاده کند."
 
-#: src/memory-management/move.md
+#: src/memory-management/move.md:164
 msgid ""
 "Unlike Rust, `=` in C++ can run arbitrary code as determined by the type "
 "which is being copied or moved."
@@ -7745,59 +7545,66 @@ msgstr ""
 "بر خلاف Rust، `=` در <span dir=ltr>C++</span> می‌تواند برای کپی کردن و هم "
 "انتقال دادن استفاده شود."
 
-#: src/memory-management/clone.md
-msgid "Clone"
-msgstr ""
-
-#: src/memory-management/clone.md
+#: src/memory-management/clone.md:3
 msgid ""
 "Sometimes you _want_ to make a copy of a value. The `Clone` trait "
 "accomplishes this."
 msgstr ""
 
-#: src/memory-management/clone.md
+#: src/memory-management/clone.md:21
 msgid ""
 "The idea of `Clone` is to make it easy to spot where heap allocations are "
-"occurring. Look for `.clone()` and a few others like `Vec::new` or `Box::"
-"new`."
+"occurring. Look for `.clone()` and a few others like `vec!` or `Box::new`."
 msgstr ""
 
-#: src/memory-management/clone.md
+#: src/memory-management/clone.md:24
 msgid ""
 "It's common to \"clone your way out\" of problems with the borrow checker, "
 "and return later to try to optimize those clones away."
 msgstr ""
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/clone.md:27
+msgid ""
+"`clone` generally performs a deep copy of the value, meaning that if you e."
+"g. clone an array, all of the elements of the array are cloned as well."
+msgstr ""
+
+#: src/memory-management/clone.md:30
+msgid ""
+"The behavior for `clone` is user-defined, so it can perform custom cloning "
+"logic if needed."
+msgstr ""
+
+#: src/memory-management/copy-types.md:3
 msgid ""
 "While move semantics are the default, certain types are copied by default:"
 msgstr ""
 "در حالی که مفهوم انتقال  به صورت پیش‌فرض است، در زبان راست چند نوع خاص به "
 "صورت پیش‌فرض کپی می‌شوند:"
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:16
 msgid "These types implement the `Copy` trait."
 msgstr "این انواع‌داده ویژگی `Copy` را پیاده‌سازی کرده‌اند:"
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:18
 msgid "You can opt-in your own types to use copy semantics:"
 msgstr "البته که میتوان برای نوع‌هایی که میسازید هم مفهوم کپی را داشته باشید:"
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:34
 msgid "After the assignment, both `p1` and `p2` own their own data."
 msgstr "پس از انتساب، هر دو `p1` و `p2` داده‌های خود مستقل خود را دارند.‌"
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:35
 msgid "We can also use `p1.clone()` to explicitly copy the data."
 msgstr ""
 "همچنین می‌توانیم از <span dir=ltr>`p1.clone()`</span>  برای کپی صریح داده‌ها "
 "استفاده کنیم."
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:40
 msgid "Copying and cloning are not the same thing:"
 msgstr "کپی‌برداری و کلون‌سازی یکسان نیستند:"
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:42
 msgid ""
 "Copying refers to bitwise copies of memory regions and does not work on "
 "arbitrary objects."
@@ -7805,14 +7612,14 @@ msgstr ""
 "کپی‌برداری به کپی‌های بیت به بیت از مناطق حافظه اشاره دارد و روی همه انواع "
 "تعریف شده توسط شما کار نمی‌کند."
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:44
 msgid ""
 "Copying does not allow for custom logic (unlike copy constructors in C++)."
 msgstr ""
 "کپی‌برداری اجازه منطق سفارشی را نمی‌دهد (بر خلاف کپی constructors در <span "
 "dir=ltr>C++</span>)."
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:45
 msgid ""
 "Cloning is a more general operation and also allows for custom behavior by "
 "implementing the `Clone` trait."
@@ -7820,16 +7627,16 @@ msgstr ""
 "کلون‌سازی یک عملیات عمومی‌تر است و همچنین با پیاده‌سازی ویژگی `Clone` امکان "
 "رفتار سفارشی را فراهم می‌کند."
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:47
 msgid "Copying does not work on types that implement the `Drop` trait."
 msgstr ""
 "کپی‌برداری روی انواع داده‌ای که ویژگی Drop را پیاده سازی کرده اند کار نمی‌کند."
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:49
 msgid "In the above example, try the following:"
 msgstr "در مثال بالا، موارد زیر را امتحان کنید:"
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:51
 msgid ""
 "Add a `String` field to `struct Point`. It will not compile because `String` "
 "is not a `Copy` type."
@@ -7837,7 +7644,7 @@ msgstr ""
 "یک فیلد `String` به `struct Point` اضافه کنید. کامپایل نمی‌شود زیرا `String` "
 "یک نوع `Copy` نیست."
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:53
 #, fuzzy
 msgid ""
 "Remove `Copy` from the `derive` attribute. The compiler error is now in the "
@@ -7846,73 +7653,82 @@ msgstr ""
 "ویژگی `Copy` را از ویژگی‌های `derive` حذف کنید. خطای کامپایلر اکنون در <span "
 "dir=ltr>`println!`</span> برای  `p1` است."
 
-#: src/memory-management/copy-types.md
+#: src/memory-management/copy-types.md:55
 msgid "Show that it works if you clone `p1` instead."
 msgstr "نشان دهید که اگر `p1` را به جای کپی آن کلون کنید، کار می‌کند."
 
-#: src/memory-management/drop.md
+#: src/memory-management/copy-types.md:59
+msgid ""
+"Shared references are `Copy`/`Clone`, mutable references are not. This is "
+"because rust requires that mutable references be exclusive, so while it's "
+"valid to make a copy of a shared reference, creating a copy of a mutable "
+"reference would violate Rust's borrowing rules."
+msgstr ""
+
+#: src/memory-management/drop.md:1
 msgid "The `Drop` Trait"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:3
 msgid ""
-"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
-"html) can specify code to run when they go out of scope:"
+"Values which implement `Drop` can specify code to run when they go out of "
+"scope:"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:13
 msgid "\"Dropping {}\""
 msgstr ""
 
-#: src/memory-management/drop.md src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/memory-management/drop.md:18
+#: src/concurrency/sync-exercises/link-checker.md:85
+#: src/concurrency/sync-exercises/solutions.md:121
 msgid "\"a\""
 msgstr ""
 
-#: src/memory-management/drop.md src/testing/googletest.md
+#: src/memory-management/drop.md:20 src/android/testing/googletest.md:12
 msgid "\"b\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:22
 msgid "\"c\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:23
 msgid "\"d\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:24
 msgid "\"Exiting block B\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:26
 msgid "\"Exiting block A\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:29
 msgid "\"Exiting main\""
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:36
 msgid "Note that `std::mem::drop` is not the same as `std::ops::Drop::drop`."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:37
 msgid "Values are automatically dropped when they go out of scope."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:38
 msgid ""
 "When a value is dropped, if it implements `std::ops::Drop` then its `Drop::"
 "drop` implementation will be called."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:40
 msgid ""
 "All its fields will then be dropped too, whether or not it implements `Drop`."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:41
 msgid ""
 "`std::mem::drop` is just an empty function that takes any value. The "
 "significance is that it takes ownership of the value, so at the end of its "
@@ -7920,183 +7736,172 @@ msgid ""
 "values earlier than they would otherwise go out of scope."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:45
 msgid ""
 "This can be useful for objects that do some work on `drop`: releasing locks, "
 "closing files, etc."
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:50
 msgid "Why doesn't `Drop::drop` take `self`?"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:51
 msgid ""
 "Short-answer: If it did, `std::mem::drop` would be called at the end of the "
 "block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
 
-#: src/memory-management/drop.md
+#: src/memory-management/drop.md:53
 msgid "Try replacing `drop(a)` with `a.drop()`."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:3
 msgid ""
 "In this example, we will implement a complex data type that owns all of its "
 "data. We will use the \"builder pattern\" to support building a new value "
 "piece-by-piece, using convenience functions."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:7
 msgid "Fill in the missing pieces."
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
-msgid "/// A representation of a software package.\n"
+#: src/memory-management/exercise.md:22 src/memory-management/solution.md:16
+msgid "/// A representation of a software package."
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:34 src/memory-management/solution.md:28
 msgid ""
-"/// Return a representation of this package as a dependency, for use in\n"
-"    /// building other packages.\n"
+"/// Return a representation of this package as a dependency, for use in /// "
+"building other packages."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:37
 msgid "\"1\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:40 src/memory-management/solution.md:37
 msgid ""
-"/// A builder for a Package. Use `build()` to create the `Package` itself.\n"
+"/// A builder for a Package. Use `build()` to create the `Package` itself."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:46
 msgid "\"2\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
-msgid "/// Set the package version.\n"
+#: src/memory-management/exercise.md:49 src/memory-management/solution.md:52
+msgid "/// Set the package version."
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
-msgid "/// Set the package authors.\n"
+#: src/memory-management/exercise.md:55 src/memory-management/solution.md:58
+msgid "/// Set the package authors."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:57
 msgid "\"3\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
-msgid "/// Add an additional dependency.\n"
+#: src/memory-management/exercise.md:60 src/memory-management/solution.md:64
+msgid "/// Add an additional dependency."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:62
 msgid "\"4\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
-msgid "/// Set the language. If not set, language defaults to None.\n"
+#: src/memory-management/exercise.md:65 src/memory-management/solution.md:70
+msgid "/// Set the language. If not set, language defaults to None."
 msgstr ""
 
-#: src/memory-management/exercise.md
+#: src/memory-management/exercise.md:67
 msgid "\"5\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
 msgid "\"base64\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:76 src/memory-management/solution.md:82
 msgid "\"0.13\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:77 src/memory-management/solution.md:83
 msgid "\"base64: {base64:?}\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
 msgid "\"log\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:79 src/memory-management/solution.md:85
 msgid "\"0.4\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:80 src/memory-management/solution.md:86
 msgid "\"log: {log:?}\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:81 src/memory-management/solution.md:87
 msgid "\"serde\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:82 src/memory-management/solution.md:88
 msgid "\"djmitche\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:83 src/memory-management/solution.md:89
 msgid "\"4.0\""
 msgstr ""
 
-#: src/memory-management/exercise.md src/memory-management/solution.md
+#: src/memory-management/exercise.md:87 src/memory-management/solution.md:93
 msgid "\"serde: {serde:?}\""
 msgstr ""
 
-#: src/memory-management/solution.md
+#: src/memory-management/solution.md:45
 msgid "\"0.1\""
 msgstr ""
 
 #: src/smart-pointers.md
-msgid "[Box"
+msgid "Box<T>"
 msgstr ""
 
 #: src/smart-pointers.md
-msgid "](./smart-pointers/box.md) (10 minutes)"
+msgid "Rc"
+msgstr "Rc"
+
+#: src/smart-pointers/box.md:3
+msgid "`Box` is an owned pointer to data on the heap:"
 msgstr ""
 
-#: src/smart-pointers.md
-msgid "[Rc](./smart-pointers/rc.md) (5 minutes)"
-msgstr ""
-
-#: src/smart-pointers.md
-msgid "[Exercise: Binary Tree](./smart-pointers/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/smart-pointers/box.md
-msgid ""
-"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
-"pointer to data on the heap:"
-msgstr ""
-
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:9
 msgid "\"five: {}\""
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:26
 msgid ""
-"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
-"trait.Deref.html#more-on-deref-coercion)."
+"`Box<T>` implements `Deref<Target = T>`, which means that you can call "
+"methods from `T` directly on a `Box<T>`."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:30
 msgid ""
 "Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
-#: src/smart-pointers/box.md
-msgid "/// A non-empty list: first element and the rest of the list.\n"
+#: src/smart-pointers/box.md:35
+msgid "/// A non-empty list: first element and the rest of the list."
 msgstr ""
 
-#: src/smart-pointers/box.md
-msgid "/// An empty list.\n"
+#: src/smart-pointers/box.md:37
+msgid "/// An empty list."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:44
 msgid "\"{list:?}\""
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:48
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
@@ -8118,137 +7923,253 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:64
 msgid ""
 "`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
 "not null."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:66
 msgid "A `Box` can be useful when you:"
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:67
 msgid ""
 "have a type whose size that can't be known at compile time, but the Rust "
 "compiler wants to know an exact size."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:69
 msgid ""
 "want to transfer ownership of a large amount of data. To avoid copying large "
 "amounts of data on the stack, instead store the data on the heap in a `Box` "
 "so only the pointer is moved."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:73
 msgid ""
 "If `Box` was not used and we attempted to embed a `List` directly into the "
-"`List`, the compiler would not compute a fixed size of the struct in memory "
-"(`List` would be of infinite size)."
+"`List`, the compiler would not be able to compute a fixed size for the "
+"struct in memory (the `List` would be of infinite size)."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:77
 msgid ""
 "`Box` solves this problem as it has the same size as a regular pointer and "
 "just points at the next element of the `List` in the heap."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:80
 msgid ""
-"Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly."
+"Remove the `Box` in the List definition and show the compiler error. We get "
+"the message \"recursive without indirection\", because for data recursion, "
+"we have to use indirection, a `Box` or reference of some kind, instead of "
+"storing the value directly."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:87
 msgid "Niche Optimization"
 msgstr "بهینه سازی Niche"
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:89
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
-"allows the compiler to optimize the memory layout:"
+"Though `Box` looks like `std::unique_ptr` in C++, it cannot be empty/null. "
+"This makes `Box` one of the types that allow the compiler to optimize "
+"storage of some enums."
 msgstr ""
 
-#: src/smart-pointers/box.md
+#: src/smart-pointers/box.md:93
 msgid ""
-"```bob\n"
-" Stack                           Heap\n"
-".- - - - - - - - - - - - - - .     .- - - - - - - - - - - - - -.\n"
-":                            :     :                           :\n"
-":    list                    :     :                           :\n"
-":   +---------+----+----+    :     :    +---------+----+----+  :\n"
-":   | Element | 1  | o--+----+-----+--->| Element | 2  | // |  :\n"
-":   +---------+----+----+    :     :    +---------+----+----+  :\n"
-":                            :     :                           :\n"
-":                            :     :                           :\n"
-"'- - - - - - - - - - - - - - '     '- - - - - - - - - - - - - -'\n"
-"```"
+"For example, `Option<Box<T>>` has the same size, as just `Box<T>`, because "
+"compiler uses NULL-value to discriminate variants instead of using explicit "
+"tag (\"Null Pointer Optimization\"):"
 msgstr ""
 
-#: src/smart-pointers/rc.md
-msgid ""
-"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
-"counted shared pointer. Use this when you need to refer to the same data "
-"from multiple places:"
+#: src/smart-pointers/box.md:103
+msgid "\"Just box\""
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/box.md:105
+#, fuzzy
+msgid "\"Optional box\""
+msgstr "استثناها"
+
+#: src/smart-pointers/box.md:111
+msgid "\"Size of just_box: {}\""
+msgstr ""
+
+#: src/smart-pointers/box.md:112
+msgid "\"Size of optional_box: {}\""
+msgstr ""
+
+#: src/smart-pointers/box.md:113
+msgid "\"Size of none: {}\""
+msgstr ""
+
+#: src/smart-pointers/rc.md:3
+msgid ""
+"`Rc` is a reference-counted shared pointer. Use this when you need to refer "
+"to the same data from multiple places:"
+msgstr ""
+
+#: src/smart-pointers/rc.md:13
 msgid "\"a: {a}\""
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:14
 msgid "\"b: {b}\""
 msgstr ""
 
-#: src/smart-pointers/rc.md
-msgid ""
-"See [`Arc`](../concurrency/shared_state/arc.md) and [`Mutex`](https://doc."
-"rust-lang.org/std/sync/struct.Mutex.html) if you are in a multi-threaded "
-"context."
+#: src/smart-pointers/rc.md:18
+msgid "See `Arc` and `Mutex` if you are in a multi-threaded context."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:19
 msgid ""
-"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
-"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+"You can _downgrade_ a shared pointer into a `Weak` pointer to create cycles "
+"that will get dropped."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:30
 msgid ""
 "`Rc`'s count ensures that its contained value is valid for as long as there "
 "are references."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:32
 msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:33
 msgid ""
 "`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
 "be ignored when looking for performance issues in code."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:36
 msgid ""
 "`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
 "and returns a mutable reference."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:38
 msgid "Use `Rc::strong_count` to check the reference count."
 msgstr ""
 
-#: src/smart-pointers/rc.md
+#: src/smart-pointers/rc.md:39
 msgid ""
 "`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
 "cycles that will be dropped properly (likely in combination with `RefCell`)."
 msgstr ""
 
-#: src/smart-pointers/exercise.md
+#: src/smart-pointers/trait-objects.md:3
+msgid ""
+"We previously saw how trait objects can be used with references, e.g `&dyn "
+"Pet`. However, we can also use trait objects with smart pointers like `Box` "
+"to create an owned trait object: `Box<dyn Pet>`."
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:43
+msgid "Memory layout after allocating `pets`:"
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:45
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                           :     :                                             :\n"
+":    \"pets: Vec<dyn Pet>\"   :     :   \"data: Cat\"         +----+----+----"
+"+----+ :\n"
+":   +-----------+-------+   :     :  +-------+-------+    | F  | i  | d  | "
+"o  | :\n"
+":   | ptr       |   o---+---+--.  :  | lives |     9 |    +----+----+----"
+"+----+ :\n"
+":   | len       |     2 |   :  |  :  +-------+-------+      "
+"^                   :\n"
+":   | capacity  |     2 |   :  |  :       ^                 "
+"|                   :\n"
+":   +-----------+-------+   :  |  :       |                 "
+"'-------.           :\n"
+":                           :  |  :       |               data:"
+"\"Dog\"|           :\n"
+":                           :  |  :       |              +-------+--|-------"
+"+   :\n"
+"`- - - - - - - - - - - - - -'  |  :   +---|-+-----+      | name  |  o, 4, 4 "
+"|   :\n"
+"                               `--+-->| o o | o o-|----->| age   |        5 "
+"|   :\n"
+"                                  :   +-|---+-|---+      +-------+----------"
+"+   :\n"
+"                                  :     |     "
+"|                                 :\n"
+"                                  `- - -| - - |- - - - - - - - - - - - - - - "
+"- -'\n"
+"                                        |     |\n"
+"                                        |     |                      "
+"\"Program text\"\n"
+"                                  .- - -| - - |- - - - - - - - - - - - - - - "
+"- -.\n"
+"                                  :     |     |       "
+"vtable                    :\n"
+"                                  :     |     |      +----------------------"
+"+   :\n"
+"                                  :     |     `----->| \"<Dog as Pet>::"
+"talk\" |   :\n"
+"                                  :     |            +----------------------"
+"+   :\n"
+"                                  :     |             "
+"vtable                    :\n"
+"                                  :     |            +----------------------"
+"+   :\n"
+"                                  :     '----------->| \"<Cat as Pet>::"
+"talk\" |   :\n"
+"                                  :                  +----------------------"
+"+   :\n"
+"                                  :                                             :\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:80
+msgid ""
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<dyn Pet>` in the example above."
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:82
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:84
+msgid ""
+"In the example, `pets` is allocated on the stack and the vector data is on "
+"the heap. The two vector elements are _fat pointers_:"
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:86
+msgid ""
+"A fat pointer is a double-width pointer. It has two components: a pointer to "
+"the actual object and a pointer to the virtual method table (vtable) for the "
+"`Pet` implementation of that particular object."
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:89
+msgid ""
+"The data for the `Dog` named Fido is the `name` and `age` fields. The `Cat` "
+"has a `lives` field."
+msgstr ""
+
+#: src/smart-pointers/trait-objects.md:91
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/smart-pointers/exercise.md:3
 msgid ""
 "A binary tree is a tree-type data structure where every node has two "
 "children (left and right). We will create a tree where each node stores a "
@@ -8256,161 +8177,136 @@ msgid ""
 "values, and all nodes in N's right subtree will contain larger values."
 msgstr ""
 
-#: src/smart-pointers/exercise.md
+#: src/smart-pointers/exercise.md:8
 msgid "Implement the following types, so that the given tests pass."
 msgstr ""
 
-#: src/smart-pointers/exercise.md
+#: src/smart-pointers/exercise.md:10
 msgid ""
 "Extra Credit: implement an iterator over a binary tree that returns the "
 "values in order."
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
-msgid "/// A node in the binary tree.\n"
+#: src/smart-pointers/exercise.md:14 src/smart-pointers/solution.md:5
+msgid "/// A node in the binary tree."
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
-msgid "/// A possibly-empty subtree.\n"
+#: src/smart-pointers/exercise.md:21 src/smart-pointers/solution.md:13
+msgid "/// A possibly-empty subtree."
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
+#: src/smart-pointers/exercise.md:25 src/smart-pointers/solution.md:17
 msgid ""
-"/// A container storing a set of values, using a binary tree.\n"
-"///\n"
-"/// If the same value is added multiple times, it is only stored once.\n"
+"/// A container storing a set of values, using a binary tree. /// /// If the "
+"same value is added multiple times, it is only stored once."
 msgstr ""
 
-#: src/smart-pointers/exercise.md
-msgid "// Implement `new`, `insert`, `len`, and `has`.\n"
+#: src/smart-pointers/exercise.md:51
+msgid "// Implement `new`, `insert`, `len`, and `has` for `Subtree`."
 msgstr ""
 
-#: src/smart-pointers/exercise.md src/smart-pointers/solution.md
-msgid "// not a unique item\n"
+#: src/smart-pointers/exercise.md:66 src/smart-pointers/solution.md:105
+msgid "// not a unique item"
 msgstr ""
 
-#: src/smart-pointers/solution.md src/testing/googletest.md
+#: src/smart-pointers/solution.md:89 src/android/testing/googletest.md:11
 msgid "\"bar\""
 msgstr ""
 
 #: src/welcome-day-3-afternoon.md
-msgid "[Borrowing](./borrowing.md) (1 hour)"
-msgstr ""
-
-#: src/welcome-day-3-afternoon.md
 msgid ""
-"[Slices and Lifetimes](./slices-and-lifetimes.md) (1 hour and 10 minutes)"
+"Including 10 minute breaks, this session should take about 1 hour and 55 "
+"minutes. It contains:"
 msgstr ""
 
-#: src/welcome-day-3-afternoon.md
-msgid ""
-"Including 10 minute breaks, this session should take about 2 hours and 20 "
-"minutes"
-msgstr ""
-
-#: src/borrowing.md
-msgid "[Borrowing a Value](./borrowing/shared.md) (10 minutes)"
-msgstr ""
-
-#: src/borrowing.md
-msgid "[Borrow Checking](./borrowing/borrowck.md) (10 minutes)"
-msgstr ""
-
-#: src/borrowing.md
-msgid "[Interior Mutability](./borrowing/interior-mutability.md) (10 minutes)"
-msgstr ""
-
-#: src/borrowing.md
-msgid "[Exercise: Health Statistics](./borrowing/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:3
 msgid ""
 "As we saw before, instead of transferring ownership when calling a function, "
 "you can let a function _borrow_ the value:"
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:24
 msgid "The `add` function _borrows_ two points and returns a new point."
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:25
 msgid "The caller retains ownership of the inputs."
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:30
 msgid ""
 "This slide is a review of the material on references from day 1, expanding "
 "slightly to include function arguments and return values."
 msgstr ""
 
-#: src/borrowing/shared.md
-msgid "Notes on stack returns:"
+#: src/borrowing/shared.md:35
+msgid "Notes on stack returns and inlining:"
 msgstr ""
 
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:37
 msgid ""
 "Demonstrate that the return from `add` is cheap because the compiler can "
-"eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground](https://play.rust-lang.org/?"
-"version=stable&mode=release&edition=2021&gist=0cb13be1c05d7e3446686ad9947c4671) "
-"or look at the assembly in [Godbolt](https://rust.godbolt.org/). In the "
-"\"DEBUG\" optimization level, the addresses should change, while they stay "
-"the same when changing to the \"RELEASE\" setting:"
+"eliminate the copy operation, by inlining the call to add into main. Change "
+"the above code to print stack addresses and run it on the Playground or look "
+"at the assembly in Godbolt. In the \"DEBUG\" optimization level, the "
+"addresses should change, while they stay the same when changing to the "
+"\"RELEASE\" setting:"
 msgstr ""
 
-#: src/borrowing/shared.md
-msgid "The Rust compiler can do return value optimization (RVO)."
-msgstr ""
-
-#: src/borrowing/shared.md
+#: src/borrowing/shared.md:63
 msgid ""
-"In C++, copy elision has to be defined in the language specification because "
-"constructors can have side effects. In Rust, this is not an issue at all. If "
-"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
-"copy."
+"The Rust compiler can do automatic inlining, that can be disabled on a "
+"function level with `#[inline(never)]`."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/shared.md:65
+msgid ""
+"Once disabled, the printed address will change on all optimization levels. "
+"Looking at Godbolt or Playground, one can see that in this case, the return "
+"of the value depends on the ABI, e.g. on amd64 the two i32 that is making up "
+"the point will be returned in 2 registers (eax and edx)."
+msgstr ""
+
+#: src/borrowing/borrowck.md:3
 msgid ""
 "Rust's _borrow checker_ puts constraints on the ways you can borrow values. "
 "For a given value, at any time:"
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:6
 msgid "You can have one or more shared references to the value, _or_"
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:7
 msgid "You can have exactly one exclusive reference to the value."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:29
 msgid ""
 "Note that the requirement is that conflicting references not _exist_ at the "
 "same point. It does not matter where the reference is dereferenced."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:31
 msgid ""
 "The above code does not compile because `a` is borrowed as mutable (through "
 "`c`) and as immutable (through `b`) at the same time."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:33
 msgid ""
 "Move the `println!` statement for `b` before the scope that introduces `c` "
 "to make the code compile."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:35
 msgid ""
 "After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:38
 msgid ""
 "The exclusive reference constraint is quite strong. Rust uses it to ensure "
 "that data races do not occur. Rust also _relies_ on this constraint to "
@@ -8418,7 +8314,7 @@ msgid ""
 "cached in a register for the lifetime of that reference."
 msgstr ""
 
-#: src/borrowing/borrowck.md
+#: src/borrowing/borrowck.md:42
 msgid ""
 "The borrow checker is designed to accommodate many common patterns, such as "
 "taking exclusive references to different fields in a struct at the same "
@@ -8426,51 +8322,80 @@ msgid ""
 "this often results in \"fighting with the borrow checker.\""
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/examples.md:3
+msgid ""
+"As a concrete example of how these borrowing rules prevent memory errors, "
+"consider the case of modifying a collection while there are references to "
+"its elements:"
+msgstr ""
+
+#: src/borrowing/examples.md:12
+msgid "\"{elem}\""
+msgstr ""
+
+#: src/borrowing/examples.md:16
+msgid "Similarly, consider the case of iterator invalidation:"
+msgstr ""
+
+#: src/borrowing/examples.md:30
+msgid ""
+"In both of these cases, modifying the collection by pushing new elements "
+"into it can potentially invalidate existing references to the collection's "
+"elements if the collection has to reallocate."
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:3
 msgid ""
 "In some situations, it's necessary to modify data behind a shared (read-"
 "only) reference. For example, a shared data structure might have an internal "
 "cache, and wish to update that cache from read-only methods."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:7
 msgid ""
 "The \"interior mutability\" pattern allows exclusive (mutable) access behind "
 "a shared reference. The standard library provides several ways to do this, "
 "all while still ensuring safety, typically by performing a runtime check."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:11
 msgid "`RefCell`"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
-msgid "\"graph: {root:#?}\""
+#: src/borrowing/interior-mutability.md:17
+#: src/borrowing/interior-mutability.md:43
+msgid "// Note that `cell` is NOT declared as mutable."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
-msgid "\"graph sum: {}\""
+#: src/borrowing/interior-mutability.md:24
+msgid ""
+"// This triggers an error at runtime. // let other = cell.borrow(); // "
+"println!(\"{}\", \\*other);"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:29
+msgid "\"{cell:?}\""
+msgstr ""
+
+#: src/borrowing/interior-mutability.md:33
 msgid "`Cell`"
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:35
 msgid ""
 "`Cell` wraps a value and allows getting or setting the value, even with a "
 "shared reference to the `Cell`. However, it does not allow any references to "
 "the value. Since there are no references, borrowing rules cannot be broken."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:54
 msgid ""
 "The main thing to take away from this slide is that Rust provides _safe_ "
 "ways to modify data behind a shared reference. There are a variety of ways "
 "to ensure that safety, and `RefCell` and `Cell` are two of them."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:58
 msgid ""
 "`RefCell` enforces Rust's usual borrowing rules (either multiple shared "
 "references or a single exclusive reference) with a runtime check. In this "
@@ -8478,301 +8403,67 @@ msgid ""
 "succeed."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:63
 msgid ""
-"`Rc` only allows shared (read-only) access to its contents, since its "
-"purpose is to allow (and count) many references. But we want to modify the "
-"value, so we need interior mutability."
+"The extra block in the `RefCell` example is to end the borrow created by the "
+"call to `borrow_mut` before we print the cell. Trying to print a borrowed "
+"`RefCell` just shows the message `\"{borrowed}\"`."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
+#: src/borrowing/interior-mutability.md:67
 msgid ""
 "`Cell` is a simpler means to ensure safety: it has a `set` method that takes "
 "`&self`. This needs no runtime check, but requires moving values, which can "
 "have its own cost."
 msgstr ""
 
-#: src/borrowing/interior-mutability.md
-msgid ""
-"Demonstrate that reference loops can be created by adding `root` to `subtree."
-"children`."
-msgstr ""
-
-#: src/borrowing/interior-mutability.md
-msgid ""
-"To demonstrate a runtime panic, add a `fn inc(&mut self)` that increments "
-"`self.value` and calls the same method on its children. This will panic in "
-"the presence of the reference loop, with `thread 'main' panicked at 'already "
-"borrowed: BorrowMutError'`."
-msgstr ""
-
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:3
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
 "you need to keep track of users' health statistics."
 msgstr ""
 
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:6
 msgid ""
 "You'll start with a stubbed function in an `impl` block as well as a `User` "
 "struct definition. Your goal is to implement the stubbed out method on the "
 "`User` `struct` defined in the `impl` block."
 msgstr ""
 
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:10
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
+"Copy the code below to https://play.rust-lang.org/ and fill in the missing "
 "method:"
 msgstr ""
 "کد زیر را در <span dir=ltr><https://play.rust-lang.org/></span> کپی کرده و "
 "توابع را پیاده‌سازی کنید:"
 
-#: src/borrowing/exercise.md
+#: src/borrowing/exercise.md:45
 msgid ""
 "\"Update a user's statistics based on measurements from a visit to the "
 "doctor\""
 msgstr ""
 
-#: src/borrowing/exercise.md src/borrowing/solution.md
-#: src/android/build-rules/library.md src/android/aidl/client.md
+#: src/borrowing/exercise.md:50 src/borrowing/exercise.md:56
+#: src/borrowing/exercise.md:60 src/borrowing/solution.md:52
+#: src/borrowing/solution.md:58 src/borrowing/solution.md:62
+#: src/android/build-rules/library.md:44
+#: src/android/aidl/example-service/client.md:15
 msgid "\"Bob\""
 msgstr ""
 
-#: src/borrowing/exercise.md src/borrowing/solution.md
+#: src/borrowing/exercise.md:51 src/borrowing/solution.md:53
 msgid "\"I'm {} and my age is {}\""
 msgstr ""
 
-#: src/slices-and-lifetimes.md
-msgid "[Slices: &\\[T\\]](./slices-and-lifetimes/slices.md) (10 minutes)"
-msgstr ""
-
-#: src/slices-and-lifetimes.md
-msgid "[String References](./slices-and-lifetimes/str.md) (10 minutes)"
-msgstr ""
-
-#: src/slices-and-lifetimes.md
-msgid ""
-"[Lifetime Annotations](./slices-and-lifetimes/lifetime-annotations.md) (10 "
-"minutes)"
-msgstr ""
-
-#: src/slices-and-lifetimes.md
-msgid ""
-"[Lifetime Elision](./slices-and-lifetimes/lifetime-elision.md) (5 minutes)"
-msgstr ""
-
-#: src/slices-and-lifetimes.md
-msgid ""
-"[Struct Lifetimes](./slices-and-lifetimes/struct-lifetimes.md) (5 minutes)"
-msgstr ""
-
-#: src/slices-and-lifetimes.md
-msgid ""
-"[Exercise: Protobuf Parsing](./slices-and-lifetimes/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/slices-and-lifetimes/slices.md
-msgid "Slices"
-msgstr "برش‌ها"
-
-#: src/slices-and-lifetimes/slices.md
-msgid "A slice gives you a view into a larger collection:"
-msgstr "یک برش به شما امکان می‌دهد نما (view) از یک مجموعه بزرگتر داشته باشید:"
-
-#: src/slices-and-lifetimes/slices.md
-msgid "Slices borrow data from the sliced type."
-msgstr "برش‌ها داده‌ها را از نوع برش‌شده قرض می‌گیرند."
-
-#: src/slices-and-lifetimes/slices.md
-msgid "Question: What happens if you modify `a[3]` right before printing `s`?"
-msgstr ""
-"پرسش: اگر <span dir=ltr>`a[3]`</span> را درست قبل از چاپ <span dir=ltr>`s`</"
-"span> تغییر دهید چه اتفاقی می‌افتد؟"
-
-#: src/slices-and-lifetimes/slices.md
-msgid ""
-"We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets."
-msgstr ""
-"ما با قرض گرفتن <span dir=ltr>`a`</span> و مشخص کردن شاخص‌های شروع و پایان در "
-"براکت‌ها، برش (slice) ایجاد می‌کنیم."
-
-#: src/slices-and-lifetimes/slices.md
-msgid ""
-"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
-"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical."
-msgstr ""
-"اگر برش از شاخص ۰ شروع شود، سینتکس راست به ما اجازه می‌دهد شاخص شروع را حذف "
-"کنیم (یعنی عدد صفر را  ننویسیم)، به این معنی که <span dir=ltr>`&a[0..a."
-"len()]`</span>  و <span dir=ltr>`&a[..a.len()]`</span> یکسان  هستند."
-
-#: src/slices-and-lifetimes/slices.md
-msgid ""
-"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical."
-msgstr ""
-"در مورد شاخص آخر نیز همینطور است، بنابراین <span dir=ltr>`&a[2..a.len()]`</"
-"span> و <span dir=ltr>`&a[2..]`</span>  یکسان هستند."
-
-#: src/slices-and-lifetimes/slices.md
-msgid ""
-"To easily create a slice of the full array, we can therefore use `&a[..]`."
-msgstr ""
-"یک روش ساده برای برش کل آرایه، این است که از <span dir=ltr>`&a[..]`</span> "
-"استفاده کنیم."
-
-#: src/slices-and-lifetimes/slices.md
-msgid ""
-"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
-"(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes."
-msgstr ""
-"<span dir=ltr>`s`</span> یک مرجع به برش i32 است. توجه داشته باشید که نوع "
-"<span dir=ltr>`s`</span> (<span dir=ltr>`&[i32]`</span>) دیگر طول آرایه را "
-"ذکر نمی‌شود. این به ما امکان می‌دهد محاسباتی را روی برش‌هایی با اندازه‌های مختلف "
-"انجام دهیم."
-
-#: src/slices-and-lifetimes/slices.md
-#, fuzzy
-msgid ""
-"Slices always borrow from another object. In this example, `a` has to remain "
-"'alive' (in scope) for at least as long as our slice."
-msgstr ""
-"برش‌ها همیشه از یک شیء دیگر قرض می‌گیرند. در این مثال، <span dir=ltr>`a`</"
-"span> باید حداقل به اندازه طول‌عمر برش ما، زنده (در محدوده) باقی بماند. "
-
-#: src/slices-and-lifetimes/slices.md
-#, fuzzy
-msgid ""
-"The question about modifying `a[3]` can spark an interesting discussion, but "
-"the answer is that for memory safety reasons you cannot do it through `a` at "
-"this point in the execution, but you can read the data from both `a` and `s` "
-"safely. It works before you created the slice, and again after the "
-"`println`, when the slice is no longer used."
-msgstr ""
-"پرسش در مورد تغییر <span dir=ltr>`a[3]`</span> می تواند یک بحث جالب را شروع "
-"کند، اما پاسخ‌اش این است که به دلایل ایمنی حافظه، نمی‌توانید این کار را از "
-"طریق <span dir=ltr>`a`</span> در این مرحله از اجرا انجام دهید، اما می‌توانید "
-"داده‌ها را از هر دو <span dir=ltr>`a`</span> و <span dir=ltr>`s`</span> به "
-"طور ایمن بخوانید. این کار قبل از ایجاد برش و دوباره بعد از <span "
-"dir=ltr>`println!`</span> کار میکند، زمانی که برش دیگر استفاده نمی شود. "
-"جزئیات بیشتری در بخش بررسی‌کننده‌قرض (the borrow checker) توضیح خواهیم داد. "
-
-#: src/slices-and-lifetimes/str.md
-msgid ""
-"We can now understand the two string types in Rust: `&str` is almost like "
-"`&[char]`, but with its data stored in a variable-length encoding (UTF-8)."
-msgstr ""
-
-#: src/slices-and-lifetimes/str.md
-msgid "\"s1: {s1}\""
-msgstr ""
-
-#: src/slices-and-lifetimes/str.md
-#, fuzzy
-msgid "\"Hello \""
-msgstr "سلام دنیا"
-
-#: src/slices-and-lifetimes/str.md
-msgid "\"s3: {s3}\""
-msgstr ""
-
-#: src/slices-and-lifetimes/str.md
-msgid "Rust terminology:"
-msgstr "اصطلاحات راست:"
-
-#: src/slices-and-lifetimes/str.md
-msgid "`&str` an immutable reference to a string slice."
-msgstr ""
-"<span dir=ltr><code class=hljs>&amp;str</code></span>  یک مرجع غیرقابل تغییر "
-"به یک برش از رشته‌ است."
-
-#: src/slices-and-lifetimes/str.md
-msgid "`String` a mutable string buffer."
-msgstr "`String` یک بافر رشته‌ای قابل تغییر است."
-
-#: src/slices-and-lifetimes/str.md
-#, fuzzy
-msgid ""
-"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data stored in a block of memory. String literals "
-"(`”Hello”`), are stored in the program’s binary."
-msgstr ""
-"<span dir=ltr>`&str`</span>  یک برش رشته‌ای را معرفی می‌کند، که یک مرجع "
-"غیرقابل تغییر به داده‌های رشته‌ای رمزشده UTF-8 است که در یک بلوک حافظه ذخیره "
-"شده است. لیترال های رشته‌ای <span dir=ltr>`String`</span>  (`”Hello”`) در "
-"باینری برنامه ذخیره می‌شوند."
-
-#: src/slices-and-lifetimes/str.md
-msgid ""
-"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned."
-msgstr ""
-"در راست نوع ‍<span dir=ltr>`String`</span> یک wrapper بر روی یک بردار از "
-"بایت‌هاست. مانند <span dir=ltr>`Vec<T>`</span>، یک نوع Owned است."
-
-#: src/slices-and-lifetimes/str.md
-#, fuzzy
-msgid ""
-"As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` creates a new empty string, to which string data "
-"can be added using the `push()` and `push_str()` methods."
-msgstr ""
-"مانند بسیاری از انواع دیگر، <span dir=ltr>`String::from()`</span> یک رشته از "
-"یک لیترال رشته ایجاد می‌کند. <span dir=ltr>`String::new()`</span> که رشته "
-"خالی جدید ایجاد می‌کند که داده های رشته‌ای می‌توانند با استفاده از متدهای <span "
-"dir=ltr>`push()`</span> و <span dir=ltr>`push_str()`</span> به آن اضافه شوند."
-
-#: src/slices-and-lifetimes/str.md
-#, fuzzy
-msgid ""
-"The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It accepts the same format specification as `println!()`."
-msgstr ""
-"ماکرو <span dir=ltr>`format!()`</span> یک راه راحت برای ایجاد یک رشته Owned "
-"از مقادیر پویا است. مثل فرمت قابل پذیرش توسط ماکرو <span dir=ltr>`println!"
-"()`</span> است."
-
-#: src/slices-and-lifetimes/str.md
-msgid ""
-"You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection. If you select a byte range that is not aligned to character "
-"boundaries, the expression will panic. The `chars` iterator iterates over "
-"characters and is preferred over trying to get character boundaries right."
-msgstr ""
-
-#: src/slices-and-lifetimes/str.md
-#, fuzzy
-msgid ""
-"For C++ programmers: think of `&str` as `std::string_view` from C++, but the "
-"one that always points to a valid string in memory. Rust `String` is a rough "
-"equivalent of `std::string` from C++ (main difference: it can only contain "
-"UTF-8 encoded bytes and will never use a small-string optimization)."
-msgstr ""
-"برای برنامه‌نویسان <span dir=ltr>`C++`</span>: <span dir=ltr>`&str`</span>را  "
-"به عنوان <span dir=ltr>`const char*`</span> در <span dir=ltr>`C++`</span> "
-"درنظر بگیرید، اما یک فرق مهم این است که در راست که همیشه به یک رشته معتبر در "
-"حافظه اشاره می کند. راست نوع <span dir=ltr>`String`</span>معادل تقریبی <span "
-"dir=ltr>`std::string`</span> در <span dir=ltr>`C++`</span> است (با این تفاوت "
-"که فقط می‌تواند حاوی بایت‌های رمزشده UTF-8 باشد و هرگز از بهینه‌سازی Small-"
-"String استفاده نمی کند)."
-
-#: src/slices-and-lifetimes/str.md
-#, fuzzy
-msgid "Byte strings literals allow you to create a `&[u8]` value directly:"
-msgstr ""
-"رشته‌های بایت به شما امکان می‌دهند مستقیماً یک مقدار <span dir=ltr>`&[u8]`</"
-"span>  ایجاد کنید:"
-
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:3
 msgid ""
 "A reference has a _lifetime_, which must not \"outlive\" the value it refers "
 "to. This is verified by the borrow checker."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:6
 msgid ""
 "The lifetime can be implicit - this is what we have seen so far. Lifetimes "
 "can also be explicit: `&'a Point`, `&'document str`. Lifetimes start with "
@@ -8780,101 +8471,100 @@ msgid ""
 "`Point` which is valid for at least the lifetime `a`\"."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:11
 msgid ""
 "Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
 "yourself. Explicit lifetime annotations create constraints where there is "
 "ambiguity; the compiler verifies that there is a valid solution."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:15
 msgid ""
 "Lifetimes become more complicated when considering passing values to and "
 "returning values from functions."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
-msgid "// What is the lifetime of p3?\n"
+#: src/lifetimes/lifetime-annotations.md:36
+msgid "// What is the lifetime of p3?"
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:37
 msgid "\"p3: {p3:?}\""
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:44
 msgid ""
-"In this example, the the compiler does not know what lifetime to infer for "
-"`p3`. Looking inside the function body shows that it can only safely assume "
-"that `p3`'s lifetime is the shorter of `p1` and `p2`. But just like types, "
-"Rust requires explicit annotations of lifetimes on function arguments and "
-"return values."
+"In this example, the compiler does not know what lifetime to infer for `p3`. "
+"Looking inside the function body shows that it can only safely assume that "
+"`p3`'s lifetime is the shorter of `p1` and `p2`. But just like types, Rust "
+"requires explicit annotations of lifetimes on function arguments and return "
+"values."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:50
 msgid "Add `'a` appropriately to `left_most`:"
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:56
 msgid ""
 "This says, \"given p1 and p2 which both outlive `'a`, the return value lives "
 "for at least `'a`."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-annotations.md
+#: src/lifetimes/lifetime-annotations.md:59
 msgid ""
 "In common cases, lifetimes can be elided, as described on the next slide."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "طول عمر در فراخوانی‌ توابع"
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:3
 msgid ""
 "Lifetimes for function arguments and return values must be fully specified, "
-"but Rust allows lifetimes to be elided in most cases with [a few simple "
-"rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html). This is not "
-"inference -- it is just a syntactic shorthand."
+"but Rust allows lifetimes to be elided in most cases with a few simple "
+"rules. This is not inference -- it is just a syntactic shorthand."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:8
 msgid "Each argument which does not have a lifetime annotation is given one."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:9
 msgid ""
 "If there is only one argument lifetime, it is given to all un-annotated "
 "return values."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:11
 msgid ""
 "If there are multiple argument lifetimes, but the first one is for `self`, "
 "that lifetime is given to all un-annotated return values."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:53
 msgid "In this example, `cab_distance` is trivially elided."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:55
 msgid ""
 "The `nearest` function provides another example of a function with multiple "
 "references in its arguments that requires explicit annotation."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:58
 msgid "Try adjusting the signature to \"lie\" about the lifetimes returned:"
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:64
 msgid ""
 "This won't compile, demonstrating that the annotations are checked for "
 "validity by the compiler. Note that this is not the case for raw pointers "
 "(unsafe), and this is a common source of errors with unsafe Rust."
 msgstr ""
 
-#: src/slices-and-lifetimes/lifetime-elision.md
+#: src/lifetimes/lifetime-elision.md:68
 msgid ""
 "Students may ask when to use lifetimes. Rust borrows _always_ have "
 "lifetimes. Most of the time, elision and type inference mean these don't "
@@ -8883,60 +8573,60 @@ msgid ""
 "just work with owned data by cloning values where necessary."
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "طول عمر در ساختمان داده"
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:3
 msgid ""
 "If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:10
 msgid "\"Bye {text}!\""
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:14
 msgid "\"The quick brown fox jumps over the lazy dog.\""
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
-msgid "// erase(text);\n"
+#: src/lifetimes/struct-lifetimes.md:17
+msgid "// erase(text);"
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:18
 msgid "\"{fox:?}\""
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:19
 msgid "\"{dog:?}\""
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:26
 msgid ""
 "In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
 "`Highlight` that uses that data."
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:29
 msgid ""
 "If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
 "the borrow checker throws an error."
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:31
 msgid ""
 "Types with borrowed data force users to hold on to the original data. This "
 "can be useful for creating lightweight views, but it generally makes them "
 "somewhat harder to use."
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:34
 msgid "When possible, make data structures own their data directly."
 msgstr ""
 
-#: src/slices-and-lifetimes/struct-lifetimes.md
+#: src/lifetimes/struct-lifetimes.md:35
 msgid ""
 "Some structs with multiple references inside can have more than one lifetime "
 "annotation. This can be necessary if there is a need to describe lifetime "
@@ -8944,15 +8634,14 @@ msgid ""
 "of the struct itself. Those are very advanced use cases."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:3
 msgid ""
-"In this exercise, you will build a parser for the [protobuf binary encoding]"
-"(https://protobuf.dev/programming-guides/encoding/). Don't worry, it's "
-"simpler than it seems! This illustrates a common parsing pattern, passing "
-"slices of data. The underlying data itself is never copied."
+"In this exercise, you will build a parser for the protobuf binary encoding. "
+"Don't worry, it's simpler than it seems! This illustrates a common parsing "
+"pattern, passing slices of data. The underlying data itself is never copied."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:8
 msgid ""
 "Fully parsing a protobuf message requires knowing the types of the fields, "
 "indexed by their field numbers. That is typically provided in a `proto` "
@@ -8960,11 +8649,11 @@ msgid ""
 "statements in functions that get called for each field."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:13
 msgid "We'll use the following proto:"
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:28
 msgid ""
 "A proto message is encoded as a series of fields, one after the next. Each "
 "is implemented as a \"tag\" followed by the value. The tag contains a field "
@@ -8972,7 +8661,7 @@ msgid ""
 "defining how the payload should be determined from the byte stream."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:33
 msgid ""
 "Integers, including the tag, are represented with a variable-length encoding "
 "called VARINT. Luckily, `parse_varint` is defined for you below. The given "
@@ -8980,129 +8669,125 @@ msgid ""
 "to parse a message into a series of calls to those callbacks."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:38
 msgid ""
 "What remains for you is to implement the `parse_field` function and the "
 "`ProtoMessage` trait for `Person` and `PhoneNumber`."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:49 src/lifetimes/solution.md:11
 msgid "\"Invalid varint\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:51 src/lifetimes/solution.md:13
 msgid "\"Invalid wire-type\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:53 src/lifetimes/solution.md:15
 msgid "\"Unexpected EOF\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:55 src/lifetimes/solution.md:17
 msgid "\"Invalid length\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:57 src/lifetimes/solution.md:19
 msgid "\"Unexpected wire-type)\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:59 src/lifetimes/solution.md:21
 msgid "\"Invalid string (not UTF-8)\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "/// A wire type as seen on the wire.\n"
+#: src/lifetimes/exercise.md:62 src/lifetimes/solution.md:24
+msgid "/// A wire type as seen on the wire."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "/// The Varint WireType indicates the value is a single VARINT.\n"
+#: src/lifetimes/exercise.md:65 src/lifetimes/solution.md:27
+msgid "/// The Varint WireType indicates the value is a single VARINT."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:67 src/lifetimes/solution.md:29
 msgid ""
-"//I64,  -- not needed for this exercise\n"
-"    /// The Len WireType indicates that the value is a length represented as "
-"a\n"
-"    /// VARINT followed by exactly that number of bytes.\n"
+"//I64,  -- not needed for this exercise /// The Len WireType indicates that "
+"the value is a length represented as a /// VARINT followed by exactly that "
+"number of bytes."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:71 src/lifetimes/solution.md:33
 msgid ""
-"/// The I32 WireType indicates that the value is precisely 4 bytes in\n"
-"    /// little-endian order containing a 32-bit signed integer.\n"
+"/// The I32 WireType indicates that the value is precisely 4 bytes in /// "
+"little-endian order containing a 32-bit signed integer."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "/// A field's value, typed based on the wire type.\n"
+#: src/lifetimes/exercise.md:76 src/lifetimes/solution.md:38
+msgid "/// A field's value, typed based on the wire type."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "//I64(i64),  -- not needed for this exercise\n"
+#: src/lifetimes/exercise.md:80 src/lifetimes/solution.md:42
+msgid "//I64(i64),  -- not needed for this exercise"
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "/// A field, containing the field number and its value.\n"
+#: src/lifetimes/exercise.md:85 src/lifetimes/solution.md:47
+msgid "/// A field, containing the field number and its value."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "//1 => WireType::I64,  -- not needed for this exercise\n"
+#: src/lifetimes/exercise.md:102 src/lifetimes/solution.md:64
+msgid "//1 => WireType::I64,  -- not needed for this exercise"
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:132 src/lifetimes/solution.md:94
+msgid "/// Parse a VARINT, returning the parsed value and the remaining bytes."
+msgstr ""
+
+#: src/lifetimes/exercise.md:140 src/lifetimes/solution.md:102
 msgid ""
-"/// Parse a VARINT, returning the parsed value and the remaining bytes.\n"
+"// This is the last byte of the VARINT, so convert it to // a u64 and return "
+"it."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid ""
-"// This is the last byte of the VARINT, so convert it to\n"
-"            // a u64 and return it.\n"
+#: src/lifetimes/exercise.md:150 src/lifetimes/solution.md:112
+msgid "// More than 7 bytes is invalid."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "// More than 7 bytes is invalid.\n"
+#: src/lifetimes/exercise.md:153 src/lifetimes/solution.md:115
+msgid "/// Convert a tag into a field number and a WireType."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "/// Convert a tag into a field number and a WireType.\n"
+#: src/lifetimes/exercise.md:161 src/lifetimes/solution.md:122
+msgid "/// Parse a field, returning the remaining bytes"
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
-msgid "/// Parse a field, returning the remaining bytes\n"
-msgstr ""
-
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:167
 msgid ""
 "\"Based on the wire type, build a Field, consuming as many bytes as "
 "necessary.\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
+#: src/lifetimes/exercise.md:169
 msgid "\"Return the field, and any un-consumed bytes.\""
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md src/slices-and-lifetimes/solution.md
+#: src/lifetimes/exercise.md:171 src/lifetimes/solution.md:153
 msgid ""
 "/// Parse a message in the given data, calling `T::add_field` for each field "
-"in\n"
-"/// the message.\n"
-"///\n"
-"/// The entire input is consumed.\n"
+"in /// the message. /// /// The entire input is consumed."
 msgstr ""
 
-#: src/slices-and-lifetimes/exercise.md
-msgid "// TODO: Implement ProtoMessage for Person and PhoneNumber.\n"
+#: src/lifetimes/exercise.md:198
+msgid "// TODO: Implement ProtoMessage for Person and PhoneNumber."
 msgstr ""
 
-#: src/slices-and-lifetimes/solution.md
-msgid "// Unwrap error because `value` is definitely 4 bytes long.\n"
+#: src/lifetimes/solution.md:146
+msgid "// Unwrap error because `value` is definitely 4 bytes long."
 msgstr ""
 
-#: src/slices-and-lifetimes/solution.md
-msgid "// skip everything else\n"
+#: src/lifetimes/solution.md:187 src/lifetimes/solution.md:198
+msgid "// skip everything else"
 msgstr ""
 
-#: src/slices-and-lifetimes/solution.md
+#: src/lifetimes/solution.md:225 src/lifetimes/solution.md:232
+#: src/lifetimes/solution.md:239
 msgid "b\"hello\""
 msgstr ""
 
@@ -9139,51 +8824,37 @@ msgid ""
 msgstr ""
 
 #: src/welcome-day-4.md
-msgid "[Welcome](./welcome-day-4.md) (3 minutes)"
-msgstr ""
-
-#: src/welcome-day-4.md
-msgid "[Iterators](./iterators.md) (45 minutes)"
-msgstr ""
-
-#: src/welcome-day-4.md
-msgid "[Modules](./modules.md) (40 minutes)"
-msgstr ""
-
-#: src/welcome-day-4.md
-msgid "[Testing](./testing.md) (1 hour and 5 minutes)"
-msgstr ""
-
-#: src/iterators.md
-msgid "[Iterator](./iterators/iterator.md) (5 minutes)"
-msgstr ""
-
-#: src/iterators.md
-msgid "[IntoIterator](./iterators/intoiterator.md) (5 minutes)"
-msgstr ""
-
-#: src/iterators.md
-msgid "[FromIterator](./iterators/fromiterator.md) (5 minutes)"
-msgstr ""
-
-#: src/iterators.md
 msgid ""
-"[Exercise: Iterator Method Chaining](./iterators/exercise.md) (30 minutes)"
+"Including 10 minute breaks, this session should take about 2 hours and 40 "
+"minutes. It contains:"
 msgstr ""
 
-#: src/iterators/iterator.md
+#: src/iterators.md
+#, fuzzy
+msgid "Iterator"
+msgstr "FromIterator"
+
+#: src/iterators.md
+#, fuzzy
+msgid "IntoIterator"
+msgstr "FromIterator"
+
+#: src/iterators.md src/iterators/fromiterator.md:1
+msgid "FromIterator"
+msgstr "FromIterator"
+
+#: src/iterators/iterator.md:3
 msgid ""
-"The [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
-"trait supports iterating over values in a collection. It requires a `next` "
-"method and provides lots of methods. Many standard library types implement "
-"`Iterator`, and you can implement it yourself, too:"
+"The `Iterator` trait supports iterating over values in a collection. It "
+"requires a `next` method and provides lots of methods. Many standard library "
+"types implement `Iterator`, and you can implement it yourself, too:"
 msgstr ""
 
-#: src/iterators/iterator.md
+#: src/iterators/iterator.md:27
 msgid "\"fib({i}): {n}\""
 msgstr ""
 
-#: src/iterators/iterator.md
+#: src/iterators/iterator.md:35
 msgid ""
 "The `Iterator` trait implements many common functional programming "
 "operations over collections (e.g. `map`, `filter`, `reduce`, etc). This is "
@@ -9192,7 +8863,7 @@ msgid ""
 "implementations."
 msgstr ""
 
-#: src/iterators/iterator.md
+#: src/iterators/iterator.md:40
 msgid ""
 "`IntoIterator` is the trait that makes for loops work. It is implemented by "
 "collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
@@ -9200,55 +8871,54 @@ msgid ""
 "vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:3
 msgid ""
 "The `Iterator` trait tells you how to _iterate_ once you have created an "
-"iterator. The related trait [`IntoIterator`](https://doc.rust-lang.org/std/"
-"iter/trait.IntoIterator.html) defines how to create an iterator for a type. "
-"It is used automatically by the `for` loop."
+"iterator. The related trait `IntoIterator` defines how to create an iterator "
+"for a type. It is used automatically by the `for` loop."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:49
 msgid "\"point = {x}, {y}\""
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:57
 msgid ""
 "Click through to the docs for `IntoIterator`. Every implementation of "
 "`IntoIterator` must declare two types:"
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:60
 msgid "`Item`: the type to iterate over, such as `i8`,"
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:61
 msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:63
 msgid ""
 "Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:66
 msgid "The example iterates over all combinations of x and y coordinates."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:68
 msgid ""
 "Try iterating over the grid twice in `main`. Why does this fail? Note that "
 "`IntoIterator::into_iter` takes ownership of `self`."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:71
 msgid ""
 "Fix this issue by implementing `IntoIterator` for `&Grid` and storing a "
 "reference to the `Grid` in `GridIter`."
 msgstr ""
 
-#: src/iterators/intoiterator.md
+#: src/iterators/intoiterator.md:74
 msgid ""
 "The same problem can occur for standard library types: `for e in "
 "some_vector` will take ownership of `some_vector` and iterate over owned "
@@ -9256,330 +8926,294 @@ msgid ""
 "over references to elements of `some_vector`."
 msgstr ""
 
-#: src/iterators/fromiterator.md
-msgid "FromIterator"
-msgstr "FromIterator"
-
-#: src/iterators/fromiterator.md
-msgid ""
-"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
-"std/iter/trait.Iterator.html)."
+#: src/iterators/fromiterator.md:3
+msgid "`FromIterator` lets you build a collection from an `Iterator`."
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:9
 msgid "\"prime_squares: {prime_squares:?}\""
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:16
 msgid "`Iterator` implements"
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:25
 msgid "There are two ways to specify `B` for this method:"
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:27
 msgid ""
 "With the \"turbofish\": `some_iterator.collect::<COLLECTION_TYPE>()`, as "
 "shown. The `_` shorthand used here lets Rust infer the type of the `Vec` "
 "elements."
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:29
 msgid ""
 "With type inference: `let prime_squares: Vec<_> = some_iterator.collect()`. "
 "Rewrite the example to use this form."
 msgstr ""
 
-#: src/iterators/fromiterator.md
+#: src/iterators/fromiterator.md:32
 msgid ""
 "There are basic implementations of `FromIterator` for `Vec`, `HashMap`, etc. "
 "There are also more specialized implementations which let you do cool things "
 "like convert an `Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 
-#: src/iterators/exercise.md
+#: src/iterators/exercise.md:3
 msgid ""
 "In this exercise, you will need to find and use some of the provided methods "
-"in the [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) "
-"trait to implement a complex calculation."
+"in the `Iterator` trait to implement a complex calculation."
 msgstr ""
 
-#: src/iterators/exercise.md
+#: src/iterators/exercise.md:6
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests "
+"Copy the following code to https://play.rust-lang.org/ and make the tests "
 "pass. Use an iterator expression and `collect` the result to construct the "
 "return value."
 msgstr ""
 
-#: src/iterators/exercise.md src/iterators/solution.md
+#: src/iterators/exercise.md:11 src/iterators/solution.md:4
 msgid ""
 "/// Calculate the differences between elements of `values` offset by "
-"`offset`,\n"
-"/// wrapping around from the end of `values` to the beginning.\n"
-"///\n"
-"/// Element `n` of the result is `values[(n+offset)%len] - values[n]`.\n"
+"`offset`, /// wrapping around from the end of `values` to the "
+"beginning. /// /// Element `n` of the result is `values[(n+offset)%len] - "
+"values[n]`."
 msgstr ""
 
-#: src/modules.md
-msgid "[Modules](./modules/modules.md) (5 minutes)"
+#: src/modules.md src/modules/paths.md:1
+msgid "use, super, self"
 msgstr ""
 
-#: src/modules.md
-msgid "[Filesystem Hierarchy](./modules/filesystem.md) (5 minutes)"
-msgstr ""
-
-#: src/modules.md
-msgid "[Visibility](./modules/visibility.md) (5 minutes)"
-msgstr ""
-
-#: src/modules.md
-msgid "[use, super, self](./modules/paths.md) (10 minutes)"
-msgstr ""
-
-#: src/modules.md
-msgid ""
-"[Exercise: Modules for a GUI Library](./modules/exercise.md) (15 minutes)"
-msgstr ""
-
-#: src/modules.md
-msgid "This segment should take about 40 minutes"
-msgstr ""
-
-#: src/modules/modules.md
+#: src/modules/modules.md:3
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:5
 msgid "Similarly, `mod` lets us namespace types and functions:"
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:10
 msgid "\"In the foo module\""
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:16
 msgid "\"In the bar module\""
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:29
 msgid ""
 "Packages provide functionality and include a `Cargo.toml` file that "
 "describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:31
 msgid ""
 "Crates are a tree of modules, where a binary crate creates an executable and "
 "a library crate compiles to a library."
 msgstr ""
 
-#: src/modules/modules.md
+#: src/modules/modules.md:33
 msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:3
 msgid ""
 "Omitting the module content will tell Rust to look for it in another file:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:9
 msgid ""
 "This tells rust that the `garden` module content is found at `src/garden."
 "rs`. Similarly, a `garden::vegetables` module can be found at `src/garden/"
 "vegetables.rs`."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:13
 msgid "The `crate` root is in:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:15
 msgid "`src/lib.rs` (for a library crate)"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:16
 msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:18
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
 "comments\". These document the item that contains them -- in this case, a "
 "module."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:22
 msgid ""
 "//! This module implements the garden, including a highly performant "
-"germination\n"
-"//! implementation.\n"
+"germination //! implementation."
 msgstr ""
 
-#: src/modules/filesystem.md
-msgid "// Re-export types from this module.\n"
+#: src/modules/filesystem.md:24
+msgid "// Re-export types from this module."
 msgstr ""
 
-#: src/modules/filesystem.md
-msgid "/// Sow the given seed packets.\n"
+#: src/modules/filesystem.md:28
+msgid "/// Sow the given seed packets."
 msgstr ""
 
-#: src/modules/filesystem.md
-msgid "/// Harvest the produce in the garden that is ready.\n"
+#: src/modules/filesystem.md:33
+msgid "/// Harvest the produce in the garden that is ready."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:43
 msgid ""
 "Before Rust 2018, modules needed to be located at `module/mod.rs` instead of "
 "`module.rs`, and this is still a working alternative for editions after 2018."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:46
 msgid ""
 "The main reason to introduce `filename.rs` as alternative to `filename/mod."
 "rs` was because many files named `mod.rs` can be hard to distinguish in IDEs."
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:49
 msgid "Deeper nesting can use folders, even if the main module is a file:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:59
 msgid ""
 "The place rust will look for modules can be changed with a compiler "
 "directive:"
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:62
 msgid "\"some/path.rs\""
 msgstr ""
 
-#: src/modules/filesystem.md
+#: src/modules/filesystem.md:66
 msgid ""
 "This is useful, for example, if you would like to place tests for a module "
 "in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:3
 msgid "Modules are a privacy boundary:"
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:5
 msgid "Module items are private by default (hides implementation details)."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:6
 msgid "Parent and sibling items are always visible."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:7
 msgid ""
 "In other words, if an item is visible in module `foo`, it's visible in all "
 "the descendants of `foo`."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:13
 msgid "\"outer::private\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:17
 msgid "\"outer::public\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:22
 msgid "\"outer::inner::private\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:26
 msgid "\"outer::inner::public\""
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:40
 msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:42
 msgid ""
 "Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
 "of public visibility."
 msgstr ""
 
-#: src/modules/visibility.md
-msgid ""
-"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
-"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
-msgstr ""
+#: src/modules/visibility.md:45
+#, fuzzy
+msgid "See the Rust Reference."
+msgstr "مراجع"
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:47
 msgid "Configuring `pub(crate)` visibility is a common pattern."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:48
 msgid "Less commonly, you can give visibility to a specific path."
 msgstr ""
 
-#: src/modules/visibility.md
+#: src/modules/visibility.md:49
 msgid ""
 "In any case, visibility must be granted to an ancestor module (and all of "
 "its descendants)."
 msgstr ""
 
-#: src/modules/paths.md
-msgid "use, super, self"
-msgstr ""
-
-#: src/modules/paths.md
+#: src/modules/paths.md:3
 msgid ""
 "A module can bring symbols from another module into scope with `use`. You "
 "will typically see something like this at the top of each module:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:11
 msgid "Paths"
 msgstr "مسیر"
 
-#: src/modules/paths.md
+#: src/modules/paths.md:13
 msgid "Paths are resolved as follows:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:15
 msgid "As a relative path:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:16
 msgid "`foo` or `self::foo` refers to `foo` in the current module,"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:17
 msgid "`super::foo` refers to `foo` in the parent module."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:19
 msgid "As an absolute path:"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:20
 msgid "`crate::foo` refers to `foo` in the root of the current crate,"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:21
 msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:26
 msgid ""
 "It is common to \"re-export\" symbols at a shorter path. For example, the "
 "top-level `lib.rs` in a crate might have"
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:36
 msgid ""
 "making `DiskStorage` and `NetworkStorage` available to other crates with a "
 "convenient, short path."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:39
 msgid ""
 "For the most part, only items that appear in a module need to be `use`'d. "
 "However, a trait must be in scope to call any methods on that trait, even if "
@@ -9588,529 +9222,346 @@ msgid ""
 "`use std::io::Read`."
 msgstr ""
 
-#: src/modules/paths.md
+#: src/modules/paths.md:45
 msgid ""
 "The `use` statement can have a wildcard: `use std::io::*`. This is "
 "discouraged because it is not clear which items are imported, and those "
 "might change over time."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:3
 msgid ""
 "In this exercise, you will reorganize a small GUI Library implementation. "
 "This library defines a `Widget` trait and a few implementations of that "
 "trait, as well as a `main` function."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:7
 msgid ""
 "It is typical to put each type or set of closely-related types into its own "
 "module, so each widget type should get its own module."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:10
 #, fuzzy
 msgid "Cargo Setup"
 msgstr "تنظیم"
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:12
 msgid ""
 "The Rust playground only supports one file, so you will need to make a Cargo "
 "project on your local filesystem:"
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:21
 msgid ""
 "Edit the resulting `src/main.rs` to add `mod` statements, and add additional "
 "files in the `src` directory."
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:24
 msgid "Source"
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:26
 msgid "Here's the single-module implementation of the GUI library:"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
-msgid "/// Natural width of `self`.\n"
+#: src/modules/exercise.md:30 src/modules/solution.md:36
+msgid "/// Natural width of `self`."
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
-msgid "/// Draw the widget into a buffer.\n"
+#: src/modules/exercise.md:33 src/modules/solution.md:39
+msgid "/// Draw the widget into a buffer."
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
-msgid "/// Draw the widget on standard output.\n"
+#: src/modules/exercise.md:36 src/modules/solution.md:42
+msgid "/// Draw the widget on standard output."
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:40 src/modules/solution.md:46
 msgid "\"{buffer}\""
 msgstr ""
 
-#: src/modules/exercise.md
-msgid "// Add 4 paddings for borders\n"
+#: src/modules/exercise.md:88
+msgid "// Add 4 paddings for borders"
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:100
 msgid ""
-"// TODO: Change draw_into to return Result<(), std::fmt::Error>. Then use "
-"the\n"
-"        // ?-operator here instead of .unwrap().\n"
+"// TODO: Change draw_into to return Result\\<(), std::fmt::Error>. Then use "
+"the // ?-operator here instead of .unwrap()."
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
-msgid "\"+-{:-<inner_width$}-+\""
+#: src/modules/exercise.md:102 src/modules/exercise.md:108
+#: src/modules/solution.md:165 src/modules/solution.md:171
+msgid "\"+-{:-\\<inner_width$}-+\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md src/testing/unit-tests.md
-#: src/testing/solution.md
+#: src/modules/exercise.md:102 src/modules/exercise.md:104
+#: src/modules/exercise.md:108 src/modules/exercise.md:122
+#: src/modules/exercise.md:126 src/modules/solution.md:110
+#: src/modules/solution.md:114 src/modules/solution.md:165
+#: src/modules/solution.md:167 src/modules/solution.md:171
+#: src/testing/unit-tests.md:27 src/testing/solution.md:89
 msgid "\"\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:103 src/modules/solution.md:166
 msgid "\"| {:^inner_width$} |\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
-msgid "\"+={:=<inner_width$}=+\""
+#: src/modules/exercise.md:104 src/modules/solution.md:167
+msgid "\"+={:=\\<inner_width$}=+\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:106 src/modules/solution.md:169
 msgid "\"| {:inner_width$} |\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
-msgid "// add a bit of padding\n"
+#: src/modules/exercise.md:114 src/modules/solution.md:100
+msgid "// add a bit of padding"
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
-msgid "\"+{:-<width$}+\""
+#: src/modules/exercise.md:122 src/modules/exercise.md:126
+#: src/modules/solution.md:110 src/modules/solution.md:114
+msgid "\"+{:-\\<width$}+\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:124 src/modules/solution.md:112
 msgid "\"|{:^width$}|\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:141 src/modules/solution.md:183
 msgid "\"Rust GUI Demo 1.23\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:142 src/modules/solution.md:185
 msgid "\"This is a small text GUI demo.\""
 msgstr ""
 
-#: src/modules/exercise.md src/modules/solution.md
+#: src/modules/exercise.md:143 src/modules/solution.md:186
 msgid "\"Click me!\""
 msgstr ""
 
-#: src/modules/exercise.md
+#: src/modules/exercise.md:151
 msgid ""
 "Encourage students to divide the code in a way that feels natural for them, "
 "and get accustomed to the required `mod`, `use`, and `pub` declarations. "
 "Afterward, discuss what organizations are most idiomatic."
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ---- src/widgets.rs ----\n"
+#: src/modules/solution.md:30
+msgid "// ---- src/widgets.rs ----"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ---- src/widgets/label.rs ----\n"
+#: src/modules/solution.md:56
+msgid "// ---- src/widgets/label.rs ----"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR_END: Label-width\n"
+#: src/modules/solution.md:71
+msgid "// ANCHOR_END: Label-width"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR: Label-draw_into\n"
+#: src/modules/solution.md:75
+msgid "// ANCHOR: Label-draw_into"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR_END: Label-draw_into\n"
+#: src/modules/solution.md:77
+msgid "// ANCHOR_END: Label-draw_into"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ---- src/widgets/button.rs ----\n"
+#: src/modules/solution.md:84
+msgid "// ---- src/widgets/button.rs ----"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR_END: Button-width\n"
+#: src/modules/solution.md:99
+msgid "// ANCHOR_END: Button-width"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR: Button-draw_into\n"
+#: src/modules/solution.md:103
+msgid "// ANCHOR: Button-draw_into"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR_END: Button-draw_into\n"
+#: src/modules/solution.md:105
+msgid "// ANCHOR_END: Button-draw_into"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ---- src/widgets/window.rs ----\n"
+#: src/modules/solution.md:120
+msgid "// ---- src/widgets/window.rs ----"
 msgstr ""
 
-#: src/modules/solution.md
+#: src/modules/solution.md:147
+msgid "// ANCHOR_END: Window-width // Add 4 paddings for borders"
+msgstr ""
+
+#: src/modules/solution.md:152
+msgid "// ANCHOR: Window-draw_into"
+msgstr ""
+
+#: src/modules/solution.md:154
+msgid "// ANCHOR_END: Window-draw_into"
+msgstr ""
+
+#: src/modules/solution.md:162
 msgid ""
-"// ANCHOR_END: Window-width\n"
-"        // Add 4 paddings for borders\n"
+"// TODO: after learning about error handling, you can change // draw_into to "
+"return Result\\<(), std::fmt::Error>. Then use // the ?-operator here "
+"instead of .unwrap()."
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR: Window-draw_into\n"
+#: src/modules/solution.md:177
+msgid "// ---- src/main.rs ----"
 msgstr ""
 
-#: src/modules/solution.md
-msgid "// ANCHOR_END: Window-draw_into\n"
-msgstr ""
-
-#: src/modules/solution.md
-msgid ""
-"// TODO: after learning about error handling, you can change\n"
-"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
-"        // the ?-operator here instead of .unwrap().\n"
-msgstr ""
-
-#: src/modules/solution.md
-msgid "// ---- src/main.rs ----\n"
-msgstr ""
-
-#: src/testing.md
-msgid "[Test Modules](./testing/unit-tests.md) (5 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Other Types of Tests](./testing/other.md) (10 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Useful Crates](./testing/useful-crates.md) (3 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[GoogleTest](./testing/googletest.md) (5 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Mocking](./testing/mocking.md) (5 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Compiler Lints and Clippy](./testing/lints.md) (5 minutes)"
-msgstr ""
-
-#: src/testing.md
-msgid "[Exercise: Luhn Algorithm](./testing/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "تست‌های واحد (Unit Tests)"
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:5
 msgid "Unit tests are supported throughout your code."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:7
 msgid "Integration tests are supported via the `tests/` directory."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:9
 msgid ""
 "Tests are marked with `#[test]`. Unit tests are often put in a nested "
 "`tests` module, using `#[cfg(test)]` to conditionally compile them only when "
 "building tests."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:37
 #, fuzzy
 msgid "\"Hello World\""
 msgstr "سلام دنیا"
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:42
 msgid "This lets you unit test private helpers."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:43
 msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
 
-#: src/testing/unit-tests.md
+#: src/testing/unit-tests.md:48
 msgid "Run the tests in the playground in order to show their results."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:3
 msgid "Integration Tests"
 msgstr "Integration Tests"
 
-#: src/testing/other.md
+#: src/testing/other.md:5
 msgid "If you want to test your library as a client, use an integration test."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:7
 msgid "Create a `.rs` file under `tests/`:"
 msgstr ""
 
-#: src/testing/other.md
-msgid "// tests/my_library.rs\n"
+#: src/testing/other.md:10
+msgid "// tests/my_library.rs"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:19
 msgid "These tests only have access to the public API of your crate."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:21
 msgid "Documentation Tests"
 msgstr "تست‌ سندها"
 
-#: src/testing/other.md
+#: src/testing/other.md:23
 msgid "Rust has built-in support for documentation tests:"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:26
 msgid ""
-"/// Shortens a string to the given length.\n"
-"///\n"
-"/// ```\n"
-"/// # use playground::shorten_string;\n"
-"/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
-"/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
-"/// ```\n"
+"/// Shortens a string to the given length. /// /// `/// # use playground::"
+"shorten_string; /// assert_eq!(shorten_string(\"Hello World\", 5), "
+"\"Hello\"); /// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello "
+"World\"); ///`"
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:38
 msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:39
 msgid "The code will be compiled and executed as part of `cargo test`."
 msgstr ""
 
-#: src/testing/other.md
+#: src/testing/other.md:40
 msgid ""
 "Adding `#` in the code will hide it from the docs, but will still compile/"
 "run it."
 msgstr ""
 
-#: src/testing/other.md
-msgid ""
-"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
-"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
-msgstr ""
+#: src/testing/other.md:42
+#, fuzzy
+msgid "Test the above code on the Rust Playground."
+msgstr "در غیر این صورت از `Rust Playground` استفاده کنید."
 
-#: src/testing/useful-crates.md
-msgid "Rust comes with only basic support for writing tests."
-msgstr ""
-
-#: src/testing/useful-crates.md
-msgid "Here are some additional crates which we recommend for writing tests:"
-msgstr ""
-
-#: src/testing/useful-crates.md
-msgid ""
-"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++."
-msgstr ""
-
-#: src/testing/useful-crates.md
-msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
-msgstr ""
-
-#: src/testing/useful-crates.md
-msgid ""
-"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
-"tests."
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"The [GoogleTest](https://docs.rs/googletest/) crate allows for flexible test "
-"assertions using _matchers_:"
-msgstr ""
-
-#: src/testing/googletest.md
-msgid "\"baz\""
-msgstr ""
-
-#: src/testing/googletest.md
-msgid "\"xyz\""
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"If we change the last element to `\"!\"`, the test fails with a structured "
-"error message pin-pointing the error:"
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"GoogleTest is not part of the Rust Playground, so you need to run this "
-"example in a local environment. Use `cargo add googletest` to quickly add it "
-"to an existing Cargo project."
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"The `use googletest::prelude::*;` line imports a number of [commonly used "
-"macros and types](https://docs.rs/googletest/latest/googletest/prelude/index."
-"html)."
-msgstr ""
-
-#: src/testing/googletest.md
-msgid "This just scratches the surface, there are many builtin matchers."
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"A particularly nice feature is that mismatches in multi-line strings strings "
-"are shown as a diff:"
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"\"Memory safety found,\\n\\\n"
-"                 Rust's strong typing guides the way,\\n\\\n"
-"                 Secure code you'll write.\""
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"\"Memory safety found,\\n\\\n"
-"            Rust's silly humor guides the way,\\n\\\n"
-"            Secure code you'll write.\""
-msgstr ""
-
-#: src/testing/googletest.md
-msgid "shows a color-coded diff (colors not shown here):"
-msgstr ""
-
-#: src/testing/googletest.md
-msgid ""
-"The crate is a Rust port of [GoogleTest for C++](https://google.github.io/"
-"googletest/)."
-msgstr ""
-
-#: src/testing/googletest.md
-msgid "GoogleTest is available for use in AOSP."
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"For mocking, [Mockall](https://docs.rs/mockall/) is a widely used library. "
-"You need to refactor your code to use traits, which you can then quickly "
-"mock:"
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"The advice here is for Android (AOSP) where Mockall is the recommended "
-"mocking library. There are other [mocking libraries available on crates.io]"
-"(https://crates.io/keywords/mock), in particular in the area of mocking HTTP "
-"services. The other mocking libraries work in a similar fashion as Mockall, "
-"meaning that they make it easy to get a mock implementation of a given trait."
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"Note that mocking is somewhat _controversial_: mocks allow you to completely "
-"isolate a test from its dependencies. The immediate result is faster and "
-"more stable test execution. On the other hand, the mocks can be configured "
-"wrongly and return output different from what the real dependencies would do."
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"If at all possible, it is recommended that you use the real dependencies. As "
-"an example, many databases allow you to configure an in-memory backend. This "
-"means that you get the correct behavior in your tests, plus they are fast "
-"and will automatically clean up after themselves."
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"Similarly, many web frameworks allow you to start an in-process server which "
-"binds to a random port on `localhost`. Always prefer this over mocking away "
-"the framework since it helps you test your code in the real environment."
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"Mockall is not part of the Rust Playground, so you need to run this example "
-"in a local environment. Use `cargo add mockall` to quickly add Mockall to an "
-"existing Cargo project."
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"Mockall has a lot more functionality. In particular, you can set up "
-"expectations which depend on the arguments passed. Here we use this to mock "
-"a cat which becomes hungry 3 hours after the last time it was fed:"
-msgstr ""
-
-#: src/testing/mocking.md
-msgid ""
-"You can use `.times(n)` to limit the number of times a mock method can be "
-"called to `n` --- the mock will automatically panic when dropped if this "
-"isn't satisfied."
-msgstr ""
-
-#: src/testing/lints.md
+#: src/testing/lints.md:3
 msgid ""
 "The Rust compiler produces fantastic error messages, as well as helpful "
-"built-in lints. [Clippy](https://doc.rust-lang.org/clippy/) provides even "
-"more lints, organized into groups that can be enabled per-project."
+"built-in lints. Clippy provides even more lints, organized into groups that "
+"can be enabled per-project."
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:14
 msgid "\"X probably fits in a u16, right? {}\""
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:21
 msgid ""
 "Run the code sample and examine the error message. There are also lints "
 "visible here, but those will not be shown once the code compiles. Switch to "
 "the Playground site to show those lints."
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:25
 msgid ""
 "After resolving the lints, run `clippy` on the playground site to show "
 "clippy warnings. Clippy has extensive documentation of its lints, and adds "
 "new lints (including default-deny lints) all the time."
 msgstr ""
 
-#: src/testing/lints.md
+#: src/testing/lints.md:29
 msgid ""
 "Note that errors or warnings with `help: ...` can be fixed with `cargo fix` "
 "or via your editor."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:3
 msgid "Luhn Algorithm"
 msgstr "الگوریتم  Luhn"
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:5
+#, fuzzy
 msgid ""
-"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to validate credit card numbers. The algorithm takes a string as input and "
-"does the following to validate the credit card number:"
+"The Luhn algorithm is used to validate credit card numbers. The algorithm "
+"takes a string as input and does the following to validate the credit card "
+"number:"
 msgstr ""
 "[الگوریتم Luhn](https://en.wikipedia.org/wiki/Luhn_algorithm) برای "
 "اعتبارسنجی شماره‌های کارت اعتباری استفاده می‌شود. این الگوریتم یک رشته را به "
 "عنوان ورودی دریافت می‌کند و برای اعتبارسنجی شماره کارت اعتباری مراحل زیر را "
 "انجام می‌دهد:"
 
-#: src/testing/exercise.md
-msgid "Ignore all spaces. Reject number with less than two digits."
+#: src/testing/exercise.md:9
+#, fuzzy
+msgid "Ignore all spaces. Reject number with fewer than two digits."
 msgstr "تمام فضاها را نادیده بگیرید.شماره‌هایی با کمتر از دو رقم را رد کنید."
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:11
 msgid ""
 "Moving from **right to left**, double every second digit: for the number "
 "`1234`, we double `3` and `1`. For the number `98765`, we double `6` and `8`."
@@ -10119,7 +9570,7 @@ msgstr ""
 "`1234`، `3` و `1` را دوبل می‌کنیم. برای شماره `98765`، `6` و `8` را دوبل "
 "می‌کنیم."
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:14
 msgid ""
 "After doubling a digit, sum the digits if the result is greater than 9. So "
 "doubling `7` becomes `14` which becomes `1 + 4 = 5`."
@@ -10128,219 +9579,194 @@ msgstr ""
 "بنابراین، دوبل کردن `7` به `14` تبدیل می‌شود که به <span dir=ltr>`1 + 4 = 5`</"
 "span> تبدیل می‌شود."
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:17
 msgid "Sum all the undoubled and doubled digits."
 msgstr "تمام ارقام دو برابر نشده و دو برابر شده را جمع کنید."
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:19
 msgid "The credit card number is valid if the sum ends with `0`."
 msgstr "اگر مجموع با ‍`0` خاتمه یابد، شماره کارت اعتباری معتبر است."
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:21
 msgid ""
 "The provided code provides a buggy implementation of the luhn algorithm, "
 "along with two basic unit tests that confirm that most the algorithm is "
 "implemented correctly."
 msgstr ""
 
-#: src/testing/exercise.md
+#: src/testing/exercise.md:25
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and write additional "
+"Copy the code below to https://play.rust-lang.org/ and write additional "
 "tests to uncover bugs in the provided implementation, fixing any bugs you "
 "find."
 msgstr ""
 "کد زیر را به <span dir=ltr><https://play.rust-lang.org/></span>  کپی کنید و "
 "تابع را پیاده‌سازی کنید."
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:57 src/testing/solution.md:69
 msgid "\"4263 9826 4026 9299\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:58 src/testing/solution.md:70
 msgid "\"4539 3195 0343 6467\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:59 src/testing/solution.md:71
 msgid "\"7992 7398 713\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:64 src/testing/solution.md:76
 msgid "\"4223 9826 4026 9299\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:65 src/testing/solution.md:77
 msgid "\"4539 3195 0343 6476\""
 msgstr ""
 
-#: src/testing/exercise.md src/testing/solution.md
+#: src/testing/exercise.md:66 src/testing/solution.md:78
 msgid "\"8273 1232 7352 0569\""
 msgstr ""
 
-#: src/testing/solution.md
-msgid "// This is the buggy version that appears in the problem.\n"
+#: src/testing/solution.md:4
+msgid "// This is the buggy version that appears in the problem."
 msgstr ""
 
-#: src/testing/solution.md
-msgid "// This is the solution and passes all of the tests below.\n"
+#: src/testing/solution.md:27
+msgid "// This is the solution and passes all of the tests below."
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:56
 msgid "\"1234 5678 1234 5670\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:58
 msgid "\"Is {cc_number} a valid credit card number? {}\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:59
 msgid "\"yes\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:59
 msgid "\"no\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:84
 msgid "\"foo 0 0\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:90
 msgid "\" \""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:91
 msgid "\"  \""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:92
 msgid "\"    \""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:97
 msgid "\"0\""
 msgstr ""
 
-#: src/testing/solution.md
+#: src/testing/solution.md:102
 msgid "\" 0 0 \""
 msgstr ""
 
-#: src/welcome-day-4-afternoon.md
-msgid "[Error Handling](./error-handling.md) (45 minutes)"
-msgstr ""
-
-#: src/welcome-day-4-afternoon.md
-msgid "[Unsafe Rust](./unsafe-rust.md) (1 hour and 5 minutes)"
-msgstr ""
-
-#: src/welcome-day-4-afternoon.md
-msgid "Including 10 minute breaks, this session should take about 2 hours"
-msgstr ""
+#: src/error-handling.md
+#, fuzzy
+msgid "Error Trait"
+msgstr "صفت‌های بیشتر"
 
 #: src/error-handling.md
-msgid "[Panics](./error-handling/panics.md) (3 minutes)"
+msgid "thiserror and anyhow"
 msgstr ""
 
-#: src/error-handling.md
-msgid "[Try Operator](./error-handling/try.md) (5 minutes)"
+#: src/error-handling.md src/error-handling/exercise.md:1
+msgid "Exercise: Rewriting with Result"
 msgstr ""
 
-#: src/error-handling.md
-msgid "[Try Conversions](./error-handling/try-conversions.md) (5 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid "[Error Trait](./error-handling/error.md) (5 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid ""
-"[thiserror and anyhow](./error-handling/thiserror-and-anyhow.md) (5 minutes)"
-msgstr ""
-
-#: src/error-handling.md
-msgid ""
-"[Exercise: Rewriting with Result](./error-handling/exercise.md) (20 minutes)"
-msgstr ""
-
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:3
 msgid "Rust handles fatal errors with a \"panic\"."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:5
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
 msgstr ""
 
-#: src/error-handling/panics.md
-msgid "\"v[100]: {}\""
+#: src/error-handling/panics.md:10
+msgid "\"v\\[100\\]: {}\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:14
 msgid "Panics are for unrecoverable and unexpected errors."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:15
 msgid "Panics are symptoms of bugs in the program."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:16
 msgid "Runtime failures like failed bounds checks can panic"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:17
 msgid "Assertions (such as `assert!`) panic on failure"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:18
 msgid "Purpose-specific panics can use the `panic!` macro."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:19
 msgid ""
 "A panic will \"unwind\" the stack, dropping values just as if the functions "
 "had returned."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:21
 msgid ""
 "Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:26
 msgid ""
 "By default, a panic will cause the stack to unwind. The unwinding can be "
 "caught:"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:32
 msgid "\"No problem here!\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:33 src/error-handling/panics.md:38
 msgid "\"{result:?}\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:36
 msgid "\"oh no!\""
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:42
 msgid ""
 "Catching is unusual; do not attempt to implement exceptions with "
 "`catch_unwind`!"
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:44
 msgid ""
 "This can be useful in servers which should keep running even if a single "
 "request crashes."
 msgstr ""
 
-#: src/error-handling/panics.md
+#: src/error-handling/panics.md:46
 msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:3
 msgid ""
 "Runtime errors like connection-refused or file-not-found are handled with "
 "the `Result` type, but matching this type on every call can be cumbersome. "
@@ -10348,80 +9774,79 @@ msgid ""
 "turn the common"
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:15
 msgid "into the much simpler"
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:21
 msgid "We can use this to simplify our error handling code:"
 msgstr ""
 
-#: src/error-handling/try.md
-msgid "//fs::write(\"config.dat\", \"alice\").unwrap();\n"
+#: src/error-handling/try.md:42
+msgid "//fs::write(\"config.dat\", \"alice\").unwrap();"
 msgstr ""
 
-#: src/error-handling/try.md src/error-handling/try-conversions.md
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/try.md:43 src/error-handling/try-conversions.md:65
+#: src/error-handling/thiserror-and-anyhow.md:36
 msgid "\"config.dat\""
 msgstr ""
 
-#: src/error-handling/try.md src/error-handling/try-conversions.md
+#: src/error-handling/try.md:44 src/error-handling/try-conversions.md:66
 msgid "\"username or error: {username:?}\""
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:51
 msgid "Simplify the `read_username` function to use `?`."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:55
 msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:56
 msgid ""
 "Use the `fs::write` call to test out the different scenarios: no file, empty "
 "file, file with username."
 msgstr ""
 
-#: src/error-handling/try.md
+#: src/error-handling/try.md:58
 msgid ""
 "Note that `main` can return a `Result<(), E>` as long as it implements `std::"
-"process:Termination`. In practice, this means that `E` implements `Debug`. "
+"process::Termination`. In practice, this means that `E` implements `Debug`. "
 "The executable will print the `Err` variant and return a nonzero exit status "
 "on error."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:3
 msgid ""
 "The effective expansion of `?` is a little more complicated than previously "
 "indicated:"
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:10
 msgid "works the same as"
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:19
 msgid ""
 "The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function. This makes it easy to encapsulate errors into "
 "higher-level errors."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:42
 msgid "\"IO error: {e}\""
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:43
 msgid "\"Found no username in {path}\""
 msgstr ""
 
-#: src/error-handling/try-conversions.md
-#: src/error-handling/thiserror-and-anyhow.md
-msgid "//fs::write(\"config.dat\", \"\").unwrap();\n"
+#: src/error-handling/try-conversions.md:64
+msgid "//std::fs::write(\"config.dat\", \"\").unwrap();"
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:73
 msgid ""
 "The `?` operator must return a value compatible with the return type of the "
 "function. For `Result`, it means that the error types have to be compatible. "
@@ -10430,31 +9855,31 @@ msgid ""
 "same type or if `ErrorOuter` implements `From<ErrorInner>`."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:79
 msgid ""
 "A common alternative to a `From` implementation is `Result::map_err`, "
 "especially when the conversion only happens in one place."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:82
 msgid ""
 "There is no compatibility requirement for `Option`. A function returning "
 "`Option<T>` can use the `?` operator on `Option<U>` for arbitrary `T` and "
 "`U` types."
 msgstr ""
 
-#: src/error-handling/try-conversions.md
+#: src/error-handling/try-conversions.md:86
 msgid ""
 "A function that returns `Result` cannot use `?` on `Option` and vice versa. "
 "However, `Option::ok_or` converts `Option` to `Result` whereas `Result::ok` "
 "turns `Result` into `Option`."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:1
 msgid "Dynamic Error Types"
 msgstr "انواع خطاهای Dynamic"
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:3
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
 "our own enum covering all the different possibilities. The `std::error::"
@@ -10462,29 +9887,29 @@ msgid ""
 "error."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:20 src/error-handling/error.md:21
 msgid "\"count.dat\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:20
 msgid "\"1i3\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:22
 msgid "\"Count: {count}\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:23
 msgid "\"Error: {err}\""
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:31
 msgid ""
 "The `read_count` function can return `std::io::Error` (from file operations) "
 "or `std::num::ParseIntError` (from `String::parse`)."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:34
 msgid ""
 "Boxing errors saves on code, but gives up the ability to cleanly handle "
 "different error cases differently in the program. As such it's generally not "
@@ -10493,110 +9918,109 @@ msgid ""
 "message somewhere."
 msgstr ""
 
-#: src/error-handling/error.md
+#: src/error-handling/error.md:40
 msgid ""
 "Make sure to implement the `std::error::Error` trait when defining a custom "
 "error type so it can be boxed. But if you need to support the `no_std` "
 "attribute, keep in mind that the `std::error::Error` trait is currently "
-"compatible with `no_std` in [nightly](https://github.com/rust-lang/rust/"
-"issues/103765) only."
+"compatible with `no_std` in nightly only."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:3
 msgid ""
-"The [`thiserror`](https://docs.rs/thiserror/) and [`anyhow`](https://docs.rs/"
-"anyhow/) crates are widely used to simplify error handling."
+"The `thiserror` and `anyhow` crates are widely used to simplify error "
+"handling."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:7
 msgid ""
 "`thiserror` is often used in libraries to create custom error types that "
 "implement `From<T>`."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:9
 msgid ""
 "`anyhow` is often used by applications to help with error handling in "
 "functions, including adding contextual information to your errors."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:19
 msgid "\"Found no username in {0}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:25
 msgid "\"Failed to open {path}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:27
 msgid "\"Failed to read\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:35
+msgid "//fs::write(\"config.dat\", \"\").unwrap();"
+msgstr ""
+
+#: src/error-handling/thiserror-and-anyhow.md:37
 msgid "\"Username: {username}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:38
 msgid "\"Error: {err:?}\""
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:46
 msgid "`thiserror`"
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:48
 msgid ""
 "The `Error` derive macro is provided by `thiserror`, and has lots of useful "
 "attributes to help define error types in a compact way."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:50
 msgid "The `std::error::Error` trait is derived automatically."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:51
 msgid "The message from `#[error]` is used to derive the `Display` trait."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:53
 msgid "`anyhow`"
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:55
 msgid ""
 "`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
 "it's again generally not a good choice for the public API of a library, but "
 "is widely used in applications."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:58
 msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:59
 msgid ""
 "Actual error type inside of it can be extracted for examination if necessary."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:60
 msgid ""
 "Functionality provided by `anyhow::Result<T>` may be familiar to Go "
 "developers, as it provides similar usage patterns and ergonomics to `(T, "
 "error)` from Go."
 msgstr ""
 
-#: src/error-handling/thiserror-and-anyhow.md
+#: src/error-handling/thiserror-and-anyhow.md:63
 msgid ""
 "`anyhow::Context` is a trait implemented for the standard `Result` and "
 "`Option` types. `use anyhow::Context` is necessary to enable `.context()` "
 "and `.with_context()` on those types."
 msgstr ""
 
-#: src/error-handling/exercise.md
-msgid "Exercise: Rewriting with Result"
-msgstr ""
-
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:3
 msgid ""
 "The following implements a very simple parser for an expression language. "
 "However, it handles errors by panicking. Rewrite it to instead use idiomatic "
@@ -10604,184 +10028,155 @@ msgid ""
 "use `thiserror` and `anyhow`."
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:8
 msgid ""
 "HINT: start by fixing error handling in the `parse` function. Once that is "
 "working correctly, update `Tokenizer` to implement "
 "`Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "/// An arithmetic operator.\n"
+#: src/error-handling/exercise.md:15 src/error-handling/solution.md:9
+msgid "/// An arithmetic operator."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "/// A token in the expression language.\n"
+#: src/error-handling/exercise.md:22 src/error-handling/solution.md:16
+msgid "/// A token in the expression language."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "/// An expression in the expression language.\n"
+#: src/error-handling/exercise.md:30 src/error-handling/solution.md:24
+msgid "/// An expression in the expression language."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "/// A reference to a variable.\n"
+#: src/error-handling/exercise.md:34 src/error-handling/solution.md:28
+msgid "/// A reference to a variable."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "/// A literal number.\n"
+#: src/error-handling/exercise.md:36 src/error-handling/solution.md:30
+msgid "/// A literal number."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "/// A binary operation.\n"
+#: src/error-handling/exercise.md:38 src/error-handling/solution.md:32
+msgid "/// A binary operation."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "'z'"
+#: src/error-handling/exercise.md:60 src/error-handling/solution.md:60
+#: src/error-handling/solution.md:75
+msgid "'\\_'"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "'_'"
-msgstr ""
-
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:76 src/error-handling/solution.md:76
 msgid "'+'"
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:77 src/error-handling/solution.md:77
 msgid "'-'"
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:78
 msgid "\"Unexpected character {c}\""
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:88 src/error-handling/solution.md:87
 msgid "\"Unexpected end of input\""
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:92
 msgid "\"Invalid 32-bit integer'\""
 msgstr ""
 
-#: src/error-handling/exercise.md
+#: src/error-handling/exercise.md:96 src/error-handling/exercise.md:106
 msgid "\"Unexpected token {tok:?}\""
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
-msgid "// Look ahead to parse a binary operation if present.\n"
+#: src/error-handling/exercise.md:98 src/error-handling/solution.md:110
+msgid "// Look ahead to parse a binary operation if present."
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:114 src/error-handling/solution.md:127
 msgid "\"10+foo+20-30\""
 msgstr ""
 
-#: src/error-handling/exercise.md src/error-handling/solution.md
+#: src/error-handling/exercise.md:115 src/error-handling/solution.md:128
 msgid "\"{expr:?}\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:42
 msgid "\"Unexpected character '{0}' in input\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:85
 msgid "\"Tokenizer error: {0}\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:89
 msgid "\"Unexpected token {0:?}\""
 msgstr ""
 
-#: src/error-handling/solution.md
+#: src/error-handling/solution.md:91
 msgid "\"Invalid number\""
 msgstr ""
 
 #: src/unsafe-rust.md
-msgid "[Unsafe](./unsafe-rust/unsafe.md) (5 minutes)"
+msgid "This segment should take about 1 hour and 5 minutes. It contains:"
 msgstr ""
 
-#: src/unsafe-rust.md
-msgid ""
-"[Dereferencing Raw Pointers](./unsafe-rust/dereferencing.md) (10 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Mutable Static Variables](./unsafe-rust/mutable-static.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Unions](./unsafe-rust/unions.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Unsafe Functions](./unsafe-rust/unsafe-functions.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Unsafe Traits](./unsafe-rust/unsafe-traits.md) (5 minutes)"
-msgstr ""
-
-#: src/unsafe-rust.md
-msgid "[Exercise: FFI Wrapper](./unsafe-rust/exercise.md) (30 minutes)"
-msgstr ""
-
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:3
 msgid "The Rust language has two parts:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:5
 msgid "**Safe Rust:** memory safe, no undefined behavior possible."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:6
 msgid ""
 "**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:8
 msgid ""
 "We saw mostly safe Rust in this course, but it's important to know what "
 "Unsafe Rust is."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
 "carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:14
 msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:16
 msgid "Dereference raw pointers."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:17
 msgid "Access or modify mutable static variables."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:18
 msgid "Access `union` fields."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:19
 msgid "Call `unsafe` functions, including `extern` functions."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:20
 msgid "Implement `unsafe` traits."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:22
 msgid ""
 "We will briefly cover unsafe capabilities next. For full details, please see "
-"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"Chapter 19.1 in the Rust Book and the Rustonomicon."
 msgstr ""
 
-#: src/unsafe-rust/unsafe.md
+#: src/unsafe-rust/unsafe.md:29
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
 "have turned off some compiler safety features and have to write correct code "
@@ -10789,118 +10184,118 @@ msgid ""
 "rules."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:7
 msgid "\"careful!\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:12
 msgid ""
-"// Safe because r1 and r2 were obtained from references and so are\n"
-"    // guaranteed to be non-null and properly aligned, the objects "
-"underlying\n"
-"    // the references from which they were obtained are live throughout the\n"
-"    // whole unsafe block, and they are not accessed either through the\n"
-"    // references or concurrently through any other pointers.\n"
+"// SAFETY: r1 and r2 were obtained from references and so are guaranteed "
+"to // be non-null and properly aligned, the objects underlying the "
+"references // from which they were obtained are live throughout the whole "
+"unsafe // block, and they are not accessed either through the references "
+"or // concurrently through any other pointers."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:18
 msgid "\"r1 is: {}\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:19
 msgid "\"uhoh\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:20
 msgid "\"r2 is: {}\""
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:23
 msgid ""
-"// NOT SAFE. DO NOT DO THIS.\n"
-"    /*\n"
-"    let r3: &String = unsafe { &*r1 };\n"
-"    drop(s);\n"
-"    println!(\"r3 is: {}\", *r3);\n"
-"    */"
+"// NOT SAFE. DO NOT DO THIS. /\\* let r3: &String = unsafe { &\\*r1 }; "
+"drop(s); println!(\"r3 is: {}\", \\*r3); \\*/"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:35
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
 "a comment for each `unsafe` block explaining how the code inside it "
 "satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:39
 msgid ""
 "In the case of pointer dereferences, this means that the pointers must be "
-"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
+"_valid_, i.e.:"
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:42
 msgid "The pointer must be non-null."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:43
 msgid ""
 "The pointer must be _dereferenceable_ (within the bounds of a single "
 "allocated object)."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:45
 msgid "The object must not have been deallocated."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:46
 msgid "There must not be concurrent accesses to the same location."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:47
 msgid ""
 "If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:50
 msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 
-#: src/unsafe-rust/dereferencing.md
+#: src/unsafe-rust/dereferencing.md:52
 msgid ""
 "The \"NOT SAFE\" section gives an example of a common kind of UB bug: `*r1` "
 "has the `'static` lifetime, so `r3` has type `&'static String`, and thus "
 "outlives `s`. Creating a reference from a pointer requires _great care_."
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:3
 msgid "It is safe to read an immutable static variable:"
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:6
 #, fuzzy
 msgid "\"Hello, world!\""
 msgstr "سلام دنیا"
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:9
 msgid "\"HELLO_WORLD: {HELLO_WORLD}\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:13
 msgid ""
 "However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:20 src/unsafe-rust/mutable-static.md:29
+msgid ""
+"// SAFETY: There are no other threads which could be accessing `COUNTER`."
+msgstr ""
+
+#: src/unsafe-rust/mutable-static.md:31
 msgid "\"COUNTER: {COUNTER}\""
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:39
 msgid ""
 "The program here is safe because it is single-threaded. However, the Rust "
 "compiler is conservative and will assume the worst. Try removing the "
@@ -10908,128 +10303,130 @@ msgid ""
 "mutate a static from multiple threads."
 msgstr ""
 
-#: src/unsafe-rust/mutable-static.md
+#: src/unsafe-rust/mutable-static.md:44
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:14
 msgid "\"int: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:15
 msgid "\"bool: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:15
 #, fuzzy
-msgid "// Undefined behavior!\n"
+msgid "// Undefined behavior!"
 msgstr "هیچ رفتار تعریف نشده‌ای در زمان اجرا:"
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:22
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
 msgstr ""
 
-#: src/unsafe-rust/unions.md
+#: src/unsafe-rust/unions.md:25
 msgid ""
 "If you just want to reinterpret bytes as a different type, you probably want "
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
-"crates/zerocopy) crate."
+"`std::mem::transmute` or a safe wrapper such as the `zerocopy` crate."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:3 src/unsafe-rust/unsafe-functions.md:76
 msgid "Calling Unsafe Functions"
 msgstr "فراخوانی متدهای ناامن"
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:5
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
 "you must uphold to avoid undefined behaviour:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md src/unsafe-rust/exercise.md
-#: src/unsafe-rust/solution.md src/android/interoperability/with-c.md
-#: src/android/interoperability/with-c/rust.md
-#: src/android/interoperability/cpp/cpp-bridge.md
-#: src/exercises/chromium/build-rules.md src/bare-metal/aps/inline-assembly.md
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/unsafe-rust/unsafe-functions.md:9 src/unsafe-rust/exercise.md:91
+#: src/unsafe-rust/solution.md:41 src/android/interoperability/with-c.md:9
+#: src/android/interoperability/with-c/rust.md:15
+#: src/android/interoperability/with-c/rust.md:30
+#: src/android/interoperability/cpp/cpp-bridge.md:29
+#: src/android/interoperability/cpp/cpp-bridge.md:38
+#: src/exercises/chromium/build-rules.md:8
+#: src/exercises/chromium/build-rules.md:21
+#: src/bare-metal/aps/inline-assembly.md:19
+#: src/bare-metal/aps/better-uart/using.md:24
+#: src/bare-metal/aps/logging/using.md:23
+#: src/exercises/bare-metal/solutions-afternoon.md:43
 msgid "\"C\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:14
 msgid "\"🗻∈🌏\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:16
 msgid ""
-"// Safe because the indices are in the correct order, within the bounds of\n"
-"    // the string slice, and lie on UTF-8 sequence boundaries.\n"
+"// SAFETY: The indices are in the correct order, within the bounds of the // "
+"string slice, and lie on UTF-8 sequence boundaries."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:19
+#: src/unsafe-rust/unsafe-functions.md:20
+#: src/unsafe-rust/unsafe-functions.md:21
 msgid "\"emoji: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:24
 msgid "\"char count: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
-#, fuzzy
-msgid "// Undefined behavior if abs misbehaves.\n"
-msgstr "هیچ رفتار تعریف نشده‌ای در زمان اجرا:"
+#: src/unsafe-rust/unsafe-functions.md:26
+msgid ""
+"// SAFETY: `abs` doesn't deal with pointers and doesn't have any safety // "
+"requirements."
+msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:29
 msgid "\"Absolute value of -3 according to C: {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:32
 msgid ""
-"// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
-"    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe {\n"
-"    // emojis.get_unchecked(0..3) }));\n"
+"// Not upholding the UTF-8 encoding requirement breaks memory safety! // "
+"println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) }); // println!"
+"(\"char count: {}\", count_chars(unsafe { // emojis.get_unchecked(0..3) }));"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:43
+#: src/unsafe-rust/unsafe-functions.md:88
 msgid "Writing Unsafe Functions"
 msgstr "نوشتن متدهای ناامن"
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:45
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
 "conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:49
 msgid ""
-"/// Swaps the values pointed to by the given pointers.\n"
-"///\n"
-"/// # Safety\n"
-"///\n"
-"/// The pointers must be valid and properly aligned.\n"
+"/// Swaps the values pointed to by the given pointers. /// /// # "
+"Safety /// /// The pointers must be valid and properly aligned."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
-msgid "// Safe because ...\n"
+#: src/unsafe-rust/unsafe-functions.md:64
+msgid "// SAFETY: ..."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:69
 msgid "\"a = {}, b = {}\""
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:78
 msgid ""
 "`get_unchecked`, like most `_unchecked` functions, is unsafe, because it can "
 "create UB if the range is incorrect. `abs` is incorrect for a different "
@@ -11039,19 +10436,17 @@ msgid ""
 "undefined behaviour under any arbitrary circumstances."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
-msgid ""
-"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
-"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
+#: src/unsafe-rust/unsafe-functions.md:85
+msgid "The `\"C\"` in this example is the ABI; other ABIs are available too."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:90
 msgid ""
 "We wouldn't actually use pointers for a `swap` function - it can be done "
 "safely with references."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-functions.md
+#: src/unsafe-rust/unsafe-functions.md:93
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
 "`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
@@ -11059,313 +10454,310 @@ msgid ""
 "edition."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "پیاده سازی صفات (Traits) ناامن"
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
 "must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:6
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks [something "
-"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks something "
+"like this:"
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:12
 msgid ""
-"/// ...\n"
-"/// # Safety\n"
-"/// The type must have a defined representation and no padding.\n"
+"/// ... /// # Safety /// The type must have a defined representation and no "
+"padding."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
-msgid "// Safe because u32 has a defined representation and no padding.\n"
+#: src/unsafe-rust/unsafe-traits.md:26
+msgid "// SAFETY: `u32` has a defined representation and no padding."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:34
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:37
 msgid ""
 "The actual safety section for `AsBytes` is rather longer and more "
 "complicated."
 msgstr ""
 
-#: src/unsafe-rust/unsafe-traits.md
+#: src/unsafe-rust/unsafe-traits.md:39
 msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:1
 msgid "Safe FFI Wrapper"
 msgstr "امن بودن FFI Wrapper"
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:3
 msgid ""
 "Rust has great support for calling functions through a _foreign function "
 "interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the names of files in a directory."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:7
 msgid "You will want to consult the manual pages:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+#: src/unsafe-rust/exercise.md:9
+msgid "`opendir(3)`"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+#: src/unsafe-rust/exercise.md:10
+msgid "`readdir(3)`"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+#: src/unsafe-rust/exercise.md:11
+msgid "`closedir(3)`"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
-"ffi/) module. There you find a number of string types which you need for the "
-"exercise:"
+"You will also want to browse the `std::ffi` module. There you find a number "
+"of string types which you need for the exercise:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:16
 msgid "Encoding"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:16
 msgid "Use"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid ""
-"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
-"(https://doc.rust-lang.org/std/string/struct.String.html)"
-msgstr ""
+#: src/unsafe-rust/exercise.md:18
+#, fuzzy
+msgid "`str` and `String`"
+msgstr "`break` و `continue`"
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:18
 msgid "UTF-8"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:18
 msgid "Text processing in Rust"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid ""
-"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
-"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
-msgstr ""
+#: src/unsafe-rust/exercise.md:19
+#, fuzzy
+msgid "`CStr` and `CString`"
+msgstr "`break` و `continue`"
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:19
 msgid "NUL-terminated"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:19
 msgid "Communicating with C functions"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid ""
-"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
-"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
-msgstr ""
+#: src/unsafe-rust/exercise.md:20
+#, fuzzy
+msgid "`OsStr` and `OsString`"
+msgstr "String"
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:20
 msgid "OS-specific"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:20
 msgid "Communicating with the OS"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:22
 msgid "You will convert between all these types:"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:24
 msgid ""
 "`&str` to `CString`: you need to allocate space for a trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:25
 msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:26
 msgid ""
 "`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
 "character,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:28
 msgid ""
 "`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
 "unknown data\","
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:30
 msgid ""
-"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
-"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use `OsStrExt` "
+"to create it,"
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:33
 msgid ""
 "`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
 "return it and call `readdir` again."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid ""
-"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
-"useful chapter about FFI."
+#: src/unsafe-rust/exercise.md:36
+msgid "The Nomicon also has a very useful chapter about FFI."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
+#: src/unsafe-rust/exercise.md:47
+#, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
+"Copy the code below to https://play.rust-lang.org/ and fill in the missing "
 "functions and methods:"
 msgstr ""
+"کد زیر را در <span dir=ltr><https://play.rust-lang.org/></span> کپی کرده و "
+"توابع را پیاده‌سازی کنید:"
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:56 src/unsafe-rust/exercise.md:69
+#: src/unsafe-rust/exercise.md:80 src/unsafe-rust/exercise.md:94
+#: src/unsafe-rust/exercise.md:102 src/unsafe-rust/solution.md:6
+#: src/unsafe-rust/solution.md:19 src/unsafe-rust/solution.md:30
+#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
 msgid "\"macos\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
-msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+#: src/unsafe-rust/exercise.md:59 src/unsafe-rust/solution.md:9
+msgid "// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:66 src/unsafe-rust/solution.md:16
 msgid ""
-"// Layout according to the Linux man page for readdir(3), where ino_t and\n"
-"    // off_t are resolved according to the definitions in\n"
-"    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
+"// Layout according to the Linux man page for readdir(3), where ino_t and // "
+"off_t are resolved according to the definitions in // /usr/include/x86_64-"
+"linux-gnu/{sys/types.h, bits/typesizes.h}."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
-msgid "// Layout according to the macOS man page for dir(5).\n"
+#: src/unsafe-rust/exercise.md:79 src/unsafe-rust/solution.md:29
+msgid "// Layout according to the macOS man page for dir(5)."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:94 src/unsafe-rust/exercise.md:102
+#: src/unsafe-rust/solution.md:44 src/unsafe-rust/solution.md:52
 msgid "\"x86_64\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:97 src/unsafe-rust/solution.md:47
 msgid ""
-"// See https://github.com/rust-lang/libc/issues/414 and the section on\n"
-"        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
-"        //\n"
-"        // \"Platforms that existed before these updates were available\" "
-"refers\n"
-"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
-"PowerPC.\n"
+"// See https://github.com/rust-lang/libc/issues/414 and the section on // "
+"\\_DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2). // // "
+"\"Platforms that existed before these updates were available\" refers // to "
+"macOS (as opposed to iOS / wearOS / etc.) on Intel and PowerPC."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:103 src/unsafe-rust/solution.md:53
 msgid "\"readdir$INODE64\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:121 src/unsafe-rust/solution.md:71
 msgid ""
-"// Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
+"// Call opendir and return a Ok value if that worked, // otherwise return "
+"Err with a message."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md
-msgid "// Keep calling readdir until we get a NULL pointer back.\n"
+#: src/unsafe-rust/exercise.md:130
+msgid "// Keep calling readdir until we get a NULL pointer back."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
-msgid "// Call closedir as needed.\n"
+#: src/unsafe-rust/exercise.md:137 src/unsafe-rust/solution.md:105
+msgid "// Call closedir as needed."
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
-#: src/android/interoperability/with-c/rust.md
+#: src/unsafe-rust/exercise.md:143 src/unsafe-rust/solution.md:116
+#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
+#: src/android/interoperability/with-c/rust.md:44
 msgid "\".\""
 msgstr ""
 
-#: src/unsafe-rust/exercise.md src/unsafe-rust/solution.md
+#: src/unsafe-rust/exercise.md:144 src/unsafe-rust/solution.md:117
 msgid "\"files: {:#?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:74
 msgid "\"Invalid path: {err}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
-msgid "// SAFETY: path.as_ptr() cannot be NULL.\n"
+#: src/unsafe-rust/solution.md:75
+msgid "// SAFETY: path.as_ptr() cannot be NULL."
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:78
 msgid "\"Could not open {:?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:88
 msgid ""
-"// Keep calling readdir until we get a NULL pointer back.\n"
-"        // SAFETY: self.dir is never NULL.\n"
+"// Keep calling readdir until we get a NULL pointer back. // SAFETY: self."
+"dir is never NULL."
 msgstr ""
 
-#: src/unsafe-rust/solution.md
-msgid "// We have reached the end of the directory.\n"
+#: src/unsafe-rust/solution.md:92
+msgid "// We have reached the end of the directory."
 msgstr ""
 
-#: src/unsafe-rust/solution.md
-msgid ""
-"// SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
-"        // terminated.\n"
+#: src/unsafe-rust/solution.md:95
+msgid "// SAFETY: dirent is not NULL and dirent.d_name is NUL // terminated."
 msgstr ""
 
-#: src/unsafe-rust/solution.md
-msgid "// SAFETY: self.dir is not NULL.\n"
+#: src/unsafe-rust/solution.md:107
+msgid "// SAFETY: self.dir is not NULL."
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:109
 msgid "\"Could not close {:?}\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:128
 msgid "\"no-such-directory\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:136 src/unsafe-rust/solution.md:151
 msgid "\"Non UTF-8 character in path\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:140 src/unsafe-rust/solution.md:155
 msgid "\"..\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:147 src/unsafe-rust/solution.md:155
 msgid "\"foo.txt\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:147
 msgid "\"The Foo Diaries\\n\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:148 src/unsafe-rust/solution.md:155
 msgid "\"bar.png\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
-msgid "\"<PNG>\\n\""
+#: src/unsafe-rust/solution.md:148
+msgid "\"<PNG>\\\\n\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:149 src/unsafe-rust/solution.md:155
 msgid "\"crab.rs\""
 msgstr ""
 
-#: src/unsafe-rust/solution.md
+#: src/unsafe-rust/solution.md:149
 msgid "\"//! Crab\\n\""
 msgstr ""
 
@@ -11395,27 +10787,19 @@ msgid ""
 msgstr ""
 
 #: src/android.md
-msgid ""
-"Service example: [DNS over HTTP](https://security.googleblog.com/2022/07/dns-"
-"over-http3-in-android.html)"
+msgid "Service example: DNS over HTTP"
 msgstr ""
 
 #: src/android.md
-msgid ""
-"Libraries: [Rutabaga Virtual Graphics Interface](https://crosvm.dev/book/"
-"appendix/rutabaga_gfx.html)"
+msgid "Libraries: Rutabaga Virtual Graphics Interface"
 msgstr ""
 
 #: src/android.md
-msgid ""
-"Kernel Drivers: [Binder](https://lore.kernel.org/rust-for-linux/20231101-"
-"rust-binder-v1-0-08ba9197f637@google.com/)"
+msgid "Kernel Drivers: Binder"
 msgstr ""
 
 #: src/android.md
-msgid ""
-"Firmware: [pKVM firmware](https://security.googleblog.com/2023/10/bare-metal-"
-"rust-in-android.html)"
+msgid "Firmware: pKVM firmware"
 msgstr ""
 
 #: src/android/setup.md
@@ -11425,9 +10809,7 @@ msgid ""
 msgstr ""
 
 #: src/android/setup.md
-msgid ""
-"Please see the [Android Developer Codelab](https://source.android.com/docs/"
-"setup/start) for details."
+msgid "Please see the Android Developer Codelab for details."
 msgstr ""
 
 #: src/android/setup.md
@@ -11553,11 +10935,7 @@ msgid ""
 msgstr ""
 
 #: src/android/build-rules.md
-msgid ""
-"There is a plan to transition [Android](https://source.android.com/docs/"
-"setup/build/bazel/introduction), [ChromeOS](https://chromium.googlesource."
-"com/chromiumos/bazel/), and [Fuchsia](https://source.android.com/docs/setup/"
-"build/bazel/introduction) to Bazel."
+msgid "There is a plan to transition Android, ChromeOS, and Fuchsia to Bazel."
 msgstr ""
 
 #: src/android/build-rules.md
@@ -11568,50 +10946,50 @@ msgstr ""
 msgid "Fun fact: Data from Star Trek is a Soong-type Android."
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:1
 msgid "Rust Binaries"
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:3
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
 "create the following files:"
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 msgid "_hello_rust/Android.bp_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:10 src/android/build-rules/binary.md:11
 msgid "\"hello_rust\""
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/build-rules/binary.md:12 src/android/build-rules/library.md:19
 #: src/android/logging.md
 msgid "\"src/main.rs\""
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
 msgid "_hello_rust/src/main.rs_:"
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
-msgid "//! Rust demo.\n"
+#: src/android/build-rules/binary.md:19 src/android/build-rules/library.md:37
+msgid "//! Rust demo."
 msgstr ""
 
-#: src/android/build-rules/binary.md src/android/build-rules/library.md
-msgid "/// Prints a greeting to standard output.\n"
+#: src/android/build-rules/binary.md:20 src/android/build-rules/library.md:41
+msgid "/// Prints a greeting to standard output."
 msgstr ""
 
-#: src/android/build-rules/binary.md src/exercises/chromium/build-rules.md
+#: src/android/build-rules/binary.md:23 src/exercises/chromium/build-rules.md:9
 msgid "\"Hello from Rust!\""
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:27
 msgid "You can now build, push, and run the binary:"
 msgstr ""
 
-#: src/android/build-rules/binary.md
+#: src/android/build-rules/binary.md:29
 msgid ""
 "```shell\n"
 "m hello_rust\n"
@@ -11620,75 +10998,74 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:1
 msgid "Rust Libraries"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:3
 msgid "You use `rust_library` to create a new Rust library for Android."
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:5
 msgid "Here we declare a dependency on two libraries:"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:7
 msgid "`libgreeting`, which we define below,"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:8
 msgid ""
-"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
-"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
-"crates/)."
+"`libtextwrap`, which is a crate already vendored in `external/rust/crates/`."
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:17 src/android/build-rules/library.md:18
 msgid "\"hello_rust_with_dep\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:21 src/android/build-rules/library.md:28
 msgid "\"libgreetings\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:22
 msgid "\"libtextwrap\""
 msgstr ""
 
-#: src/android/build-rules/library.md
-msgid "// Need this to avoid dynamic link error.\n"
+#: src/android/build-rules/library.md:24
+msgid "// Need this to avoid dynamic link error."
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:29
 msgid "\"greetings\""
 msgstr ""
 
-#: src/android/build-rules/library.md src/android/aidl/implementation.md
-#: src/android/interoperability/java.md
+#: src/android/build-rules/library.md:30
+#: src/android/aidl/example-service/service.md:28 src/android/testing.md
+#: src/android/interoperability/java.md:39
 msgid "\"src/lib.rs\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:48
 msgid "_hello_rust/src/lib.rs_:"
 msgstr ""
 
-#: src/android/build-rules/library.md
-msgid "//! Greeting library.\n"
+#: src/android/build-rules/library.md:51
+msgid "//! Greeting library."
 msgstr ""
 
-#: src/android/build-rules/library.md
-msgid "/// Greet `name`.\n"
+#: src/android/build-rules/library.md:52
+msgid "/// Greet `name`."
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:55
 msgid "\"Hello {name}, it is very nice to meet you!\""
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:59
 msgid "You build, push, and run the binary like before:"
 msgstr ""
 
-#: src/android/build-rules/library.md
+#: src/android/build-rules/library.md:61
 msgid ""
 "```shell\n"
 "m hello_rust_with_dep\n"
@@ -11699,9 +11076,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl.md
-msgid ""
-"The [Android Interface Definition Language (AIDL)](https://developer.android."
-"com/guide/components/aidl) is supported in Rust:"
+msgid "The Android Interface Definition Language (AIDL) is supported in Rust:"
 msgstr ""
 
 #: src/android/aidl.md
@@ -11712,139 +11087,243 @@ msgstr ""
 msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
-#: src/android/aidl/interface.md
+#: src/android/aidl/birthday-service.md:3
+msgid ""
+"To illustrate how to use Rust with Binder, we're going to walk through the "
+"process of creating a Binder interface. We're then going to both implement "
+"the described service and write client code that talks to that service."
+msgstr ""
+
+#: src/android/aidl/example-service/interface.md:1
 msgid "AIDL Interfaces"
 msgstr ""
 
-#: src/android/aidl/interface.md
+#: src/android/aidl/example-service/interface.md:3
 msgid "You declare the API of your service using an AIDL interface:"
 msgstr ""
 
-#: src/android/aidl/interface.md
+#: src/android/aidl/example-service/interface.md:5
+#: src/android/aidl/example-service/service-bindings.md:6
 msgid ""
 "_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
 
-#: src/android/aidl/interface.md src/android/aidl/changing.md
-msgid "/** Birthday service interface. */"
+#: src/android/aidl/example-service/interface.md:8
+#: src/android/aidl/example-service/service-bindings.md:9
+#: src/android/aidl/example-service/changing-definition.md:8
+msgid "/\\*\\* Birthday service interface. \\*/"
 msgstr ""
 
-#: src/android/aidl/interface.md src/android/aidl/changing.md
-msgid "/** Generate a Happy Birthday message. */"
+#: src/android/aidl/example-service/interface.md:10
+#: src/android/aidl/example-service/service-bindings.md:11
+#: src/android/aidl/example-service/changing-definition.md:11
+msgid "/\\*\\* Generate a Happy Birthday message. \\*/"
 msgstr ""
 
-#: src/android/aidl/interface.md
+#: src/android/aidl/example-service/interface.md:15
 msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/interface.md
+#: src/android/aidl/example-service/interface.md:19
 msgid "\"com.example.birthdayservice\""
 msgstr ""
 
-#: src/android/aidl/interface.md
-msgid "\"com/example/birthdayservice/*.aidl\""
+#: src/android/aidl/example-service/interface.md:20
+msgid "\"com/example/birthdayservice/\\*.aidl\""
 msgstr ""
 
-#: src/android/aidl/interface.md
-msgid "// Rust is not enabled by default\n"
+#: src/android/aidl/example-service/interface.md:23
+msgid "// Rust is not enabled by default"
 msgstr ""
 
-#: src/android/aidl/interface.md
+#: src/android/aidl/example-service/interface.md:32
 msgid ""
-"Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor partition."
+"Note that the directory structure under the `aidl/` directory needs to match "
+"the package name used in the AIDL file, i.e. the package is `com.example."
+"birthdayservice` and the file is at `aidl/com/example/IBirthdayService.aidl`."
 msgstr ""
 
-#: src/android/aidl/implementation.md
+#: src/android/aidl/example-service/service-bindings.md:1
+msgid "Generated Service API"
+msgstr ""
+
+#: src/android/aidl/example-service/service-bindings.md:3
+msgid ""
+"Binder generates a trait corresponding to the interface definition. trait to "
+"talk to the service."
+msgstr ""
+
+#: src/android/aidl/example-service/service-bindings.md:16
+#, fuzzy
+msgid "_Generated trait_:"
+msgstr "Rust ناایمن"
+
+#: src/android/aidl/example-service/service-bindings.md:24
+msgid ""
+"Your service will need to implement this trait, and your client will use "
+"this trait to talk to the service."
+msgstr ""
+
+#: src/android/aidl/example-service/service-bindings.md:29
+msgid ""
+"The generated bindings can be found at `out/soong/.intermediates/<path to "
+"module>/`."
+msgstr ""
+
+#: src/android/aidl/example-service/service-bindings.md:31
+msgid ""
+"Point out how the generated function signature, specifically the argument "
+"and return types, correspond the interface definition."
+msgstr ""
+
+#: src/android/aidl/example-service/service-bindings.md:33
+msgid ""
+"`String` for an argument results in a different Rust type than `String` as a "
+"return type."
+msgstr ""
+
+#: src/android/aidl/example-service/service.md:1
 msgid "Service Implementation"
 msgstr ""
 
-#: src/android/aidl/implementation.md
+#: src/android/aidl/example-service/service.md:3
 msgid "We can now implement the AIDL service:"
 msgstr ""
 
-#: src/android/aidl/implementation.md
+#: src/android/aidl/example-service/service.md:5
+#: src/android/aidl/example-service/changing-implementation.md:5
 msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md
-msgid "//! Implementation of the `IBirthdayService` AIDL interface.\n"
+#: src/android/aidl/example-service/service.md:10
+msgid "/// The `IBirthdayService` implementation."
 msgstr ""
 
-#: src/android/aidl/implementation.md
-msgid "/// The `IBirthdayService` implementation.\n"
-msgstr ""
-
-#: src/android/aidl/implementation.md
+#: src/android/aidl/example-service/service.md:18
+#: src/android/aidl/example-service/changing-implementation.md:16
+#: src/android/aidl/types/file-descriptor.md:57
 msgid "\"Happy Birthday {name}, congratulations with the {years} years!\""
 msgstr ""
 
-#: src/android/aidl/implementation.md src/android/aidl/server.md
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/service.md:23
+#: src/android/aidl/example-service/server.md:28
+#: src/android/aidl/example-service/client.md:31
 msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
-#: src/android/aidl/implementation.md src/android/aidl/server.md
+#: src/android/aidl/example-service/service.md:27
+#: src/android/aidl/example-service/server.md:38
 msgid "\"libbirthdayservice\""
 msgstr ""
 
-#: src/android/aidl/implementation.md src/android/aidl/server.md
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/service.md:29
+#: src/android/aidl/example-service/server.md:13
+#: src/android/aidl/example-service/client.md:11
 msgid "\"birthdayservice\""
 msgstr ""
 
-#: src/android/aidl/implementation.md src/android/aidl/server.md
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/service.md:31
+#: src/android/aidl/example-service/server.md:36
+#: src/android/aidl/example-service/client.md:39
 msgid "\"com.example.birthdayservice-rust\""
 msgstr ""
 
-#: src/android/aidl/implementation.md src/android/aidl/server.md
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/service.md:32
+#: src/android/aidl/example-service/server.md:37
+#: src/android/aidl/example-service/client.md:40
 msgid "\"libbinder_rs\""
 msgstr ""
 
-#: src/android/aidl/server.md
+#: src/android/aidl/example-service/service.md:39
+msgid ""
+"Point out the path to the generated `IBirthdayService` trait, and explain "
+"why each of the segments is necessary."
+msgstr ""
+
+#: src/android/aidl/example-service/service.md:41
+msgid ""
+"TODO: What does the `binder::Interface` trait do? Are there methods to "
+"override? Where source?"
+msgstr ""
+
+#: src/android/aidl/example-service/server.md:1
 msgid "AIDL Server"
 msgstr ""
 
-#: src/android/aidl/server.md
+#: src/android/aidl/example-service/server.md:3
 msgid "Finally, we can create a server which exposes the service:"
 msgstr ""
 
-#: src/android/aidl/server.md
+#: src/android/aidl/example-service/server.md:5
 msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
-#: src/android/aidl/server.md src/android/aidl/client.md
-msgid "//! Birthday service.\n"
+#: src/android/aidl/example-service/server.md:8
+msgid "//! Birthday service."
 msgstr ""
 
-#: src/android/aidl/server.md
-msgid "/// Entry point for birthday service.\n"
+#: src/android/aidl/example-service/server.md:14
+msgid "/// Entry point for birthday service."
 msgstr ""
 
-#: src/android/aidl/server.md
+#: src/android/aidl/example-service/server.md:23
 msgid "\"Failed to register service\""
 msgstr ""
 
-#: src/android/aidl/server.md
+#: src/android/aidl/example-service/server.md:32
+#: src/android/aidl/example-service/server.md:33
 msgid "\"birthday_server\""
 msgstr ""
 
-#: src/android/aidl/server.md
+#: src/android/aidl/example-service/server.md:34
 #, fuzzy
 msgid "\"src/server.rs\""
 msgstr "سرورها"
 
-#: src/android/aidl/server.md src/android/aidl/client.md
-msgid "// To avoid dynamic link error.\n"
+#: src/android/aidl/example-service/server.md:40
+#: src/android/aidl/example-service/client.md:42
+msgid "// To avoid dynamic link error."
 msgstr ""
 
-#: src/android/aidl/deploy.md
+#: src/android/aidl/example-service/server.md:46
+msgid ""
+"The process for taking a user-defined service implementation (in this case "
+"the `BirthdayService` type, which implements the `IBirthdayService`) and "
+"starting it as a Binder service has multiple steps, and may appear more "
+"complicated than students are used to if they've used Binder from C++ or "
+"another language. Explain to students why each step is necessary."
+msgstr ""
+
+#: src/android/aidl/example-service/server.md:52
+msgid "Create an instance of your service type (`BirthdayService`)."
+msgstr ""
+
+#: src/android/aidl/example-service/server.md:53
+msgid ""
+"Wrap the service object in corresponding `Bn*` type (`BnBirthdayService` in "
+"this case). This type is generated by Binder and provides the common Binder "
+"functionality that would be provided by the `BnBinder` base class in C++. We "
+"don't have inheritance in Rust, so instead we use composition, putting our "
+"`BirthdayService` within the generated `BnBinderService`."
+msgstr ""
+
+#: src/android/aidl/example-service/server.md:58
+msgid ""
+"Call `add_service`, giving it a service identifier and your service object "
+"(the `BnBirthdayService` object in the example)."
+msgstr ""
+
+#: src/android/aidl/example-service/server.md:60
+msgid ""
+"Call `join_thread_pool` to add the current thread to Binder's thread pool "
+"and start listening for connections."
+msgstr ""
+
+#: src/android/aidl/example-service/deploy.md:3
 msgid "We can now build, push, and start the service:"
 msgstr ""
 
-#: src/android/aidl/deploy.md
+#: src/android/aidl/example-service/deploy.md:5
 msgid ""
 "```shell\n"
 "m birthday_server\n"
@@ -11855,59 +11334,64 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/deploy.md
+#: src/android/aidl/example-service/deploy.md:12
 msgid "In another terminal, check that the service runs:"
 msgstr ""
 
-#: src/android/aidl/deploy.md
+#: src/android/aidl/example-service/deploy.md:22
 msgid "You can also call the service with `service call`:"
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:1
 msgid "AIDL Client"
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:3
 msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:5
+#: src/android/aidl/example-service/changing-implementation.md:29
 msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
-#: src/android/aidl/client.md
-msgid "/// Connect to the BirthdayService.\n"
+#: src/android/aidl/example-service/client.md:12
+msgid "/// Call the birthday service."
 msgstr ""
 
-#: src/android/aidl/client.md
-msgid "/// Call the birthday service.\n"
-msgstr ""
-
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:23
+#: src/android/aidl/types/objects.md:54
+#: src/android/aidl/types/parcelables.md:32
+#: src/android/aidl/types/file-descriptor.md:20
 msgid "\"Failed to connect to BirthdayService\""
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:25
+msgid "// Call the service."
+msgstr ""
+
+#: src/android/aidl/example-service/client.md:27
 msgid "\"{msg}\""
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:35
+#: src/android/aidl/example-service/client.md:36
 msgid "\"birthday_client\""
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:37
 msgid "\"src/client.rs\""
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:46
 msgid "Notice that the client does not depend on `libbirthdayservice`."
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:48
 msgid "Build, push, and run the client on your device:"
 msgstr ""
 
-#: src/android/aidl/client.md
+#: src/android/aidl/example-service/client.md:50
 msgid ""
 "```shell\n"
 "m birthday_client\n"
@@ -11917,10 +11401,580 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md
+#: src/android/aidl/example-service/client.md:62
+msgid ""
+"`Strong<dyn IBirthdayService>` is the trait object representing the service "
+"that the client has connected to."
+msgstr ""
+
+#: src/android/aidl/example-service/client.md:64
+msgid ""
+"`Strong` is a custom smart pointer type for Binder. It handles both an in-"
+"process ref count for the service trait object, and the global Binder ref "
+"count that tracks how many processes have a reference to the object."
+msgstr ""
+
+#: src/android/aidl/example-service/client.md:67
+msgid ""
+"Note that the trait object that the client uses to talk to the service uses "
+"the exact same trait that the server implements. For a given Binder "
+"interface, there is a single Rust trait generated that both client and "
+"server use."
+msgstr ""
+
+#: src/android/aidl/example-service/client.md:71
+msgid ""
+"Use the same service identifier used when registering the service. This "
+"should ideally be defined in a common crate that both the client and server "
+"can depend on."
+msgstr ""
+
+#: src/android/aidl/example-service/changing-definition.md:3
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
 "specify a list of lines for the birthday card:"
+msgstr ""
+
+#: src/android/aidl/example-service/changing-definition.md:16
+msgid "This results in an updated trait definition for `IBirthdayService`:"
+msgstr ""
+
+#: src/android/aidl/example-service/changing-definition.md:31
+msgid ""
+"Note how the `String[]` in the AIDL definition is translated as a "
+"`&[String]` in Rust, i.e. that idiomatic Rust types are used in the "
+"generated bindings wherever possible:"
+msgstr ""
+
+#: src/android/aidl/example-service/changing-definition.md:34
+msgid "`in` array arguments are translated to slices."
+msgstr ""
+
+#: src/android/aidl/example-service/changing-definition.md:35
+msgid "`out` and `inout` args are translated to `&mut Vec<T>`."
+msgstr ""
+
+#: src/android/aidl/example-service/changing-definition.md:36
+msgid "Return values are translated to returning a `Vec<T>`."
+msgstr ""
+
+#: src/android/aidl/example-service/changing-implementation.md:1
+msgid "Updating Client and Service"
+msgstr ""
+
+#: src/android/aidl/example-service/changing-implementation.md:3
+msgid "Update the client and server code to account for the new API."
+msgstr ""
+
+#: src/android/aidl/example-service/changing-implementation.md:20
+msgid "'\\n'"
+msgstr ""
+
+#: src/android/aidl/example-service/changing-implementation.md:36
+msgid "\"Habby birfday to yuuuuu\""
+msgstr ""
+
+#: src/android/aidl/example-service/changing-implementation.md:37
+msgid "\"And also: many more\""
+msgstr ""
+
+#: src/android/aidl/example-service/changing-implementation.md:44
+msgid ""
+"TODO: Move code snippets into project files where they'll actually be built?"
+msgstr ""
+
+#: src/android/aidl/types.md:1
+msgid "Working With AIDL Types"
+msgstr ""
+
+#: src/android/aidl/types.md:3
+msgid "AIDL types translate into the appropriate idiomatic Rust type:"
+msgstr ""
+
+#: src/android/aidl/types.md:5
+msgid "Primitive types map (mostly) to idiomatic Rust types."
+msgstr ""
+
+#: src/android/aidl/types.md:6
+msgid "Collection types like slices, `Vec`s and string types are supported."
+msgstr ""
+
+#: src/android/aidl/types.md:7
+msgid ""
+"References to AIDL objects and file handles can be sent between clients and "
+"services."
+msgstr ""
+
+#: src/android/aidl/types.md:9
+msgid "File handles and parcelables are fully supported."
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:3
+msgid "Primitive types map (mostly) idiomatically:"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:5
+#, fuzzy
+msgid "AIDL Type"
+msgstr "AIDL"
+
+#: src/android/aidl/types/primitives.md:5 src/android/aidl/types/arrays.md:7
+#: src/android/interoperability/cpp/type-mapping.md:3
+#, fuzzy
+msgid "Rust Type"
+msgstr "انواع داده‌های بازگشتی"
+
+#: src/android/aidl/types/primitives.md:5
+msgid "Note"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:7
+#, fuzzy
+msgid "`boolean`"
+msgstr "بولین‌ها"
+
+#: src/android/aidl/types/primitives.md:8
+msgid "`byte`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:8
+msgid "`i8`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:8
+msgid "Note that bytes are signed."
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:9
+msgid "`u16`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:9
+msgid "Note the usage of `u16`, NOT `u32`."
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:10
+msgid "`int`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:10
+msgid "`i32`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:11
+msgid "`long`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:11
+msgid "`i64`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:12
+msgid "`float`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:12
+msgid "`f32`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:13
+msgid "`double`"
+msgstr ""
+
+#: src/android/aidl/types/primitives.md:13
+msgid "`f64`"
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:3
+msgid ""
+"The array types (`T[]`, `byte[]`, and `List<T>`) get translated to the "
+"appropriate Rust array type depending on how they are used in the function "
+"signature:"
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:7
+#, fuzzy
+msgid "Position"
+msgstr "راه حل‌ها"
+
+#: src/android/aidl/types/arrays.md:9
+msgid "`in` argument"
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:9
+#, fuzzy
+msgid "`&[T]`"
+msgstr "برش‌ها"
+
+#: src/android/aidl/types/arrays.md:10
+msgid "`out`/`inout` argument"
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:10
+msgid "`&mut Vec<T>`"
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:11
+msgid "Return"
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:11
+#: src/android/interoperability/cpp/type-mapping.md:11
+msgid "`Vec<T>`"
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:15
+msgid ""
+"In Android 13 or higher, fixed-size arrays are supported, i.e. `T[N]` "
+"becomes `[T; N]`. Fixed-size arrays can have multiple dimensions (e.g. "
+"int\\[3\\]\\[4\\]). In the Java backend, fixed-size arrays are represented "
+"as array types."
+msgstr ""
+
+#: src/android/aidl/types/arrays.md:18
+msgid "Arrays in parcelable fields always get translated to `Vec<T>`."
+msgstr ""
+
+#: src/android/aidl/types/objects.md:3
+msgid ""
+"AIDL objects can be sent either as a concrete AIDL type or as the type-"
+"erased `IBinder` interface:"
+msgstr ""
+
+#: src/android/aidl/types/objects.md:6
+msgid ""
+"**birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider."
+"aidl**:"
+msgstr ""
+
+#: src/android/aidl/types/objects.md:17
+#: src/android/aidl/types/parcelables.md:16
+#: src/android/aidl/types/file-descriptor.md:6
+msgid ""
+"**birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl**:"
+msgstr ""
+
+#: src/android/aidl/types/objects.md:23
+msgid "/\\*\\* The same thing, but using a binder object. \\*/"
+msgstr ""
+
+#: src/android/aidl/types/objects.md:26
+msgid "/\\*\\* The same thing, but using `IBinder`. \\*/"
+msgstr ""
+
+#: src/android/aidl/types/objects.md:31
+#: src/android/aidl/types/parcelables.md:27
+#: src/android/aidl/types/file-descriptor.md:15
+msgid "**birthday_service/src/client.rs**:"
+msgstr ""
+
+#: src/android/aidl/types/objects.md:34
+msgid "/// Rust struct implementing the `IBirthdayInfoProvider` interface."
+msgstr ""
+
+#: src/android/aidl/types/objects.md:56
+msgid "// Create a binder object for the `IBirthdayInfoProvider` interface."
+msgstr ""
+
+#: src/android/aidl/types/objects.md:62
+msgid "// Send the binder object to the service."
+msgstr ""
+
+#: src/android/aidl/types/objects.md:65
+msgid ""
+"// Perform the same operation but passing the provider as an `SpIBinder`."
+msgstr ""
+
+#: src/android/aidl/types/objects.md:72
+msgid ""
+"Note the usage of `BnBirthdayInfoProvider`. This serves the same purpose as "
+"`BnBirthdayService` that we saw previously."
+msgstr ""
+
+#: src/android/aidl/types/parcelables.md:3
+msgid "Binder for Rust supports sending parcelables directly:"
+msgstr ""
+
+#: src/android/aidl/types/parcelables.md:5
+msgid ""
+"**birthday_service/aidl/com/example/birthdayservice/BirthdayInfo.aidl**:"
+msgstr ""
+
+#: src/android/aidl/types/parcelables.md:22
+msgid "/\\*\\* The same thing, but with a parcelable. \\*/"
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:3
+msgid ""
+"Files can be sent between Binder clients/servers using the "
+"`ParcelFileDescriptor` type:"
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:10
+msgid "/\\*\\* The same thing, but loads info from a file. \\*/"
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:22
+msgid "// Open a file and put the birthday info in it."
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:23
+msgid "\"/data/local/tmp/birthday.info\""
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:24
+msgid "\"{name}\""
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:25
+msgid "\"{years}\""
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:27
+msgid "// Create a `ParcelFileDescriptor` from the file and send it."
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:33
+msgid "**birthday_service/src/lib.rs**:"
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:41
+msgid ""
+"// Convert the file descriptor to a `File`. `ParcelFileDescriptor` wraps // "
+"an `OwnedFd`, which can be cloned and then used to create a `File` // object."
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:48
+msgid "\"Invalid file handle\""
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:64
+msgid ""
+"`ParcelFileDescriptor` wraps an `OwnedFd`, and so can be created from a "
+"`File` (or any other type that wraps an `OwnedFd`), and can be used to "
+"create a new `File` handle on the other side."
+msgstr ""
+
+#: src/android/aidl/types/file-descriptor.md:67
+msgid ""
+"Other types of file descriptors can be wrapped and sent, e.g. TCP, UDP, and "
+"UNIX sockets."
+msgstr ""
+
+#: src/android/testing.md
+#, fuzzy
+msgid "Testing in Android"
+msgstr "Rust در اندروید"
+
+#: src/android/testing.md
+msgid ""
+"Building on Testing, we will now look at how unit tests work in AOSP. Use "
+"the `rust_test` module for your unit tests:"
+msgstr ""
+
+#: src/android/testing.md
+#, fuzzy
+msgid "_testing/Android.bp_:"
+msgstr "Rust در اندروید"
+
+#: src/android/testing.md
+msgid "\"libleftpad\""
+msgstr ""
+
+#: src/android/testing.md
+msgid "\"leftpad\""
+msgstr ""
+
+#: src/android/testing.md
+msgid "\"libleftpad_test\""
+msgstr ""
+
+#: src/android/testing.md
+msgid "\"leftpad_test\""
+msgstr ""
+
+#: src/android/testing.md src/android/interoperability/with-c/bindgen.md:116
+msgid "\"general-tests\""
+msgstr ""
+
+#: src/android/testing.md
+msgid "_testing/src/lib.rs_:"
+msgstr ""
+
+#: src/android/testing.md
+msgid "//! Left-padding library."
+msgstr ""
+
+#: src/android/testing.md
+msgid "/// Left-pad `s` to `width`."
+msgstr ""
+
+#: src/android/testing.md
+msgid "\"{s:>width$}\""
+msgstr ""
+
+#: src/android/testing.md
+msgid "\"  foo\""
+msgstr ""
+
+#: src/android/testing.md
+msgid "\"foobar\""
+msgstr ""
+
+#: src/android/testing.md
+msgid "You can now run the test with"
+msgstr ""
+
+#: src/android/testing.md
+msgid "The output looks like this:"
+msgstr ""
+
+#: src/android/testing.md
+msgid ""
+"```text\n"
+"INFO: Elapsed time: 2.666s, Critical Path: 2.40s\n"
+"INFO: 3 processes: 2 internal, 1 linux-sandbox.\n"
+"INFO: Build completed successfully, 3 total actions\n"
+"//comprehensive-rust-android/testing:libleftpad_test_host            PASSED "
+"in 2.3s\n"
+"    PASSED  libleftpad_test.tests::long_string (0.0s)\n"
+"    PASSED  libleftpad_test.tests::short_string (0.0s)\n"
+"Test cases: finished with 2 passing and 0 failing out of 2 test cases\n"
+"```"
+msgstr ""
+
+#: src/android/testing.md
+msgid ""
+"Notice how you only mention the root of the library crate. Tests are found "
+"recursively in nested modules."
+msgstr ""
+
+#: src/android/testing/googletest.md:3
+msgid ""
+"The GoogleTest crate allows for flexible test assertions using _matchers_:"
+msgstr ""
+
+#: src/android/testing/googletest.md:11
+msgid "\"baz\""
+msgstr ""
+
+#: src/android/testing/googletest.md:12
+msgid "\"xyz\""
+msgstr ""
+
+#: src/android/testing/googletest.md:16
+msgid ""
+"If we change the last element to `\"!\"`, the test fails with a structured "
+"error message pin-pointing the error:"
+msgstr ""
+
+#: src/android/testing/googletest.md:37
+msgid ""
+"GoogleTest is not part of the Rust Playground, so you need to run this "
+"example in a local environment. Use `cargo add googletest` to quickly add it "
+"to an existing Cargo project."
+msgstr ""
+
+#: src/android/testing/googletest.md:41
+msgid ""
+"The `use googletest::prelude::*;` line imports a number of commonly used "
+"macros and types."
+msgstr ""
+
+#: src/android/testing/googletest.md:44
+msgid ""
+"This just scratches the surface, there are many builtin matchers. Consider "
+"going through the first chapter of \"Advanced testing for Rust "
+"applications\", a self-guided Rust course: it provides a guided introduction "
+"to the library, with exercises to help you get comfortable with `googletest` "
+"macros, its matchers and its overall philosophy."
+msgstr ""
+
+#: src/android/testing/googletest.md:51
+msgid ""
+"A particularly nice feature is that mismatches in multi-line strings are "
+"shown as a diff:"
+msgstr ""
+
+#: src/android/testing/googletest.md:57
+msgid ""
+"\"Memory safety found,\\n  \n"
+"Rust's strong typing guides the way,\\n  \n"
+"Secure code you'll write.\""
+msgstr ""
+
+#: src/android/testing/googletest.md:62
+msgid ""
+"\"Memory safety found,\\n  \n"
+"Rust's silly humor guides the way,\\n  \n"
+"Secure code you'll write.\""
+msgstr ""
+
+#: src/android/testing/googletest.md:69
+msgid "shows a color-coded diff (colors not shown here):"
+msgstr ""
+
+#: src/android/testing/googletest.md:86
+msgid "The crate is a Rust port of GoogleTest for C++."
+msgstr ""
+
+#: src/android/testing/mocking.md:3
+msgid ""
+"For mocking, Mockall is a widely used library. You need to refactor your "
+"code to use traits, which you can then quickly mock:"
+msgstr ""
+
+#: src/android/testing/mocking.md:27
+msgid ""
+"Mockall is the recommended mocking library in Android (AOSP). There are "
+"other mocking libraries available on crates.io, in particular in the area of "
+"mocking HTTP services. The other mocking libraries work in a similar fashion "
+"as Mockall, meaning that they make it easy to get a mock implementation of a "
+"given trait."
+msgstr ""
+
+#: src/android/testing/mocking.md:33
+msgid ""
+"Note that mocking is somewhat _controversial_: mocks allow you to completely "
+"isolate a test from its dependencies. The immediate result is faster and "
+"more stable test execution. On the other hand, the mocks can be configured "
+"wrongly and return output different from what the real dependencies would do."
+msgstr ""
+
+#: src/android/testing/mocking.md:38
+msgid ""
+"If at all possible, it is recommended that you use the real dependencies. As "
+"an example, many databases allow you to configure an in-memory backend. This "
+"means that you get the correct behavior in your tests, plus they are fast "
+"and will automatically clean up after themselves."
+msgstr ""
+
+#: src/android/testing/mocking.md:43
+msgid ""
+"Similarly, many web frameworks allow you to start an in-process server which "
+"binds to a random port on `localhost`. Always prefer this over mocking away "
+"the framework since it helps you test your code in the real environment."
+msgstr ""
+
+#: src/android/testing/mocking.md:47
+msgid ""
+"Mockall is not part of the Rust Playground, so you need to run this example "
+"in a local environment. Use `cargo add mockall` to quickly add Mockall to an "
+"existing Cargo project."
+msgstr ""
+
+#: src/android/testing/mocking.md:51
+msgid ""
+"Mockall has a lot more functionality. In particular, you can set up "
+"expectations which depend on the arguments passed. Here we use this to mock "
+"a cat which becomes hungry 3 hours after the last time it was fed:"
+msgstr ""
+
+#: src/android/testing/mocking.md:69
+msgid ""
+"You can use `.times(n)` to limit the number of times a mock method can be "
+"called to `n` --- the mock will automatically panic when dropped if this "
+"isn't satisfied."
 msgstr ""
 
 #: src/android/logging.md
@@ -11950,11 +12004,11 @@ msgid "_hello_rust_logs/src/main.rs_:"
 msgstr ""
 
 #: src/android/logging.md
-msgid "//! Rust logging demo.\n"
+msgid "//! Rust logging demo."
 msgstr ""
 
 #: src/android/logging.md
-msgid "/// Logs a greeting.\n"
+msgid "/// Logs a greeting."
 msgstr ""
 
 #: src/android/logging.md
@@ -11973,8 +12027,8 @@ msgstr ""
 msgid "\"Something went wrong!\""
 msgstr ""
 
-#: src/android/logging.md src/android/interoperability/with-c/bindgen.md
-#: src/android/interoperability/with-c/rust.md
+#: src/android/logging.md src/android/interoperability/with-c/bindgen.md:99
+#: src/android/interoperability/with-c/rust.md:72
 msgid "Build, push, and run the binary on your device:"
 msgstr ""
 
@@ -12012,153 +12066,164 @@ msgid ""
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:1
 msgid "Interoperability with C"
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:3
 msgid ""
 "Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:6
 msgid "You can do it by hand if you want:"
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:15
+msgid "// SAFETY: `abs` doesn't have any safety requirements."
+msgstr ""
+
+#: src/android/interoperability/with-c.md:17
 msgid "\"{x}, {abs_x}\""
 msgstr ""
 
-#: src/android/interoperability/with-c.md
-msgid ""
-"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
-"safe-ffi-wrapper.md)."
+#: src/android/interoperability/with-c.md:21
+msgid "We already saw this in the Safe FFI Wrapper exercise."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:24
 msgid ""
 "This assumes full knowledge of the target platform. Not recommended for "
 "production."
 msgstr ""
 
-#: src/android/interoperability/with-c.md
+#: src/android/interoperability/with-c.md:27
 msgid "We will look at better options next."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:1
 msgid "Using Bindgen"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
-msgid ""
-"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool can auto-generate bindings from a C header file."
+#: src/android/interoperability/with-c/bindgen.md:3
+msgid "The bindgen tool can auto-generate bindings from a C header file."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:6
 msgid "First create a small C library:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:8
 msgid "_interoperability/bindgen/libbirthday.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:19
 msgid "_interoperability/bindgen/libbirthday.c_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
-msgid "<stdio.h>"
+#: src/android/interoperability/with-c/bindgen.md:22
+msgid "\\<stdio.h>"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:23
+#: src/android/interoperability/with-c/bindgen.md:50
 msgid "\"libbirthday.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:26
+#: src/android/interoperability/with-c/bindgen.md:29
 msgid "\"+--------------\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:27
 msgid "\"| Happy Birthday %s!\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:28
 msgid "\"| Congratulations with the %i years!\\n\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:33
 msgid "Add this to your `Android.bp` file:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:35
+#: src/android/interoperability/with-c/bindgen.md:55
+#: src/android/interoperability/with-c/bindgen.md:69
+#: src/android/interoperability/with-c/bindgen.md:109
 msgid "_interoperability/bindgen/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:39
+#: src/android/interoperability/with-c/bindgen.md:63
 msgid "\"libbirthday\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:40
 msgid "\"libbirthday.c\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
 "Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:47
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:53
 msgid "You can now auto-generate the bindings:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:59
+#: src/android/interoperability/with-c/bindgen.md:75
 msgid "\"libbirthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:60
 msgid "\"birthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:61
 msgid "\"libbirthday_wrapper.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:62
 msgid "\"bindings\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:67
 msgid "Finally, we can use the bindings in our Rust program:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:73
 msgid "\"print_birthday_card\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:74
 msgid "\"main.rs\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:79
 msgid "_interoperability/bindgen/main.rs_:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
-msgid "//! Bindgen demo.\n"
+#: src/android/interoperability/with-c/bindgen.md:82
+msgid "//! Bindgen demo."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
-msgid "// SAFETY: `print_card` is safe to call with a valid `card` pointer.\n"
+#: src/android/interoperability/with-c/bindgen.md:89
+msgid ""
+"// SAFETY: The pointer we pass is valid because it came from a Rust // "
+"reference, and the `name` it contains refers to `name` above which also // "
+"remains valid. `print_card` doesn't store either pointer to use later // "
+"after it returns."
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:101
 msgid ""
 "```shell\n"
 "m print_birthday_card\n"
@@ -12168,103 +12233,102 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:107
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:113
+#: src/android/interoperability/with-c/bindgen.md:115
 msgid "\"libbirthday_bindgen_test\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:114
 msgid "\":libbirthday_bindgen\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
-msgid "\"general-tests\""
-msgstr ""
-
-#: src/android/interoperability/with-c/bindgen.md
+#: src/android/interoperability/with-c/bindgen.md:118
+#: src/android/interoperability/with-c/bindgen.md:119
 msgid "\"none\""
 msgstr ""
 
-#: src/android/interoperability/with-c/bindgen.md
-msgid "// Generated file, skip linting\n"
+#: src/android/interoperability/with-c/bindgen.md:118
+msgid "// Generated file, skip linting"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:1
 msgid "Calling Rust"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:3
 msgid "Exporting Rust functions and types to C is easy:"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:5
 msgid "_interoperability/rust/libanalyze/analyze.rs_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
-msgid "//! Rust FFI demo.\n"
+#: src/android/interoperability/with-c/rust.md:8
+msgid "//! Rust FFI demo."
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
-msgid "/// Analyze the numbers.\n"
+#: src/android/interoperability/with-c/rust.md:12
+msgid "/// Analyze the numbers."
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:17
 msgid "\"x ({x}) is smallest!\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:19
 msgid "\"y ({y}) is probably larger than x ({x})\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:24
 msgid "_interoperability/rust/libanalyze/analyze.h_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:37
 msgid "_interoperability/rust/libanalyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:41
+#: src/android/interoperability/with-c/rust.md:68
 msgid "\"libanalyze_ffi\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:42
 msgid "\"analyze_ffi\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:43
 msgid "\"analyze.rs\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:48
 msgid "We can now call this from a C binary:"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:50
 msgid "_interoperability/rust/analyze/main.c_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:53
 msgid "\"analyze.h\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:62
 msgid "_interoperability/rust/analyze/Android.bp_"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:66
 msgid "\"analyze_numbers\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:67
 msgid "\"main.c\""
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:74
 msgid ""
 "```shell\n"
 "m analyze_numbers\n"
@@ -12274,118 +12338,117 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability/with-c/rust.md
+#: src/android/interoperability/with-c/rust.md:82
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
 "will just be the name of the function. You can also use `#[export_name = "
 "\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
-#: src/android/interoperability/cpp.md
+#: src/android/interoperability/cpp.md:3
 msgid ""
-"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
-"interoperability between Rust and C++."
+"The CXX crate makes it possible to do safe interoperability between Rust and "
+"C++."
 msgstr ""
 
-#: src/android/interoperability/cpp.md
+#: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:3
 msgid ""
 "CXX relies on a description of the function signatures that will be exposed "
 "from each language to the other. You provide this description using extern "
 "blocks in a Rust module annotated with the `#[cxx::bridge]` attribute macro."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:9
 msgid "\"org::blobstore\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-msgid "// Shared structs with fields visible to both languages.\n"
+#: src/android/interoperability/cpp/bridge.md:11
+msgid "// Shared structs with fields visible to both languages."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/generated-cpp.md
-msgid "// Rust types and signatures exposed to C++.\n"
+#: src/android/interoperability/cpp/bridge.md:17
+#: src/android/interoperability/cpp/generated-cpp.md:6
+msgid "// Rust types and signatures exposed to C++."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/rust-bridge.md
-#: src/android/interoperability/cpp/generated-cpp.md
-#: src/android/interoperability/cpp/rust-result.md
-#: src/chromium/interoperability-with-cpp/example-bindings.md
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/android/interoperability/cpp/bridge.md:18
+#: src/android/interoperability/cpp/rust-bridge.md:6
+#: src/android/interoperability/cpp/generated-cpp.md:7
+#: src/android/interoperability/cpp/rust-result.md:6
+#: src/chromium/interoperability-with-cpp/example-bindings.md:9
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:10
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:9
 #, fuzzy
 msgid "\"Rust\""
 msgstr "Rustdoc"
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/cpp-bridge.md
-msgid "// C++ types and signatures exposed to Rust.\n"
+#: src/android/interoperability/cpp/bridge.md:24
+#: src/android/interoperability/cpp/cpp-bridge.md:6
+msgid "// C++ types and signatures exposed to Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/cpp-bridge.md
-#: src/android/interoperability/cpp/cpp-exception.md
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/android/interoperability/cpp/bridge.md:25
+#: src/android/interoperability/cpp/cpp-bridge.md:7
+#: src/android/interoperability/cpp/cpp-exception.md:6
+#: src/chromium/interoperability-with-cpp/example-bindings.md:15
 msgid "\"C++\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/bridge.md:26
+#: src/android/interoperability/cpp/cpp-bridge.md:8
 msgid "\"include/blobstore.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:40
 msgid "The bridge is generally declared in an `ffi` module within your crate."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:41
 msgid ""
 "From the declarations made in the bridge module, CXX will generate matching "
 "Rust and C++ type/function definitions in order to expose those items to "
 "both languages."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:44
 msgid ""
-"To view the generated Rust code, use [cargo-expand](https://github.com/"
-"dtolnay/cargo-expand) to view the expanded proc macro. For most of the "
-"examples you would use `cargo expand ::ffi` to expand just the `ffi` module "
-"(though this doesn't apply for Android projects)."
+"To view the generated Rust code, use cargo-expand to view the expanded proc "
+"macro. For most of the examples you would use `cargo expand ::ffi` to expand "
+"just the `ffi` module (though this doesn't apply for Android projects)."
 msgstr ""
 
-#: src/android/interoperability/cpp/bridge.md
+#: src/android/interoperability/cpp/bridge.md:47
 msgid "To view the generated C++ code, look in `target/cxxbridge`."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:1
 msgid "Rust Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
-msgid "// Opaque type\n"
+#: src/android/interoperability/cpp/rust-bridge.md:7
+msgid "// Opaque type"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
-msgid "// Method on `MyType`\n"
+#: src/android/interoperability/cpp/rust-bridge.md:8
+msgid "// Method on `MyType`"
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:9
 #, fuzzy
-msgid "// Free function\n"
+msgid "// Free function"
 msgstr "توابع"
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:28
 msgid ""
 "Items declared in the `extern \"Rust\"` reference items that are in scope in "
 "the parent module."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-bridge.md
+#: src/android/interoperability/cpp/rust-bridge.md:30
 msgid ""
 "The CXX code generator uses your `extern \"Rust\"` section(s) to produce a C+"
 "+ header file containing the corresponding C++ declarations. The generated "
@@ -12393,48 +12456,48 @@ msgid ""
 "except with a .rs.h file extension."
 msgstr ""
 
-#: src/android/interoperability/cpp/generated-cpp.md
+#: src/android/interoperability/cpp/generated-cpp.md:15
 msgid "Results in (roughly) the following C++:"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:1
 msgid "C++ Bridge Declarations"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:20
 msgid "Results in (roughly) the following Rust:"
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:30
 msgid "\"org$blobstore$cxxbridge1$new_blobstore_client\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:39
 msgid "\"org$blobstore$cxxbridge1$BlobstoreClient$put\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:56
 msgid ""
 "The programmer does not need to promise that the signatures they have typed "
 "in are accurate. CXX performs static assertions that the signatures exactly "
 "correspond with what is declared in C++."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-bridge.md
+#: src/android/interoperability/cpp/cpp-bridge.md:59
 msgid ""
 "`unsafe extern` blocks allow you to declare C++ functions that are safe to "
 "call from Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md
-msgid "// A=1, J=11, Q=12, K=13\n"
+#: src/android/interoperability/cpp/shared-types.md:9
+msgid "// A=1, J=11, Q=12, K=13"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md
+#: src/android/interoperability/cpp/shared-types.md:23
 msgid "Only C-like (unit) enums are supported."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-types.md
+#: src/android/interoperability/cpp/shared-types.md:24
 msgid ""
 "A limited number of traits are supported for `#[derive()]` on shared types. "
 "Corresponding functionality is also generated for the C++ code, e.g. if you "
@@ -12442,16 +12505,16 @@ msgid ""
 "corresponding C++ type."
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md
+#: src/android/interoperability/cpp/shared-enums.md:15
 #, fuzzy
 msgid "Generated Rust:"
 msgstr "Rust ناایمن"
 
-#: src/android/interoperability/cpp/shared-enums.md
+#: src/android/interoperability/cpp/shared-enums.md:33
 msgid "Generated C++:"
 msgstr ""
 
-#: src/android/interoperability/cpp/shared-enums.md
+#: src/android/interoperability/cpp/shared-enums.md:46
 msgid ""
 "On the Rust side, the code generated for shared enums is actually a struct "
 "wrapping a numeric value. This is because it is not UB in C++ for an enum "
@@ -12459,48 +12522,48 @@ msgid ""
 "Rust representation needs to have the same behavior."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:13
 msgid "\"fallible1 requires depth > 0\""
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:16
 msgid "\"Success!\""
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:22
 msgid ""
 "Rust functions that return `Result` are translated to exceptions on the C++ "
 "side."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:24
 msgid ""
 "The exception thrown will always be of type `rust::Error`, which primarily "
 "exposes a way to get the error message string. The error message will come "
 "from the error type's `Display` impl."
 msgstr ""
 
-#: src/android/interoperability/cpp/rust-result.md
+#: src/android/interoperability/cpp/rust-result.md:27
 msgid ""
 "A panic unwinding from Rust to C++ will always cause the process to "
 "immediately terminate."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:7
 msgid "\"example/include/example.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:14
 msgid "\"Error: {}\""
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:22
 msgid ""
 "C++ functions declared to return a `Result` will catch any thrown exception "
 "on the C++ side and return it as an `Err` value to the calling Rust function."
 msgstr ""
 
-#: src/android/interoperability/cpp/cpp-exception.md
+#: src/android/interoperability/cpp/cpp-exception.md:24
 msgid ""
 "If an exception is thrown from an extern \"C++\" function that is not "
 "declared by the CXX bridge to return `Result`, the program calls C++'s `std::"
@@ -12508,303 +12571,296 @@ msgid ""
 "through a `noexcept` C++ function."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
-#, fuzzy
-msgid "Rust Type"
-msgstr "انواع داده‌های بازگشتی"
-
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:3
 #, fuzzy
 msgid "C++ Type"
 msgstr "مثالی در <span dir=ltr>C++</span>"
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:5
 #, fuzzy
 msgid "`rust::String`"
 msgstr "String"
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:6
 msgid "`&str`"
 msgstr "<span dir=ltr><code class=hljs>&str</code></span>"
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:6
 msgid "`rust::Str`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:7
 #, fuzzy
 msgid "`CxxString`"
 msgstr "String"
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:7
 #, fuzzy
 msgid "`std::string`"
 msgstr "String"
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:8
 msgid "`&[T]`/`&mut [T]`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:8
 msgid "`rust::Slice`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:9
 msgid "`rust::Box<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:10
 msgid "`UniquePtr<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:10
 msgid "`std::unique_ptr<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
-msgid "`Vec<T>`"
-msgstr ""
-
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:11
 msgid "`rust::Vec<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:12
 msgid "`CxxVector<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:12
 msgid "`std::vector<T>`"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:16
 msgid ""
 "These types can be used in the fields of shared structs and the arguments "
 "and returns of extern functions."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:18
 msgid ""
 "Note that Rust's `String` does not map directly to `std::string`. There are "
 "a few reasons for this:"
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:20
 msgid ""
 "`std::string` does not uphold the UTF-8 invariant that `String` requires."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:21
 msgid ""
 "The two types have different layouts in memory and so can't be passed "
 "directly between languages."
 msgstr ""
 
-#: src/android/interoperability/cpp/type-mapping.md
+#: src/android/interoperability/cpp/type-mapping.md:23
 msgid ""
 "`std::string` requires move constructors that don't match Rust's move "
 "semantics, so a `std::string` can't be passed by value to Rust."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-cpp-genrules.md
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-cpp.md:1
+#: src/android/interoperability/cpp/android-cpp-genrules.md:1
+#: src/android/interoperability/cpp/android-build-rust.md:1
 #, fuzzy
 msgid "Building in Android"
 msgstr "Rust در اندروید"
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:3
 msgid ""
 "Create a `cc_library_static` to build the C++ library, including the CXX "
 "generated header and source file."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-cpp.md:8
+#: src/android/interoperability/cpp/android-build-rust.md:10
 msgid "\"libcxx_test_cpp\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:9
 msgid "\"cxx_test.cpp\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:11
 msgid "\"cxx-bridge-header\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-build-cpp.md:12
+#: src/android/interoperability/cpp/android-cpp-genrules.md:10
 msgid "\"libcxx_test_bridge_header\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-build-cpp.md:14
+#: src/android/interoperability/cpp/android-cpp-genrules.md:19
 msgid "\"libcxx_test_bridge_code\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:20
 msgid ""
 "Point out that `libcxx_test_bridge_header` and `libcxx_test_bridge_code` are "
 "the dependencies for the CXX-generated C++ bindings. We'll show how these "
 "are setup on the next slide."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:23
 msgid ""
 "Note that you also need to depend on the `cxx-bridge-header` library in "
 "order to pull in common CXX definitions."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-cpp.md
+#: src/android/interoperability/cpp/android-build-cpp.md:25
 msgid ""
-"Full docs for using CXX in Android can be found in [the Android docs]"
-"(https://source.android.com/docs/setup/build/rust/building-rust-modules/"
-"android-rust-patterns#rust-cpp-interop-using-cxx). You may want to share "
-"that link with the class so that students know where they can find these "
-"instructions again in the future."
+"Full docs for using CXX in Android can be found in the Android docs. You may "
+"want to share that link with the class so that students know where they can "
+"find these instructions again in the future."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:3
 msgid ""
 "Create two genrules: One to generate the CXX header, and one to generate the "
 "CXX source file. These are then used as inputs to the `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:7
 msgid ""
-"// Generate a C++ header containing the C++ bindings\n"
-"// to the Rust exported functions in lib.rs.\n"
+"// Generate a C++ header containing the C++ bindings // to the Rust exported "
+"functions in lib.rs."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:11
+#: src/android/interoperability/cpp/android-cpp-genrules.md:20
 msgid "\"cxxbridge\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:12
 msgid "\"$(location cxxbridge) $(in) --header > $(out)\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:13
+#: src/android/interoperability/cpp/android-cpp-genrules.md:22
+#: src/android/interoperability/cpp/android-build-rust.md:8
 msgid "\"lib.rs\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:14
 msgid "\"lib.rs.h\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
-msgid "// Generate the C++ code that Rust calls into.\n"
+#: src/android/interoperability/cpp/android-cpp-genrules.md:16
+msgid "// Generate the C++ code that Rust calls into."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:21
 msgid "\"$(location cxxbridge) $(in) > $(out)\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:23
 msgid "\"lib.rs.cc\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:29
 msgid ""
 "The `cxxbridge` tool is a standalone tool that generates the C++ side of the "
 "bridge module. It is included in Android and available as a Soong tool."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-cpp-genrules.md
+#: src/android/interoperability/cpp/android-cpp-genrules.md:31
 msgid ""
 "By convention, if your Rust source file is `lib.rs` your header file will be "
 "named `lib.rs.h` and your source file will be named `lib.rs.cc`. This naming "
 "convention isn't enforced, though."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-rust.md:3
 msgid ""
 "Create a `rust_binary` that depends on `libcxx` and your `cc_library_static`."
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-rust.md:7
 msgid "\"cxx_test\""
 msgstr ""
 
-#: src/android/interoperability/cpp/android-build-rust.md
+#: src/android/interoperability/cpp/android-build-rust.md:9
 msgid "\"libcxx\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:1
 msgid "Interoperability with Java"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface (JNI)](https://en."
-"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
-"jni/) allows you to create a compatible library."
+"Java can load shared objects via Java Native Interface (JNI). The `jni` "
+"crate allows you to create a compatible library."
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:8
 msgid "First, we create a Rust function to export to Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:10
 msgid "_interoperability/java/src/lib.rs_:"
 msgstr ""
 
-#: src/android/interoperability/java.md
-msgid "//! Rust <-> Java FFI demo.\n"
+#: src/android/interoperability/java.md:13
+msgid "//! Rust \\<\\-> Java FFI demo."
 msgstr ""
 
-#: src/android/interoperability/java.md
-msgid "/// HelloWorld::hello method implementation.\n"
+#: src/android/interoperability/java.md:18
+msgid "/// HelloWorld::hello method implementation."
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:21
 msgid "\"system\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:27
 msgid "\"Hello, {input}!\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:33
+#: src/android/interoperability/java.md:63
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:37
+#: src/android/interoperability/java.md:70
 msgid "\"libhello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:38
+#: src/android/interoperability/java.md:53
 msgid "\"hello_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:40
 msgid "\"libjni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:44
 msgid "We then call this function from Java:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:46
 msgid "_interoperability/java/HelloWorld.java_:"
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:67
 msgid "\"helloworld_jni\""
 msgstr ""
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:68
 #, fuzzy
 msgid "\"HelloWorld.java\""
 msgstr "سلام دنیا"
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:69
 #, fuzzy
 msgid "\"HelloWorld\""
 msgstr "سلام دنیا"
 
-#: src/android/interoperability/java.md
+#: src/android/interoperability/java.md:74
 msgid "Finally, you can build, sync, and run the binary:"
 msgstr ""
 
@@ -12861,9 +12917,8 @@ msgstr ""
 
 #: src/chromium/setup.md
 msgid ""
-"See [How to build Chromium](https://www.chromium.org/developers/how-tos/get-"
-"the-code/) if you aren't already at that point. Be warned: setting up to "
-"build Chromium takes time."
+"See How to build Chromium if you aren't already at that point. Be warned: "
+"setting up to build Chromium takes time."
 msgstr ""
 
 #: src/chromium/setup.md
@@ -12884,9 +12939,8 @@ msgstr ""
 
 #: src/chromium/cargo.md
 msgid ""
-"Rust community typically uses `cargo` and libraries from [crates.io](https://"
-"crates.io/). Chromium is built using `gn` and `ninja` and a curated set of "
-"dependencies."
+"The Rust community typically uses `cargo` and libraries from crates.io. "
+"Chromium is built using `gn` and `ninja` and a curated set of dependencies."
 msgstr ""
 
 #: src/chromium/cargo.md
@@ -12902,15 +12956,12 @@ msgstr ""
 
 #: src/chromium/cargo.md
 msgid ""
-"Use `cargo`, but [restrict yourself to Chromium's audited toolchain and "
-"crates](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/"
-"docs/rust.md#Using-cargo)"
+"Use `cargo`, but restrict yourself to Chromium's audited toolchain and crates"
 msgstr ""
 
 #: src/chromium/cargo.md
 msgid ""
-"Use `cargo`, trusting a [toolchain](https://rustup.rs/) and/or [crates "
-"downloaded from the internet](https://crates.io/)"
+"Use `cargo`, trusting a toolchain and/or crates downloaded from the internet"
 msgstr ""
 
 #: src/chromium/cargo.md
@@ -13040,13 +13091,13 @@ msgstr ""
 msgid ""
 "Disclaimer: a unique reason for using `cargo` was unavailability of `gn` "
 "when building and bootstrapping Rust standard library when building Rust "
-"toolchain.)"
+"toolchain."
 msgstr ""
 
 #: src/chromium/cargo.md
 msgid ""
 "`run_gnrt.py` uses Chromium's copy of `cargo` and `rustc`. `gnrt` depends on "
-"third-party libraries downloaded from the internet, by `run_gnrt.py` asks "
+"third-party libraries downloaded from the internet, but `run_gnrt.py` asks "
 "`cargo` that only `--locked` content is allowed via `Cargo.lock`.)"
 msgstr ""
 
@@ -13100,17 +13151,14 @@ msgstr ""
 #: src/chromium/policy.md
 msgid ""
 "Chromium does not yet allow first-party Rust except in rare cases as "
-"approved by Chromium's [Area Tech Leads](https://source.chromium.org/"
-"chromium/chromium/src/+/main:ATL_OWNERS)."
+"approved by Chromium's Area Tech Leads."
 msgstr ""
 
 #: src/chromium/policy.md
 msgid ""
-"Chromium's policy on third party libraries is outlined [here](https://"
-"chromium.googlesource.com/chromium/src/+/main/docs/adding_to_third_party."
-"md#rust) - Rust is allowed for third party libraries under various "
-"circumstances, including if they're the best option for performance or for "
-"security."
+"Chromium's policy on third party libraries is outlined here - Rust is "
+"allowed for third party libraries under various circumstances, including if "
+"they're the best option for performance or for security."
 msgstr ""
 
 #: src/chromium/policy.md
@@ -13226,17 +13274,16 @@ msgstr ""
 #: src/chromium/build-rules.md
 msgid ""
 "Students might be wondering why we need a gn template, rather than using "
-"[gn's built-in support for Rust static libraries](https://gn.googlesource."
-"com/gn/+/main/docs/reference.md#func_static_library). The answer is that "
-"this template provides support for CXX interop, Rust features, and unit "
-"tests, some of which we'll use later."
+"gn's built-in support for Rust static libraries. The answer is that this "
+"template provides support for CXX interop, Rust features, and unit tests, "
+"some of which we'll use later."
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md
+#: src/chromium/build-rules/unsafe.md:1
 msgid "Including `unsafe` Rust Code"
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md
+#: src/chromium/build-rules/unsafe.md:3
 msgid ""
 "Unsafe Rust code is forbidden in `rust_static_library` by default --- it "
 "won't compile. If you need unsafe Rust code, add `allow_unsafe = true` to "
@@ -13244,7 +13291,7 @@ msgid ""
 "necessary.)"
 msgstr ""
 
-#: src/chromium/build-rules/unsafe.md
+#: src/chromium/build-rules/unsafe.md:7
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13260,11 +13307,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules/depending.md
+#: src/chromium/build-rules/depending.md:3
 msgid "Simply add the above target to the `deps` of some Chromium C++ target."
 msgstr ""
 
-#: src/chromium/build-rules/depending.md
+#: src/chromium/build-rules/depending.md:5
 msgid ""
 "```gn\n"
 "import(\"//build/rust/rust_static_library.gni\")\n"
@@ -13281,108 +13328,108 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:3
 msgid ""
 "Types are elided in Rust code, which makes a good IDE even more useful than "
 "for C++. Visual Studio code works well for Rust in Chromium. To use it,"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:6
 msgid ""
 "Ensure your VSCode has the `rust-analyzer` extension, not earlier forms of "
 "Rust support"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:8
 msgid ""
 "`gn gen out/Debug --export-rust-project` (or equivalent for your output "
 "directory)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:10
 msgid "`ln -s out/Debug/rust-project.json rust-project.json`"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:16
 msgid ""
 "A demo of some of the code annotation and exploration features of rust-"
 "analyzer might be beneficial if the audience are naturally skeptical of IDEs."
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:19
 msgid ""
 "The following steps may help with the demo (but feel free to instead use a "
 "piece of Chromium-related Rust that you are most familiar with):"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:22
 msgid "Open `components/qr_code_generator/qr_code_generator_ffi_glue.rs`"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:23
 msgid ""
 "Place the cursor over the `QrCode::new` call (around line 26) in "
 "\\`qr_code_generator_ffi_glue.rs"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:25
 msgid ""
 "Demo **show documentation** (typical bindings: vscode = ctrl k i; vim/CoC = "
 "K)."
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:27
 msgid ""
 "Demo **go to definition** (typical bindings: vscode = F12; vim/CoC = g d). "
 "(This will take you to `//third_party/rust/.../qr_code-.../src/lib.rs`.)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:29
 msgid ""
 "Demo **outline** and navigate to the `QrCode::with_bits` method (around line "
 "164; the outline is in the file explorer pane in vscode; typical vim/CoC "
 "bindings = space o)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:32
 msgid ""
 "Demo **type annotations** (there are quote a few nice examples in the "
 "`QrCode::with_bits` method)"
 msgstr ""
 
-#: src/chromium/build-rules/vscode.md
+#: src/chromium/build-rules/vscode.md:35
 msgid ""
 "It may be worth pointing out that `gn gen ... --export-rust-project` will "
 "need to be rerun after editing `BUILD.gn` files (which we will do a few "
 "times throughout the exercises in this session)."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:1
 #, fuzzy
 msgid "Build rules exercise"
 msgstr "قوانین ساخت"
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:3
 msgid ""
 "In your Chromium build, add a new Rust target to `//ui/base/BUILD.gn` "
 "containing:"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:13
 msgid ""
 "**Important**: note that `no_mangle` here is considered a type of unsafety "
-"by the Rust compiler, so you'll need to to allow unsafe code in your `gn` "
+"by the Rust compiler, so you'll need to allow unsafe code in your `gn` "
 "target."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:16
 msgid ""
 "Add this new Rust target as a dependency of `//ui/base:base`. Declare this "
 "function at the top of `ui/base/resource/resource_bundle.cc` (later, we'll "
 "see how this can be automated by bindings generation tools):"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:24
 msgid ""
 "Call this function from somewhere in `ui/base/resource/resource_bundle.cc` - "
 "we suggest the top of `ResourceBundle::MaybeMangleLocalizedString`. Build "
@@ -13390,50 +13437,39 @@ msgid ""
 "times."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:28
 msgid ""
 "If you use VSCode, now set up Rust to work well in VSCode. It will be useful "
 "in subsequent exercises. If you've succeeded, you will be able to use right-"
 "click \"Go to definition\" on `println!`."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/build-rules.md:32
+#: src/exercises/chromium/interoperability-with-cpp.md:48
 msgid "Where to find help"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
-msgid ""
-"The options available to the [`rust_static_library` gn template](https://"
-"source.chromium.org/chromium/chromium/src/+/main:build/rust/"
-"rust_static_library.gni;l=16)"
+#: src/exercises/chromium/build-rules.md:34
+msgid "The options available to the `rust_static_library` gn template"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
-msgid ""
-"Information about [`#[no_mangle]`](https://doc.rust-lang.org/beta/reference/"
-"abi.html#the-no_mangle-attribute)"
+#: src/exercises/chromium/build-rules.md:35
+msgid "Information about `#[no_mangle]`"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
-msgid ""
-"Information about [`extern \"C\"`](https://doc.rust-lang.org/std/keyword."
-"extern.html)"
+#: src/exercises/chromium/build-rules.md:36
+msgid "Information about `extern \"C\"`"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
-msgid ""
-"Information about gn's [`--export-rust-project`](https://gn.googlesource.com/"
-"gn/+/main/docs/reference.md#compilation-database) switch"
+#: src/exercises/chromium/build-rules.md:37
+msgid "Information about gn's `--export-rust-project` switch"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
-msgid ""
-"[How to install rust-analyzer in VSCode](https://code.visualstudio.com/docs/"
-"languages/rust)"
+#: src/exercises/chromium/build-rules.md:38
+msgid "How to install rust-analyzer in VSCode"
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:44
 msgid ""
 "This example is unusual because it boils down to the lowest-common-"
 "denominator interop language, C. Both C++ and Rust can natively declare and "
@@ -13441,14 +13477,14 @@ msgid ""
 "Rust."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:48
 msgid ""
 "`allow_unsafe = true` is required here because `#[no_mangle]` might allow "
 "Rust to generate two functions with the same name, and Rust can no longer "
 "guarantee that the right one is called."
 msgstr ""
 
-#: src/exercises/chromium/build-rules.md
+#: src/exercises/chromium/build-rules.md:52
 msgid ""
 "If you need a pure Rust executable, you can also do that using the "
 "`rust_executable` gn template."
@@ -13457,8 +13493,8 @@ msgstr ""
 #: src/chromium/testing.md
 msgid ""
 "Rust community typically authors unit tests in a module placed in the same "
-"source file as the code being tested. This was covered [earlier](../testing."
-"md) in the course and looks like this:"
+"source file as the code being tested. This was covered earlier in the course "
+"and looks like this:"
 msgstr ""
 
 #: src/chromium/testing.md
@@ -13523,36 +13559,34 @@ msgid ""
 "functionality may benefit from separate tests authored in Rust."
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
-msgid ""
-"The [`rust_gtest_interop`](https://chromium.googlesource.com/chromium/src/+/"
-"main/testing/rust_gtest_interop/README.md) library provides a way to:"
+#: src/chromium/testing/rust-gtest-interop.md:3
+msgid "The `rust_gtest_interop` library provides a way to:"
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
+#: src/chromium/testing/rust-gtest-interop.md:5
 msgid ""
 "Use a Rust function as a `gtest` testcase (using the `#[gtest(...)]` "
 "attribute)"
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
+#: src/chromium/testing/rust-gtest-interop.md:7
 msgid ""
 "Use `expect_eq!` and similar macros (similar to `assert_eq!` but not "
 "panicking and not terminating the test when the assertion fails)."
 msgstr ""
 
-#: src/chromium/testing/rust-gtest-interop.md
+#: src/chromium/testing/rust-gtest-interop.md:10
 #, fuzzy
 msgid "Example:"
 msgstr "مثال"
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:3
 msgid ""
 "The simplest way to build Rust `gtest` tests is to add them to an existing "
 "test binary that already contains tests authored in C++. For example:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:6
 msgid ""
 "```gn\n"
 "test(\"ui_base_unittests\") {\n"
@@ -13563,13 +13597,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:14
 msgid ""
 "Authoring Rust tests in a separate `static_library` also works, but requires "
 "manually declaring the dependency on the support libraries:"
 msgstr ""
 
-#: src/chromium/testing/build-gn.md
+#: src/chromium/testing/build-gn.md:17
 msgid ""
 "```gn\n"
 "rust_static_library(\"my_rust_lib_unittests\") {\n"
@@ -13590,7 +13624,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:3
 msgid ""
 "After adding `:my_rust_lib` to GN `deps`, we still need to learn how to "
 "import and use `my_rust_lib` from `my_rust_lib_unittest.rs`. We haven't "
@@ -13600,23 +13634,21 @@ msgid ""
 "from the automatically-imported `chromium` crate:"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:12
 msgid "\"//ui/base:my_rust_lib\""
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:18
 msgid "Under the covers the macro expands to something similar to:"
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:26
 msgid ""
-"More information can be found in [the doc comment](https://source.chromium."
-"org/chromium/chromium/src/+/main:build/rust/chromium_prelude/"
-"chromium_prelude.rs?q=f:chromium_prelude.rs%20pub.use.*%5Cbimport%5Cb;%20-f:"
-"third_party&ss=chromium%2Fchromium%2Fsrc) of the `chromium::import` macro."
+"More information can be found in the doc comment of the `chromium::import` "
+"macro."
 msgstr ""
 
-#: src/chromium/testing/chromium-import-macro.md
+#: src/chromium/testing/chromium-import-macro.md:31
 msgid ""
 "`rust_static_library` supports specifying an explicit name via `crate_name` "
 "property, but doing this is discouraged. And it is discouraged because the "
@@ -13625,35 +13657,35 @@ msgid ""
 "covered in a later section) use short crate names."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:1
 #, fuzzy
 msgid "Testing exercise"
 msgstr "تمرین‌ها"
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:3
 msgid "Time for another exercise!"
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:5
 msgid "In your Chromium build:"
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:7
 msgid ""
 "Add a testable function next to `hello_from_rust`. Some suggestions: adding "
 "two integers received as arguments, computing the nth Fibonacci number, "
 "summing integers in a slice, etc."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:10
 msgid "Add a separate `..._unittest.rs` file with a test for the new function."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:11
 msgid "Add the new tests to `BUILD.gn`."
 msgstr ""
 
-#: src/exercises/chromium/testing.md
+#: src/exercises/chromium/testing.md:12
 msgid "Build the tests, run them, and verify that the new test works."
 msgstr ""
 
@@ -13672,9 +13704,7 @@ msgid ""
 msgstr ""
 
 #: src/chromium/interoperability-with-cpp.md
-msgid ""
-"See the [CXX tutorial](https://cxx.rs/tutorial.html) for a full example of "
-"using this."
+msgid "See the CXX tutorial for a full example of using this."
 msgstr ""
 
 #: src/chromium/interoperability-with-cpp.md
@@ -13729,25 +13759,25 @@ msgid ""
 "terminate a string)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:3
 msgid ""
 "CXX requires that the whole C++/Rust boundary is declared in `cxx::bridge` "
 "modules inside `.rs` source code."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:16
 msgid "\"example/include/blobstore.h\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
-msgid "// Definitions of Rust types and functions go here\n"
+#: src/chromium/interoperability-with-cpp/example-bindings.md:24
+msgid "// Definitions of Rust types and functions go here"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:30
 msgid "Point out:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:32
 msgid ""
 "Although this looks like a regular Rust `mod`, the `#[cxx::bridge]` "
 "procedural macro does complex things to it. The generated code is quite a "
@@ -13755,24 +13785,24 @@ msgid ""
 "`ffi` in your code."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:36
 msgid "Native support for C++'s `std::unique_ptr` in Rust"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:37
 #, fuzzy
 msgid "Native support for Rust slices in C++"
 msgstr "پشتیبانی درون-ساختی از تست نویسی"
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:38
 msgid "Calls from C++ to Rust, and Rust types (in the top part)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:39
 msgid "Calls from Rust to C++, and C++ types (in the bottom part)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/example-bindings.md
+#: src/chromium/interoperability-with-cpp/example-bindings.md:41
 msgid ""
 "**Common misconception**: It _looks_ like a C++ header is being parsed by "
 "Rust, but this is misleading. This header is never interpreted by Rust, but "
@@ -13780,35 +13810,33 @@ msgid ""
 "compilers."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
-msgid ""
-"By far the most useful page when using CXX is the [type reference](https://"
-"cxx.rs/bindings.html)."
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:3
+msgid "By far the most useful page when using CXX is the type reference."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:5
 msgid "CXX fundamentally suits cases where:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:7
 msgid ""
 "Your Rust-C++ interface is sufficiently simple that you can declare all of "
 "it."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:8
 msgid ""
 "You're using only the types natively supported by CXX already, for example "
 "`std::unique_ptr`, `std::string`, `&[u8]` etc."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:11
 msgid ""
 "It has many limitations --- for example lack of support for Rust's `Option` "
 "type."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:14
 msgid ""
 "These limitations constrain us to using Rust in Chromium only for well "
 "isolated \"leaf nodes\" rather than for arbitrary Rust-C++ interop. When "
@@ -13817,89 +13845,87 @@ msgid ""
 "enough."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:26
 msgid ""
 "You should also discuss some of the other sticky points with CXX, for "
 "example:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:28
 msgid ""
 "Its error handling is based around C++ exceptions (given on the next slide)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md
+#: src/chromium/interoperability-with-cpp/limitations-of-cxx.md:29
 msgid "Function pointers are awkward to use."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:3
 msgid ""
-"CXX's [support for `Result<T,E>`](https://cxx.rs/binding/result.html) relies "
-"on C++ exceptions, so we can't use that in Chromium. Alternatives:"
+"CXX's support for `Result<T,E>` relies on C++ exceptions, so we can't use "
+"that in Chromium. Alternatives:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:6
 msgid "The `T` part of `Result<T, E>` can be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:7
 msgid ""
 "Returned via out parameters (e.g. via `&mut T`). This requires that `T` can "
 "be passed across the FFI boundary - for example `T` has to be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:9
 msgid "A primitive type (like `u32` or `usize`)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:10
 msgid ""
 "A type natively supported by `cxx` (like `UniquePtr<T>`) that has a suitable "
 "default value to use in a failure case (_unlike_ `Box<T>`)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:12
 msgid ""
 "Retained on the Rust side, and exposed via reference. This may be needed "
 "when `T` is a Rust type, which cannot be passed across the FFI boundary, and "
 "cannot be stored in `UniquePtr<T>`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:16
 msgid "The `E` part of `Result<T, E>` can be:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:17
 msgid ""
 "Returned as a boolean (e.g. `true` representing success, and `false` "
 "representing failure)"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling.md
+#: src/chromium/interoperability-with-cpp/error-handling.md:19
 msgid ""
 "Preserving error details is in theory possible, but so far hasn't been "
 "needed in practice."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:1
 #, fuzzy
 msgid "CXX Error Handling: QR Example"
 msgstr "مدیریت خطا (Error Handling)"
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:3
 msgid ""
-"The QR code generator is [an example](https://source.chromium.org/chromium/"
-"chromium/src/+/main:components/qr_code_generator/qr_code_generator_ffi_glue."
-"rs;l=13-18;drc=7bf1b75b910ca430501b9c6a74c1d18a0223ecca) where a boolean is "
-"used to communicate success vs failure, and where the successful result can "
-"be passed across the FFI boundary:"
+"The QR code generator is an example where a boolean is used to communicate "
+"success vs failure, and where the successful result can be passed across the "
+"FFI boundary:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:8
 msgid "\"qr_code_generator\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:23
 msgid ""
 "Students may be curious about the semantics of the `out_qr_size` output. "
 "This is not the size of the vector, but the size of the QR code (and "
@@ -13907,7 +13933,7 @@ msgid ""
 "the vector)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:27
 msgid ""
 "It may be worth pointing out the importance of initializing `out_qr_size` "
 "before calling into the Rust function. Creation of a Rust reference that "
@@ -13915,43 +13941,43 @@ msgid ""
 "when only the act of dereferencing such memory results in UB)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-qr.md
+#: src/chromium/interoperability-with-cpp/error-handling-qr.md:32
 msgid ""
 "If students ask about `Pin`, then explain why CXX needs it for mutable "
 "references to C++ data: the answer is that C++ data can’t be moved around "
 "like Rust data, because it may contain self-referential pointers."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:1
 #, fuzzy
 msgid "CXX Error Handling: PNG Example"
 msgstr "مدیریت خطا (Error Handling)"
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:3
 msgid ""
 "A prototype of a PNG decoder illustrates what can be done when the "
 "successful result cannot be passed across the FFI boundary:"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:7
 msgid "\"gfx::rust_bindings\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:10
 msgid ""
-"/// This returns an FFI-friendly equivalent of `Result<PngReader<'a>,\n"
-"        /// ()>`.\n"
+"/// This returns an FFI-friendly equivalent of "
+"`Result<PngReader<'a>,         /// ()>`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
-msgid "/// C++ bindings for the `crate::png::ResultOfPngReader` type.\n"
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:14
+msgid "/// C++ bindings for the `crate::png::ResultOfPngReader` type."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
-msgid "/// C++ bindings for the `crate::png::PngReader` type.\n"
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:21
+msgid "/// C++ bindings for the `crate::png::PngReader` type."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:32
 msgid ""
 "`PngReader` and `ResultOfPngReader` are Rust types --- objects of these "
 "types cannot cross the FFI boundary without indirection of a `Box<T>`. We "
@@ -13959,7 +13985,7 @@ msgid ""
 "to store Rust objects by value."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/error-handling-png.md
+#: src/chromium/interoperability-with-cpp/error-handling-png.md:37
 msgid ""
 "This example illustrates that even though CXX doesn't support arbitrary "
 "generics nor templates, we can still pass them across the FFI boundary by "
@@ -13969,18 +13995,18 @@ msgid ""
 "`as_mut`)."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:1
 msgid "Using cxx in Chromium"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:3
 msgid ""
 "In Chromium, we define an independent `#[cxx::bridge] mod` for each leaf-"
 "node where we want to use Rust. You'd typically have one for each "
 "`rust_static_library`. Just add"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:7
 msgid ""
 "```gn\n"
 "cxx_bindings = [ \"my_rust_file.rs\" ]\n"
@@ -13989,198 +14015,192 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:13
 msgid ""
 "to your existing `rust_static_library` target alongside `crate_root` and "
 "`sources`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:16
 msgid "C++ headers will be generated at a sensible location, so you can just"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:19
 msgid "\"ui/base/my_rust_file.rs.h\""
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:22
 msgid ""
 "You will find some utility functions in `//base` to convert to/from Chromium "
-"C++ types to CXX Rust types --- for example [`SpanToRustSlice`](https://"
-"source.chromium.org/chromium/chromium/src/+/main:base/containers/span_rust.h;"
-"l=21)."
+"C++ types to CXX Rust types --- for example `SpanToRustSlice`."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:27
 msgid "Students may ask --- why do we still need `allow_unsafe = true`?"
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:29
 msgid ""
 "The broad answer is that no C/C++ code is \"safe\" by the normal Rust "
 "standards. Calling back and forth to C/C++ from Rust may do arbitrary things "
 "to memory, and compromise the safety of Rust's own data layouts. Presence of "
 "_too many_ `unsafe` keywords in C/C++ interop can harm the signal-to-noise "
-"ratio of such a keyword, and is [controversial](https://steveklabnik.com/"
-"writing/the-cxx-debate), but strictly, bringing any foreign code into a Rust "
-"binary can cause unexpected behavior from Rust's perspective."
+"ratio of such a keyword, and is controversial, but strictly, bringing any "
+"foreign code into a Rust binary can cause unexpected behavior from Rust's "
+"perspective."
 msgstr ""
 
-#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md
+#: src/chromium/interoperability-with-cpp/using-cxx-in-chromium.md:36
 msgid ""
-"The narrow answer lies in the diagram at the top of [this page](../"
-"interoperability-with-cpp.md) --- behind the scenes, CXX generates Rust "
-"`unsafe` and `extern \"C\"` functions just like we did manually in the "
-"previous section."
+"The narrow answer lies in the diagram at the top of this page --- behind the "
+"scenes, CXX generates Rust `unsafe` and `extern \"C\"` functions just like "
+"we did manually in the previous section."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:1
 #, fuzzy
 msgid "Exercise: Interoperability with C++"
 msgstr "قابلیت همکاری"
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:3
 msgid "Part one"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:5
 msgid ""
 "In the Rust file you previously created, add a `#[cxx::bridge]` which "
 "specifies a single function, to be called from C++, called "
 "`hello_from_rust`, taking no parameters and returning no value."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:8
 msgid ""
 "Modify your previous `hello_from_rust` function to remove `extern \"C\"` and "
 "`#[no_mangle]`. This is now just a standard Rust function."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:10
 msgid "Modify your `gn` target to build these bindings."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:11
 msgid ""
 "In your C++ code, remove the forward-declaration of `hello_from_rust`. "
 "Instead, include the generated header file."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:13
 msgid "Build and run!"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:15
 msgid "Part two"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:17
 msgid ""
 "It's a good idea to play with CXX a little. It helps you think about how "
 "flexible Rust in Chromium actually is."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:20
 #, fuzzy
 msgid "Some things to try:"
 msgstr "نکته:"
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:22
 msgid "Call back into C++ from Rust. You will need:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:23
 msgid ""
 "An additional header file which you can `include!` from your `cxx::bridge`. "
 "You'll need to declare your C++ function in that new header file."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:25
 msgid ""
 "An `unsafe` block to call such a function, or alternatively specify the "
-"`unsafe` keyword in your `#[cxx::bridge]` [as described here](https://cxx.rs/"
-"extern-c++.html#functions-and-member-functions)."
+"`unsafe` keyword in your `#[cxx::bridge]` as described here."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:27
 msgid ""
 "You may also need to `#include \"third_party/rust/cxx/v1/crate/include/cxx."
 "h\"`"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:29
 msgid "Pass a C++ string from C++ into Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:30
 msgid "Pass a reference to a C++ object into Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:31
 msgid ""
 "Intentionally get the Rust function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:33
 msgid ""
 "Intentionally get the C++ function signatures mismatched from the `#[cxx::"
 "bridge]`, and get used to the errors you see."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:35
 msgid ""
 "Pass a `std::unique_ptr` of some type from C++ into Rust, so that Rust can "
 "own some C++ object."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:37
 msgid ""
 "Create a Rust object and pass it into C++, so that C++ owns it. (Hint: you "
 "need a `Box`)."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:39
 msgid "Declare some methods on a C++ type. Call them from Rust."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:40
 msgid "Declare some methods on a Rust type. Call them from C++."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:42
 msgid "Part three"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:44
 msgid ""
 "Now you understand the strengths and limitations of CXX interop, think of a "
 "couple of use-cases for Rust in Chromium where the interface would be "
 "sufficiently simple. Sketch how you might define that interface."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
-msgid "The [`cxx` binding reference](https://cxx.rs/bindings.html)"
+#: src/exercises/chromium/interoperability-with-cpp.md:50
+msgid "The `cxx` binding reference"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
-msgid ""
-"The [`rust_static_library` gn template](https://source.chromium.org/chromium/"
-"chromium/src/+/main:build/rust/rust_static_library.gni;l=16)"
+#: src/exercises/chromium/interoperability-with-cpp.md:51
+msgid "The `rust_static_library` gn template"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:57
 msgid "Some of the questions you may encounter:"
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:59
 msgid ""
 "I'm seeing a problem initializing a variable of type X with type Y, where X "
 "and Y are both function types. This is because your C++ function doesn't "
 "quite match the declaration in your `cxx::bridge`."
 msgstr ""
 
-#: src/exercises/chromium/interoperability-with-cpp.md
+#: src/exercises/chromium/interoperability-with-cpp.md:62
 msgid ""
 "I seem to be able to freely convert C++ references into Rust references. "
 "Doesn't that risk UB? For CXX's _opaque_ types, no, because they are zero-"
@@ -14190,10 +14210,13 @@ msgstr ""
 
 #: src/chromium/adding-third-party-crates.md
 msgid ""
-"Rust libraries are called \"crates\" and are found at [crates.io](https://"
-"crates.io). It's _very easy_ for Rust crates to depend upon one another. So "
-"they do!"
+"Rust libraries are called \"crates\" and are found at crates.io. It's _very "
+"easy_ for Rust crates to depend upon one another. So they do!"
 msgstr ""
+
+#: src/chromium/adding-third-party-crates.md
+msgid "Property"
+msgstr "ویژگی"
 
 #: src/chromium/adding-third-party-crates.md
 #, fuzzy
@@ -14270,19 +14293,17 @@ msgstr ""
 msgid "How to audit its source code for sufficient safety."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:1
 msgid "Configuring the `Cargo.toml` file to add crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:3
 msgid ""
 "Chromium has a single set of centrally-managed direct crate dependencies. "
-"These are managed through a single [`Cargo.toml`](https://source.chromium."
-"org/chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/Cargo."
-"toml):"
+"These are managed through a single `Cargo.toml`:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:6
 msgid ""
 "```toml\n"
 "[dependencies]\n"
@@ -14293,141 +14314,136 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:14
 msgid ""
-"As with any other `Cargo.toml`, you can specify [more details about the "
-"dependencies](https://doc.rust-lang.org/cargo/reference/specifying-"
-"dependencies.html) --- most commonly, you'll want to specify the `features` "
-"that you wish to enable in the crate."
+"As with any other `Cargo.toml`, you can specify more details about the "
+"dependencies --- most commonly, you'll want to specify the `features` that "
+"you wish to enable in the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+#: src/chromium/adding-third-party-crates/configuring-cargo-toml.md:18
 msgid ""
 "When adding a crate to Chromium, you'll often need to provide some extra "
 "information in an additional file, `gnrt_config.toml`, which we'll meet next."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:3
 msgid ""
-"Alongside `Cargo.toml` is [`gnrt_config.toml`](https://source.chromium.org/"
-"chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/gnrt_config."
-"toml). This contains Chromium-specific extensions to crate handling."
+"Alongside `Cargo.toml` is `gnrt_config.toml`. This contains Chromium-"
+"specific extensions to crate handling."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:6
 msgid ""
 "If you add a new crate, you should specify at least the `group`. This is one "
 "of:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:15
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:15
 msgid "For instance,"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:22
 msgid ""
 "Depending on the crate source code layout, you may also need to use this "
 "file to specify where its `LICENSE` file(s) can be found."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md
+#: src/chromium/adding-third-party-crates/configuring-gnrt-config-toml.md:25
 msgid ""
 "Later, we'll see some other things you will need to configure in this file "
 "to resolve problems."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:3
 msgid ""
 "A tool called `gnrt` knows how to download crates and how to generate `BUILD."
 "gn` rules."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:6
 msgid "To start, download the crate you want like this:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:13
 msgid ""
 "Although the `gnrt` tool is part of the Chromium source code, by running "
 "this command you will be downloading and running its dependencies from "
-"`crates.io`. See [the earlier section](../cargo.md) discussing this security "
-"decision."
+"`crates.io`. See the earlier section discussing this security decision."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:17
 msgid "This `vendor` command may download:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:19
 #, fuzzy
 msgid "Your crate"
 msgstr "جعبه‌های (crates) کاربردی"
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:20
 msgid "Direct and transitive dependencies"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:21
 msgid ""
 "New versions of other crates, as required by `cargo` to resolve the complete "
 "set of crates required by Chromium."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/downloading-crates.md
+#: src/chromium/adding-third-party-crates/downloading-crates.md:24
 msgid ""
 "Chromium maintains patches for some crates, kept in `//third_party/rust/"
 "chromium_crates_io/patches`. These will be reapplied automatically, but if "
 "patching fails you may need to take manual action."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:3
 msgid ""
 "Once you've downloaded the crate, generate the `BUILD.gn` files like this:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:9
 msgid "Now run `git status`. You should find:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:11
 msgid ""
 "At least one new crate source code in `third_party/rust/chromium_crates_io/"
 "vendor`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:13
 msgid ""
 "At least one new `BUILD.gn` in `third_party/rust/<crate name>/v<major semver "
 "version>`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:15
 msgid "An appropriate `README.chromium`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:17
 #, fuzzy
-msgid ""
-"The \"major semver version\" is a [Rust \"semver\" version number](https://"
-"doc.rust-lang.org/cargo/reference/semver.html)."
+msgid "The \"major semver version\" is a Rust \"semver\" version number."
 msgstr ""
 "لطفا به  [مرجع Rust ](https://doc.rust-lang.org/reference/type-layout.html) "
 "مراجعه کنید."
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:19
 msgid ""
 "Take a close look, especially at the things generated in `third_party/rust`."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md
+#: src/chromium/adding-third-party-crates/generating-gn-build-rules.md:23
 msgid ""
 "Talk a little about semver --- and specifically the way that in Chromium "
 "it's to allow multiple incompatible versions of a crate, which is "
 "discouraged but sometimes necessary in the Cargo ecosystem."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:3
 msgid ""
 "If your build fails, it may be because of a `build.rs`: programs which do "
 "arbitrary things at build time. This is fundamentally at odds with the "
@@ -14435,78 +14451,90 @@ msgid ""
 "to maximize parallelism and repeatability of builds."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:8
 msgid ""
 "Some `build.rs` actions are automatically supported; others require action:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
 msgid "build script effect"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
 msgid "Supported by our gn templates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:10
 msgid "Work required by you"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
 msgid "Checking rustc version to configure features on and off"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
+msgid "Yes"
+msgstr "بلی"
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:12
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
 msgid "None"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:13
 msgid "Checking platform or CPU to configure features on and off"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
 #, fuzzy
 msgid "Generating code"
 msgstr "جنریک‌ها"
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:14
 msgid "Yes - specify in `gnrt_config.toml`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
 msgid "Building C/C++"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
+msgid "No"
+msgstr "خیر"
+
+#: src/chromium/adding-third-party-crates/resolving-problems.md:15
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
 msgid "Patch around it"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:16
 msgid "Arbitrary other actions"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems.md
+#: src/chromium/adding-third-party-crates/resolving-problems.md:18
 msgid ""
 "Fortunately, most crates don't contain a build script, and fortunately, most "
 "build scripts only do the top two actions."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:3
 msgid ""
 "If `ninja` complains about missing files, check the `build.rs` to see if it "
 "writes source code files."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:6
 msgid ""
-"If so, modify [`gnrt_config.toml`](../configuring-gnrt-config-toml.md) to "
-"add `build-script-outputs` to the crate. If this is a transitive dependency, "
-"that is, one on which Chromium code should not directly depend, also add "
-"`allow-first-party-usage=false`. There are several examples already in that "
-"file:"
+"If so, modify `gnrt_config.toml` to add `build-script-outputs` to the crate. "
+"If this is a transitive dependency, that is, one on which Chromium code "
+"should not directly depend, also add `allow-first-party-usage=false`. There "
+"are several examples already in that file:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:11
 msgid ""
 "```toml\n"
 "[crate.unicode-linebreak]\n"
@@ -14515,55 +14543,51 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-generate-code.md:17
 msgid ""
-"Now rerun [`gnrt.py -- gen`](../generating-gn-build-rules.md) to regenerate "
-"`BUILD.gn` files to inform ninja that this particular output file is input "
-"to subsequent build steps."
+"Now rerun `gnrt.py -- gen` to regenerate `BUILD.gn` files to inform ninja "
+"that this particular output file is input to subsequent build steps."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:3
 msgid ""
-"Some crates use the [`cc`](https://crates.io/crates/cc) crate to build and "
-"link C/C++ libraries. Other crates parse C/C++ using [`bindgen`](https://"
-"crates.io/crates/bindgen) within their build scripts. These actions can't be "
-"supported in a Chromium context --- our gn, ninja and LLVM build system is "
-"very specific in expressing relationships between build actions."
+"Some crates use the `cc` crate to build and link C/C++ libraries. Other "
+"crates parse C/C++ using `bindgen` within their build scripts. These actions "
+"can't be supported in a Chromium context --- our gn, ninja and LLVM build "
+"system is very specific in expressing relationships between build actions."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:8
 msgid "So, your options are:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:10
 msgid "Avoid these crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:11
 msgid "Apply a patch to the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md
+#: src/chromium/adding-third-party-crates/resolving-problems/build-scripts-which-take-arbitrary-actions.md:13
 msgid ""
 "Patches should be kept in `third_party/rust/chromium_crates_io/patches/"
-"<crate>` - see for example the [patches against the `cxx` crate](https://"
-"source.chromium.org/chromium/chromium/src/+/main:third_party/rust/"
-"chromium_crates_io/patches/cxx/) - and will be applied automatically by "
-"`gnrt` each time it upgrades the crate."
+"<crate>` - see for example the patches against the `cxx` crate - and will be "
+"applied automatically by `gnrt` each time it upgrades the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:3
 msgid ""
 "Once you've added a third-party crate and generated build rules, depending "
 "on a crate is simple. Find your `rust_static_library` target, and add a "
 "`dep` on the `:lib` target within your crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:7
 msgid "Specifically,"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:9
 msgid ""
 "```bob\n"
 "                     +------------+      +----------------------+\n"
@@ -14573,7 +14597,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/depending-on-a-crate.md
+#: src/chromium/adding-third-party-crates/depending-on-a-crate.md:17
 msgid ""
 "```gn\n"
 "rust_static_library(\"my_rust_lib\") {\n"
@@ -14584,32 +14608,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:1
 msgid "Auditing Third Party Crates"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:3
 msgid ""
-"Adding new libraries is subject to Chromium's standard [policies](https://"
-"chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/rust."
-"md#Third_party-review), but of course also subject to security review. As "
-"you may be bringing in not just a single crate but also transitive "
-"dependencies, there may be a lot of code to review. On the other hand, safe "
-"Rust code can have limited negative side effects. How should you review it?"
+"Adding new libraries is subject to Chromium's standard policies, but of "
+"course also subject to security review. As you may be bringing in not just a "
+"single crate but also transitive dependencies, there may be a lot of code to "
+"review. On the other hand, safe Rust code can have limited negative side "
+"effects. How should you review it?"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
-msgid ""
-"Over time Chromium aims to move to a process based around [cargo vet]"
-"(https://mozilla.github.io/cargo-vet/)."
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:9
+msgid "Over time Chromium aims to move to a process based around cargo vet."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:11
 msgid ""
 "Meanwhile, for each new crate addition, we are checking for the following:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:13
 msgid ""
 "Understand why each crate is used. What's the relationship between crates? "
 "If the build system for each crate contains a `build.rs` or procedural "
@@ -14617,77 +14638,73 @@ msgid ""
 "is normally built?"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:17
 msgid "Check each crate seems to be reasonably well maintained"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:18
 msgid ""
 "Use `cd third-party/rust/chromium_crates_io; cargo audit` to check for known "
 "vulnerabilities (first you'll need to `cargo install cargo-audit`, which "
-"ironically involves downloading lots of dependencies from the internet[2](../"
-"cargo.md))"
+"ironically involves downloading lots of dependencies from the internet2)"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
-msgid ""
-"Ensure any `unsafe` code is good enough for the [Rule of Two](https://"
-"chromium.googlesource.com/chromium/src/+/main/docs/security/rule-of-2."
-"md#unsafe-code-in-safe-languages)"
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:21
+msgid "Ensure any `unsafe` code is good enough for the Rule of Two"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:22
 msgid "Check for any use of `fs` or `net` APIs"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:23
 msgid ""
 "Read all the code at a sufficient level to look for anything out of place "
 "that might have been maliciously inserted. (You can't realistically aim for "
 "100% perfection here: there's often just too much code.)"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/reviews-and-audits.md
+#: src/chromium/adding-third-party-crates/reviews-and-audits.md:27
 msgid ""
 "These are just guidelines --- work with reviewers from `security@chromium."
 "org` to work out the right way to become confident of the crate."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:1
 msgid "Checking Crates into Chromium Source Code"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:3
 msgid "`git status` should reveal:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:5
 msgid "Crate code in `//third_party/rust/chromium_crates_io`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:6
 msgid ""
 "Metadata (`BUILD.gn` and `README.chromium`) in `//third_party/rust/<crate>/"
 "<version>`"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:9
 msgid "Please also add an `OWNERS` file in the latter location."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:11
 msgid ""
 "You should land all this, along with your `Cargo.toml` and `gnrt_config."
 "toml` changes, into the Chromium repo."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:14
 msgid ""
 "**Important**: you need to use `git add -f` because otherwise `.gitignore` "
 "files may result in some files being skipped."
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/checking-in.md
+#: src/chromium/adding-third-party-crates/checking-in.md:17
 msgid ""
 "As you do so, you might find presubmit checks fail because of non-inclusive "
 "language. This is because Rust crate data tends to include names of git "
@@ -14695,80 +14712,76 @@ msgid ""
 "you may need to run:"
 msgstr ""
 
-#: src/chromium/adding-third-party-crates/keeping-up-to-date.md
+#: src/chromium/adding-third-party-crates/keeping-up-to-date.md:3
 msgid ""
-"As the OWNER of any third party Chromium dependency, you are [expected to "
-"keep it up to date with any security fixes](https://chromium.googlesource."
-"com/chromium/src/+/main/docs/adding_to_third_party.md#add-owners). It is "
-"hoped that we will soon automate this for Rust crates, but for now, it's "
-"still your responsibility just as it is for any other third party dependency."
+"As the OWNER of any third party Chromium dependency, you are expected to "
+"keep it up to date with any security fixes. It is hoped that we will soon "
+"automate this for Rust crates, but for now, it's still your responsibility "
+"just as it is for any other third party dependency."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:3
 msgid ""
-"Add [uwuify](https://crates.io/crates/uwuify) to Chromium, turning off the "
-"crate's [default features](https://doc.rust-lang.org/cargo/reference/"
-"features.html#the-default-feature). Assume that the crate will be used in "
-"shipping Chromium, but won't be used to handle untrustworthy input."
+"Add uwuify to Chromium, turning off the crate's default features. Assume "
+"that the crate will be used in shipping Chromium, but won't be used to "
+"handle untrustworthy input."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:7
 msgid ""
 "(In the next exercise we'll use uwuify from Chromium, but feel free to skip "
 "ahead and do that now if you like. Or, you could create a new "
-"[`rust_executable` target](https://source.chromium.org/chromium/chromium/src/"
-"+/main:build/rust/rust_executable.gni) which uses `uwuify`)."
+"`rust_executable` target which uses `uwuify`)."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:13
 msgid "Students will need to download lots of transitive dependencies."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:15
 msgid "The total crates needed are:"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:17
 msgid "`instant`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:18
 msgid "`lock_api`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:19
 msgid "`parking_lot`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:20
 msgid "`parking_lot_core`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:21
 msgid "`redox_syscall`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:22
 msgid "`scopeguard`,"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:23
 msgid "`smallvec`, and"
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:24
 msgid "`uwuify`."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
+#: src/exercises/chromium/third-party.md:26
 msgid ""
 "If students are downloading even more than that, they probably forgot to "
 "turn off the default features."
 msgstr ""
 
-#: src/exercises/chromium/third-party.md
-msgid ""
-"Thanks to [Daniel Liu](https://github.com/Daniel-Liu-c0deb0t) for this crate!"
+#: src/exercises/chromium/third-party.md:29
+msgid "Thanks to Daniel Liu for this crate!"
 msgstr ""
 
 #: src/exercises/chromium/bringing-it-together.md
@@ -14806,9 +14819,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/chromium/bringing-it-together.md
-msgid ""
-"In fact, you already [imported that crate in the previous exercise](https://"
-"crates.io/crates/uwuify)."
+msgid "In fact, you already imported that crate in the previous exercise."
 msgstr ""
 
 #: src/exercises/chromium/bringing-it-together.md
@@ -14844,10 +14855,8 @@ msgstr ""
 #: src/exercises/chromium/bringing-it-together.md
 msgid ""
 "If students decide to do the conversion on the Rust side, they'll need to "
-"consider [`String::from_utf16`](https://doc.rust-lang.org/std/string/struct."
-"String.html#method.from_utf16), consider error handling, and consider which "
-"[CXX supported types can transfer a lot of u16s](https://cxx.rs/binding/"
-"slice.html)."
+"consider `String::from_utf16`, consider error handling, and consider which "
+"CXX supported types can transfer a lot of u16s."
 msgstr ""
 
 #: src/exercises/chromium/bringing-it-together.md
@@ -14855,10 +14864,10 @@ msgid ""
 "Students may design the C++/Rust boundary in several different ways, e.g. "
 "taking and returning strings by value, or taking a mutable reference to a "
 "string. If a mutable reference is used, CXX will likely tell the student "
-"that they need to use [`Pin`](https://doc.rust-lang.org/std/pin/). You may "
-"need to explain what `Pin` does, and then explain why CXX needs it for "
-"mutable references to C++ data: the answer is that C++ data can't be moved "
-"around like Rust data, because it may contain self-referential pointers."
+"that they need to use `Pin`. You may need to explain what `Pin` does, and "
+"then explain why CXX needs it for mutable references to C++ data: the answer "
+"is that C++ data can't be moved around like Rust data, because it may "
+"contain self-referential pointers."
 msgstr ""
 
 #: src/exercises/chromium/bringing-it-together.md
@@ -14875,9 +14884,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/chromium/solutions.md
-msgid ""
-"Solutions to the Chromium exercises can be found in [this series of CLs]"
-"(https://chromium-review.googlesource.com/c/chromium/src/+/5096560)."
+msgid "Solutions to the Chromium exercises can be found in this series of CLs."
 msgstr ""
 
 #: src/bare-metal.md
@@ -14916,11 +14923,10 @@ msgstr ""
 
 #: src/bare-metal.md
 msgid ""
-"For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2 as an example. It's a [development board](https://"
-"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
-"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
-"an on-board SWD debugger."
+"For the microcontroller part of the course we will use the BBC micro:bit v2 "
+"as an example. It's a development board based on the Nordic nRF52833 "
+"microcontroller with some LEDs and buttons, an I2C-connected accelerometer "
+"and compass, and an on-board SWD debugger."
 msgstr ""
 
 #: src/bare-metal.md
@@ -14933,7 +14939,7 @@ msgid ""
 "And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
 
-#: src/bare-metal.md src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal.md src/bare-metal/microcontrollers/debugging.md:33
 msgid "On MacOS:"
 msgstr ""
 
@@ -15037,86 +15043,83 @@ msgstr ""
 msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:1
 msgid "A minimal `no_std` program"
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:19
 msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:20
 msgid "`std` provides a panic handler; without it we must provide our own."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:21
 msgid "It can also be provided by another crate, such as `panic-halt`."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:22
 msgid ""
 "Depending on the target, you may need to compile with `panic = \"abort\"` to "
 "avoid an error about `eh_personality`."
 msgstr ""
 
-#: src/bare-metal/minimal.md
+#: src/bare-metal/minimal.md:24
 msgid ""
 "Note that there is no `main` or any other entry point; it's up to you to "
 "define your own entry point. This will typically involve a linker script and "
 "some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
-#: src/bare-metal/alloc.md
-msgid ""
-"To use `alloc` you must implement a [global (heap) allocator](https://doc."
-"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
+#: src/bare-metal/alloc.md:3
+msgid "To use `alloc` you must implement a global (heap) allocator."
 msgstr ""
 
-#: src/bare-metal/alloc.md
-msgid ""
-"// Safe because `HEAP` is only used here and `entry` is only called once.\n"
+#: src/bare-metal/alloc.md:23
+msgid "// SAFETY: `HEAP` is only used here and `entry` is only called once."
 msgstr ""
 
-#: src/bare-metal/alloc.md
-msgid "// Give the allocator some memory to allocate.\n"
+#: src/bare-metal/alloc.md:25
+msgid "// Give the allocator some memory to allocate."
 msgstr ""
 
-#: src/bare-metal/alloc.md
-msgid "// Now we can do things that require heap allocation.\n"
+#: src/bare-metal/alloc.md:29
+msgid "// Now we can do things that require heap allocation."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:31
 #, fuzzy
 msgid "\"A string\""
 msgstr "String"
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:37
 msgid ""
 "`buddy_system_allocator` is a third-party crate implementing a basic buddy "
 "system allocator. Other crates are available, or you can write your own or "
 "hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:40
 msgid ""
 "The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
 "in this case it can allocate regions of up to 2\\*\\*32 bytes."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:42
 msgid ""
 "If any crate in your dependency tree depends on `alloc` then you must have "
 "exactly one global allocator defined in your binary. Usually this is done in "
 "the top-level binary crate."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:45
 msgid ""
 "`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
 "crate is linked in so we get its panic handler."
 msgstr ""
 
-#: src/bare-metal/alloc.md
+#: src/bare-metal/alloc.md:47
 msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
@@ -15142,173 +15145,171 @@ msgstr ""
 msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
 "turning on an LED on our micro:bit:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-msgid "/// GPIO port 0 peripheral address\n"
+#: src/bare-metal/microcontrollers/mmio.md:16
+msgid "/// GPIO port 0 peripheral address"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-msgid "// GPIO peripheral offsets\n"
+#: src/bare-metal/microcontrollers/mmio.md:19
+msgid "// GPIO peripheral offsets"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-msgid "// PIN_CNF fields\n"
+#: src/bare-metal/microcontrollers/mmio.md:24
+msgid "// PIN_CNF fields"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-#: src/bare-metal/microcontrollers/pacs.md
-#: src/bare-metal/microcontrollers/hals.md
-msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
+#: src/bare-metal/microcontrollers/mmio.md:34
+#: src/bare-metal/microcontrollers/pacs.md:21
+#: src/bare-metal/microcontrollers/hals.md:26
+msgid "// Configure GPIO 0 pins 21 and 28 as push-pull outputs."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:37
+#: src/bare-metal/microcontrollers/mmio.md:59
 msgid ""
-"// Safe because the pointers are to valid peripheral control registers, and\n"
-"    // no aliases exist.\n"
+"// SAFETY: The pointers are to valid peripheral control registers, and no // "
+"aliases exist."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-#: src/bare-metal/microcontrollers/pacs.md
-#: src/bare-metal/microcontrollers/hals.md
-msgid "// Set pin 28 low and pin 21 high to turn the LED on.\n"
+#: src/bare-metal/microcontrollers/mmio.md:56
+#: src/bare-metal/microcontrollers/pacs.md:39
+#: src/bare-metal/microcontrollers/hals.md:30
+msgid "// Set pin 28 low and pin 21 high to turn the LED on."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
+#: src/bare-metal/microcontrollers/mmio.md:72
 msgid ""
 "GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
 "to the first row."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md
-#: src/bare-metal/microcontrollers/pacs.md
-#: src/bare-metal/microcontrollers/hals.md
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/mmio.md:75
+#: src/bare-metal/microcontrollers/pacs.md:61
+#: src/bare-metal/microcontrollers/hals.md:44
+#: src/bare-metal/microcontrollers/board-support.md:37
 msgid "Run the example with:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:1
 msgid "Peripheral Access Crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
-"[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
-"pack/doc/CMSIS/SVD/html/index.html) files."
+"`svd2rust` generates mostly-safe Rust wrappers for memory-mapped peripherals "
+"from CMSIS-SVD files."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
 "SVD (System View Description) files are XML files typically provided by "
 "silicon vendors which describe the memory map of the device."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:51
 msgid ""
 "They are organised by peripheral, register, field and value, with names, "
 "descriptions, addresses and so on."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:53
 msgid ""
 "SVD files are often buggy and incomplete, so there are various projects "
 "which patch the mistakes, add missing details, and publish the generated "
 "crates."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:56
 msgid "`cortex-m-rt` provides the vector table, among other things."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/pacs.md
+#: src/bare-metal/microcontrollers/pacs.md:57
 msgid ""
 "If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
 "pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:1
 msgid "HAL crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
-"[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for many microcontrollers provide wrappers around "
-"various peripherals. These generally implement traits from [`embedded-hal`]"
-"(https://crates.io/crates/embedded-hal)."
+"HAL crates for many microcontrollers provide wrappers around various "
+"peripherals. These generally implement traits from `embedded-hal`."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
-msgid "// Create HAL wrapper for GPIO port 0.\n"
+#: src/bare-metal/microcontrollers/hals.md:23
+msgid "// Create HAL wrapper for GPIO port 0."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:40
 msgid ""
 "`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/hals.md
+#: src/bare-metal/microcontrollers/hals.md:41
 msgid ""
 "HAL crates exist for many Cortex-M and RISC-V devices, including various "
 "STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:1
 msgid "Board support crates"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:3
 msgid ""
 "Board support crates provide a further level of wrapping for a specific "
 "board for convenience."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:31
 msgid ""
 "In this case the board support crate is just providing more useful names, "
 "and a bit of initialisation."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:33
 msgid ""
 "The crate may also include drivers for some on-board devices outside of the "
 "microcontroller itself."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/board-support.md
+#: src/bare-metal/microcontrollers/board-support.md:35
 msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:1
 msgid "The type state pattern"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
-msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved.\n"
+#: src/bare-metal/microcontrollers/type-state.md:11
+msgid "// let gpio0_01_again = gpio0.p0_01; // Error, moved."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
-msgid "// pin_input.is_high(); // Error, moved.\n"
+#: src/bare-metal/microcontrollers/type-state.md:19
+msgid "// pin_input.is_high(); // Error, moved."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:33
 msgid ""
 "Pins don't implement `Copy` or `Clone`, so only one instance of each can "
 "exist. Once a pin is moved out of the port struct nobody else can take it."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:35
 msgid ""
 "Changing the configuration of a pin consumes the old pin instance, so you "
 "can’t keep use the old instance afterwards."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:37
 msgid ""
 "The type of a value indicates the state that it is in: e.g. in this case, "
 "the configuration state of a GPIO pin. This encodes the state machine into "
@@ -15317,234 +15318,239 @@ msgid ""
 "caught at compile time."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:42
 msgid ""
 "You can call `is_high` on an input pin and `set_high` on an output pin, but "
 "not vice-versa."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/type-state.md
+#: src/bare-metal/microcontrollers/type-state.md:44
 msgid "Many HAL crates follow this pattern."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
-"The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits covering common microcontroller peripherals."
+"The `embedded-hal` crate provides a number of traits covering common "
+"microcontroller peripherals:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:6
 msgid "GPIO"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "ADC"
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "PWM"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "I2C, SPI, UART, CAN"
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "Delay timers"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "RNG"
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "I2C and SPI buses and devices"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "Timers"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid "Watchdogs"
-msgstr ""
-
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
 msgid ""
-"Other crates then implement [drivers](https://github.com/rust-embedded/"
-"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
-"accelerometer driver might need an I2C or SPI bus implementation."
+"Similar traits for byte streams (e.g. UARTs), CAN buses and RNGs and broken "
+"out into `embedded-io`, `embedded-can` and `rand_core` respectively."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:14
+msgid ""
+"Other crates then implement drivers in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI device instance."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:19
+msgid ""
+"The traits cover using the peripherals but not initialising or configuring "
+"them, as initialisation and configuration is usually highly platform-"
+"specific."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
 msgid ""
 "There are implementations for many microcontrollers, as well as other "
 "platforms such as Linux on Raspberry Pi."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/embedded-hal.md
-msgid ""
-"There is work in progress on an `async` version of `embedded-hal`, but it "
-"isn't stable yet."
+#: src/bare-metal/microcontrollers/embedded-hal.md:23
+msgid "`embedded-hal-async` provides async versions of the traits."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/embedded-hal.md:24
 msgid ""
-"[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better integrated."
+"`embedded-hal-nb` provides another approach to non-blocking I/O, based on "
+"the `nb` crate."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:3
+msgid ""
+"probe-rs is a handy toolset for embedded debugging, like OpenOCD but better "
+"integrated."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
 msgid ""
 "SWD (Serial Wire Debug) and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:7
 msgid "GDB stub and Microsoft DAP (Debug Adapter Protocol) server"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:8
 msgid "Cargo integration"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:10
 msgid ""
 "`cargo-embed` is a cargo subcommand to build and flash binaries, log RTT "
 "(Real Time Transfers) output and connect GDB. It's configured by an `Embed."
 "toml` file in your project directory."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard protocol over USB for an in-circuit debugger to access the "
-"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
-"on-board debugger on the BBC micro:bit uses."
+"CMSIS-DAP is an Arm standard protocol over USB for an in-circuit debugger to "
+"access the CoreSight Debug Access Port of various Arm Cortex processors. "
+"It's what the on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:20
 msgid ""
 "ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
 "is a range from SEGGER."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:22
 msgid ""
 "The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
 "Serial Wire Debug."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:24
 msgid ""
 "probe-rs is a library which you can integrate into your own tools if you "
 "want to."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:26
 msgid ""
-"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
-"supported microcontroller."
+"The Microsoft Debug Adapter Protocol lets VSCode and other IDEs debug code "
+"running on any supported microcontroller."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:30
 msgid "cargo-embed is a binary built using the probe-rs library."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/probe-rs.md
+#: src/bare-metal/microcontrollers/probe-rs.md:31
 msgid ""
 "RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
 "host and the target through a number of ringbuffers."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:3
 msgid "_Embed.toml_:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:15
 msgid "In one terminal under `src/bare-metal/microcontrollers/examples/`:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:23
 msgid "In another terminal in the same directory:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:25
 msgid "On gLinux or Debian:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md
+#: src/bare-metal/microcontrollers/debugging.md:43
 msgid "In GDB, try running:"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:1
+#: src/bare-metal/aps/other-projects.md:1
 msgid "Other projects"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-msgid "[RTIC](https://rtic.rs/)"
+#: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "RTIC"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:4
 msgid "\"Real-Time Interrupt-driven Concurrency\""
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
 "Shared resource management, message passing, task scheduling, timer queue"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-msgid "[Embassy](https://embassy.dev/)"
-msgstr ""
+#: src/bare-metal/microcontrollers/other-projects.md:6
+#, fuzzy
+msgid "Embassy"
+msgstr "vmbase"
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:7
 msgid "`async` executors with priorities, timers, networking, USB"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "TockOS"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:9
 msgid ""
 "Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
 "support"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-msgid "[Hubris](https://hubris.oxide.computer/)"
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid "Hubris"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:12
 msgid ""
 "Microkernel RTOS from Oxide Computer Company with memory protection, "
 "unprivileged drivers, IPC"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+#: src/bare-metal/microcontrollers/other-projects.md:14
+msgid "Bindings for FreeRTOS"
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
-msgid ""
-"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
-"github.io/book/overview/using-the-standard-library.html)."
+#: src/bare-metal/microcontrollers/other-projects.md:15
+msgid "Some platforms have `std` implementations, e.g. esp-idf."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid "RTIC can be considered either an RTOS or a concurrency framework."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:21
 msgid "It doesn't include any HALs."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:22
 msgid ""
 "It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
 "scheduling rather than a proper kernel."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:24
 msgid "Cortex-M only."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:25
 msgid ""
 "Google uses TockOS on the Haven microcontroller for Titan security keys."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/other-projects.md
+#: src/bare-metal/microcontrollers/other-projects.md:26
 msgid ""
 "FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
@@ -15556,158 +15562,139 @@ msgid ""
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/morning.md src/exercises/concurrency/morning.md
-msgid ""
-"After looking at the exercises, you can look at the [solutions](solutions-"
-"morning.md) provided."
+#: src/exercises/bare-metal/morning.md src/exercises/bare-metal/afternoon.md
+#, fuzzy
+msgid "After looking at the exercises, you can look at the solutions provided."
 msgstr ""
 "پس از دیدن تمرین‌ها، می‌توانید به [راه حل‌ها] (solutions-morning.md) ارائه شده "
 "نگاه کنید."
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
 "serial port. If you have time, try displaying it on the LEDs somehow too, or "
 "use the buttons somehow."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:7
 msgid "Hints:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:9
 msgid ""
-"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
-"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
-"org/hardware/)."
+"Check the documentation for the `lsm303agr` and `microbit-v2` crates, as "
+"well as the micro:bit hardware."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:13
 msgid ""
 "The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:14
 msgid ""
 "TWI is another name for I2C, so the I2C master peripheral is called TWIM."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:15
 msgid ""
 "The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
-"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+"blocking::i2c::WriteRead` trait. The `microbit::hal::Twim` struct implements "
+"this."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:19
 msgid ""
-"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html) struct with fields for the various pins and peripherals."
+"You have a `microbit::Board` struct with fields for the various pins and "
+"peripherals."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:22
 msgid ""
-"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
-"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
-"this exercise."
+"You can also look at the nRF52833 datasheet if you want, but it shouldn't be "
+"necessary for this exercise."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:26
 msgid ""
-"Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `compass` directory for the following files."
+"Download the exercise template and look in the `compass` directory for the "
+"following files."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/compass.md:29 src/exercises/bare-metal/rtc.md:22
 msgid "_src/main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
-#: src/exercises/bare-metal/solutions-morning.md
-msgid "// Configure serial port.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md
-#: src/exercises/bare-metal/solutions-morning.md
-msgid "// Use the system timer as a delay provider.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md
-msgid ""
-"// Set up the I2C controller and Inertial Measurement Unit.\n"
-"    // TODO\n"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md
-#: src/exercises/bare-metal/solutions-morning.md
-msgid "\"Ready.\""
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md
-msgid ""
-"// Read compass data and log it to the serial port.\n"
-"        // TODO\n"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/compass.md:71 src/exercises/bare-metal/rtc.md:393
 msgid "_Cargo.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:93
 msgid "_Embed.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/compass.md:109 src/exercises/bare-metal/rtc.md:1000
 msgid "_.cargo/config.toml_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:122
 msgid "See the serial output on Linux with:"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:130
 msgid ""
 "Or on Mac OS something like (the device name may be slightly different):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md
+#: src/exercises/bare-metal/compass.md:138
 msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:1
 msgid "Bare Metal Rust Morning Exercise"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
-msgid "([back to exercise](compass.md))"
+#: src/exercises/bare-metal/solutions-morning.md:5
+#: src/exercises/bare-metal/solutions-afternoon.md:5
+msgid "(back to exercise)"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
-msgid "// Set up the I2C controller and Inertial Measurement Unit.\n"
+#: src/exercises/bare-metal/solutions-morning.md:34
+msgid "// Configure serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:42
+msgid "// Use the system timer as a delay provider."
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:45
+msgid "// Set up the I2C controller and Inertial Measurement Unit."
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:46
 msgid "\"Setting up IMU...\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
-msgid "// Set up display and timer.\n"
+#: src/exercises/bare-metal/solutions-morning.md:64
+msgid "// Set up display and timer."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
-msgid "// Read compass data and log it to the serial port.\n"
+#: src/exercises/bare-metal/solutions-morning.md:71
+msgid "\"Ready.\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:74
+msgid "// Read compass data and log it to the serial port."
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-morning.md:82
 msgid "\"{},{},{}\\t{},{},{}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-morning.md
+#: src/exercises/bare-metal/solutions-morning.md:120
 msgid ""
 "// If button A is pressed, switch to the next mode and briefly blink all "
-"LEDs\n"
-"        // on.\n"
+"LEDs // on."
 msgstr ""
 
 #: src/bare-metal/aps.md
@@ -15718,8 +15705,7 @@ msgstr ""
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
 "Now let's try writing something for Cortex-A. For simplicity we'll just work "
-"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
-"virt.html) board."
+"with QEMU's aarch64 'virt' board."
 msgstr ""
 
 #: src/bare-metal/aps.md
@@ -15736,12 +15722,12 @@ msgid ""
 "hardware, but is designed purely for virtual machines."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:3
 msgid ""
 "Before we can start running Rust code, we need to do some initialisation."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:5
 msgid ""
 "```armasm\n"
 ".section .init.entry, \"ax\"\n"
@@ -15817,13 +15803,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:77
 msgid ""
 "This is the same as it would be for C: initialising the processor state, "
 "zeroing the BSS, and setting up the stack pointer."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:79
 msgid ""
 "The BSS (block starting symbol, for historical reasons) is the part of the "
 "object file which containing statically allocated variables which are "
@@ -15832,19 +15818,19 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:84
 msgid ""
 "The BSS may already be zeroed, depending on how memory is initialised and "
 "the image is loaded, but we zero it to be sure."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:86
 msgid ""
 "We need to enable the MMU and cache before reading or writing any memory. If "
 "we don't:"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:88
 msgid ""
 "Unaligned accesses will fault. We build the Rust code for the `aarch64-"
 "unknown-none` target which sets `+strict-align` to prevent the compiler "
@@ -15852,7 +15838,7 @@ msgid ""
 "is not necessarily the case in general."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:92
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -15863,7 +15849,7 @@ msgid ""
 "not VA or IPA.)"
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:99
 msgid ""
 "For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
 "identity maps the first 1 GiB of address space for devices, the next 1 GiB "
@@ -15871,86 +15857,86 @@ msgid ""
 "memory layout that QEMU uses."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:103
 msgid ""
 "We also set up the exception vector (`vbar_el1`), which we'll see more about "
 "later."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md
+#: src/bare-metal/aps/entry-point.md:105
 msgid ""
 "All examples this afternoon assume we will be running at exception level 1 "
 "(EL1). If you need to run at a different exception level you'll need to "
 "modify `entry.S` accordingly."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:1
 msgid "Inline assembly"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
 "Rust code. For example, to make an HVC (hypervisor call) to tell the "
 "firmware to power off the system:"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:20
 msgid ""
-"// Safe because this only uses the declared registers and doesn't do\n"
-"    // anything with memory.\n"
+"// SAFETY: this only uses the declared registers and doesn't do anything // "
+"with memory."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:23
 msgid "\"hvc #0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:24
 msgid "\"w0\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:25
 msgid "\"w1\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:26
 msgid "\"w2\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:27
 msgid "\"w3\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:28
 msgid "\"w4\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:29
 msgid "\"w5\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:30
 msgid "\"w6\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:31
 msgid "\"w7\""
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:40
 msgid ""
-"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
-"smccc) crate which has wrappers for all these functions.)"
+"(If you actually want to do this, use the `smccc` crate which has wrappers "
+"for all these functions.)"
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:45
 msgid ""
 "PSCI is the Arm Power State Coordination Interface, a standard set of "
 "functions to manage system and CPU power states, among other things. It is "
 "implemented by EL3 firmware and hypervisors on many systems."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:48
 msgid ""
 "The `0 => _` syntax means initialise the register to 0 before running the "
 "inline assembly code, and ignore its contents afterwards. We need to use "
@@ -15958,13 +15944,13 @@ msgid ""
 "contents of the registers."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:52
 msgid ""
 "This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
 "it is called from our entry point in `entry.S`."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:54
 msgid ""
 "`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
 "used by the bootloader to pass things like a pointer to the device tree. "
@@ -15974,111 +15960,101 @@ msgid ""
 "special except make sure it doesn't change these registers."
 msgstr ""
 
-#: src/bare-metal/aps/inline-assembly.md
+#: src/bare-metal/aps/inline-assembly.md:60
 msgid ""
 "Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:1
 msgid "Volatile memory access for MMIO"
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:3
 msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:4
 msgid "Never hold a reference."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
 "`addr_of!` lets you get fields of structs without creating an intermediate "
 "reference."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:10
 msgid ""
 "Volatile access: read or write operations may have side-effects, so prevent "
 "the compiler or hardware from reordering, duplicating or eliding them."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:12
 msgid ""
 "Usually if you write and then read, e.g. via a mutable reference, the "
 "compiler may assume that the value read is the same as the value just "
 "written, and not bother actually reading memory."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:15
 msgid ""
 "Some existing crates for volatile access to hardware do hold references, but "
 "this is unsound. Whenever a reference exist, the compiler may choose to "
 "dereference it."
 msgstr ""
 
-#: src/bare-metal/aps/mmio.md
+#: src/bare-metal/aps/mmio.md:18
 msgid ""
 "Use the `addr_of!` macro to get struct field pointers from a pointer to the "
 "struct."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:1
 msgid "Let's write a UART driver"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
-"documentation/ddi0183/g) UART, so let's write a driver for that."
+"The QEMU 'virt' machine has a PL011 UART, so let's write a driver for that."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
-msgid "/// Minimal driver for a PL011 UART.\n"
+#: src/bare-metal/aps/uart.md:9
+msgid "/// Minimal driver for a PL011 UART."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/uart.md:17 src/bare-metal/aps/better-uart/driver.md:13
 msgid ""
-"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
-"    /// given base address.\n"
-"    ///\n"
-"    /// # Safety\n"
-"    ///\n"
-"    /// The given base address must point to the 8 MMIO control registers of "
-"a\n"
-"    /// PL011 device, which must be mapped into the address space of the "
-"process\n"
-"    /// as device memory and not have any other aliases.\n"
+"/// Constructs a new instance of the UART driver for a PL011 device at "
+"the /// given base address. /// /// # Safety /// /// The given base address "
+"must point to the 8 MMIO control registers of a /// PL011 device, which must "
+"be mapped into the address space of the process /// as device memory and not "
+"have any other aliases."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
-#: src/exercises/bare-metal/rtc.md
-msgid "/// Writes a single byte to the UART.\n"
+#: src/bare-metal/aps/uart.md:29 src/bare-metal/aps/better-uart/driver.md:25
+msgid "/// Writes a single byte to the UART."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
-#: src/exercises/bare-metal/rtc.md
-msgid "// Wait until there is room in the TX buffer.\n"
+#: src/bare-metal/aps/uart.md:31 src/bare-metal/aps/better-uart/driver.md:27
+msgid "// Wait until there is room in the TX buffer."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:34 src/bare-metal/aps/uart.md:46
 msgid ""
-"// Safe because we know that the base address points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
+"// SAFETY: We know that the base address points to the control // registers "
+"of a PL011 device which is appropriately mapped."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
-#: src/exercises/bare-metal/rtc.md
-msgid "// Write to the TX buffer.\n"
+#: src/bare-metal/aps/uart.md:37 src/bare-metal/aps/better-uart/driver.md:33
+msgid "// Write to the TX buffer."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md src/bare-metal/aps/better-uart/driver.md
-#: src/exercises/bare-metal/rtc.md
-msgid "// Wait until the UART is no longer busy.\n"
+#: src/bare-metal/aps/uart.md:41 src/bare-metal/aps/better-uart/driver.md:37
+msgid "// Wait until the UART is no longer busy."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:55
 msgid ""
 "Note that `Uart::new` is unsafe while the other methods are safe. This is "
 "because as long as the caller of `Uart::new` guarantees that its safety "
@@ -16088,403 +16064,423 @@ msgid ""
 "necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:61
 msgid ""
 "We could have done it the other way around (making `new` safe but "
 "`write_byte` unsafe), but that would be much less convenient to use as every "
 "place that calls `write_byte` would need to reason about the safety"
 msgstr ""
 
-#: src/bare-metal/aps/uart.md
+#: src/bare-metal/aps/uart.md:64
 msgid ""
 "This is a common pattern for writing safe wrappers of unsafe code: moving "
 "the burden of proof for soundness from a large number of places to a smaller "
 "number of places."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:1
 msgid "More traits"
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:3
 msgid ""
 "We derived the `Debug` trait. It would be useful to implement a few more "
 "traits too."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/bare-metal/aps/uart/traits.md:17
 msgid ""
-"// Safe because it just contains a pointer to device memory, which can be\n"
-"// accessed from any context.\n"
+"// SAFETY: `Uart` just contains a pointer to device memory, which can be // "
+"accessed from any context."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:25
 msgid ""
 "Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
 "`Uart` type."
 msgstr ""
 
-#: src/bare-metal/aps/uart/traits.md
+#: src/bare-metal/aps/uart/traits.md:27
 msgid ""
 "Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:1
 msgid "A better UART driver"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
-"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
-"offsets to construct pointers to access them is error-prone and hard to "
-"read. Plus, some of them are bit fields which would be nice to access in a "
-"structured way."
+"The PL011 actually has a bunch more registers, and adding offsets to "
+"construct pointers to access them is error-prone and hard to read. Plus, "
+"some of them are bit fields which would be nice to access in a structured "
+"way."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:7
 msgid "Offset"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:7
 msgid "Register name"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:7
 msgid "Width"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:9
 msgid "0x00"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:9
 msgid "DR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:9
 msgid "12"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:10
 msgid "0x04"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:10
 msgid "RSR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
 msgid "0x18"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:11
 msgid "FR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:11
 msgid "9"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:12
 msgid "0x20"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:12
 msgid "ILPR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
 msgid "0x24"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:13
 msgid "IBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
 msgid "16"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:14
 msgid "0x28"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:14
 msgid "FBRD"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
 msgid "0x2c"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:15
 msgid "LCR_H"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:16
 msgid "0x30"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:16
 msgid "CR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:17
 msgid "0x34"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:17
 msgid "IFLS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:18
 msgid "0x38"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:18
 msgid "IMSC"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
 msgid "11"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:19
 msgid "0x3c"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:19
 msgid "RIS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:20
 msgid "0x40"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:20
 msgid "MIS"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:21
 msgid "0x44"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:21
 msgid "ICR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:22
 msgid "0x48"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:22
 msgid "DMACR"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart.md
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:26
 msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
-msgid ""
-"The [`bitflags`](https://crates.io/crates/bitflags) crate is useful for "
-"working with bitflags."
+#: src/bare-metal/aps/better-uart/bitflags.md:3
+msgid "The `bitflags` crate is useful for working with bitflags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Flags from the UART flag register.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:10
+msgid "/// Flags from the UART flag register."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Clear to send.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:14
+msgid "/// Clear to send."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Data set ready.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:16
+msgid "/// Data set ready."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Data carrier detect.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:18
+msgid "/// Data carrier detect."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// UART busy transmitting data.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:20
+msgid "/// UART busy transmitting data."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Receive FIFO is empty.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:22
+msgid "/// Receive FIFO is empty."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Transmit FIFO is full.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:24
+msgid "/// Transmit FIFO is full."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Receive FIFO is full.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:26
+msgid "/// Receive FIFO is full."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Transmit FIFO is empty.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:28
+msgid "/// Transmit FIFO is empty."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md src/exercises/bare-metal/rtc.md
-msgid "/// Ring indicator.\n"
+#: src/bare-metal/aps/better-uart/bitflags.md:30
+msgid "/// Ring indicator."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/bitflags.md
+#: src/bare-metal/aps/better-uart/bitflags.md:38
 msgid ""
 "The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
 "with a bunch of method implementations to get and set flags."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md
+#: src/bare-metal/aps/better-uart/registers.md:1
 msgid "Multiple registers"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md
+#: src/bare-metal/aps/better-uart/registers.md:3
 msgid ""
 "We can use a struct to represent the memory layout of the UART's registers."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/registers.md
+#: src/bare-metal/aps/better-uart/registers.md:43
 msgid ""
-"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells the compiler to lay the struct fields out in order, "
+"`#[repr(C)]` tells the compiler to lay the struct fields out in order, "
 "following the same rules as C. This is necessary for our struct to have a "
 "predictable layout, as default Rust representation allows the compiler to "
 "(among other things) reorder fields however it sees fit."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:3
 msgid "Now let's use the new `Registers` struct in our driver."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
-msgid "/// Driver for a PL011 UART.\n"
+#: src/bare-metal/aps/better-uart/driver.md:6
+msgid "/// Driver for a PL011 UART."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md src/exercises/bare-metal/rtc.md
+#: src/bare-metal/aps/better-uart/driver.md:30
+#: src/bare-metal/aps/better-uart/driver.md:56
 msgid ""
-"// Safe because we know that self.registers points to the control\n"
-"        // registers of a PL011 device which is appropriately mapped.\n"
+"// SAFETY: We know that self.registers points to the control registers // of "
+"a PL011 device which is appropriately mapped."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md src/exercises/bare-metal/rtc.md
+#: src/bare-metal/aps/better-uart/driver.md:41
 msgid ""
-"/// Reads and returns a pending byte, or `None` if nothing has been\n"
-"    /// received.\n"
+"/// Reads and returns a pending byte, or `None` if nothing has been /// "
+"received."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md src/exercises/bare-metal/rtc.md
-msgid "// TODO: Check for error conditions in bits 8-11.\n"
+#: src/bare-metal/aps/better-uart/driver.md:47
+msgid ""
+"// SAFETY: We know that self.registers points to the control // registers of "
+"a PL011 device which is appropriately mapped."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/driver.md
+#: src/bare-metal/aps/better-uart/driver.md:50
+msgid "// TODO: Check for error conditions in bits 8-11."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/driver.md:65
 msgid ""
 "Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
 "fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/better-uart/using.md:1
+#: src/bare-metal/aps/logging/using.md:1
 msgid "Using it"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
 "and echo incoming bytes."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Base address of the primary PL011 UART.\n"
+#: src/bare-metal/aps/better-uart/using.md:19
+#: src/bare-metal/aps/logging/using.md:18
+#: src/exercises/bare-metal/solutions-afternoon.md:33
+msgid "/// Base address of the primary PL011 UART."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/bare-metal/aps/better-uart/using.md:25
+#: src/bare-metal/aps/logging/using.md:24
+#: src/exercises/bare-metal/solutions-afternoon.md:44
 msgid ""
-"// Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
-"    // and nothing else accesses that address range.\n"
+"// SAFETY: `PL011_BASE_ADDRESS` is the base address of a PL011 device, "
+"and // nothing else accesses that address range."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/better-uart/using.md:29
+#: src/bare-metal/aps/logging/using.md:29
 msgid "\"main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})\""
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:35
 msgid "b'\\r'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md src/async/pitfalls/cancellation.md
+#: src/bare-metal/aps/better-uart/using.md:36
+#: src/concurrency/async-pitfalls/cancellation.md:27
 msgid "b'\\n'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:38
 msgid "b'q'"
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:44
 msgid "\"Bye!\""
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:51
 msgid ""
-"As in the [inline assembly](../inline-assembly.md) example, this `main` "
-"function is called from our entry point code in `entry.S`. See the speaker "
-"notes there for details."
+"As in the inline assembly example, this `main` function is called from our "
+"entry point code in `entry.S`. See the speaker notes there for details."
 msgstr ""
 
-#: src/bare-metal/aps/better-uart/using.md
+#: src/bare-metal/aps/better-uart/using.md:54
 msgid ""
 "Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md
+#: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`]"
-"(https://crates.io/crates/log) crate. We can do this by implementing the "
-"`Log` trait."
+"It would be nice to be able to use the logging macros from the `log` crate. "
+"We can do this by implementing the `Log` trait."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md src/exercises/bare-metal/rtc.md
-msgid "\"[{}] {}\""
+#: src/bare-metal/aps/logging.md:26
+msgid "\"\\[{}\\] {}\""
 msgstr ""
 
-#: src/bare-metal/aps/logging.md src/exercises/bare-metal/rtc.md
-msgid "/// Initialises UART logger.\n"
+#: src/bare-metal/aps/logging.md:35
+msgid "/// Initialises UART logger."
 msgstr ""
 
-#: src/bare-metal/aps/logging.md
+#: src/bare-metal/aps/logging.md:48
 msgid ""
 "The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/logging/using.md:3
 msgid "We need to initialise the logger before we use it."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/bare-metal/aps/logging/using.md:38
+#: src/exercises/bare-metal/solutions-afternoon.md:115
 msgid "\"{info}\""
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/logging/using.md:46
 msgid "Note that our panic handler can now log details of panics."
 msgstr ""
 
-#: src/bare-metal/aps/logging/using.md
+#: src/bare-metal/aps/logging/using.md:47
 msgid ""
 "Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:3
 msgid ""
 "AArch64 defines an exception vector table with 16 entries, for 4 types of "
 "exceptions (synchronous, IRQ, FIQ, SError) from 4 states (current EL with "
@@ -16493,81 +16489,79 @@ msgid ""
 "calling into Rust code:"
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:67
 msgid "EL is exception level; all our examples this afternoon run in EL1."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:68
 msgid ""
 "For simplicity we aren't distinguishing between SP0 and SPx for the current "
 "EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:70
 msgid ""
 "For this example we just log the exception and power down, as we don't "
 "expect any of them to actually happen."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md
+#: src/bare-metal/aps/exceptions.md:72
 msgid ""
 "We can think of exception handlers and our main execution context more or "
-"less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
-"md) will control what we can share between them, just like with threads. For "
-"example, if we want to share some value between exception handlers and the "
-"rest of the program, and it's `Send` but not `Sync`, then we'll need to wrap "
-"it in something like a `Mutex` and put it in a static."
+"less like different threads. `Send` and `Sync` will control what we can "
+"share between them, just like with threads. For example, if we want to share "
+"some value between exception handlers and the rest of the program, and it's "
+"`Send` but not `Sync`, then we'll need to wrap it in something like a "
+"`Mutex` and put it in a static."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
-msgid "[oreboot](https://github.com/oreboot/oreboot)"
+#: src/bare-metal/aps/other-projects.md:3
+msgid "oreboot"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:4
 msgid "\"coreboot without the C\""
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:5
 msgid "Supports x86, aarch64 and RISC-V."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:6
 msgid "Relies on LinuxBoot rather than having many drivers itself."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
-msgid ""
-"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)"
+#: src/bare-metal/aps/other-projects.md:7
+msgid "Rust RaspberryPi OS tutorial"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:8
 msgid ""
 "Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
 "exception handling, page tables"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:10
 msgid ""
 "Some dodginess around cache maintenance and initialisation in Rust, not "
 "necessarily a good example to copy for production code."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
-msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+#: src/bare-metal/aps/other-projects.md:12
+msgid "`cargo-call-stack`"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:13
 msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:17
 msgid ""
 "The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
 "enabled. This will read and write memory (e.g. the stack). However:"
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:19
 msgid ""
 "Without the MMU and cache, unaligned accesses will fault. It builds with "
 "`aarch64-unknown-none` which sets `+strict-align` to prevent the compiler "
@@ -16575,7 +16569,7 @@ msgid ""
 "necessarily the case in general."
 msgstr ""
 
-#: src/bare-metal/aps/other-projects.md
+#: src/bare-metal/aps/other-projects.md:23
 msgid ""
 "If it were running in a VM, this can lead to cache coherency issues. The "
 "problem is that the VM is accessing memory directly with the cache disabled, "
@@ -16596,157 +16590,148 @@ msgid ""
 "programming."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
-"traits and macros for safely converting between byte sequences and other "
-"types."
+"The `zerocopy` crate (from Fuchsia) provides traits and macros for safely "
+"converting between byte sequences and other types."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:42
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
 "but can be useful for working with structures shared with hardware e.g. by "
 "DMA, or sent over some external interface."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:48
 msgid ""
 "`FromBytes` can be implemented for types for which any byte pattern is "
 "valid, and so can safely be converted from an untrusted sequence of bytes."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:50
 msgid ""
 "Attempting to derive `FromBytes` for these types would fail, because "
 "`RequestType` doesn't use all possible u32 values as discriminants, so not "
 "all byte patterns are valid."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:53
 msgid ""
 "`zerocopy::byteorder` has types for byte-order aware numeric primitives."
 msgstr ""
 
-#: src/bare-metal/useful-crates/zerocopy.md
+#: src/bare-metal/useful-crates/zerocopy.md:54
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "zerocopy-example/`. (It won't run in the Playground because of the crate "
 "dependency.)"
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
-"you create page tables according to the AArch64 Virtual Memory System "
-"Architecture."
+"The `aarch64-paging` crate lets you create page tables according to the "
+"AArch64 Virtual Memory System Architecture."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
-msgid "// Create a new page table with identity mapping.\n"
+#: src/bare-metal/useful-crates/aarch64-paging.md:14
+msgid "// Create a new page table with identity mapping."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
-msgid "// Map a 2 MiB region of memory as read-only.\n"
+#: src/bare-metal/useful-crates/aarch64-paging.md:16
+msgid "// Map a 2 MiB region of memory as read-only."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
-msgid "// Set `TTBR0_EL1` to activate the page table.\n"
+#: src/bare-metal/useful-crates/aarch64-paging.md:21
+msgid "// Set `TTBR0_EL1` to activate the page table."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
 "For now it only supports EL1, but support for other exception levels should "
 "be straightforward to add."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
-msgid ""
-"This is used in Android for the [Protected VM Firmware](https://cs.android."
-"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
-"pvmfw/)."
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid "This is used in Android for the Protected VM Firmware."
 msgstr ""
 
-#: src/bare-metal/useful-crates/aarch64-paging.md
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
 msgid ""
 "There's no easy way to run this example, as it needs to run on real hardware "
 "or under QEMU."
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
-"is a third-party crate implementing a basic buddy system allocator. It can "
-"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
-"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
-"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
-"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
-"allocating other address space. For example, we might want to allocate MMIO "
-"space for PCI BARs:"
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. It can be used both for `LockedHeap` implementing "
+"`GlobalAlloc` so you can use the standard `alloc` crate (as we saw before), "
+"or for allocating other address space. For example, we might want to "
+"allocate MMIO space for PCI BARs:"
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:29
 msgid "PCI BARs always have alignment equal to their size."
 msgstr ""
 
-#: src/bare-metal/useful-crates/buddy_system_allocator.md
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
 msgid ""
 "Run the example with `cargo run` under `src/bare-metal/useful-crates/"
 "allocator-example/`. (It won't run in the Playground because of the crate "
 "dependency.)"
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md
+#: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
-"this: a vector backed by an array or slice, which could be statically "
-"allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to use more than are allocated."
+"heap allocation. `tinyvec` provides this: a vector backed by an array or "
+"slice, which could be statically allocated or on the stack, which keeps "
+"track of how many elements are used and panics if you try to use more than "
+"are allocated."
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md
+#: src/bare-metal/useful-crates/tinyvec.md:25
 msgid ""
 "`tinyvec` requires that the element type implement `Default` for "
 "initialisation."
 msgstr ""
 
-#: src/bare-metal/useful-crates/tinyvec.md
+#: src/bare-metal/useful-crates/tinyvec.md:27
 msgid ""
 "The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
 "are not available in `core` or `alloc`. How can we manage synchronisation or "
 "interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:7
 msgid ""
-"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
-"equivalents of many of these primitives."
+"The `spin` crate provides spinlock-based equivalents of many of these "
+"primitives."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:26
 msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:27
 msgid ""
 "`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
 "`Barrier` and `Once` from `std::sync`; and `Lazy` for lazy initialisation."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:29
 msgid ""
-"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
-"useful types for late initialisation with a slightly different approach to "
-"`spin::once::Once`."
+"The `once_cell` crate also has some useful types for late initialisation "
+"with a slightly different approach to `spin::once::Once`."
 msgstr ""
 
-#: src/bare-metal/useful-crates/spin.md
+#: src/bare-metal/useful-crates/spin.md:31
 msgid ""
 "The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
@@ -16759,25 +16744,24 @@ msgid ""
 "to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase](https://android."
-"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
-"master/vmbase/) library provides a linker script and useful defaults for the "
-"build rules, along with an entry point, UART console logging and more."
+"For VMs running under crosvm on aarch64, the vmbase library provides a "
+"linker script and useful defaults for the build rules, along with an entry "
+"point, UART console logging and more."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:24
 msgid ""
 "The `main!` macro marks your main function, to be called from the `vmbase` "
 "entry point."
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md
+#: src/bare-metal/android/vmbase.md:26
 msgid ""
 "The `vmbase` entry point handles console initialisation, and issues a "
 "PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
@@ -16787,1201 +16771,623 @@ msgstr ""
 msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
-#: src/exercises/bare-metal/afternoon.md src/exercises/concurrency/afternoon.md
-msgid ""
-"After looking at the exercises, you can look at the [solutions](solutions-"
-"afternoon.md) provided."
-msgstr ""
-"پس از بررسی تمرین‌ها، می‌توانید به [راه‌حل ها](solutions-afternoon.md) ارائه "
-"شده نگاهی بیندازید."
-
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/rtc.md:1
+#: src/exercises/bare-metal/solutions-afternoon.md:3
 msgid "RTC driver"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
-"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
-"you should write a driver for it."
+"The QEMU aarch64 virt machine has a PL031 real-time clock at 0x9010000. For "
+"this exercise, you should write a driver for it."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:6
 msgid ""
 "Use it to print the current time to the serial console. You can use the "
-"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+"`chrono` crate for date/time formatting."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:8
 msgid ""
 "Use the match register and raw interrupt status to busy-wait until a given "
-"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
-"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+"time, e.g. 3 seconds in the future. (Call `core::hint::spin_loop` inside the "
+"loop.)"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:11
 msgid ""
 "_Extension if you have time:_ Enable and handle the interrupt generated by "
-"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
-"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+"the RTC match. You can use the driver provided in the `arm-gic` crate to "
+"configure the Arm Generic Interrupt Controller."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:14
 msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:15
 msgid ""
 "Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
 "wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:19
 msgid ""
-"Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `rtc` directory for the following files."
+"Download the exercise template and look in the `rtc` directory for the "
+"following files."
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Base addresses of the GICv3.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid ""
-"// Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
-"    // addresses of a GICv3 distributor and redistributor respectively, and\n"
-"    // nothing else accesses those address ranges.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "// TODO: Create instance of RTC driver and print current time.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "// TODO: Wait for 3 seconds.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:79
 msgid ""
 "_src/exceptions.rs_ (you should only need to change this for the 3rd part of "
 "the exercise):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"// Copyright 2023 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"sync_exception_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"irq_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"No pending interrupt\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"IRQ {intid:?}\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"fiq_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"serr_current\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"sync_lower\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"irq_lower\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"fiq_lower\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"serr_lower\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:156
 msgid "_src/logger.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid "// ANCHOR: main\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:216
 msgid "_src/pl011.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid "// ANCHOR: Flags\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "// ANCHOR_END: Flags\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"/// Flags from the UART Receive Status Register / Error Clear Register.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "/// Framing error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "/// Parity error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "/// Break error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "/// Overrun error.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "// ANCHOR: Registers\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "// ANCHOR_END: Registers\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"// ANCHOR: Uart\n"
-"/// Driver for a PL011 UART.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"/// Constructs a new instance of the UART driver for a PL011 device at the\n"
-"    /// given base address.\n"
-"    ///\n"
-"    /// # Safety\n"
-"    ///\n"
-"    /// The given base address must point to the MMIO control registers of "
-"a\n"
-"    /// PL011 device, which must be mapped into the address space of the "
-"process\n"
-"    /// as device memory and not have any other aliases.\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "// ANCHOR_END: Uart\n"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:419
 msgid "_build.rs_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid "\"linux\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"CROSS_COMPILE\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-#, fuzzy
-msgid "\"aarch64-linux-gnu\""
-msgstr "aarch64-paging"
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"aarch64-none-elf\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"entry.S\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-#, fuzzy
-msgid "\"exceptions.S\""
-msgstr "استثناها"
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"idmap.S\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "\"empty\""
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:456
 msgid "_entry.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"```armasm\n"
-"/*\n"
-" * Copyright 2023 Google LLC\n"
-" *\n"
-" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-" * you may not use this file except in compliance with the License.\n"
-" * You may obtain a copy of the License at\n"
-" *\n"
-" *     https://www.apache.org/licenses/LICENSE-2.0\n"
-" *\n"
-" * Unless required by applicable law or agreed to in writing, software\n"
-" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-" * See the License for the specific language governing permissions and\n"
-" * limitations under the License.\n"
-" */\n"
-"\n"
-".macro adr_l, reg:req, sym:req\n"
-"\tadrp \\reg, \\sym\n"
-"\tadd \\reg, \\reg, :lo12:\\sym\n"
-".endm\n"
-"\n"
-".macro mov_i, reg:req, imm:req\n"
-"\tmovz \\reg, :abs_g3:\\imm\n"
-"\tmovk \\reg, :abs_g2_nc:\\imm\n"
-"\tmovk \\reg, :abs_g1_nc:\\imm\n"
-"\tmovk \\reg, :abs_g0_nc:\\imm\n"
-".endm\n"
-"\n"
-".set .L_MAIR_DEV_nGnRE,\t0x04\n"
-".set .L_MAIR_MEM_WBWA,\t0xff\n"
-".set .Lmairval, .L_MAIR_DEV_nGnRE | (.L_MAIR_MEM_WBWA << 8)\n"
-"\n"
-"/* 4 KiB granule size for TTBR0_EL1. */\n"
-".set .L_TCR_TG0_4KB, 0x0 << 14\n"
-"/* 4 KiB granule size for TTBR1_EL1. */\n"
-".set .L_TCR_TG1_4KB, 0x2 << 30\n"
-"/* Disable translation table walk for TTBR1_EL1, generating a translation "
-"fault instead. */\n"
-".set .L_TCR_EPD1, 0x1 << 23\n"
-"/* Translation table walks for TTBR0_EL1 are inner sharable. */\n"
-".set .L_TCR_SH_INNER, 0x3 << 12\n"
-"/*\n"
-" * Translation table walks for TTBR0_EL1 are outer write-back read-allocate "
-"write-allocate\n"
-" * cacheable.\n"
-" */\n"
-".set .L_TCR_RGN_OWB, 0x1 << 10\n"
-"/*\n"
-" * Translation table walks for TTBR0_EL1 are inner write-back read-allocate "
-"write-allocate\n"
-" * cacheable.\n"
-" */\n"
-".set .L_TCR_RGN_IWB, 0x1 << 8\n"
-"/* Size offset for TTBR0_EL1 is 2**39 bytes (512 GiB). */\n"
-".set .L_TCR_T0SZ_512, 64 - 39\n"
-".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | ."
-"L_TCR_RGN_OWB\n"
-".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | ."
-"L_TCR_T0SZ_512\n"
-"\n"
-"/* Stage 1 instruction access cacheability is unaffected. */\n"
-".set .L_SCTLR_ELx_I, 0x1 << 12\n"
-"/* SP alignment fault if SP is not aligned to a 16 byte boundary. */\n"
-".set .L_SCTLR_ELx_SA, 0x1 << 3\n"
-"/* Stage 1 data access cacheability is unaffected. */\n"
-".set .L_SCTLR_ELx_C, 0x1 << 2\n"
-"/* EL0 and EL1 stage 1 MMU enabled. */\n"
-".set .L_SCTLR_ELx_M, 0x1 << 0\n"
-"/* Privileged Access Never is unchanged on taking an exception to EL1. */\n"
-".set .L_SCTLR_EL1_SPAN, 0x1 << 23\n"
-"/* SETEND instruction disabled at EL0 in aarch32 mode. */\n"
-".set .L_SCTLR_EL1_SED, 0x1 << 8\n"
-"/* Various IT instructions are disabled at EL0 in aarch32 mode. */\n"
-".set .L_SCTLR_EL1_ITD, 0x1 << 7\n"
-".set .L_SCTLR_EL1_RES1, (0x1 << 11) | (0x1 << 20) | (0x1 << 22) | (0x1 << "
-"28) | (0x1 << 29)\n"
-".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | ."
-"L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
-".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | ."
-"L_SCTLR_EL1_RES1\n"
-"\n"
-"/**\n"
-" * This is a generic entry point for an image. It carries out the operations "
-"required to prepare the\n"
-" * loaded image to be run. Specifically, it zeroes the bss section using "
-"registers x25 and above,\n"
-" * prepares the stack, enables floating point, and sets up the exception "
-"vector. It preserves x0-x3\n"
-" * for the Rust entry point, as these may contain boot parameters.\n"
-" */\n"
-".section .init.entry, \"ax\"\n"
-".global entry\n"
-"entry:\n"
-"\t/* Load and apply the memory management configuration, ready to enable MMU "
-"and caches. */\n"
-"\tadrp x30, idmap\n"
-"\tmsr ttbr0_el1, x30\n"
-"\n"
-"\tmov_i x30, .Lmairval\n"
-"\tmsr mair_el1, x30\n"
-"\n"
-"\tmov_i x30, .Ltcrval\n"
-"\t/* Copy the supported PA range into TCR_EL1.IPS. */\n"
-"\tmrs x29, id_aa64mmfr0_el1\n"
-"\tbfi x30, x29, #32, #4\n"
-"\n"
-"\tmsr tcr_el1, x30\n"
-"\n"
-"\tmov_i x30, .Lsctlrval\n"
-"\n"
-"\t/*\n"
-"\t * Ensure everything before this point has completed, then invalidate any "
-"potentially stale\n"
-"\t * local TLB entries before they start being used.\n"
-"\t */\n"
-"\tisb\n"
-"\ttlbi vmalle1\n"
-"\tic iallu\n"
-"\tdsb nsh\n"
-"\tisb\n"
-"\n"
-"\t/*\n"
-"\t * Configure sctlr_el1 to enable MMU and cache and don't proceed until "
-"this has completed.\n"
-"\t */\n"
-"\tmsr sctlr_el1, x30\n"
-"\tisb\n"
-"\n"
-"\t/* Disable trapping floating point access in EL1. */\n"
-"\tmrs x30, cpacr_el1\n"
-"\torr x30, x30, #(0x3 << 20)\n"
-"\tmsr cpacr_el1, x30\n"
-"\tisb\n"
-"\n"
-"\t/* Zero out the bss section. */\n"
-"\tadr_l x29, bss_begin\n"
-"\tadr_l x30, bss_end\n"
-"0:\tcmp x29, x30\n"
-"\tb.hs 1f\n"
-"\tstp xzr, xzr, [x29], #16\n"
-"\tb 0b\n"
-"\n"
-"1:\t/* Prepare the stack. */\n"
-"\tadr_l x30, boot_stack_end\n"
-"\tmov sp, x30\n"
-"\n"
-"\t/* Set up exception vector. */\n"
-"\tadr x30, vector_table_el1\n"
-"\tmsr vbar_el1, x30\n"
-"\n"
-"\t/* Call into Rust code. */\n"
-"\tbl main\n"
-"\n"
-"\t/* Loop forever waiting for interrupts. */\n"
-"2:\twfi\n"
-"\tb 2b\n"
-"```"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:606
 msgid "_exceptions.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"```armasm\n"
-"/*\n"
-" * Copyright 2023 Google LLC\n"
-" *\n"
-" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-" * you may not use this file except in compliance with the License.\n"
-" * You may obtain a copy of the License at\n"
-" *\n"
-" *     https://www.apache.org/licenses/LICENSE-2.0\n"
-" *\n"
-" * Unless required by applicable law or agreed to in writing, software\n"
-" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-" * See the License for the specific language governing permissions and\n"
-" * limitations under the License.\n"
-" */\n"
-"\n"
-"/**\n"
-" * Saves the volatile registers onto the stack. This currently takes 14\n"
-" * instructions, so it can be used in exception handlers with 18 "
-"instructions\n"
-" * left.\n"
-" *\n"
-" * On return, x0 and x1 are initialised to elr_el2 and spsr_el2 "
-"respectively,\n"
-" * which can be used as the first and second arguments of a subsequent "
-"call.\n"
-" */\n"
-".macro save_volatile_to_stack\n"
-"\t/* Reserve stack space and save registers x0-x18, x29 & x30. */\n"
-"\tstp x0, x1, [sp, #-(8 * 24)]!\n"
-"\tstp x2, x3, [sp, #8 * 2]\n"
-"\tstp x4, x5, [sp, #8 * 4]\n"
-"\tstp x6, x7, [sp, #8 * 6]\n"
-"\tstp x8, x9, [sp, #8 * 8]\n"
-"\tstp x10, x11, [sp, #8 * 10]\n"
-"\tstp x12, x13, [sp, #8 * 12]\n"
-"\tstp x14, x15, [sp, #8 * 14]\n"
-"\tstp x16, x17, [sp, #8 * 16]\n"
-"\tstr x18, [sp, #8 * 18]\n"
-"\tstp x29, x30, [sp, #8 * 20]\n"
-"\n"
-"\t/*\n"
-"\t * Save elr_el1 & spsr_el1. This such that we can take nested exception\n"
-"\t * and still be able to unwind.\n"
-"\t */\n"
-"\tmrs x0, elr_el1\n"
-"\tmrs x1, spsr_el1\n"
-"\tstp x0, x1, [sp, #8 * 22]\n"
-".endm\n"
-"\n"
-"/**\n"
-" * Restores the volatile registers from the stack. This currently takes 14\n"
-" * instructions, so it can be used in exception handlers while still leaving "
-"18\n"
-" * instructions left; if paired with save_volatile_to_stack, there are 4\n"
-" * instructions to spare.\n"
-" */\n"
-".macro restore_volatile_from_stack\n"
-"\t/* Restore registers x2-x18, x29 & x30. */\n"
-"\tldp x2, x3, [sp, #8 * 2]\n"
-"\tldp x4, x5, [sp, #8 * 4]\n"
-"\tldp x6, x7, [sp, #8 * 6]\n"
-"\tldp x8, x9, [sp, #8 * 8]\n"
-"\tldp x10, x11, [sp, #8 * 10]\n"
-"\tldp x12, x13, [sp, #8 * 12]\n"
-"\tldp x14, x15, [sp, #8 * 14]\n"
-"\tldp x16, x17, [sp, #8 * 16]\n"
-"\tldr x18, [sp, #8 * 18]\n"
-"\tldp x29, x30, [sp, #8 * 20]\n"
-"\n"
-"\t/* Restore registers elr_el1 & spsr_el1, using x0 & x1 as scratch. */\n"
-"\tldp x0, x1, [sp, #8 * 22]\n"
-"\tmsr elr_el1, x0\n"
-"\tmsr spsr_el1, x1\n"
-"\n"
-"\t/* Restore x0 & x1, and release stack space. */\n"
-"\tldp x0, x1, [sp], #8 * 24\n"
-".endm\n"
-"\n"
-"/**\n"
-" * This is a generic handler for exceptions taken at the current EL while "
-"using\n"
-" * SP0. It behaves similarly to the SPx case by first switching to SPx, "
-"doing\n"
-" * the work, then switching back to SP0 before returning.\n"
-" *\n"
-" * Switching to SPx and calling the Rust handler takes 16 instructions. To\n"
-" * restore and return we need an additional 16 instructions, so we can "
-"implement\n"
-" * the whole handler within the allotted 32 instructions.\n"
-" */\n"
-".macro current_exception_sp0 handler:req\n"
-"\tmsr spsel, #1\n"
-"\tsave_volatile_to_stack\n"
-"\tbl \\handler\n"
-"\trestore_volatile_from_stack\n"
-"\tmsr spsel, #0\n"
-"\teret\n"
-".endm\n"
-"\n"
-"/**\n"
-" * This is a generic handler for exceptions taken at the current EL while "
-"using\n"
-" * SPx. It saves volatile registers, calls the Rust handler, restores "
-"volatile\n"
-" * registers, then returns.\n"
-" *\n"
-" * This also works for exceptions taken from EL0, if we don't care about\n"
-" * non-volatile registers.\n"
-" *\n"
-" * Saving state and jumping to the Rust handler takes 15 instructions, and\n"
-" * restoring and returning also takes 15 instructions, so we can fit the "
-"whole\n"
-" * handler in 30 instructions, under the limit of 32.\n"
-" */\n"
-".macro current_exception_spx handler:req\n"
-"\tsave_volatile_to_stack\n"
-"\tbl \\handler\n"
-"\trestore_volatile_from_stack\n"
-"\teret\n"
-".endm\n"
-"\n"
-".section .text.vector_table_el1, \"ax\"\n"
-".global vector_table_el1\n"
-".balign 0x800\n"
-"vector_table_el1:\n"
-"sync_cur_sp0:\n"
-"\tcurrent_exception_sp0 sync_exception_current\n"
-"\n"
-".balign 0x80\n"
-"irq_cur_sp0:\n"
-"\tcurrent_exception_sp0 irq_current\n"
-"\n"
-".balign 0x80\n"
-"fiq_cur_sp0:\n"
-"\tcurrent_exception_sp0 fiq_current\n"
-"\n"
-".balign 0x80\n"
-"serr_cur_sp0:\n"
-"\tcurrent_exception_sp0 serr_current\n"
-"\n"
-".balign 0x80\n"
-"sync_cur_spx:\n"
-"\tcurrent_exception_spx sync_exception_current\n"
-"\n"
-".balign 0x80\n"
-"irq_cur_spx:\n"
-"\tcurrent_exception_spx irq_current\n"
-"\n"
-".balign 0x80\n"
-"fiq_cur_spx:\n"
-"\tcurrent_exception_spx fiq_current\n"
-"\n"
-".balign 0x80\n"
-"serr_cur_spx:\n"
-"\tcurrent_exception_spx serr_current\n"
-"\n"
-".balign 0x80\n"
-"sync_lower_64:\n"
-"\tcurrent_exception_spx sync_lower\n"
-"\n"
-".balign 0x80\n"
-"irq_lower_64:\n"
-"\tcurrent_exception_spx irq_lower\n"
-"\n"
-".balign 0x80\n"
-"fiq_lower_64:\n"
-"\tcurrent_exception_spx fiq_lower\n"
-"\n"
-".balign 0x80\n"
-"serr_lower_64:\n"
-"\tcurrent_exception_spx serr_lower\n"
-"\n"
-".balign 0x80\n"
-"sync_lower_32:\n"
-"\tcurrent_exception_spx sync_lower\n"
-"\n"
-".balign 0x80\n"
-"irq_lower_32:\n"
-"\tcurrent_exception_spx irq_lower\n"
-"\n"
-".balign 0x80\n"
-"fiq_lower_32:\n"
-"\tcurrent_exception_spx fiq_lower\n"
-"\n"
-".balign 0x80\n"
-"serr_lower_32:\n"
-"\tcurrent_exception_spx serr_lower\n"
-"```"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:792
 msgid "_idmap.S_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"```armasm\n"
-"/*\n"
-" * Copyright 2023 Google LLC\n"
-" *\n"
-" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-" * you may not use this file except in compliance with the License.\n"
-" * You may obtain a copy of the License at\n"
-" *\n"
-" *     https://www.apache.org/licenses/LICENSE-2.0\n"
-" *\n"
-" * Unless required by applicable law or agreed to in writing, software\n"
-" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-" * See the License for the specific language governing permissions and\n"
-" * limitations under the License.\n"
-" */\n"
-"\n"
-".set .L_TT_TYPE_BLOCK, 0x1\n"
-".set .L_TT_TYPE_PAGE,  0x3\n"
-".set .L_TT_TYPE_TABLE, 0x3\n"
-"\n"
-"/* Access flag. */\n"
-".set .L_TT_AF, 0x1 << 10\n"
-"/* Not global. */\n"
-".set .L_TT_NG, 0x1 << 11\n"
-".set .L_TT_XN, 0x3 << 53\n"
-"\n"
-".set .L_TT_MT_DEV, 0x0 << 2\t\t\t// MAIR #0 (DEV_nGnRE)\n"
-".set .L_TT_MT_MEM, (0x1 << 2) | (0x3 << 8)\t// MAIR #1 (MEM_WBWA), inner "
-"shareable\n"
-"\n"
-".set .L_BLOCK_DEV, .L_TT_TYPE_BLOCK | .L_TT_MT_DEV | .L_TT_AF | .L_TT_XN\n"
-".set .L_BLOCK_MEM, .L_TT_TYPE_BLOCK | .L_TT_MT_MEM | .L_TT_AF | .L_TT_NG\n"
-"\n"
-".section \".rodata.idmap\", \"a\", %progbits\n"
-".global idmap\n"
-".align 12\n"
-"idmap:\n"
-"\t/* level 1 */\n"
-"\t.quad\t\t.L_BLOCK_DEV | 0x0\t\t    // 1 GiB of device mappings\n"
-"\t.quad\t\t.L_BLOCK_MEM | 0x40000000\t// 1 GiB of DRAM\n"
-"\t.fill\t\t254, 8, 0x0\t\t\t// 254 GiB of unmapped VA space\n"
-"\t.quad\t\t.L_BLOCK_DEV | 0x4000000000 // 1 GiB of device mappings\n"
-"\t.fill\t\t255, 8, 0x0\t\t\t// 255 GiB of remaining VA space\n"
-"```"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:842
 msgid "_image.ld_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid ""
-"```ld\n"
-"/*\n"
-" * Copyright 2023 Google LLC\n"
-" *\n"
-" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-" * you may not use this file except in compliance with the License.\n"
-" * You may obtain a copy of the License at\n"
-" *\n"
-" *     https://www.apache.org/licenses/LICENSE-2.0\n"
-" *\n"
-" * Unless required by applicable law or agreed to in writing, software\n"
-" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-" * See the License for the specific language governing permissions and\n"
-" * limitations under the License.\n"
-" */\n"
-"\n"
-"/*\n"
-" * Code will start running at this symbol which is placed at the start of "
-"the\n"
-" * image.\n"
-" */\n"
-"ENTRY(entry)\n"
-"\n"
-"MEMORY\n"
-"{\n"
-"\timage : ORIGIN = 0x40080000, LENGTH = 2M\n"
-"}\n"
-"\n"
-"SECTIONS\n"
-"{\n"
-"\t/*\n"
-"\t * Collect together the code.\n"
-"\t */\n"
-"\t.init : ALIGN(4096) {\n"
-"\t\ttext_begin = .;\n"
-"\t\t*(.init.entry)\n"
-"\t\t*(.init.*)\n"
-"\t} >image\n"
-"\t.text : {\n"
-"\t\t*(.text.*)\n"
-"\t} >image\n"
-"\ttext_end = .;\n"
-"\n"
-"\t/*\n"
-"\t * Collect together read-only data.\n"
-"\t */\n"
-"\t.rodata : ALIGN(4096) {\n"
-"\t\trodata_begin = .;\n"
-"\t\t*(.rodata.*)\n"
-"\t} >image\n"
-"\t.got : {\n"
-"\t\t*(.got)\n"
-"\t} >image\n"
-"\trodata_end = .;\n"
-"\n"
-"\t/*\n"
-"\t * Collect together the read-write data including .bss at the end which\n"
-"\t * will be zero'd by the entry code.\n"
-"\t */\n"
-"\t.data : ALIGN(4096) {\n"
-"\t\tdata_begin = .;\n"
-"\t\t*(.data.*)\n"
-"\t\t/*\n"
-"\t\t * The entry point code assumes that .data is a multiple of 32\n"
-"\t\t * bytes long.\n"
-"\t\t */\n"
-"\t\t. = ALIGN(32);\n"
-"\t\tdata_end = .;\n"
-"\t} >image\n"
-"\n"
-"\t/* Everything beyond this point will not be included in the binary. */\n"
-"\tbin_end = .;\n"
-"\n"
-"\t/* The entry point code assumes that .bss is 16-byte aligned. */\n"
-"\t.bss : ALIGN(16)  {\n"
-"\t\tbss_begin = .;\n"
-"\t\t*(.bss.*)\n"
-"\t\t*(COMMON)\n"
-"\t\t. = ALIGN(16);\n"
-"\t\tbss_end = .;\n"
-"\t} >image\n"
-"\n"
-"\t.stack (NOLOAD) : ALIGN(4096) {\n"
-"\t\tboot_stack_begin = .;\n"
-"\t\t. += 40 * 4096;\n"
-"\t\t. = ALIGN(4096);\n"
-"\t\tboot_stack_end = .;\n"
-"\t} >image\n"
-"\n"
-"\t. = ALIGN(4K);\n"
-"\tPROVIDE(dma_region = .);\n"
-"\n"
-"\t/*\n"
-"\t * Remove unused sections from the image.\n"
-"\t */\n"
-"\t/DISCARD/ : {\n"
-"\t\t/* The image loads itself so doesn't need these sections. */\n"
-"\t\t*(.gnu.hash)\n"
-"\t\t*(.hash)\n"
-"\t\t*(.interp)\n"
-"\t\t*(.eh_frame_hdr)\n"
-"\t\t*(.eh_frame)\n"
-"\t\t*(.note.gnu.build-id)\n"
-"\t}\n"
-"}\n"
-"```"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:954
 msgid "_Makefile_ (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md
-msgid "# Copyright 2023 Google LLC"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "$(shell uname -s)"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-#, fuzzy
-msgid "aarch64-linux-gnu"
-msgstr "aarch64-paging"
-
-#: src/exercises/bare-metal/rtc.md
-msgid "stdio -display none -kernel $< -s"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
-msgid "cargo clean"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md
+#: src/exercises/bare-metal/rtc.md:1011
 msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "عصرانه با  Bare Metal Rust"
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "([back to exercise](rtc.md))"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:7
 msgid "_main.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Base address of the PL031 RTC.\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:29
+msgid "/// Base addresses of the GICv3."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// The IRQ used by the PL031 RTC.\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:36
+msgid "/// Base address of the PL031 RTC."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:38
+msgid "/// The IRQ used by the PL031 RTC."
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:49
+msgid "\"main({:#x}, {:#x}, {:#x}, {:#x})\""
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:51
 msgid ""
-"// Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
-"    // and nothing else accesses that address range.\n"
+"// SAFETY: `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base // "
+"addresses of a GICv3 distributor and redistributor respectively, and // "
+"nothing else accesses those address ranges."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:57
+msgid ""
+"// SAFETY: `PL031_BASE_ADDRESS` is the base address of a PL031 device, "
+"and // nothing else accesses that address range."
+msgstr ""
+
+#: src/exercises/bare-metal/solutions-afternoon.md:62
 msgid "\"RTC: {time}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "// Wait for 3 seconds, without interrupts.\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:70
+msgid "// Wait for 3 seconds, without interrupts."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:73
+#: src/exercises/bare-metal/solutions-afternoon.md:91
 msgid "\"Waiting for {}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:75
+#: src/exercises/bare-metal/solutions-afternoon.md:83
+#: src/exercises/bare-metal/solutions-afternoon.md:96
+#: src/exercises/bare-metal/solutions-afternoon.md:104
 msgid "\"matched={}, interrupt_pending={}\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:87
+#: src/exercises/bare-metal/solutions-afternoon.md:108
 msgid "\"Finished waiting\""
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "// Wait another 3 seconds for an interrupt.\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:89
+msgid "// Wait another 3 seconds for an interrupt."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:121
 msgid "_pl031.rs_:"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Data register\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:128
+msgid "/// Data register"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Match register\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:130
+msgid "/// Match register"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Load register\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:132
+msgid "/// Load register"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Control register\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:134
+msgid "/// Control register"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Interrupt Mask Set or Clear register\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:137
+msgid "/// Interrupt Mask Set or Clear register"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Raw Interrupt Status\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:140
+msgid "/// Raw Interrupt Status"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Masked Interrupt Status\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:143
+msgid "/// Masked Interrupt Status"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Interrupt Clear Register\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:146
+msgid "/// Interrupt Clear Register"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Driver for a PL031 real-time clock.\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:150
+msgid "/// Driver for a PL031 real-time clock."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:158
 msgid ""
-"/// Constructs a new instance of the RTC driver for a PL031 device at the\n"
-"    /// given base address.\n"
-"    ///\n"
-"    /// # Safety\n"
-"    ///\n"
-"    /// The given base address must point to the MMIO control registers of "
-"a\n"
-"    /// PL031 device, which must be mapped into the address space of the "
-"process\n"
-"    /// as device memory and not have any other aliases.\n"
+"/// Constructs a new instance of the RTC driver for a PL031 device at "
+"the /// given base address. /// /// # Safety /// /// The given base address "
+"must point to the MMIO control registers of a /// PL031 device, which must "
+"be mapped into the address space of the process /// as device memory and not "
+"have any other aliases."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Reads the current RTC value.\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:170
+msgid "/// Reads the current RTC value."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:172
+#: src/exercises/bare-metal/solutions-afternoon.md:180
+#: src/exercises/bare-metal/solutions-afternoon.md:188
+#: src/exercises/bare-metal/solutions-afternoon.md:199
+#: src/exercises/bare-metal/solutions-afternoon.md:211
+#: src/exercises/bare-metal/solutions-afternoon.md:218
 msgid ""
-"// Safe because we know that self.registers points to the control\n"
-"        // registers of a PL031 device which is appropriately mapped.\n"
+"// SAFETY: We know that self.registers points to the control registers // of "
+"a PL031 device which is appropriately mapped."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:177
 msgid ""
-"/// Writes a match value. When the RTC value matches this then an interrupt\n"
-"    /// will be generated (if it is enabled).\n"
+"/// Writes a match value. When the RTC value matches this then an "
+"interrupt /// will be generated (if it is enabled)."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:185
 msgid ""
 "/// Returns whether the match register matches the RTC value, whether or "
-"not\n"
-"    /// the interrupt is enabled.\n"
+"not /// the interrupt is enabled."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:194
 msgid ""
-"/// Returns whether there is currently an interrupt pending.\n"
-"    ///\n"
-"    /// This should be true if and only if `matched` returns true and the\n"
-"    /// interrupt is masked.\n"
+"/// Returns whether there is currently an interrupt pending. /// /// This "
+"should be true if and only if `matched` returns true and the /// interrupt "
+"is masked."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
+#: src/exercises/bare-metal/solutions-afternoon.md:205
 msgid ""
-"/// Sets or clears the interrupt mask.\n"
-"    ///\n"
-"    /// When the mask is true the interrupt is enabled; when it is false "
-"the\n"
-"    /// interrupt is disabled.\n"
+"/// Sets or clears the interrupt mask. /// /// When the mask is true the "
+"interrupt is enabled; when it is false the /// interrupt is disabled."
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md
-msgid "/// Clears a pending interrupt, if any.\n"
+#: src/exercises/bare-metal/solutions-afternoon.md:216
+msgid "/// Clears a pending interrupt, if any."
 msgstr ""
 
-#: src/concurrency.md
+#: src/exercises/bare-metal/solutions-afternoon.md:223
+msgid ""
+"// SAFETY: `Rtc` just contains a pointer to device memory, which can be // "
+"accessed from any context."
+msgstr ""
+
+#: src/concurrency/welcome.md
 msgid "Welcome to Concurrency in Rust"
 msgstr ""
 
-#: src/concurrency.md
+#: src/concurrency/welcome.md
 msgid ""
 "Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 
-#: src/concurrency.md
+#: src/concurrency/welcome.md
 msgid ""
 "The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
 "you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/welcome.md src/concurrency/welcome-async.md
+msgid ""
+"Including 10 minute breaks, this session should take about 3 hours and 20 "
+"minutes. It contains:"
+msgstr ""
+
+#: src/concurrency/welcome.md
+msgid ""
+"Rust lets us access OS concurrency toolkit: threads, sync. primitives, etc."
+msgstr ""
+
+#: src/concurrency/welcome.md
+msgid ""
+"The type system gives us safety for concurrency without any special features."
+msgstr ""
+
+#: src/concurrency/welcome.md
+msgid ""
+"The same tools that help with \"concurrent\" access in a single thread (e."
+"g., a called function that might mutate an argument or save references to it "
+"to read later) save us from multi-threading issues."
+msgstr ""
+
+#: src/concurrency/threads.md src/concurrency/shared-state.md
+#: src/concurrency/async.md
+msgid "This segment should take about 30 minutes. It contains:"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:3
 msgid "Rust threads work similarly to threads in other languages:"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:12
 msgid "\"Count in thread: {i}!\""
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:18
 msgid "\"Main thread: {i}\""
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:24
 msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:25
 msgid "Thread panics are independent of each other."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:26
 msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
 msgstr ""
 
-#: src/concurrency/threads.md
-msgid ""
-"Notice that the thread is stopped before it reaches 10 --- the main thread "
-"is not waiting."
+#: src/concurrency/threads/plain.md:31
+msgid "Rust thread APIs look not too different from e.g. C++ ones."
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:33
+msgid "Run the example."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:34
+msgid ""
+"5ms timing is loose enough that main and spawned threads stay mostly in "
+"lockstep."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:36
+msgid "Notice that the program ends before the spawned thread reaches 10!"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:37
+msgid ""
+"This is because main ends the program and spawned threads do not make it "
+"persist."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:39
+msgid "Compare to pthreads/C++ std::thread/boost::thread if desired."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:41
+msgid "How do we wait around for the spawned thread to complete?"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:42
+msgid "`thread::spawn` returns a `JoinHandle`. Look at the docs."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:43
+msgid "`JoinHandle` has a `.join()` method that blocks."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:45
 msgid ""
 "Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
-"the thread to finish."
+"the thread to finish and have the program count all the way to 10."
 msgstr ""
 
-#: src/concurrency/threads.md
-msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+#: src/concurrency/threads/plain.md:48
+msgid "Now what if we want to return a value?"
 msgstr ""
 
-#: src/concurrency/threads.md
+#: src/concurrency/threads/plain.md:49
+msgid "Look at docs again:"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:50
+msgid "`thread::spawn`'s closure returns `T`"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:51
+msgid "`JoinHandle` `.join()` returns `thread::Result<T>`"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:53
 msgid ""
 "Use the `Result` return value from `handle.join()` to get access to the "
-"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
-"lang.org/std/any/index.html)."
+"returned value."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/plain.md:56
+msgid "Ok, what about the other case?"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:57
+msgid "Trigger a panic in the thread. Note that this doesn't panic `main`."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:58
+msgid "Access the panic payload. This is a good time to talk about `Any`."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:60
+msgid "Now we can return values from threads! What about taking inputs?"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:61
+msgid "Capture something by reference in the thread closure."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:62
+msgid "An error message indicates we must move it."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:63
+msgid "Move it in, see we can compute and then return a derived value."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:65
+msgid "If we want to borrow?"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:66
+msgid ""
+"Main kills child threads when it returns, but another function would just "
+"return and leave them running."
+msgstr ""
+
+#: src/concurrency/threads/plain.md:68
+msgid "That would be stack use-after-return, which violates memory safety!"
+msgstr ""
+
+#: src/concurrency/threads/plain.md:69
+msgid "How do we avoid this? see next slide."
+msgstr ""
+
+#: src/concurrency/threads/scoped.md:3
 msgid "Normal threads cannot borrow from their environment:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
-msgid ""
-"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
-"fn.scope.html) for this:"
+#: src/concurrency/threads/scoped.md:20
+msgid "However, you can use a scoped thread for this:"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md:41
 msgid ""
 "The reason for that is that when the `thread::scope` function completes, all "
 "the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md
+#: src/concurrency/threads/scoped.md:43
 msgid ""
 "Normal Rust borrowing rules apply: you can either borrow mutably by one "
 "thread, or immutably by any number of threads."
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels.md src/concurrency/async-control-flow.md
+msgid "This segment should take about 20 minutes. It contains:"
+msgstr ""
+
+#: src/concurrency/channels/senders-receivers.md:3
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
 "parts are connected via the channel, but you only see the end-points."
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md:15
+#: src/concurrency/channels/senders-receivers.md:16
+#: src/concurrency/channels/senders-receivers.md:20
 msgid "\"Received: {:?}\""
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md:27
 msgid ""
 "`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
 "implement `Clone` (so you can make multiple producers) but `Receiver` does "
 "not."
 msgstr ""
 
-#: src/concurrency/channels.md
+#: src/concurrency/channels/senders-receivers.md:30
 msgid ""
 "`send()` and `recv()` return `Result`. If they return `Err`, it means the "
 "counterpart `Sender` or `Receiver` is dropped and the channel is closed."
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md
+#: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:16
+#: src/concurrency/channels/bounded.md:16
 msgid "\"Message {i}\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:17
+#: src/concurrency/channels/bounded.md:17
 msgid "\"{thread_id:?}: sent Message {i}\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:19
+#: src/concurrency/channels/bounded.md:19
 msgid "\"{thread_id:?}: done\""
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md src/concurrency/channels/bounded.md
+#: src/concurrency/channels/unbounded.md:24
+#: src/concurrency/channels/bounded.md:24
 msgid "\"Main: got {msg}\""
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:3
 msgid ""
 "With bounded (synchronous) channels, `send` can block the current thread:"
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:32
 msgid ""
 "Calling `send` will block the current thread until there is space in the "
 "channel for the new message. The thread can be blocked indefinitely if there "
 "is nobody who reads from the channel."
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:35
 msgid ""
 "A call to `send` will abort with an error (that is why it returns `Result`) "
 "if the channel is closed. A channel is closed when the receiver is dropped."
 msgstr ""
 
-#: src/concurrency/channels/bounded.md
+#: src/concurrency/channels/bounded.md:37
 msgid ""
 "A bounded channel with a size of zero is called a \"rendezvous channel\". "
-"Every send will block the current thread until another thread calls `read`."
+"Every send will block the current thread until another thread calls `recv`."
 msgstr ""
 
 #: src/concurrency/send-sync.md
+msgid "Send"
+msgstr "ارسال"
+
+#: src/concurrency/send-sync.md
+msgid "Sync"
+msgstr "همگام سازی"
+
+#: src/concurrency/send-sync/marker-traits.md:3
 msgid ""
 "How does Rust know to forbid shared access across threads? The answer is in "
 "two traits:"
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:6
 msgid ""
-"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
-"is `Send` if it is safe to move a `T` across a thread boundary."
+"`Send`: a type `T` is `Send` if it is safe to move a `T` across a thread "
+"boundary."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:8
 msgid ""
-"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
-"is `Sync` if it is safe to move a `&T` across a thread boundary."
+"`Sync`: a type `T` is `Sync` if it is safe to move a `&T` across a thread "
+"boundary."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:11
 msgid ""
-"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
-"compiler will automatically derive them for your types as long as they only "
-"contain `Send` and `Sync` types. You can also implement them manually when "
-"you know it is valid."
+"`Send` and `Sync` are unsafe traits. The compiler will automatically derive "
+"them for your types as long as they only contain `Send` and `Sync` types. "
+"You can also implement them manually when you know it is valid."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:22
 msgid ""
 "One can think of these traits as markers that the type has certain thread-"
 "safety properties."
 msgstr ""
 
-#: src/concurrency/send-sync.md
+#: src/concurrency/send-sync/marker-traits.md:24
 msgid "They can be used in the generic constraints as normal traits."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md
+#: src/concurrency/send-sync/send.md:3
 msgid ""
-"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
-"if it is safe to move a `T` value to another thread."
+"A type `T` is `Send` if it is safe to move a `T` value to another thread."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md
+#: src/concurrency/send-sync/send.md:5
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
 "run in that thread. So the question is when you can allocate a value in one "
 "thread and deallocate it in another."
 msgstr ""
 
-#: src/concurrency/send-sync/send.md
+#: src/concurrency/send-sync/send.md:14
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
 "a single thread."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:3
 msgid ""
-"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
-"if it is safe to access a `T` value from multiple threads at the same time."
+"A type `T` is `Sync` if it is safe to access a `T` value from multiple "
+"threads at the same time."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:6
 msgid "More precisely, the definition is:"
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:8
 msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:15
 msgid ""
 "This statement is essentially a shorthand way of saying that if a type is "
 "thread-safe for shared use, it is also thread-safe to pass references of it "
 "across threads."
 msgstr ""
 
-#: src/concurrency/send-sync/sync.md
+#: src/concurrency/send-sync/sync.md:19
 msgid ""
 "This is because if a type is Sync it means that it can be shared across "
 "multiple threads without the risk of data races or other synchronization "
@@ -17990,285 +17396,262 @@ msgid ""
 "be accessed from any thread safely."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:3
 msgid "`Send + Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:5
 msgid "Most types you come across are `Send + Sync`:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:7
 msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:8
 msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:9
 msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:10
 msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:11
 msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:12
+msgid "`mpsc::Sender<T>`: As of 1.72.0."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:13
 msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:15
 msgid ""
 "The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:18
 msgid "`Send + !Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:20
 msgid ""
 "These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
-msgid "`mpsc::Sender<T>`"
-msgstr ""
-
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:23
 msgid "`mpsc::Receiver<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:24
 msgid "`Cell<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:25
 msgid "`RefCell<T>`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:27
 msgid "`!Send + Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:29
 msgid ""
 "These types are thread-safe, but they cannot be moved to another thread:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:31
 msgid ""
 "`MutexGuard<T: Sync>`: Uses OS level primitives which must be deallocated on "
 "the thread which created them."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:34
 msgid "`!Send + !Sync`"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:36
 msgid "These types are not thread-safe and cannot be moved to other threads:"
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:38
 msgid ""
 "`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
 "atomic reference count."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md
+#: src/concurrency/send-sync/examples.md:40
 msgid ""
 "`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
 "considerations."
 msgstr ""
 
-#: src/concurrency/shared_state.md
-msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This is "
-"primarily done via two types:"
+#: src/concurrency/shared-state.md
+msgid "Arc"
+msgstr "Shared State"
+
+#: src/concurrency/shared-state.md
+msgid "Mutex"
+msgstr "Mutex"
+
+#: src/concurrency/shared-state/arc.md:3
+msgid "`Arc<T>` allows shared read-only access via `Arc::clone`:"
 msgstr ""
 
-#: src/concurrency/shared_state.md
-msgid ""
-"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
-"reference counted `T`: handles sharing between threads and takes care to "
-"deallocate `T` when the last reference is dropped,"
-msgstr ""
-
-#: src/concurrency/shared_state.md
-msgid ""
-"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
-"mutually exclusive access to the `T` value."
-msgstr ""
-
-#: src/concurrency/shared_state/arc.md
-msgid ""
-"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
-"read-only access via `Arc::clone`:"
-msgstr ""
-
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:16
 msgid "\"{thread_id:?}: {v:?}\""
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/arc.md:21
+#: src/concurrency/shared-state/example.md:17
+#: src/concurrency/shared-state/example.md:46
 msgid "\"v: {v:?}\""
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:30
 msgid ""
 "`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
 "that uses atomic operations."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:32
 msgid ""
 "`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
 "and `Sync` if and only if `T` implements them both."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:34
 msgid ""
 "`Arc::clone()` has the cost of atomic operations that get executed, but "
 "after that the use of the `T` is free."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:36
 msgid ""
 "Beware of reference cycles, `Arc` does not use a garbage collector to detect "
 "them."
 msgstr ""
 
-#: src/concurrency/shared_state/arc.md
+#: src/concurrency/shared-state/arc.md:38
 msgid "`std::sync::Weak` can help."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:3
 msgid ""
-"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
-"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
-"interface (another form of [interior mutability](../../borrowing/interior-"
-"mutability)):"
+"`Mutex<T>` ensures mutual exclusion _and_ allows mutable access to `T` "
+"behind a read-only interface (another form of interior mutability):"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:12
+#: src/concurrency/shared-state/mutex.md:19
 msgid "\"v: {:?}\""
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:23
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
-"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
+"Notice how we have a `impl<T: Send> Sync for Mutex<T>` blanket "
 "implementation."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:33
 msgid ""
 "`Mutex` in Rust looks like a collection with just one element --- the "
 "protected data."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:35
 msgid ""
 "It is not possible to forget to acquire the mutex before accessing the "
 "protected data."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:37
 msgid ""
 "You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
 "`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:39
 msgid ""
 "`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
 "implements `Send`."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:41
 msgid "A read-write lock counterpart: `RwLock`."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:42
 msgid "Why does `lock()` return a `Result`?"
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md
+#: src/concurrency/shared-state/mutex.md:43
 msgid ""
 "If the thread that held the `Mutex` panicked, the `Mutex` becomes "
 "\"poisoned\" to signal that the data it protected might be in an "
 "inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
-"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
-"You can call `into_inner()` on the error to recover the data regardless."
+"`PoisonError`. You can call `into_inner()` on the error to recover the data "
+"regardless."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:3
 msgid "Let us see `Arc` and `Mutex` in action:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
-msgid "// use std::sync::{Arc, Mutex};\n"
+#: src/concurrency/shared-state/example.md:6
+msgid "// use std::sync::{Arc, Mutex};"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:24
 msgid "Possible solution:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:50
 msgid "Notable parts:"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:52
 msgid ""
 "`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
 "orthogonal."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:54
 msgid ""
 "Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
 "between threads."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:56
 msgid ""
 "`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
 "thread. Note `move` was added to the lambda signature."
 msgstr ""
 
-#: src/concurrency/shared_state/example.md
+#: src/concurrency/shared-state/example.md:58
 msgid ""
 "Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
 
-#: src/exercises/concurrency/morning.md
-msgid "Let us practice our new concurrency skills with"
+#: src/concurrency/sync-exercises.md src/concurrency/async-exercises.md
+msgid "This segment should take about 1 hour and 10 minutes. It contains:"
 msgstr ""
 
-#: src/exercises/concurrency/morning.md
-msgid "Dining philosophers: a classic problem in concurrency."
-msgstr ""
-
-#: src/exercises/concurrency/morning.md
-msgid ""
-"Multi-threaded link checker: a larger project where you'll use Cargo to "
-"download dependencies and then check links in parallel."
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:3
 msgid "The dining philosophers problem is a classic problem in concurrency:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:5
 msgid ""
 "Five philosophers dine together at the same table. Each philosopher has "
 "their own place at the table. There is a fork between each plate. The dish "
@@ -18280,103 +17663,99 @@ msgid ""
 "down both forks."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:13
 msgid ""
-"You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
-"out the blanks, and test that `cargo run` does not deadlock:"
+"You will need a local Cargo installation for this exercise. Copy the code "
+"below to a file called `src/main.rs`, fill out the blanks, and test that "
+"`cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-msgid ""
-"// left_fork: ...\n"
-"    // right_fork: ...\n"
-"    // thoughts: ...\n"
+#: src/concurrency/sync-exercises/dining-philosophers.md:28
+#: src/concurrency/async-exercises/dining-philosophers.md:23
+msgid "// left_fork: ... // right_fork: ... // thoughts: ..."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:36
+#: src/concurrency/sync-exercises/solutions.md:22
+#: src/concurrency/async-exercises/dining-philosophers.md:31
+#: src/concurrency/async-exercises/solutions.md:23
 msgid "\"Eureka! {} has a new idea!\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// Pick up forks...\n"
+#: src/concurrency/sync-exercises/dining-philosophers.md:41
+#: src/concurrency/async-exercises/solutions.md:31
+msgid "// Pick up forks..."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:42
+#: src/concurrency/sync-exercises/solutions.md:31
+#: src/concurrency/async-exercises/dining-philosophers.md:38
+#: src/concurrency/async-exercises/solutions.md:51
 msgid "\"{} is eating...\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Socrates\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Hypatia\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Plato\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Aristotle\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/solutions-morning.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:48
+#: src/concurrency/sync-exercises/solutions.md:37
+#: src/concurrency/async-exercises/dining-philosophers.md:44
+#: src/concurrency/async-exercises/solutions.md:59
 msgid "\"Pythagoras\""
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// Create forks\n"
+#: src/concurrency/sync-exercises/dining-philosophers.md:51
+#: src/concurrency/async-exercises/dining-philosophers.md:48
+#: src/concurrency/async-exercises/solutions.md:63
+msgid "// Create forks"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// Create philosophers\n"
+#: src/concurrency/sync-exercises/dining-philosophers.md:53
+#: src/concurrency/async-exercises/dining-philosophers.md:50
+#: src/concurrency/async-exercises/solutions.md:67
+msgid "// Create philosophers"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-msgid "// Make each of them think and eat 100 times\n"
+#: src/concurrency/sync-exercises/dining-philosophers.md:55
+msgid "// Make each of them think and eat 100 times"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// Output their thoughts\n"
+#: src/concurrency/sync-exercises/dining-philosophers.md:57
+#: src/concurrency/async-exercises/dining-philosophers.md:54
+#: src/concurrency/async-exercises/solutions.md:95
+msgid "// Output their thoughts"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:61
 msgid "You can use the following `Cargo.toml`:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md
+#: src/concurrency/sync-exercises/dining-philosophers.md:65
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -18386,7 +17765,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:3
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
 "should start at a webpage and check that links on the page are valid. It "
@@ -18394,36 +17773,29 @@ msgid ""
 "until all pages have been validated."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
-"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as `reqwest`. You will also need "
+"a way to find links, we can use `scraper`. Finally, we'll need some way of "
+"handling errors, we will use `thiserror`."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:12
+msgid "Create a new Cargo project and `reqwest` it as a dependency with:"
+msgstr ""
+
+#: src/concurrency/sync-exercises/link-checker.md:22
 msgid ""
 "If `cargo add` fails with `error: no such subcommand`, then please edit the "
 "`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-msgid ""
-"You will also need a way to find links. We can use [`scraper`](https://docs."
-"rs/scraper/) for that:"
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md
-msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`]"
-"(https://docs.rs/thiserror/) for that:"
-msgstr ""
-
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:25
 msgid ""
 "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:29
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -18440,130 +17812,112 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:42
 msgid ""
 "You can now download the start page. Try with a small site such as `https://"
 "www.google.org/`."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:45
 msgid "Your `src/main.rs` file should look something like this:"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:57
+#: src/concurrency/sync-exercises/solutions.md:93
 msgid "\"request error: {0}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:59
+#: src/concurrency/sync-exercises/solutions.md:95
 msgid "\"bad http response: {0}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:70
+#: src/concurrency/sync-exercises/solutions.md:106
 msgid "\"Checking {:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:88
+#: src/concurrency/sync-exercises/solutions.md:124
 msgid "\"href\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:95
+#: src/concurrency/sync-exercises/solutions.md:131
 msgid "\"On {base_url:#}: ignored unparsable {href:?}: {err}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/link-checker.md:104
+#: src/concurrency/sync-exercises/solutions.md:241
 msgid "\"https://www.google.org\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:107
 msgid "\"Links: {links:#?}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:108
 msgid "\"Could not extract links: {err:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:113
 msgid "Run the code in `src/main.rs` with"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:121
 msgid ""
 "Use threads to check the links in parallel: send the URLs to be checked to a "
 "channel and let a few threads check the URLs in parallel."
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md
+#: src/concurrency/sync-exercises/link-checker.md:123
 msgid ""
 "Extend this to recursively extract links from all pages on the `www.google."
 "org` domain. Put an upper limit of 100 pages or so so that you don't end up "
 "being blocked by the site."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
-msgid "Concurrency Morning Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md
-msgid "([back to exercise](dining-philosophers.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:27
 msgid "\"{} is trying to eat\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:51
 msgid ""
-"// To avoid a deadlock, we have to break the symmetry\n"
-"        // somewhere. This will swap the forks without deinitializing\n"
-"        // either of them.\n"
+"// To avoid a deadlock, we have to break the symmetry // somewhere. This "
+"will swap the forks without deinitializing // either of them."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:75
 msgid "\"{thought}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:80
 msgid "Link Checker"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
-msgid "([back to exercise](link-checker.md))"
+#: src/concurrency/sync-exercises/solutions.md:150
+msgid "/// Determine whether links within the given page should be extracted."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:158
 msgid ""
-"/// Determine whether links within the given page should be extracted.\n"
+"/// Mark the given page as visited, returning false if it had already /// "
+"been visited."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
-msgid ""
-"/// Mark the given page as visited, returning false if it had already\n"
-"    /// been visited.\n"
+#: src/concurrency/sync-exercises/solutions.md:184
+msgid "// The sender got dropped. No more commands coming in."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
-msgid "// The sender got dropped. No more commands coming in.\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:225
 msgid "\"Got crawling error: {:#}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-morning.md
+#: src/concurrency/sync-exercises/solutions.md:243
 msgid "\"Bad URLs: {:#?}\""
 msgstr ""
 
-#: src/async.md
-msgid "Async Rust"
-msgstr ""
-
-#: src/async.md
+#: src/concurrency/welcome-async.md
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
 "concurrently by executing each task until it would block, then switching to "
@@ -18573,96 +17927,98 @@ msgid ""
 "primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
 "that may be completed in the future. Futures are \"polled\" until they "
 "signal that they are complete."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md
 msgid ""
 "Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md
 msgid ""
 "Python has a similar model in its `asyncio`. However, its `Future` type is "
 "callback-based, and not polled. Async Python programs require a \"loop\", "
 "similar to a runtime in Rust."
 msgstr ""
 
-#: src/async.md
+#: src/concurrency/welcome-async.md
 msgid ""
 "JavaScript's `Promise` is similar, but again callback-based. The language "
 "runtime implements the event loop, so many of the details of Promise "
 "resolution are hidden."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async.md
+msgid "async/await"
+msgstr "async/await"
+
+#: src/concurrency/async/async-await.md:3
 msgid ""
 "At a high level, async Rust code looks very much like \"normal\" sequential "
 "code:"
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:10
 msgid "\"Count is: {i}!\""
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:28
 msgid ""
 "Note that this is a simplified example to show the syntax. There is no long "
 "running operation or any real concurrency in it!"
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:31
 msgid "What is the return type of an async call?"
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:32
 msgid "Use `let future: () = async_main(10);` in `main` to see the type."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:34
 msgid ""
 "The \"async\" keyword is syntactic sugar. The compiler replaces the return "
 "type with a future."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:37
 msgid ""
 "You cannot make `main` async, without additional instructions to the "
 "compiler on how to use the returned future."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:40
 msgid ""
 "You need an executor to run async code. `block_on` blocks the current thread "
 "until the provided future has run to completion."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:43
 msgid ""
 "`.await` asynchronously waits for the completion of another operation. "
 "Unlike `block_on`, `.await` doesn't block the current thread."
 msgstr ""
 
-#: src/async/async-await.md
+#: src/concurrency/async/async-await.md:46
 msgid ""
 "`.await` can only be used inside an `async` function (or block; these are "
 "introduced later)."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
-"trait, implemented by objects that represent an operation that may not be "
-"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
-"doc.rust-lang.org/std/task/enum.Poll.html)."
+"`Future` is a trait, implemented by objects that represent an operation that "
+"may not be complete yet. A future can be polled, and `poll` returns a `Poll`."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
 "uncommon) to implement `Future` for your own types. For example, the "
@@ -18670,76 +18026,74 @@ msgid ""
 "joining to it."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
 "to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:33
 msgid ""
 "The `Future` and `Poll` types are implemented exactly as shown; click the "
 "links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:36
 msgid ""
 "We will not get to `Pin` and `Context`, as we will focus on writing async "
 "code, rather than building new async primitives. Briefly:"
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:39
 msgid ""
 "`Context` allows a Future to schedule itself to be polled again when an "
 "event occurs."
 msgstr ""
 
-#: src/async/futures.md
+#: src/concurrency/async/futures.md:42
 msgid ""
 "`Pin` ensures that the Future isn't moved in memory, so that pointers into "
 "that future remain valid. This is required to allow references to remain "
 "valid after an `.await`."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:3
 msgid ""
 "A _runtime_ provides support for performing operations asynchronously (a "
 "_reactor_) and is responsible for executing futures (an _executor_). Rust "
 "does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:7
 msgid ""
-"[Tokio](https://tokio.rs/): performant, with a well-developed ecosystem of "
-"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
-"github.com/hyperium/tonic) for gRPC."
+"Tokio: performant, with a well-developed ecosystem of functionality like "
+"Hyper for HTTP or Tonic for gRPC."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:10
 msgid ""
-"[async-std](https://async.rs/): aims to be a \"std for async\", and includes "
-"a basic runtime in `async::task`."
+"async-std: aims to be a \"std for async\", and includes a basic runtime in "
+"`async::task`."
 msgstr ""
 
-#: src/async/runtimes.md
-msgid "[smol](https://docs.rs/smol/latest/smol/): simple and lightweight"
+#: src/concurrency/async/runtimes.md:12
+msgid "smol: simple and lightweight"
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example, [Fuchsia]"
-"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
-"async/src/lib.rs) already has one."
+"Several larger applications have their own runtimes. For example, Fuchsia "
+"already has one."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:21
 msgid ""
 "Note that of the listed runtimes, only Tokio is supported in the Rust "
 "playground. The playground also does not permit any I/O, so most interesting "
 "async things can't run in the playground."
 msgstr ""
 
-#: src/async/runtimes.md
+#: src/concurrency/async/runtimes.md:25
 msgid ""
 "Futures are \"inert\" in that they do not do anything (not even start an I/O "
 "operation) unless there is an executor polling them. This differs from JS "
@@ -18747,66 +18101,66 @@ msgid ""
 "used."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:3
 msgid "Tokio provides:"
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:5
 msgid "A multi-threaded runtime for executing asynchronous code."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:6
 msgid "An asynchronous version of the standard library."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:7
 msgid "A large ecosystem of libraries."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:14
 msgid "\"Count in task: {i}!\""
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:24
 msgid "\"Main task: {i}\""
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:32
 msgid "With the `tokio::main` macro we can now make `main` async."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:34
 msgid "The `spawn` function creates a new, concurrent \"task\"."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:36
 msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:38
 msgid "**Further exploration:**"
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:40
 msgid ""
 "Why does `count_to` not (usually) get to 10? This is an example of async "
 "cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
 "until it finishes."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:44
 msgid "Try `count_to(10).await` instead of spawning."
 msgstr ""
 
-#: src/async/runtimes/tokio.md
+#: src/concurrency/async/runtimes/tokio.md:46
 msgid "Try awaiting the task returned from `tokio::spawn`."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:3
 msgid "Rust has a task system, which is a form of lightweight threading."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:5
 msgid ""
 "A task has a single top-level future which the executor polls to make "
 "progress. That future may have one or more nested futures that its `poll` "
@@ -18815,170 +18169,150 @@ msgid ""
 "and an I/O operation."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:16
 msgid "\"127.0.0.1:0\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:17
 msgid "\"listening on port {}\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:22
 msgid "\"connection from {addr:?}\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:25
 msgid "b\"Who are you?\\n\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:25 src/concurrency/async/tasks.md:28
+#: src/concurrency/async/tasks.md:31
 msgid "\"socket error\""
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:30
 msgid "\"Thanks for dialing in, {name}!\\n\""
 msgstr ""
 
-#: src/async/tasks.md src/async/control-flow/join.md
+#: src/concurrency/async/tasks.md:40
+#: src/concurrency/async-control-flow/join.md:37
 msgid ""
 "Copy this example into your prepared `src/main.rs` and run it from there."
 msgstr ""
 
-#: src/async/tasks.md
-msgid ""
-"Try connecting to it with a TCP connection tool like [nc](https://www.unix."
-"com/man-page/linux/1/nc/) or [telnet](https://www.unix.com/man-page/linux/1/"
-"telnet/)."
+#: src/concurrency/async/tasks.md:42
+msgid "Try connecting to it with a TCP connection tool like nc or telnet."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:46
 msgid ""
 "Ask students to visualize what the state of the example server would be with "
 "a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:49
 msgid ""
 "This is the first time we've seen an `async` block. This is similar to a "
 "closure, but does not take any arguments. Its return value is a Future, "
 "similar to an `async fn`."
 msgstr ""
 
-#: src/async/tasks.md
+#: src/concurrency/async/tasks.md:53
 msgid ""
 "Refactor the async block into a function, and improve the error handling "
 "using `?`."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:3
 msgid ""
 "Several crates have support for asynchronous channels. For instance `tokio`:"
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:13
 msgid "\"Received {count} pings so far.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:16
 msgid "\"ping_handler complete\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:24
 msgid "\"Failed to send ping.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:25
 msgid "\"Sent {} pings so far.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:29
 msgid "\"Something went wrong in ping handler task.\""
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:36
 msgid "Change the channel size to `3` and see how it affects the execution."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:38
 msgid ""
 "Overall, the interface is similar to the `sync` channels as seen in the "
-"[morning class](concurrency/channels.md)."
+"morning class."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:41
 msgid "Try removing the `std::mem::drop` call. What happens? Why?"
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:43
 msgid ""
-"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
-"implement both `sync` and `async` `send` and `recv`. This can be convenient "
-"for complex applications with both IO and heavy CPU processing tasks."
+"The Flume crate has channels that implement both `sync` and `async` `send` "
+"and `recv`. This can be convenient for complex applications with both IO and "
+"heavy CPU processing tasks."
 msgstr ""
 
-#: src/async/channels.md
+#: src/concurrency/async-control-flow/channels.md:47
 msgid ""
 "What makes working with `async` channels preferable is the ability to "
 "combine them with other `future`s to combine them and create complex control "
 "flow."
 msgstr ""
 
-#: src/async/control-flow.md
-msgid "Futures Control Flow"
-msgstr ""
-
-#: src/async/control-flow.md
-msgid ""
-"Futures can be combined together to produce concurrent compute flow graphs. "
-"We have already seen tasks, that function as independent threads of "
-"execution."
-msgstr ""
-
-#: src/async/control-flow.md
-msgid "[Join](control-flow/join.md)"
-msgstr ""
-
-#: src/async/control-flow.md
-msgid "[Select](control-flow/select.md)"
-msgstr ""
-
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:3
 msgid ""
 "A join operation waits until all of a set of futures are ready, and returns "
 "a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:21
 msgid "\"https://google.com\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:22
 msgid "\"https://httpbin.org/ip\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:23
 msgid "\"https://play.rust-lang.org/\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:24
 msgid "\"BAD_URL\""
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:39
 msgid ""
 "For multiple futures of disjoint types, you can use `std::future::join!` but "
 "you must know how many futures you will have at compile time. This is "
 "currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:43
 msgid ""
 "The risk of `join` is that one of the futures may never resolve, this would "
 "cause your program to stall."
 msgstr ""
 
-#: src/async/control-flow/join.md
+#: src/concurrency/async-control-flow/join.md:46
 msgid ""
 "You can also combine `join_all` with `join!` for instance to join all "
 "requests to an http service as well as a database query. Try adding a "
@@ -18987,7 +18321,7 @@ msgid ""
 "demonstrates `join!`."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
 "responds to that future's result. In JavaScript, this is similar to `Promise."
@@ -18995,7 +18329,7 @@ msgid ""
 "FIRST_COMPLETED)`."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:8
 msgid ""
 "Similar to a match statement, the body of `select!` has a number of arms, "
 "each of the form `pattern = future => statement`. When a `future` is ready, "
@@ -19004,31 +18338,27 @@ msgid ""
 "of the `select!` macro."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:40
 msgid "\"Felix\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:40
 msgid "\"Failed to send cat.\""
 msgstr ""
 
-#: src/async/control-flow/select.md
-msgid "\"Rex\""
-msgstr ""
-
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:44
 msgid "\"Failed to send dog.\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:49
 msgid "\"Failed to receive winner\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:51
 msgid "\"Winner is {winner:?}\""
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:58
 msgid ""
 "In this example, we have a race between a cat and a dog. "
 "`first_animal_to_finish_race` listens to both channels and will pick "
@@ -19036,63 +18366,47 @@ msgid ""
 "that take 500ms."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:63
 msgid ""
 "You can use `oneshot` channels in this example as the channels are supposed "
 "to receive only one `send`."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:66
 msgid ""
 "Try adding a deadline to the race, demonstrating selecting different sorts "
 "of futures."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:69
 msgid ""
 "Note that `select!` drops unmatched branches, which cancels their futures. "
 "It is easiest to use when every execution of `select!` creates new futures."
 msgstr ""
 
-#: src/async/control-flow/select.md
+#: src/concurrency/async-control-flow/select.md:72
 msgid ""
 "An alternative is to pass `&mut future` instead of the future itself, but "
 "this can lead to issues, further discussed in the pinning slide."
 msgstr ""
 
-#: src/async/pitfalls.md
-msgid "Pitfalls of async/await"
-msgstr ""
-
-#: src/async/pitfalls.md
+#: src/concurrency/async-pitfalls.md
 msgid ""
 "Async / await provides convenient and efficient abstraction for concurrent "
 "asynchronous programming. However, the async/await model in Rust also comes "
 "with its share of pitfalls and footguns. We illustrate some of them in this "
-"chapter:"
+"chapter."
 msgstr ""
 
-#: src/async/pitfalls.md
-msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
-msgstr ""
+#: src/concurrency/async-pitfalls.md
+msgid "Pin"
+msgstr "Pin"
 
-#: src/async/pitfalls.md
-msgid "[Pin](pitfalls/pin.md)"
-msgstr ""
-
-#: src/async/pitfalls.md
-msgid "[Async Traits](pitfalls/async-traits.md)"
-msgstr ""
-
-#: src/async/pitfalls.md
-msgid "[Cancellation](pitfalls/cancellation.md)"
-msgstr ""
-
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:1
 msgid "Blocking the executor"
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:3
 msgid ""
 "Most async runtimes only allow IO tasks to run concurrently. This means that "
 "CPU blocking tasks will block the executor and prevent other tasks from "
@@ -19100,39 +18414,39 @@ msgid ""
 "possible."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:14
 msgid "\"future {id} slept for {duration_ms}ms, finished after {}ms\""
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:19
 msgid "\"current_thread\""
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:30
 msgid ""
 "Run the code and see that the sleeps happen consecutively rather than "
 "concurrently."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:33
 msgid ""
 "The `\"current_thread\"` flavor puts all tasks on a single thread. This "
 "makes the effect more obvious, but the bug is still present in the multi-"
 "threaded flavor."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:37
 msgid ""
 "Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:39
 msgid ""
 "Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
 "thread and transforms its handle into a future without blocking the executor."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:42
 msgid ""
 "You should not think of tasks as OS threads. They do not map 1 to 1 and most "
 "executors will allow many tasks to run on a single OS thread. This is "
@@ -19142,27 +18456,27 @@ msgid ""
 "situations."
 msgstr ""
 
-#: src/async/pitfalls/blocking-executor.md
+#: src/concurrency/async-pitfalls/blocking-executor.md:48
 msgid ""
 "Use sync mutexes with care. Holding a mutex over an `.await` may cause "
 "another task to block, and that task may be running on the same thread."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:3
 msgid ""
 "Async blocks and functions return types implementing the `Future` trait. The "
 "type returned is the result of a compiler transformation which turns local "
 "variables into data stored inside the future."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:7
 msgid ""
 "Some of those variables can hold pointers to other local variables. Because "
 "of that, the future should never be moved to a different memory location, as "
 "it would invalidate those pointers."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:11
 msgid ""
 "To prevent moving the future type in memory, it can only be polled through a "
 "pinned pointer. `Pin` is a wrapper around a reference that disallows all "
@@ -19170,95 +18484,95 @@ msgid ""
 "location."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:20
 msgid ""
-"// A work item. In this case, just sleep for the given time and respond\n"
-"// with a message on the `respond_on` channel.\n"
+"// A work item. In this case, just sleep for the given time and respond // "
+"with a message on the `respond_on` channel."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
-msgid "// A worker which listens for work on a queue and performs it.\n"
+#: src/concurrency/async-pitfalls/pin.md:28
+msgid "// A worker which listens for work on a queue and performs it."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
-msgid "// Pretend to work.\n"
+#: src/concurrency/async-pitfalls/pin.md:35
+msgid "// Pretend to work."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:38
 msgid "\"failed to send response\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
-msgid "// TODO: report number of iterations every 100ms\n"
+#: src/concurrency/async-pitfalls/pin.md:41
+msgid "// TODO: report number of iterations every 100ms"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
-msgid "// A requester which requests work and waits for it to complete.\n"
+#: src/concurrency/async-pitfalls/pin.md:45
+msgid "// A requester which requests work and waits for it to complete."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:52
 msgid "\"failed to send on work queue\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:53
 msgid "\"failed waiting for response\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:62
 msgid "\"work result for iteration {i}: {resp}\""
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:70
 msgid ""
 "You may recognize this as an example of the actor pattern. Actors typically "
 "call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:73
 msgid ""
 "This serves as a summation of a few of the previous lessons, so take your "
 "time with it."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:76
 msgid ""
 "Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
 "the `select!`. This will never execute. Why?"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:79
 msgid ""
 "Instead, add a `timeout_fut` containing that future outside of the `loop`:"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:90
 msgid ""
 "This still doesn't work. Follow the compiler errors, adding `&mut` to the "
 "`timeout_fut` in the `select!` to work around the move, then using `Box::"
 "pin`:"
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:104
 msgid ""
 "This compiles, but once the timeout expires it is `Poll::Ready` on every "
 "iteration (a fused future would help with this). Update to reset "
 "`timeout_fut` every time it expires."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:108
 msgid ""
 "Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
 "stabilized, with older code often using `tokio::pin!`) is also an option, "
 "but that is difficult to use for a future that is reassigned."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:112
 msgid ""
 "Another alternative is to not use `pin` at all but spawn another task that "
 "will send to a `oneshot` channel every 100ms."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:115
 msgid ""
 "Data that contains pointers to itself is called self-referential. Normally, "
 "the Rust borrow checker would prevent self-referential data from being "
@@ -19267,64 +18581,80 @@ msgid ""
 "borrow checker."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:121
 msgid ""
 "`Pin` is a wrapper around a reference. An object cannot be moved from its "
 "place using a pinned pointer. However, it can still be moved through an "
 "unpinned pointer."
 msgstr ""
 
-#: src/async/pitfalls/pin.md
+#: src/concurrency/async-pitfalls/pin.md:125
 msgid ""
 "The `poll` method of the `Future` trait uses `Pin<&mut Self>` instead of "
 "`&mut Self` to refer to the instance. That's why it can only be called on a "
 "pinned pointer."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:3
 msgid ""
-"Async methods in traits are not yet supported in the stable channel ([An "
-"experimental feature exists in nightly and should be stabilized in the mid "
-"term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-"
-"nightly.html))"
+"Async methods in traits are were stabilized only recently, in the 1.75 "
+"release. This required support for using return-position `impl Trait` (RPIT) "
+"in traits, as the desugaring for `async fn` includes `-> impl Future<Output "
+"= ...>`."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:7
 msgid ""
-"The crate [async_trait](https://docs.rs/async-trait/latest/async_trait/) "
-"provides a workaround through a macro:"
+"However, even with the native support today there are some pitfalls around "
+"`async fn` and RPIT in traits:"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:10
+msgid ""
+"Return-position impl Trait captures all in-scope lifetimes (so some patterns "
+"of borrowing cannot be expressed)"
+msgstr ""
+
+#: src/concurrency/async-pitfalls/async-traits.md:13
+msgid ""
+"Traits whose methods use return-position `impl trait` or `async` are not "
+"`dyn` compatible."
+msgstr ""
+
+#: src/concurrency/async-pitfalls/async-traits.md:16
+msgid ""
+"If we do need `dyn` support, the crate async_trait provides a workaround "
+"through a macro, with some caveats:"
+msgstr ""
+
+#: src/concurrency/async-pitfalls/async-traits.md:46
 msgid "\"running all sleepers..\""
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:50
 msgid "\"slept for {}ms\""
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:68
 msgid ""
 "`async_trait` is easy to use, but note that it's using heap allocations to "
 "achieve this. This heap allocation has performance overhead."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:71
 msgid ""
 "The challenges in language support for `async trait` are deep Rust and "
 "probably not worth describing in-depth. Niko Matsakis did a good job of "
-"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
-"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
-"digging deeper."
+"explaining them in this post if you are interested in digging deeper."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md
+#: src/concurrency/async-pitfalls/async-traits.md:77
 msgid ""
 "Try creating a new sleeper struct that will sleep for a random amount of "
 "time and adding it to the Vec."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:3
 msgid ""
 "Dropping a future implies it can never be polled again. This is called "
 "_cancellation_ and it can occur at any `await` point. Care is needed to "
@@ -19332,119 +18662,102 @@ msgid ""
 "example, it shouldn't deadlock or lose data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:35
 msgid "\"not UTF-8\""
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:51
 msgid "\"hi\\nthere\\n\""
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:57
 msgid "\"tick!\""
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:73
 msgid ""
 "The compiler doesn't help with cancellation-safety. You need to read API "
 "documentation and consider what state your `async fn` holds."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:76
 msgid ""
 "Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
 "error-handling)."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:79
 msgid "The example loses parts of the string."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:81
 msgid ""
 "Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
 "dropped."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:84
 msgid ""
 "`LinesReader` can be made cancellation-safe by making `buf` part of the "
 "struct:"
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
-msgid "// prefix buf and bytes with self.\n"
+#: src/concurrency/async-pitfalls/cancellation.md:98
+msgid "// prefix buf and bytes with self."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:107
 msgid ""
-"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
-"html#method.tick) is cancellation-safe because it keeps track of whether a "
+"`Interval::tick` is cancellation-safe because it keeps track of whether a "
 "tick has been 'delivered'."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:111
 msgid ""
-"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
-"AsyncReadExt.html#method.read) is cancellation-safe because it either "
-"returns or doesn't read data."
+"`AsyncReadExt::read` is cancellation-safe because it either returns or "
+"doesn't read data."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md
+#: src/concurrency/async-pitfalls/cancellation.md:114
 msgid ""
-"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
-"AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
+"`AsyncBufReadExt::read_line` is similar to the example and _isn't_ "
 "cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
 
-#: src/exercises/concurrency/afternoon.md
-msgid ""
-"To practice your Async Rust skills, we have again two exercises for you:"
-msgstr ""
-
-#: src/exercises/concurrency/afternoon.md
-msgid ""
-"Dining philosophers: we already saw this problem in the morning. This time "
-"you are going to implement it with Async Rust."
-msgstr ""
-
-#: src/exercises/concurrency/afternoon.md
-msgid ""
-"A Broadcast Chat Application: this is a larger project that allows you "
-"experiment with more advanced Async Rust features."
-msgstr ""
-
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/dining-philosophers.md:1
+#: src/concurrency/async-exercises/solutions.md:3
 #, fuzzy
 msgid "Dining Philosophers --- Async"
 msgstr "فلسفه Dining"
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:3
+msgid "See dining philosophers for a description of the problem."
+msgstr ""
+
+#: src/concurrency/async-exercises/dining-philosophers.md:6
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the "
-"problem."
+"As before, you will need a local Cargo installation for this exercise. Copy "
+"the code below to a file called `src/main.rs`, fill out the blanks, and test "
+"that `cargo run` does not deadlock:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
-msgid ""
-"As before, you will need a local [Cargo installation](../../cargo/running-"
-"locally.md) for this exercise. Copy the code below to a file called `src/"
-"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
+#: src/concurrency/async-exercises/dining-philosophers.md:37
+#: src/concurrency/async-exercises/solutions.md:29
+msgid "// Keep trying until we have both forks"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// Make them think and eat\n"
+#: src/concurrency/async-exercises/dining-philosophers.md:52
+#: src/concurrency/async-exercises/solutions.md:85
+msgid "// Make them think and eat"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:58
 msgid ""
 "Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:63
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -19458,17 +18771,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:73
 msgid ""
 "Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers-async.md
+#: src/concurrency/async-exercises/dining-philosophers.md:79
 msgid "Can you make your implementation single-threaded?"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:3
 msgid ""
 "In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
@@ -19477,23 +18790,21 @@ msgid ""
 "that it receives to all the clients."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
-"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
-"(https://docs.rs/tokio-websockets/) for the communication between the client "
-"and the server."
+"For this, we use a broadcast channel on the server, and `tokio_websockets` "
+"for the communication between the client and the server."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:12
 msgid "Create a new Cargo project and add the following dependencies:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:14
 msgid "_Cargo.toml_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:18
 msgid ""
 "```toml\n"
 "[package]\n"
@@ -19503,140 +18814,134 @@ msgid ""
 "\n"
 "[dependencies]\n"
 "futures-util = { version = \"0.3.30\", features = [\"sink\"] }\n"
-"http = \"1.0.0\"\n"
-"tokio = { version = \"1.28.1\", features = [\"full\"] }\n"
-"tokio-websockets = { version = \"0.5.1\", features = [\"client\", "
+"http = \"1.1.0\"\n"
+"tokio = { version = \"1.38.0\", features = [\"full\"] }\n"
+"tokio-websockets = { version = \"0.8.3\", features = [\"client\", "
 "\"fastrand\", \"server\", \"sha1_smol\"] }\n"
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:31
 msgid "The required APIs"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:33
 msgid ""
 "You are going to need the following functions from `tokio` and "
-"[`tokio_websockets`](https://docs.rs/tokio-websockets/). Spend a few minutes "
-"to familiarize yourself with the API."
+"`tokio_websockets`. Spend a few minutes to familiarize yourself with the API."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:37
 msgid ""
-"[StreamExt::next()](https://docs.rs/futures-util/0.3.28/futures_util/stream/"
-"trait.StreamExt.html#method.next) implemented by `WebSocketStream`: for "
-"asynchronously reading messages from a Websocket Stream."
+"StreamExt::next() implemented by `WebSocketStream`: for asynchronously "
+"reading messages from a Websocket Stream."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:39
 msgid ""
-"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
-"trait.SinkExt.html#method.send) implemented by `WebSocketStream`: for "
-"asynchronously sending messages on a Websocket Stream."
+"SinkExt::send() implemented by `WebSocketStream`: for asynchronously sending "
+"messages on a Websocket Stream."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:41
 msgid ""
-"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
-"html#method.next_line): for asynchronously reading user messages from the "
+"Lines::next_line(): for asynchronously reading user messages from the "
 "standard input."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-msgid ""
-"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
-"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
+#: src/concurrency/async-exercises/chat-app.md:43
+msgid "Sender::subscribe(): for subscribing to a broadcast channel."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:45
 msgid "Two binaries"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:47
 msgid ""
 "Normally in a Cargo project, you can have only one binary, and one `src/main."
 "rs` file. In this project, we need two binaries. One for the client, and one "
 "for the server. You could potentially make them two separate Cargo projects, "
 "but we are going to put them in a single Cargo project with two binaries. "
 "For this to work, the client and the server code should go under `src/bin` "
-"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
-"targets.html#binaries))."
+"(see the documentation)."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:54
 msgid ""
 "Copy the following server and client code into `src/bin/server.rs` and `src/"
 "bin/client.rs`, respectively. Your task is to complete these files as "
 "described below."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:58
+#: src/concurrency/async-exercises/solutions.md:104
 msgid "_src/bin/server.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-msgid "// TODO: For a hint, see the description of the task below.\n"
+#: src/concurrency/async-exercises/chat-app.md:77
+#: src/concurrency/async-exercises/chat-app.md:124
+msgid "// TODO: For a hint, see the description of the task below."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:85
+#: src/concurrency/async-exercises/solutions.md:154
 msgid "\"127.0.0.1:2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:86
+#: src/concurrency/async-exercises/solutions.md:155
 msgid "\"listening on port 2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:90
+#: src/concurrency/async-exercises/solutions.md:159
 msgid "\"New connection from {addr:?}\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// Wrap the raw TCP stream into a websocket.\n"
+#: src/concurrency/async-exercises/chat-app.md:93
+#: src/concurrency/async-exercises/solutions.md:162
+msgid "// Wrap the raw TCP stream into a websocket."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:102
+#: src/concurrency/async-exercises/solutions.md:171
 msgid "_src/bin/client.rs_:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/chat-app.md:116
+#: src/concurrency/async-exercises/solutions.md:183
 msgid "\"ws://127.0.0.1:2000\""
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:129
 msgid "Running the binaries"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:131
 msgid "Run the server with:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:137
 msgid "and the client with:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:145
 msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:146
 msgid ""
 "Hint: Use `tokio::select!` for concurrently performing two tasks in a "
 "continuous loop. One task receives messages from the client and broadcasts "
 "them. The other sends messages received by the server to the client."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:149
 msgid "Complete the main function in `src/bin/client.rs`."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:150
 msgid ""
 "Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
 "performing two tasks: (1) reading user messages from standard input and "
@@ -19644,69 +18949,56 @@ msgid ""
 "displaying them for the user."
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md
+#: src/concurrency/async-exercises/chat-app.md:154
 msgid ""
 "Optional: Once you are done, change the code to broadcast messages to all "
 "clients, but the sender of the message."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "Concurrency Afternoon Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "([back to exercise](dining-philosophers-async.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:35
 msgid ""
-"// Add a delay before picking the second fork to allow the execution\n"
-"        // to transfer to another task\n"
+"// If we didn't get the left fork, drop the right fork if we // have it and "
+"let other tasks make progress."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// The locks are dropped here\n"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:42
 msgid ""
-"// To avoid a deadlock, we have to break the symmetry\n"
-"            // somewhere. This will swap the forks without deinitializing\n"
-"            // either of them.\n"
+"// If we didn't get the right fork, drop the left fork and let // other "
+"tasks make progress."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// tx is dropped here, so we don't need to explicitly drop it later\n"
+#: src/concurrency/async-exercises/solutions.md:54
+msgid "// The locks are dropped here"
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:82
+msgid "// tx is dropped here, so we don't need to explicitly drop it later"
+msgstr ""
+
+#: src/concurrency/async-exercises/solutions.md:97
 msgid "\"Here is a thought: {thought}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "([back to exercise](chat-app.md))"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:122
 msgid "\"Welcome to chat! Type a message\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:126
 msgid ""
-"// A continuous loop for concurrently performing two tasks: (1) receiving\n"
-"    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
-"    // messages on `bcast_rx` and sending them to the client.\n"
+"// A continuous loop for concurrently performing two tasks: (1) receiving // "
+"messages from `ws_stream` and broadcasting them, and (2) receiving // "
+"messages on `bcast_rx` and sending them to the client."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:135
 msgid "\"From client {addr:?} {text:?}\""
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
-msgid "// Continuous loop for concurrently sending and receiving messages.\n"
+#: src/concurrency/async-exercises/solutions.md:190
+msgid "// Continuous loop for concurrently sending and receiving messages."
 msgstr ""
 
-#: src/exercises/concurrency/solutions-afternoon.md
+#: src/concurrency/async-exercises/solutions.md:197
 msgid "\"From server: {}\""
 msgstr ""
 
@@ -19720,8 +19012,7 @@ msgstr ""
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
 "perfect, so if you spotted any mistakes or have ideas for improvements, "
-"please get in [contact with us on GitHub](https://github.com/google/"
-"comprehensive-rust/discussions). We would love to hear from you."
+"please get in contact with us on GitHub. We would love to hear from you."
 msgstr ""
 
 #: src/glossary.md
@@ -19731,10 +19022,11 @@ msgid ""
 "the English original."
 msgstr ""
 
+#. Please add the English term in italic after your translated term. Also, please keep the hard line breaks to ensure a nice formatting.
 #: src/glossary.md
 msgid ""
 "allocate:  \n"
-"Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md)."
+"Dynamic memory allocation on the heap."
 msgstr ""
 
 #: src/glossary.md
@@ -19747,19 +19039,19 @@ msgstr ""
 msgid ""
 "Bare-metal Rust:  \n"
 "Low-level Rust development, often deployed to a system without an operating "
-"system. See [Bare-metal Rust](bare-metal.md)."
+"system. See Bare-metal Rust."
 msgstr ""
 
 #: src/glossary.md
 msgid ""
 "block:  \n"
-"See [Blocks](control-flow/blocks.md) and _scope_."
+"See Blocks and _scope_."
 msgstr ""
 
 #: src/glossary.md
 msgid ""
 "borrow:  \n"
-"See [Borrowing](ownership/borrowing.md)."
+"See Borrowing."
 msgstr ""
 
 #: src/glossary.md
@@ -19790,7 +19082,7 @@ msgstr ""
 #: src/glossary.md
 msgid ""
 "channel:  \n"
-"Used to safely pass messages [between threads](concurrency/channels.md)."
+"Used to safely pass messages between threads."
 msgstr ""
 
 #: src/glossary.md
@@ -19808,7 +19100,7 @@ msgstr ""
 #: src/glossary.md
 msgid ""
 "Concurrency in Rust:  \n"
-"See [Concurrency in Rust](concurrency.md)."
+"See Concurrency in Rust."
 msgstr ""
 
 #: src/glossary.md
@@ -20032,19 +19324,19 @@ msgstr ""
 #: src/glossary.md
 msgid ""
 "Rust Fundamentals:  \n"
-"Days 1 to 3 of this course."
+"Days 1 to 4 of this course."
 msgstr ""
 
 #: src/glossary.md
 msgid ""
 "Rust in Android:  \n"
-"See [Rust in Android](android.md)."
+"See Rust in Android."
 msgstr ""
 
 #: src/glossary.md
 msgid ""
 "Rust in Chromium:  \n"
-"See [Rust in Chromium](chromium.md)."
+"See Rust in Chromium."
 msgstr ""
 
 #: src/glossary.md
@@ -20076,8 +19368,7 @@ msgstr ""
 #: src/glossary.md
 msgid ""
 "string:  \n"
-"A data type storing textual data. See [`String` vs `str`](basic-syntax/"
-"string-slices.html) for more."
+"A data type storing textual data. See Strings for more."
 msgstr ""
 
 #: src/glossary.md
@@ -20159,7 +19450,7 @@ msgstr ""
 msgid ""
 "unit test:  \n"
 "Rust comes with built-in support for running small unit tests and larger "
-"integration tests. See [Unit Tests](testing/unit-tests.html)."
+"integration tests. See Unit Tests."
 msgstr ""
 
 #: src/glossary.md
@@ -20172,7 +19463,7 @@ msgstr ""
 msgid ""
 "unsafe:  \n"
 "The subset of Rust which allows you to trigger _undefined behavior_. See "
-"[Unsafe Rust](unsafe.html)."
+"Unsafe Rust."
 msgstr ""
 
 #: src/glossary.md
@@ -20201,29 +19492,26 @@ msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
-"canonical free book about Rust. Covers the language in detail and includes a "
-"few projects for people to build."
+"The Rust Programming Language: the canonical free book about Rust. Covers "
+"the language in detail and includes a few projects for people to build."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust syntax via a series of examples which showcase different constructs. "
-"Sometimes includes small exercises where you are asked to expand on the code "
-"in the examples."
+"Rust By Example: covers the Rust syntax via a series of examples which "
+"showcase different constructs. Sometimes includes small exercises where you "
+"are asked to expand on the code in the examples."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
-"of the standard library for Rust."
+"Rust Standard Library: full documentation of the standard library for Rust."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book which describes the Rust grammar and memory model."
+"The Rust Reference: an incomplete book which describes the Rust grammar and "
+"memory model."
 msgstr ""
 
 #: src/other-resources.md
@@ -20232,23 +19520,20 @@ msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
-"including working with raw pointers and interfacing with other languages "
-"(FFI)."
+"The Rustonomicon: covers unsafe Rust, including working with raw pointers "
+"and interfacing with other languages (FFI)."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
-"covers the new asynchronous programming model which was introduced after the "
-"Rust Book was written."
+"Asynchronous Programming in Rust: covers the new asynchronous programming "
+"model which was introduced after the Rust Book was written."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an introduction to using Rust on embedded devices without an operating "
-"system."
+"The Embedded Rust Book: an introduction to using Rust on embedded devices "
+"without an operating system."
 msgstr ""
 
 #: src/other-resources.md
@@ -20261,72 +19546,70 @@ msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
-"from the perspective of low-level C programmers."
+"Learn Rust the Dangerous Way: covers Rust from the perspective of low-level "
+"C programmers."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
-"rust_for_c/): covers Rust from the perspective of developers who write "
-"firmware in C."
+"Rust for Embedded C Programmers: covers Rust from the perspective of "
+"developers who write firmware in C."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
-"covers the syntax of Rust using side-by-side comparisons with other "
-"languages such as C, C++, Java, JavaScript, and Python."
+"Rust for professionals: covers the syntax of Rust using side-by-side "
+"comparisons with other languages such as C, C++, Java, JavaScript, and "
+"Python."
+msgstr ""
+
+#: src/other-resources.md
+msgid "Rust on Exercism: 100+ exercises to help you learn Rust."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
-"you learn Rust."
+"Ferrous Teaching Material: a series of small presentations covering both "
+"basic and advanced part of the Rust language. Other topics such as "
+"WebAssembly, and async/await are also covered."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
-"material/index.html): a series of small presentations covering both basic "
-"and advanced part of the Rust language. Other topics such as WebAssembly, "
-"and async/await are also covered."
+"Advanced testing for Rust applications: a self-paced workshop that goes "
+"beyond Rust's built-in testing framework. It covers `googletest`, snapshot "
+"testing, mocking as well as how to write your own custom test harness."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
-"series-to-rust/) and [Take your first steps with Rust](https://docs."
-"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
-"new developers. The first is a set of 35 videos and the second is a set of "
-"11 modules which covers Rust syntax and basic constructs."
+"Beginner's Series to Rust and Take your first steps with Rust: two Rust "
+"guides aimed at new developers. The first is a set of 35 videos and the "
+"second is a set of 11 modules which covers Rust syntax and basic constructs."
 msgstr ""
 
 #: src/other-resources.md
 msgid ""
-"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
-"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
-"rules, through implementing a few different types of list structures."
+"Learn Rust With Entirely Too Many Linked Lists: in-depth exploration of "
+"Rust's memory management rules, through implementing a few different types "
+"of list structures."
 msgstr ""
 
 #: src/other-resources.md
-msgid ""
-"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for even more Rust books."
+msgid "Please see the Little Book of Rust Books for even more Rust books."
 msgstr ""
 
 #: src/credits.md
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation. See the page on [other resources](other-resources.md) for a "
-"full list of useful resources."
+"documentation. See the page on other resources for a full list of useful "
+"resources."
 msgstr ""
 
 #: src/credits.md
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
-"rust/blob/main/LICENSE) for details."
+"2.0 license, please see `LICENSE` for details."
 msgstr ""
 
 #: src/credits.md
@@ -20335,10 +19618,9 @@ msgstr ""
 
 #: src/credits.md
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by "
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
-"`third_party/rust-by-example/` directory for details, including the license "
-"terms."
+"Some examples and exercises have been copied and adapted from Rust by "
+"Example. Please see the `third_party/rust-by-example/` directory for "
+"details, including the license terms."
 msgstr ""
 
 #: src/credits.md
@@ -20347,9 +19629,9 @@ msgstr ""
 
 #: src/credits.md
 msgid ""
-"Some exercises have been copied and adapted from [Rust on Exercism](https://"
-"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
-"directory for details, including the license terms."
+"Some exercises have been copied and adapted from Rust on Exercism. Please "
+"see the `third_party/rust-on-exercism/` directory for details, including the "
+"license terms."
 msgstr ""
 
 #: src/credits.md
@@ -20358,10 +19640,351 @@ msgstr ""
 
 #: src/credits.md
 msgid ""
-"The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory for details, including the license terms."
+"The Interoperability with C++ section uses an image from CXX. Please see the "
+"`third_party/cxx/` directory for details, including the license terms."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Static and Const"
+#~ msgstr "نمادهای ایستا و ثابت"
+
+#, fuzzy
+#~ msgid "Slices and Lifetimes"
+#~ msgstr "چرخه حیات"
+
+#, fuzzy
+#~ msgid "String References"
+#~ msgstr "ارجاعات تعلیق شده"
+
+#~ msgid "Control Flow"
+#~ msgstr "کنترل جریان"
+
+#, fuzzy
+#~ msgid "[Pattern Matching](../pattern-matching.md) (50 minutes)"
+#~ msgstr ""
+#~ "به [تطبیق الگو](../pattern-matching.md) مراجعه کنید تا در مورد الگوها در "
+#~ "Rust اطلاعات بیشتری کسب کنید."
+
+#~ msgid "Arrow-Left"
+#~ msgstr "Arrow-Left"
+
+#~ msgid "Arrow-Right"
+#~ msgstr "Arrow-Right"
+
+#~ msgid "Ctrl + Enter"
+#~ msgstr "Ctrl + Enter"
+
+#~ msgid "s"
+#~ msgstr "s"
+
+#~ msgid ""
+#~ "[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-"
+#~ "BR/) by [@rastringer](https://github.com/rastringer), [@hugojacob]"
+#~ "(https://github.com/hugojacob), [@joaovicmendes](https://github.com/"
+#~ "joaovicmendes), and [@henrif75](https://github.com/henrif75)."
+#~ msgstr ""
+#~ "[پرتغالی برزیلی](https://google.github.io/comprehensive-rust/pt-BR/) توسط "
+#~ "[@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
+#~ "com/hugojacob), [@joaovicmendes](https://github.com/joaovicmendes) و  "
+#~ "[@henrif75](https://github.com/henrif75)."
+
+#~ msgid ""
+#~ "[Chinese (Simplified)](https://google.github.io/comprehensive-rust/zh-"
+#~ "CN/) by [@suetfei](https://github.com/suetfei), [@wnghl](https://github."
+#~ "com/wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github."
+#~ "com/kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd]"
+#~ "(https://github.com/superwhd), [@SketchK](https://github.com/SketchK), "
+#~ "and [@nodmp](https://github.com/nodmp)."
+#~ msgstr ""
+#~ "[چینی (ساده‌شده)](https://google.github.io/comprehensive-rust/zh-CN/) توسط "
+#~ "[@suetfei](https://github.com/suetfei), [@wnghl](https://github.com/"
+#~ "wnghl), [@anlunx](https://github.com/anlunx), [@kongy](https://github.com/"
+#~ "kongy), [@noahdragon](https://github.com/noahdragon), [@superwhd](https://"
+#~ "github.com/superwhd), [@SketchK](https://github.com/SketchK) و [@nodmp]"
+#~ "(https://github.com/nodmp)."
+
+#~ msgid ""
+#~ "[Chinese (Traditional)](https://google.github.io/comprehensive-rust/zh-"
+#~ "TW/) by [@hueich](https://github.com/hueich), [@victorhsieh](https://"
+#~ "github.com/victorhsieh), [@mingyc](https://github.com/mingyc), "
+#~ "[@kuanhungchen](https://github.com/kuanhungchen), and [@johnathan79717]"
+#~ "(https://github.com/johnathan79717)."
+#~ msgstr ""
+#~ "[چینی (سنتی)](https://google.github.io/comprehensive-rust/zh-TW/) توسط "
+#~ "[@hueich](https://github.com/hueich), [@victorhsieh](https://github.com/"
+#~ "victorhsieh), [@mingyc](https://github.com/mingyc), [@kuanhungchen]"
+#~ "(https://github.com/kuanhungchen) و [@johnathan79717](https://github.com/"
+#~ "johnathan79717)."
+
+#~ msgid ""
+#~ "[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+#~ "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), "
+#~ "and [@jooyunghan](https://github.com/jooyunghan)."
+#~ msgstr ""
+#~ "[کره ای](https://google.github.io/comprehensive-rust/ko/) توسط [@keispace]"
+#~ "(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) و "
+#~ "[@jooyunghan](https://github.com/jooyunghan)."
+
+#~ msgid ""
+#~ "[Spanish](https://google.github.io/comprehensive-rust/es/) by [@deavid]"
+#~ "(https://github.com/deavid)."
+#~ msgstr ""
+#~ "[Spanish](https://google.github.io/comprehensive-rust/es/) توسط [@deavid]"
+#~ "(https://github.com/deavid)."
+
+#~ msgid ""
+#~ "[Bengali](https://google.github.io/comprehensive-rust/bn/) by "
+#~ "[@raselmandol](https://github.com/raselmandol)."
+#~ msgstr ""
+#~ "[بنگالی](https://google.github.io/comprehensive-rust/bn/) توسط "
+#~ "[@raselmandol](https://github.com/raselmandol)."
+
+#~ msgid ""
+#~ "[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+#~ "(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+#~ msgstr ""
+#~ "[فرانسویی](https://google.github.io/comprehensive-rust/fr/) توسط [@KookaS]"
+#~ "(https://github.com/KookaS) و [@vcaen](https://github.com/vcaen)."
+
+#~ msgid ""
+#~ "[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+#~ "(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+#~ msgstr ""
+#~ "[آلمانی](https://google.github.io/comprehensive-rust/de/) توسط [@Throvn]"
+#~ "(https://github.com/Throvn) و [@ronaldfw](https://github.com/ronaldfw)."
+
+#~ msgid ""
+#~ "[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-"
+#~ "JPN](https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+#~ "momotaro1105)."
+#~ msgstr ""
+#~ "[ژاپنی](https://google.github.io/comprehensive-rust/ja/) توسط [@CoinEZ-"
+#~ "JPN](https://github.com/CoinEZ) و [@momotaro1105](https://github.com/"
+#~ "momotaro1105)."
+
+#~ msgid ""
+#~ "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+#~ msgstr ""
+#~ "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+
+#~ msgid ""
+#~ "[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+#~ "html)"
+#~ msgstr ""
+#~ "[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+#~ "html)"
+
+#~ msgid ""
+#~ "[global installation](https://doc.rust-lang.org/cargo/commands/cargo-"
+#~ "install.html)"
+#~ msgstr ""
+#~ "[global installation](https://doc.rust-lang.org/cargo/commands/cargo-"
+#~ "install.html)"
+
+#~ msgid "You can use "
+#~ msgstr "همان طور که مشاهده می‌کنید"
+
+#~ msgid ""
+#~ "Rust supports many [platforms and architectures](https://doc.rust-lang."
+#~ "org/nightly/rustc/platform-support.html):"
+#~ msgstr ""
+#~ " راست از بسیاری از [بسترها و معماری‌ها](https://doc.rust-lang.org/nightly/"
+#~ "rustc/platform-support.html) پشتیبانی می کند :"
+
+#~ msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
+#~ msgstr "بسیاری از دستور زبان Rust مشابه زبان‌های C، C++ یا Java خواهد بود:"
+
+#, fuzzy
+#~ msgid "Blocks are delimited by curly braces."
+#~ msgstr "بلاک‌ها و اسکوپ‌ها با پرانتزهای باز و بسته مشخص می‌شوند."
+
+#~ msgid ""
+#~ "Line comments are started with `//`, block comments are delimited by `/"
+#~ "* ... */`."
+#~ msgstr ""
+#~ "کامنت‌های تک خطی با ‍`//` شروع می‌شوند و کامنت‌های چند خطی با `/* ... */` "
+#~ "مشخص می‌شوند."
+
+#~ msgid "Keywords like `if` and `while` work the same."
+#~ msgstr "کلمات کلیدی مانند `if `و `while` به همان صورت عمل می‌کنند."
+
+#~ msgid "Variable assignment is done with `=`, comparison is done with `==`."
+#~ msgstr "انتساب متغیر با `=` انجام می‌شود، مقایسه با `==` انجام می‌شود."
+
+#~ msgid ""
+#~ "In this case we break the outer loop after 3 iterations of the inner loop."
+#~ msgstr ""
+#~ "در این مورد، پس از 3 تکرار حلقه `inner`، از حلقه `outer` خارج می‌شویم."
+
+#~ msgid "`[T; N]`"
+#~ msgstr "<span dir=ltr><code class=hljs>[T; N]</code></span>"
+
+#~ msgid "`[20, 30, 40]`, `[0; 3]`"
+#~ msgstr ""
+#~ "<span dir=ltr><code class=hljs>[20, 30, 40]</code>, <code class=hljs>[0; "
+#~ "3]</code></span>"
+
+#~ msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+#~ msgstr ""
+#~ "<span dir=ltr><code class=hljs>()</code>, <code class=hljs>(T,)</code>, "
+#~ "<code class=hljs>(T1, T2)</code>, …</span>"
+
+#~ msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+#~ msgstr ""
+#~ "<span dir=ltr><code class=hljs>()</code>, <code class=hljs>('x',)</code>, "
+#~ "<code class=hljs>('x', 1.2)</code>, …</span>"
+
+#~ msgid "Array assignment and access:"
+#~ msgstr "انتساب و دسترسی به آرایه:"
+
+#~ msgid "Tuple assignment and access:"
+#~ msgstr "انتساب و دسترسی به تاپل:"
+
+#~ msgid "Arrays:"
+#~ msgstr "آرایه‌ها:"
+
+#~ msgid "Tuples:"
+#~ msgstr ":تاپل‌ها"
+
+#, fuzzy
+#~ msgid ""
+#~ "The empty tuple `()` is also known as the \"unit type\". It is both a "
+#~ "type, and the only valid value of that type --- that is to say both the "
+#~ "type and its value are expressed as `()`. It is used to indicate, for "
+#~ "example, that a function or expression has no return value, as we'll see "
+#~ "in a future slide."
+#~ msgstr ""
+#~ "تاپل خالی <span dir=ltr>`()`</span> همچنین به عنوان «نوع یکه» شناخته "
+#~ "می‌شود. این هم یک نوع است و هم تنها مقدار معتبر آن نوع - یعنی هم نوع و هم "
+#~ "مقدار آن به صورت <span dir=ltr>`()`</span> بیان می‌شوند.رای مثال برای نشان "
+#~ "دادن اینکه یک تابع یا عبارت هیچ مقدار برگشتی ندارد استفاده می‌شود، همانطور "
+#~ "که در اسلاید بعدی خواهیم دید. "
+
+#, fuzzy
+#~ msgid ""
+#~ "You can think of it as `void` that can be familiar to you from other "
+#~ "programming languages."
+#~ msgstr ""
+#~ "می‌توانید آن را به عنوان `void` در نظر بگیرید که ممکن است از سایر زبان‌های "
+#~ "برنامه‌نویسی برایتان آشنا باشد."
+
+#, fuzzy
+#~ msgid "You can destructure tuples and arrays by matching on their elements:"
+#~ msgstr ""
+#~ "می توانید آرایه‌ها، تاپل‌ها و برش‌ها را با تطابق با عناصر آنها destructure "
+#~ "کنید."
+
+#, fuzzy
+#~ msgid "Create a new array pattern using `_` to represent an element."
+#~ msgstr "یک الگوی جدید با استفاده از `_` برای نمایش یک عنصر ایجاد کنید."
+
+#~ msgid "Add more values to the array."
+#~ msgstr "مقادیر بیشتری را به آرایه اضافه کنید."
+
+#~ msgid ""
+#~ "Point out that how `..` will expand to account for different number of "
+#~ "elements."
+#~ msgstr ""
+#~ "اشاره کنید که چگونه `..` برای در نظر گرفتن تعداد عناصر مختلف، گسترش خواهد "
+#~ "یافت."
+
+#~ msgid ""
+#~ "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+#~ msgstr ""
+#~ "مطابقت با انتهای آرایه رو با با الگوهای <span dir=ltr>`[.., b]`</span>  و "
+#~ "<span dir=ltr>`[a@..,b]`</span> را نشان دهید."
+
+#~ msgid "Hard-code both functions to operate on 3 × 3 matrices."
+#~ msgstr "هر دو تابع را برای کار بر روی ماتریس‌های 3 × 3 هاردکد کنید."
+
+#, fuzzy
+#~ msgid ""
+#~ "Static and constant variables are two different ways to create globally-"
+#~ "scoped values that cannot be moved or reallocated during the execution of "
+#~ "the program."
+#~ msgstr ""
+#~ "متغیرهای `ثابت` و `ایستا` دو روش متفاوت برای ایجاد مقادیر با اسکوپ گلوبال "
+#~ "(قابل دسترس در کل برنامه) هستند که نمی‌توانند در طول اجرای برنامه منتقل یا "
+#~ "دوباره تعریف شوند."
+
+#~ msgid "Properties table:"
+#~ msgstr "جدول خاصیت‌ها:"
+
+#~ msgid "Has an address in memory"
+#~ msgstr "دارای یک آدرس واقعی در حافظه"
+
+#~ msgid "No (inlined)"
+#~ msgstr "خیر (به صورت درون خطی)"
+
+#~ msgid "Lives for the entire duration of the program"
+#~ msgstr "در طول‌عمر کل برنامه زنده می‌ماند؟"
+
+#~ msgid "Can be mutable"
+#~ msgstr "میتوان قابل تغییر اش کرد"
+
+#~ msgid "Yes (unsafe)"
+#~ msgstr "بلی (unsafe)"
+
+#~ msgid "Evaluated at compile time"
+#~ msgstr "ارزیابی در زمان کامپایل"
+
+#~ msgid "Yes (initialised at compile time)"
+#~ msgstr "بلی (در زمان کامپایل ساخته می‌شود)"
+
+#~ msgid "Inlined wherever it is used"
+#~ msgstr "به صورت درون‌خطی هر جا که استفاده میشود قرار میگیرد"
+
+#, fuzzy
+#~ msgid "[Pattern Matching](./pattern-matching.md) (50 minutes)"
+#~ msgstr ""
+#~ "به [تطبیق الگو](../pattern-matching.md) مراجعه کنید تا در مورد الگوها در "
+#~ "Rust اطلاعات بیشتری کسب کنید."
+
+#~ msgid "`match` expressions"
+#~ msgstr "عبارت `match`"
+
+#, fuzzy
+#~ msgid ""
+#~ "All of the details about [loops](https://doc.rust-lang.org/stable/"
+#~ "reference/expressions/loop-expr.html)."
+#~ msgstr ""
+#~ "اگر می‌خواهید زودتر از یک حلقه خارج شوید، از [`break`](https://doc.rust-"
+#~ "lang.org/reference/expressions/loop-expr.html#break-expressions) استفاده "
+#~ "کنید,"
+
+#~ msgid "Rust terminology:"
+#~ msgstr "اصطلاحات راست:"
+
+#~ msgid "`&str` an immutable reference to a string slice."
+#~ msgstr ""
+#~ "<span dir=ltr><code class=hljs>&amp;str</code></span>  یک مرجع غیرقابل "
+#~ "تغییر به یک برش از رشته‌ است."
+
+#~ msgid "`String` a mutable string buffer."
+#~ msgstr "`String` یک بافر رشته‌ای قابل تغییر است."
+
+#, fuzzy
+#~ msgid "// Undefined behavior if abs misbehaves.\n"
+#~ msgstr "هیچ رفتار تعریف نشده‌ای در زمان اجرا:"
+
+#~ msgid ""
+#~ "After looking at the exercises, you can look at the [solutions](solutions-"
+#~ "afternoon.md) provided."
+#~ msgstr ""
+#~ "پس از بررسی تمرین‌ها، می‌توانید به [راه‌حل ها](solutions-afternoon.md) ارائه "
+#~ "شده نگاهی بیندازید."
+
+#, fuzzy
+#~ msgid "\"aarch64-linux-gnu\""
+#~ msgstr "aarch64-paging"
+
+#, fuzzy
+#~ msgid "\"exceptions.S\""
+#~ msgstr "استثناها"
+
+#, fuzzy
+#~ msgid "aarch64-linux-gnu"
+#~ msgstr "aarch64-paging"
 
 #~ msgid "Small Example"
 #~ msgstr "یک مثال ساده"
@@ -20396,9 +20019,6 @@ msgstr ""
 #~ msgid "Arrays and for Loops"
 #~ msgstr "آرایه ها و حلقه های for"
 
-#~ msgid "if expressions"
-#~ msgstr "عبارت if"
-
 #~ msgid "for expressions"
 #~ msgstr "عبارت  for"
 
@@ -20417,9 +20037,6 @@ msgstr ""
 #~ msgid "Enum Sizes"
 #~ msgstr "اندازه ی Enum ها"
 
-#~ msgid "Novel Control Flow"
-#~ msgstr "کنترل جریان پیشرفته"
-
 #~ msgid "if let expressions"
 #~ msgstr "عبارت if let"
 
@@ -20428,9 +20045,6 @@ msgstr ""
 
 #~ msgid "match expressions"
 #~ msgstr "عبارت تطبیق"
-
-#~ msgid "Destructuring Structs"
-#~ msgstr "تخریب ساختارها"
 
 #~ msgid "Destructuring Arrays"
 #~ msgstr "تخریب آرایه‌ها"
@@ -20474,26 +20088,14 @@ msgstr ""
 #~ msgid "Field Shorthand Syntax"
 #~ msgstr "نحو اختصاری فیلد"
 
-#~ msgid "Method Receiver"
-#~ msgstr "متد دریافتی"
-
 #~ msgid "Storing Books"
 #~ msgstr "ذخیره سازی کتاب"
 
 #~ msgid "Option and Result"
 #~ msgstr "Option و Result"
 
-#~ msgid "Vec"
-#~ msgstr "Vec"
-
-#~ msgid "HashMap"
-#~ msgstr "HashMap"
-
 #~ msgid "Box"
 #~ msgstr "Box"
-
-#~ msgid "Rc"
-#~ msgstr "Rc"
 
 #~ msgid "Iterators and Ownership"
 #~ msgstr "تکرار کننده ها و مالکیت"
@@ -20510,14 +20112,8 @@ msgstr ""
 #~ msgid "Default Methods"
 #~ msgstr "متدهای پیشفرض"
 
-#~ msgid "impl Trait"
-#~ msgstr "صفات impl  (impl Trait)"
-
 #~ msgid "Important Traits"
 #~ msgstr "صفات مهم"
-
-#~ msgid "From and Into"
-#~ msgstr "From و Into"
 
 #~ msgid "Default"
 #~ msgstr "پیش‌فرض"
@@ -20572,27 +20168,6 @@ msgstr ""
 
 #~ msgid "spin"
 #~ msgstr "چرخش"
-
-#~ msgid "Send and Sync"
-#~ msgstr "ارسال و همگام سازی"
-
-#~ msgid "Send"
-#~ msgstr "ارسال"
-
-#~ msgid "Sync"
-#~ msgstr "همگام سازی"
-
-#~ msgid "Arc"
-#~ msgstr "Shared State"
-
-#~ msgid "Mutex"
-#~ msgstr "Mutex"
-
-#~ msgid "async/await"
-#~ msgstr "async/await"
-
-#~ msgid "Pin"
-#~ msgstr "Pin"
 
 #~ msgid "Day 1 Morning"
 #~ msgstr "روز ۱ صبح"
@@ -21158,9 +20733,6 @@ msgstr ""
 #~ msgid "`String` vs `str`"
 #~ msgstr "<span dir=ltr>`String`</span> در مقابل <span dir=ltr>`str`</span> "
 
-#~ msgid "We can now understand the two string types in Rust:"
-#~ msgstr "حالا می‌توانیم دو نوع رشته‌ای را در راست درک کنیم:"
-
 #~ msgid ""
 #~ "You can borrow `&str` slices from `String` via `&` and optionally range "
 #~ "selection."
@@ -21313,9 +20885,6 @@ msgstr ""
 #~ "در صورت امکان، از نصب محلی راست استفاده کنید. از این طریق می‌توانید از "
 #~ "تکمیل خودکار در ویرایشگر خود استفاده کنید.  برای جزئیات بیشتر در مورد نصب "
 #~ "راست، صفحه مربوط به [استفاده از کارگو](../../cargo.md)  را ببینید."
-
-#~ msgid "Alternatively, use the Rust Playground."
-#~ msgstr "در غیر این صورت از `Rust Playground` استفاده کنید."
 
 #~ msgid ""
 #~ "The code snippets are not editable on purpose: the inline code snippets "
@@ -22059,10 +21628,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "control flow:"
 #~ msgstr "کنترل جریان"
-
-#, fuzzy
-#~ msgid "enumeration:"
-#~ msgstr "پیاده سازی"
 
 #, fuzzy
 #~ msgid "error handling:"


### PR DESCRIPTION
Updating `fa.po` translations based on the latest changes. If we merge this before the #2038, it's easier to review that merge request.

Related to #671.