### PR TITLE
Avoid `[T]` in slices title

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -55,7 +55,7 @@
 - [References](references.md)
   - [Shared References](references/shared.md)
   - [Exclusive References](references/exclusive.md)
-  - [Slices: `&[T]`](references/slices.md)
+  - [Slices](references/slices.md)
   - [Strings](references/strings.md)
   - [Exercise: Geometry](references/exercise.md)
     - [Solution](references/solution.md)


### PR DESCRIPTION
There is a problem in how we generate the segment tables: we use the `Chapter::name` field as given to us from `mdbook`. The problem is that this string is stripped from formatting:

    Slices: `&[T]`

becomes

    Slices: &[T]

The string now looks like a reference link, but of course there is no definition of the `T` link:

    warning: Potential incomplete link
      ┌─ references.md:9:12
      │
    9 │ | Slices: &[T] | 10 minutes |
      │            ^^^ Did you forget to define a URL for `T`?
      │
      = hint: declare the link's URL. For example: `[T]: http://example.com/`

For now, I will simply take out the reference. This also makes the titles more uniform in this segment: we don’t add `&T` or `&mut T` to the other slide titles.