### PR TITLE
Lower dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - djmitche
       - mgeisler
@@ -23,7 +23,7 @@ updates:
   - package-ecosystem: cargo
     directory: /src/bare-metal/alloc-example/
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - djmitche
       - mgeisler
@@ -40,7 +40,7 @@ updates:
   - package-ecosystem: cargo
     directory: /src/bare-metal/aps/examples/
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - djmitche
       - mgeisler
@@ -57,7 +57,7 @@ updates:
   - package-ecosystem: cargo
     directory: /src/bare-metal/microcontrollers/examples/
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - djmitche
       - mgeisler
@@ -74,7 +74,7 @@ updates:
   - package-ecosystem: cargo
     directory: /src/exercises/bare-metal/compass/
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - djmitche
       - mgeisler
@@ -91,7 +91,7 @@ updates:
   - package-ecosystem: cargo
     directory: /src/exercises/bare-metal/rtc/
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - djmitche
       - mgeisler
@@ -108,7 +108,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - djmitche
       - mgeisler


### PR DESCRIPTION
We are not super dependent on using the latest patch releases of every crate, so a monthly update frequency should be more than enough.

Note that we still get PRs if/when there is a [security update](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval).