### PR TITLE
Clarify and fix grammatical errors

### DIFF
--- a/src/control-flow-basics/blocks-and-scopes/scopes.md
+++ b/src/control-flow-basics/blocks-and-scopes/scopes.md
@@ -25,7 +25,7 @@ fn main() {
 
 - Show that a variable's scope is limited by adding a `b` in the inner block in
   the last example, and then trying to access it outside that block.
-- Shadowing is different from mutation, because after shadowing both variable's
+- Shadowing is different from mutation, because after shadowing both variables'
   memory locations exist at the same time. Both are available under the same
   name, depending where you use it in the code.
 - A shadowing variable can have a different type.

--- a/src/control-flow-basics/break-continue.md
+++ b/src/control-flow-basics/break-continue.md
@@ -30,7 +30,7 @@ fn main() {
 
 <details>
 
-Note that `loop` is the only looping construct which can returns a non-trivial
+Note that `loop` is the only looping construct which can return a non-trivial
 value. This is because it's guaranteed to only return at a `break` statement
 (unlike `while` and `for` loops, which can also return when the condition
 fails).

--- a/src/control-flow-basics/functions.md
+++ b/src/control-flow-basics/functions.md
@@ -29,7 +29,7 @@ fn main() {
   can be used for early return, but the "bare value" form is idiomatic at the
   end of a function (refactor `gcd` to use a `return`).
 - Some functions have no return value, and return the 'unit type', `()`. The
-  compiler will infer this if the `-> ()` return type is omitted.
+  compiler will infer this if the return type is omitted.
 - Overloading is not supported -- each function has a single implementation.
   - Always takes a fixed number of parameters. Default arguments are not
     supported. Macros can be used to support variadic functions.


### PR DESCRIPTION
Fix minor grammatical errors in Day 1: Morning.

Speaker notes 6.5: "the `-> ()` return type" changed to "the return type".

The compiler will infer the unit type for any type omitted.

