### PR TITLE
Change let-else example to demonstrate undesirable nesting

### DIFF
--- a/src/pattern-matching/let-control-flow.md
+++ b/src/pattern-matching/let-control-flow.md
@@ -42,22 +42,18 @@ off the end of the block).
 
 ```rust,editable
 fn hex_or_die_trying(maybe_string: Option<String>) -> Result<u32, String> {
-    let s = if let Some(s) = maybe_string {
-        s
+    if let Some(s) = maybe_string {
+        if let Some(first_byte_char) = s.chars().next() {
+            if let Some(digit) = first_byte_char.to_digit(16) {
+                Ok(digit)
+            } else {
+                return Err(String::from("not a hex digit"));
+            }
+        } else {
+            return Err(String::from("got empty string"));
+        }
     } else {
         return Err(String::from("got None"));
-    };
-
-    let first_byte_char = if let Some(first_byte_char) = s.chars().next() {
-        first_byte_char
-    } else {
-        return Err(String::from("got empty string"));
-    };
-
-    if let Some(digit) = first_byte_char.to_digit(16) {
-        Ok(digit)
-    } else {
-        Err(String::from("not a hex digit"))
     }
 }
 


### PR DESCRIPTION
Fixes #2070.

Previously we showed a forcibly de-nested version using both let and if-let. this is not a construction that new learners of Rust are likely to have seen or written, while nesting if-let is closer to patterns that appear in other languages and better motivates the de-nesting transformation to let-else