### PR TITLE
Apply `clippy::semicolon_if_nothing_returned`

### DIFF
--- a/mdbook-course/src/markdown.rs
+++ b/mdbook-course/src/markdown.rs
@@ -92,7 +92,7 @@ impl<const N: usize> fmt::Display for Table<N> {
         self.write_row(f, self.header.iter().map(|s| s.as_str()))?;
         self.write_row(f, self.header.iter().map(|_| "-"))?;
         for row in &self.rows {
-            self.write_row(f, row.iter().map(|s| s.as_str()))?
+            self.write_row(f, row.iter().map(|s| s.as_str()))?;
         }
         Ok(())
     }
@@ -156,42 +156,42 @@ mod test {
 
     #[test]
     fn duration_no_time() {
-        assert_eq!(duration(0), "0 minutes")
+        assert_eq!(duration(0), "0 minutes");
     }
 
     #[test]
     fn duration_single_minute() {
-        assert_eq!(duration(1), "1 minute")
+        assert_eq!(duration(1), "1 minute");
     }
 
     #[test]
     fn duration_two_minutes() {
-        assert_eq!(duration(2), "2 minutes")
+        assert_eq!(duration(2), "2 minutes");
     }
 
     #[test]
     fn duration_seven_minutes() {
-        assert_eq!(duration(7), "10 minutes")
+        assert_eq!(duration(7), "10 minutes");
     }
 
     #[test]
     fn duration_hour() {
-        assert_eq!(duration(60), "1 hour")
+        assert_eq!(duration(60), "1 hour");
     }
 
     #[test]
     fn duration_hour_mins() {
-        assert_eq!(duration(61), "1 hour and 5 minutes")
+        assert_eq!(duration(61), "1 hour and 5 minutes");
     }
 
     #[test]
     fn duration_hours() {
-        assert_eq!(duration(120), "2 hours")
+        assert_eq!(duration(120), "2 hours");
     }
 
     #[test]
     fn duration_hours_mins() {
-        assert_eq!(duration(130), "2 hours and 10 minutes")
+        assert_eq!(duration(130), "2 hours and 10 minutes");
     }
 
     #[test]

--- a/src/android/aidl/birthday_service/src/server.rs
+++ b/src/android/aidl/birthday_service/src/server.rs
@@ -29,5 +29,5 @@ fn main() {
     );
     binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder.as_binder())
         .expect("Failed to register service");
-    binder::ProcessState::join_thread_pool()
+    binder::ProcessState::join_thread_pool();
 }

--- a/src/bare-metal/aps/examples/build.rs
+++ b/src/bare-metal/aps/examples/build.rs
@@ -23,5 +23,5 @@ fn main() {
         .file("entry.S")
         .file("exceptions.S")
         .file("idmap.S")
-        .compile("empty")
+        .compile("empty");
 }


### PR DESCRIPTION
This is for consistency: if a block returns `()`, and the last
expression of the block also returns `()`, then the final `;` can be
left out.

However, this is a little confusing (I was asked about this in a class
today) and it is inconsistent.

See
https://rust-lang.github.io/rust-clippy/master/index.html#/semicolon_if_nothing_returned
for details.
