### PR TITLE
Remove lifetime trait bound on ProtoMessage

### DIFF
--- a/src/lifetimes/exercise.rs
+++ b/src/lifetimes/exercise.rs
@@ -43,7 +43,7 @@ struct Field<'a> {
     value: FieldValue<'a>,
 }
 
-trait ProtoMessage<'a>: Default + 'a {
+trait ProtoMessage<'a>: Default {
     fn add_field(&mut self, field: Field<'a>);
 }
 


### PR DESCRIPTION
The lifetime trait bound is unncessary, and the code compiles without it.