### PR TITLE
Temporarily remove po formatting

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -11,9 +11,6 @@
     }, {
       "command": "rustup run stable rustfmt --edition 2021",
       "exts": ["rs"]
-    }, {
-      "command": "msgcat -",
-      "exts": ["po"]
     }]
   },
   "excludes": [


### PR DESCRIPTION
Until #2173 is resolved, this temporarily removes the inconsistent formatting of .po files depending on msgcat versions.