### PR TITLE
Update "Rust advanced testing" links to point at the hosted book version

### DIFF
--- a/src/android/testing/googletest.md
+++ b/src/android/testing/googletest.md
@@ -40,7 +40,7 @@ Error: See failure output above
 
 - This just scratches the surface, there are many builtin matchers. Consider
   going through the first chapter of
-  ["Advanced testing for Rust applications"](https://github.com/mainmatter/rust-advanced-testing-workshop),
+  ["Advanced testing for Rust applications"](https://rust-exercises.com/advanced-testing/),
   a self-guided Rust course: it provides a guided introduction to the library,
   with exercises to help you get comfortable with `googletest` macros, its
   matchers and its overall philosophy.

--- a/src/other-resources.md
+++ b/src/other-resources.md
@@ -47,7 +47,7 @@ A small selection of other guides and tutorial for Rust:
   a series of small presentations covering both basic and advanced part of the
   Rust language. Other topics such as WebAssembly, and async/await are also
   covered.
-- [Advanced testing for Rust applications](https://github.com/mainmatter/rust-advanced-testing-workshop):
+- [Advanced testing for Rust applications](https://rust-exercises.com/advanced-testing/):
   a self-paced workshop that goes beyond Rust's built-in testing framework. It
   covers `googletest`, snapshot testing, mocking as well as how to write your
   own custom test harness.


### PR DESCRIPTION
Following up on @mgeisler's comment in https://github.com/google/comprehensive-rust/pull/2029