### PR TITLE
Update udev rule for microbit.

### DIFF
--- a/src/bare-metal.md
+++ b/src/bare-metal.md
@@ -42,7 +42,7 @@ And give users in the `plugdev` group access to the micro:bit programmer:
 <!-- mdbook-xgettext: skip -->
 
 ```bash
-echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", MODE="0664", GROUP="plugdev"' |\
+echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0d28", MODE="0660", GROUP="logindev", TAG+="uaccess"' |\
   sudo tee /etc/udev/rules.d/50-microbit.rules
 sudo udevadm control --reload-rules
 ```


### PR DESCRIPTION
The subsystem seems to have changed with a newer version of udev, and using logindev and uaccess rather than plugdev is consistent with how other similar devices are handled.