### PR TITLE
Fix issues in std-types/result.md

### DIFF
--- a/src/std-types/result.md
+++ b/src/std-types/result.md
@@ -5,9 +5,8 @@ minutes: 5
 # Result
 
 `Result` is similar to `Option`, but indicates the success or failure of an
-operation, each with a different type. This is similar to the `Res` defined in
-the expression exercise, but generic: `Result<T, E>` where `T` is used in the
-`Ok` variant and `E` appears in the `Err` variant.
+operation, each with a different enum variant. It is generic: `Result<T, E>`
+where `T` is used in the `Ok` variant and `E` appears in the `Err` variant.
 
 ```rust,editable
 use std::fs::File;


### PR DESCRIPTION
The expression excercise is using the standard `Result` type instead of `Res`.