### PR TITLE
Add Google's Project IDX files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ pnpm-lock.yaml
 
 # Crowdin Config (Contains API Keys)
 crowdin.yml
+
+# Google's Project IDX files
+.idx/


### PR DESCRIPTION
Add [Project IDX](https://idx.dev/) files to `.gitignore`