### PR TITLE
Set Rust caching key per language group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,8 @@ jobs:
 
       - name: Setup Rust cache
         uses: ./.github/workflows/setup-rust-cache
+        with:
+          key: ${{ contains(fromJSON(env.LINK_CHECKED_LANGUAGES), matrix.language) }}
 
       - name: Install Gettext
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,9 @@ jobs:
       matrix:
         language: ${{ fromJSON(needs.find-languages.outputs.languages) }}
       fail-fast: false
+    env:
+      # Opt-in for checking links in translations - add the language below.
+      LINK_CHECKED_LANGUAGES: '["en", ]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,8 +152,7 @@ jobs:
           msgfmt -o /dev/null --statistics po/messages.pot
 
       - name: Install mdbook-linkcheck
-        # Opt-in for checking links in translations - add the language below.
-        if: contains(fromJSON('["en", ]'), matrix.language)
+        if: contains(fromJSON(env.LINK_CHECKED_LANGUAGES), matrix.language)
         run: cargo install mdbook-linkcheck --locked --version 0.7.7
 
       - name: Build ${{ matrix.language }} translation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -2,6 +2,12 @@ name: Setup Rust cache
 
 description: Configure the rust-cache workflow.
 
+inputs:
+  key:
+    description: Additional caching key
+    required: false
+    default:
+
 runs:
   using: composite
   steps:
@@ -11,5 +17,5 @@ runs:
         # Only save the cache on the main branch to avoid PRs filling
         # up the cache.
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        # Further, save the cache per language.
-        key: ${{ matrix.language }}
+        # Further, save the cache per key - e.g. language grouping.
+        key: ${{ inputs.key }}

--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -19,3 +19,4 @@ runs:
         save-if: ${{ github.ref == 'refs/heads/main' }}
         # Further, save the cache per key - e.g. language grouping.
         key: ${{ inputs.key }}
+        prefix-key: v1-rust

--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -19,4 +19,3 @@ runs:
         save-if: ${{ github.ref == 'refs/heads/main' }}
         # Further, save the cache per key - e.g. language grouping.
         key: ${{ inputs.key }}
-        prefix-key: v1-rust

--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -9,6 +9,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         # Only save the cache on the main branch to avoid PRs filling
-        # up the cache. Further, only save it if we are working on the
-        # English source (or if no language has been set).
-        save-if: ${{ github.ref == 'refs/heads/main' && (matrix.language == 'en' || matrix.language == '') }}
+        # up the cache.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+        # Further, save the cache per language.
+        key: ${{ matrix.language }}

--- a/src/bare-metal/android/vmbase.md
+++ b/src/bare-metal/android/vmbase.md
@@ -28,4 +28,4 @@ pub fn main(arg0: u64, arg1: u64, arg2: u64, arg3: u64) {
 
 </details>
 
-[1]: https://android.googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/master/vmbase/
+[1]: https://android.googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/main/libs/libvmbase/


### PR DESCRIPTION
Fixes #2247 (a follow-up from #2195).

* Add a workflow dispatch manual trigger to the tests workflow.
* Move the link-checked languages JSON list to the build job's env.
* Set a caching key per language group to avoid extra `mdbook-linkcheck` installation on non-link-checked translations.
  For the meaning of this key, see:
  https://github.com/Swatinem/rust-cache?tab=readme-ov-file#example-usage
* Fix newly broken web link in 8a3ed21 ✅ 

I tested it on my fork, and it looks good:
https://github.com/jond01/comprehensive-rust/actions/workflows/build.yml
https://github.com/jond01/comprehensive-rust/actions/caches