### PR TITLE
Make page title more specific

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -347,7 +347,7 @@
   - [`buddy_system_allocator`](bare-metal/useful-crates/buddy_system_allocator.md)
   - [`tinyvec`](bare-metal/useful-crates/tinyvec.md)
   - [`spin`](bare-metal/useful-crates/spin.md)
-- [Android](bare-metal/android.md)
+- [Bare-Metal Android](bare-metal/android.md)
   - [`vmbase`](bare-metal/android/vmbase.md)
 - [Exercises](exercises/bare-metal/afternoon.md)
   - [RTC Driver](exercises/bare-metal/rtc.md)

--- a/src/bare-metal/android.md
+++ b/src/bare-metal/android.md
@@ -1,4 +1,4 @@
-# Android
+# Bare-Metal Android
 
 To build a bare-metal Rust binary in AOSP, you need to use a `rust_ffi_static`
 Soong rule to build your Rust code, then a `cc_binary` with a linker script to


### PR DESCRIPTION
Naming the slide “Bare-Metal Android” avoids an annoying situation
when searching: before, searching for “android” would list this slide
as a top hit because it matches the search term precisely. This meant
that the whole Rust in Android section course was harder to find.

With this change, the “Welcome to Rust in Android” page becomes easier
to find.
