### PR TITLE
Update the link to the first dining philosophers exercise

### DIFF
--- a/src/concurrency/async-exercises/dining-philosophers.md
+++ b/src/concurrency/async-exercises/dining-philosophers.md
@@ -4,7 +4,7 @@ minutes: 20
 
 # Dining Philosophers --- Async
 
-See [dining philosophers](dining-philosophers.md) for a description of the
+See [dining philosophers](concurrency/sync-exercises/dining-philosophers.md) for a description of the
 problem.
 
 As before, you will need a local

--- a/src/concurrency/async-exercises/dining-philosophers.md
+++ b/src/concurrency/async-exercises/dining-philosophers.md
@@ -4,8 +4,8 @@ minutes: 20
 
 # Dining Philosophers --- Async
 
-See [dining philosophers](concurrency/sync-exercises/dining-philosophers.md) for a description of the
-problem.
+See [dining philosophers](concurrency/sync-exercises/dining-philosophers.md) for
+a description of the problem.
 
 As before, you will need a local
 [Cargo installation](../../cargo/running-locally.md) for this exercise. Copy the


### PR DESCRIPTION
The current one leads to the same page.
https://google.github.io/comprehensive-rust/concurrency/async-exercises/dining-philosophers.html