### PR TITLE
Add a map_err in speaker notes

### DIFF
--- a/src/concurrency/async-pitfalls/cancellation.md
+++ b/src/concurrency/async-pitfalls/cancellation.md
@@ -101,7 +101,7 @@ async fn main() -> std::io::Result<()> {
             // prefix buf and bytes with self.
             // ...
             let raw = std::mem::take(&mut self.bytes);
-            let s = String::from_utf8(raw)
+            let s = String::from_utf8(raw).unwrap();
             // ...
         }
     }

--- a/src/concurrency/async-pitfalls/cancellation.md
+++ b/src/concurrency/async-pitfalls/cancellation.md
@@ -101,7 +101,8 @@ async fn main() -> std::io::Result<()> {
             // prefix buf and bytes with self.
             // ...
             let raw = std::mem::take(&mut self.bytes);
-            let s = String::from_utf8(raw).unwrap();
+            let s = String::from_utf8(raw)
+                .map_err(|_| io::Error::new(ErrorKind::InvalidData, "not UTF-8"))?;
             // ...
         }
     }


### PR DESCRIPTION
The type returned by  `String::from_utf8(raw)`, is `Result<_>` and needs to be mapped to match the type of the return type of `next`. You get this error otherwise:

```
    Compiling playground v0.0.1 (/playground)
warning: unused import: `ErrorKind`
 --> src/main.rs:1:21
  |
1 | use std::io::{self, ErrorKind};
  |                     ^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0308]: mismatched types
   --> src/main.rs:29:17
    |
29  |         Ok(Some(s))
    |            ---- ^ expected `String`, found `Result<String, FromUtf8Error>`
    |            |
    |            arguments to this enum variant are incorrect
    |
    = note: expected struct `String`
                 found enum `Result<String, FromUtf8Error>`
help: the type constructed contains `Result<String, FromUtf8Error>` due to the type of the argument passed
   --> src/main.rs:29:12
    |
29  |         Ok(Some(s))
    |            ^^^^^-^
    |                 |
    |                 this argument influences the type of `Some`
note: tuple variant defined here
   --> /playground/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:579:5
    |
579 |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     ^^^^
help: use the `?` operator to extract the `Result<String, FromUtf8Error>` value, propagating a `Result::Err` value to the caller
    |
29  |         Ok(Some(s?))
    |                  +

For more information about this error, try `rustc --explain E0308`.
warning: `playground` (bin "playground") generated 1 warning
error: could not compile `playground` (bin "playground") due to 1 previous error; 1 warning emitted
```