### PR TITLE
Fix publish workflow for synced translation report

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Setup Rust cache
         uses: ./.github/workflows/setup-rust-cache
 
+      - name: Install Gettext
+        run: |
+          sudo apt update
+          sudo apt install gettext
+
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook
 


### PR DESCRIPTION
Building the synced translation report requires gettext for `msgmerge.`