### PR TITLE
Update if.md

### DIFF
--- a/src/control-flow-basics/if.md
+++ b/src/control-flow-basics/if.md
@@ -38,7 +38,7 @@ Because `if` is an expression and must have a particular type, both of its
 branch blocks must have the same type. Show what happens if you add `;` after
 `"small"` in the second example.
 
-`if` expression should be used in the same way as the other expressions. For
+An `if` expression should be used in the same way as the other expressions. For
 example, when it is used in a `let` statement, the statement must be terminated
 with a `;` as well. Remove the `;` before `println!` to see the compiler error.
 

--- a/src/control-flow-basics/if.md
+++ b/src/control-flow-basics/if.md
@@ -38,8 +38,8 @@ Because `if` is an expression and must have a particular type, both of its
 branch blocks must have the same type. Show what happens if you add `;` after
 `"small"` in the second example.
 
-When `if` is used in an expression, the expression must have a `;` to separate
-it from the next statement. Remove the `;` before `println!` to see the compiler
-error.
+`if` expression should be used in the same way as the other expressions. For
+example, when it is used in a `let` statement, the statement must be terminated
+with a `;` as well. Remove the `;` before `println!` to see the compiler error.
 
 </details>


### PR DESCRIPTION
The original phrasing may imply that you have to always terminated a `if` expression with `;`. But the real reason that we have to do that is because we are using it in a `let` statement here, and `let` statement has to be terminated by `;`