### PR TITLE
Use stable rustfmt

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -9,7 +9,7 @@
       "command": "yapf3",
       "exts": ["py"]
     }, {
-      "command": "rustup run nightly rustfmt --edition 2021",
+      "command": "rustup run stable rustfmt --edition 2021",
       "exts": ["rs"]
     }, {
       "command": "msgcat -",


### PR DESCRIPTION
This uses the `rustfmt` from the stable toolchain, instead of nightly. At the moment, nightly's `rustfmt` is nonfunctional, but in general we don't need bleeding-edge formatting (and in fact, the more often formatting changes, the more often we'll get spurious failures on PRs, as we are today).

Fixes #2165.