### PR TITLE
Misc. Android Improvements

### DIFF
--- a/src/android/aidl/birthday_service/src/client.rs
+++ b/src/android/aidl/birthday_service/src/client.rs
@@ -43,9 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("{msg}");
     // ANCHOR_END: main
 
-    // ANCHOR: wish_with_info
     service.wishWithInfo(&BirthdayInfo { name: name.clone(), years })?;
-    // ANCHOR_END: wish_with_info
 
     // ANCHOR: wish_with_provider
 

--- a/src/android/aidl/example-service/interface.md
+++ b/src/android/aidl/example-service/interface.md
@@ -5,6 +5,8 @@ You declare the API of your service using an AIDL interface:
 _birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:
 
 ```java
+package com.example.birthdayservice;
+
 {{#include ../birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl:IBirthdayService}}
 }
 ```

--- a/src/android/aidl/types/parcelables.md
+++ b/src/android/aidl/types/parcelables.md
@@ -25,6 +25,7 @@ fn main() {
     binder::ProcessState::start_thread_pool();
     let service = connect().expect("Failed to connect to BirthdayService");
 
-{{#include ../birthday_service/src/client.rs:wish_with_info}}
+    let info = BirthdayInfo { name: "Alice".into(), years: 123 };
+    service.wishWithInfo(&info)?;
 }
 ```

--- a/src/android/logging.md
+++ b/src/android/logging.md
@@ -32,3 +32,10 @@ adb logcat -s rust
 09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going fine.
 09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went wrong!
 ```
+
+<details>
+
+- The logger implementation in `liblogger` is only needed in the final binary,
+  if you're logging from a library you only need the `log` facade crate.
+
+</details>


### PR DESCRIPTION
- Add missing package declaration on the AIDL interface slide.
- Make the parcelable example more self-contained. The existing code was referencing variables that weren't declared in the example code.
- Add a speaker note to the logging slide about explaining that the logger implementation is only needed in binaries, and that just the log facade is needed in libraries.






