### PR TITLE
Remove outdated tip about handling division by zero

### DIFF
--- a/src/pattern-matching/exercise.md
+++ b/src/pattern-matching/exercise.md
@@ -27,9 +27,6 @@ get the tests to pass one-by-one. You can also skip a test temporarily with
 fn test_value() { .. }
 ```
 
-If you finish early, try writing a test that results in division by zero or
-integer overflow. How could you handle this with `Result` instead of a panic?
-
 ```rust
 {{#include exercise.rs:Operation}}
 


### PR DESCRIPTION
The exercise text already asks you to handle this.