### PR TITLE
concurrency: avoid 1.. loops

### DIFF
--- a/src/concurrency/async/async-await.md
+++ b/src/concurrency/async/async-await.md
@@ -10,7 +10,7 @@ At a high level, async Rust code looks very much like "normal" sequential code:
 use futures::executor::block_on;
 
 async fn count_to(count: i32) {
-    for i in 1..=count {
+    for i in 0..count {
         println!("Count is: {i}!");
     }
 }

--- a/src/concurrency/async/runtimes/tokio.md
+++ b/src/concurrency/async/runtimes/tokio.md
@@ -10,7 +10,7 @@ Tokio provides:
 use tokio::time;
 
 async fn count_to(count: i32) {
-    for i in 1..=count {
+    for i in 0..count {
         println!("Count in task: {i}!");
         time::sleep(time::Duration::from_millis(5)).await;
     }
@@ -20,7 +20,7 @@ async fn count_to(count: i32) {
 async fn main() {
     tokio::spawn(count_to(10));
 
-    for i in 1..5 {
+    for i in 0..5 {
         println!("Main task: {i}");
         time::sleep(time::Duration::from_millis(5)).await;
     }

--- a/src/concurrency/channels/bounded.md
+++ b/src/concurrency/channels/bounded.md
@@ -16,7 +16,7 @@ fn main() {
 
     thread::spawn(move || {
         let thread_id = thread::current().id();
-        for i in 1..10 {
+        for i in 0..10 {
             tx.send(format!("Message {i}")).unwrap();
             println!("{thread_id:?}: sent Message {i}");
         }

--- a/src/concurrency/channels/unbounded.md
+++ b/src/concurrency/channels/unbounded.md
@@ -16,7 +16,7 @@ fn main() {
 
     thread::spawn(move || {
         let thread_id = thread::current().id();
-        for i in 1..10 {
+        for i in 0..10 {
             tx.send(format!("Message {i}")).unwrap();
             println!("{thread_id:?}: sent Message {i}");
         }

--- a/src/concurrency/shared-state/arc.md
+++ b/src/concurrency/shared-state/arc.md
@@ -13,7 +13,7 @@ use std::thread;
 fn main() {
     let v = Arc::new(vec![10, 20, 30]);
     let mut handles = Vec::new();
-    for _ in 1..5 {
+    for _ in 0..5 {
         let v = Arc::clone(&v);
         handles.push(thread::spawn(move || {
             let thread_id = thread::current().id();

--- a/src/concurrency/threads/plain.md
+++ b/src/concurrency/threads/plain.md
@@ -12,13 +12,13 @@ use std::time::Duration;
 
 fn main() {
     thread::spawn(|| {
-        for i in 1..10 {
+        for i in 0..10 {
             println!("Count in thread: {i}!");
             thread::sleep(Duration::from_millis(5));
         }
     });
 
-    for i in 1..5 {
+    for i in 0..5 {
         println!("Main thread: {i}");
         thread::sleep(Duration::from_millis(5));
     }


### PR DESCRIPTION
Fixes #2060. Note that this does not change the "blocking executor" example because on that slide it is worthwhile to sleep for 1 * 10ms on the first iteration and so on. But we shouldn't use one-indexed inclusive loops when the only significant feature of the loop is its iteration count.