### PR TITLE
interior-mutability.md: swap Cell/RefCell order and improve explanation

### DIFF
--- a/src/borrowing/interior-mutability.md
+++ b/src/borrowing/interior-mutability.md
@@ -12,7 +12,35 @@ The "interior mutability" pattern allows exclusive (mutable) access behind a
 shared reference. The standard library provides several ways to do this, all
 while still ensuring safety, typically by performing a runtime check.
 
+## `Cell`
+
+`Cell` wraps a value and allows getting or setting the value using only a shared
+reference to the `Cell`. However, it does not allow any references to the inner
+value. Since there are no references, borrowing rules cannot be broken.
+
+```rust,editable
+use std::cell::Cell;
+
+fn main() {
+    // Note that `cell` is NOT declared as mutable.
+    let cell = Cell::new(5);
+
+    cell.set(123);
+    println!("{}", cell.get());
+}
+```
+
 ## `RefCell`
+
+`RefCell` allows accessing and mutating a wrapped value by providing alternative
+types `Ref` and `RefMut` that emulate `&T`/`&mut T` without actually being Rust
+references.
+
+These types perform dynamic checks using a counter in the `RefCell` to prevent
+existence of a `RefMut` alongside another `Ref`/`RefMut`.
+
+By implementing `Deref` (and `DerefMut` for `RefMut`), these types allow calling
+methods on the inner value without allowing references to escape.
 
 ```rust,editable
 use std::cell::RefCell;
@@ -31,24 +59,6 @@ fn main() {
     }
 
     println!("{cell:?}");
-}
-```
-
-## `Cell`
-
-`Cell` wraps a value and allows getting or setting the value, even with a shared
-reference to the `Cell`. However, it does not allow any references to the value.
-Since there are no references, borrowing rules cannot be broken.
-
-```rust,editable
-use std::cell::Cell;
-
-fn main() {
-    // Note that `cell` is NOT declared as mutable.
-    let cell = Cell::new(5);
-
-    cell.set(123);
-    println!("{}", cell.get());
 }
 ```
 


### PR DESCRIPTION
Fixes #2249.