### PR TITLE
Use Clang rather than GCC for assembly.

### DIFF
--- a/src/bare-metal.md
+++ b/src/bare-metal.md
@@ -29,7 +29,7 @@ To get started, install some tools we'll need later. On gLinux or Debian:
 <!-- mdbook-xgettext: skip -->
 
 ```bash
-sudo apt install gcc-aarch64-linux-gnu gdb-multiarch libudev-dev picocom pkg-config qemu-system-arm
+sudo apt install gdb-multiarch libudev-dev picocom pkg-config qemu-system-arm
 rustup update
 rustup target add aarch64-unknown-none thumbv7em-none-eabihf
 rustup component add llvm-tools-preview
@@ -54,7 +54,6 @@ On MacOS:
 ```bash
 xcode-select --install
 brew install gdb picocom qemu
-brew install --cask gcc-aarch64-embedded
 rustup update
 rustup target add aarch64-unknown-none thumbv7em-none-eabihf
 rustup component add llvm-tools-preview

--- a/src/bare-metal/aps/examples/Makefile
+++ b/src/bare-metal/aps/examples/Makefile
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-UNAME := $(shell uname -s)
-ifeq ($(UNAME),Linux)
-	TARGET = aarch64-linux-gnu
-else
-	TARGET = aarch64-none-elf
-endif
-OBJCOPY = $(TARGET)-objcopy
-
 .PHONY: build qemu qemu_logger qemu_minimal qemu_psci
 
 all: minimal.bin improved.bin logger.bin
@@ -28,13 +20,13 @@ build:
 	cargo build
 
 improved.bin: build
-	$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/improved $@
+	cargo objcopy --bin improved -- -O binary $@
 logger.bin: build
-	$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/logger $@
+	cargo objcopy --bin logger -- -O binary $@
 minimal.bin: build
-	$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/minimal $@
+	cargo objcopy --bin minimal -- -O binary $@
 psci.bin: build
-	$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/psci $@
+	cargo objcopy --bin psci -- -O binary $@
 
 qemu: improved.bin
 	qemu-system-aarch64 -machine virt -cpu max -serial mon:stdio -display none -kernel $< -s

--- a/src/bare-metal/aps/examples/build.rs
+++ b/src/bare-metal/aps/examples/build.rs
@@ -16,10 +16,8 @@ use cc::Build;
 use std::env;
 
 fn main() {
-    #[cfg(target_os = "linux")]
-    env::set_var("CROSS_COMPILE", "aarch64-linux-gnu");
-    #[cfg(not(target_os = "linux"))]
     env::set_var("CROSS_COMPILE", "aarch64-none-elf");
+    env::set_var("CC", "clang");
 
     Build::new()
         .file("entry.S")

--- a/src/exercises/bare-metal/rtc/Makefile
+++ b/src/exercises/bare-metal/rtc/Makefile
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-UNAME := $(shell uname -s)
-ifeq ($(UNAME),Linux)
-	TARGET = aarch64-linux-gnu
-else
-	TARGET = aarch64-none-elf
-endif
-OBJCOPY = $(TARGET)-objcopy
-
 .PHONY: build qemu_minimal qemu qemu_logger
 
 all: rtc.bin
@@ -28,7 +20,7 @@ build:
 	cargo build
 
 rtc.bin: build
-	$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@
+	cargo objcopy -- -O binary $@
 
 qemu: rtc.bin
 	qemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio -display none -kernel $< -s

--- a/src/exercises/bare-metal/rtc/build.rs
+++ b/src/exercises/bare-metal/rtc/build.rs
@@ -16,10 +16,8 @@ use cc::Build;
 use std::env;
 
 fn main() {
-    #[cfg(target_os = "linux")]
-    env::set_var("CROSS_COMPILE", "aarch64-linux-gnu");
-    #[cfg(not(target_os = "linux"))]
     env::set_var("CROSS_COMPILE", "aarch64-none-elf");
+    env::set_var("CC", "clang");
 
     Build::new()
         .file("entry.S")


### PR DESCRIPTION
This avoids the hack for using aarch64-linux-gnu on Linux, and also removes a dependency.

Also switched to using `cargo-objcopy`, as we require `cargo-binutils` already and it makes the Makefiles simpler.