### PR TITLE
Upgrade `mdbook-pandoc` and disable it except during CI workflows

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -36,6 +36,9 @@ else
     fi
 fi
 
+# Enable mdbook-pandoc to build PDF version of the course
+export MDBOOK_OUTPUT__PANDOC__DISABLED=false
+
 mdbook build -d "$dest_dir"
 
 # Disable the redbox button in built versions of the course

--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -17,11 +17,11 @@ runs:
 
     - name: Install mdbook-pandoc and related dependencies
       run: |
-        cargo install mdbook-pandoc --locked --version 0.6.4
+        cargo install mdbook-pandoc --locked --version 0.7.0
         sudo apt-get update
         sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
-        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.2/pandoc-3.2-linux-amd64.tar.gz | tar zxf -
-        echo "$PWD/pandoc-3.2/bin" >> $GITHUB_PATH
+        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.2.1/pandoc-3.2.1-linux-amd64.tar.gz | tar zxf -
+        echo "$PWD/pandoc-3.2.1/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: Install mdbook-i18n-helpers

--- a/book.toml
+++ b/book.toml
@@ -24,6 +24,7 @@ verbose = false # Report timing information.
 
 [output.pandoc]
 optional = true
+disabled = true
 hosted-html = "https://google.github.io/comprehensive-rust/"
 
 [output.pandoc.profile.pdf]


### PR DESCRIPTION
Implements the approach summarized in https://github.com/google/mdbook-i18n-helpers/issues/200#issuecomment-2220035461 to disable running `mdbook-pandoc` even if it is available to avoid dependency-related issues during local rendering.

Should address https://github.com/google/comprehensive-rust/issues/1911 since `mdbook-pandoc` will no longer run locally.