### PR TITLE
Use both `break` and `continue` for consistency

### DIFF
--- a/src/bare-metal/aps/examples/src/main_improved.rs
+++ b/src/bare-metal/aps/examples/src/main_improved.rs
@@ -45,7 +45,7 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
                     uart.write_byte(b'\n');
                 }
                 b'q' => break,
-                _ => {}
+                _ => continue,
             }
         }
     }


### PR DESCRIPTION
To me, this little change makes it a little clearer that we either
print something, we break, or we continue in the loop.
