### PR TITLE
Ensure examples compile on latest version of AOSP

### DIFF
--- a/src/android/interoperability/java/src/lib.rs
+++ b/src/android/interoperability/java/src/lib.rs
@@ -22,12 +22,12 @@ use jni::JNIEnv;
 /// HelloWorld::hello method implementation.
 #[no_mangle]
 pub extern "system" fn Java_HelloWorld_hello(
-    env: JNIEnv,
+    mut env: JNIEnv,
     _class: JClass,
     name: JString,
 ) -> jstring {
-    let input: String = env.get_string(name).unwrap().into();
+    let input: String = env.get_string(&name).unwrap().into();
     let greeting = format!("Hello, {input}!");
     let output = env.new_string(greeting).unwrap();
-    output.into_inner()
+    output.into_raw()
 }

--- a/src/android/logging/src/main.rs
+++ b/src/android/logging/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     logger::init(
         logger::Config::default()
             .with_tag_on_device("rust")
-            .with_min_level(log::Level::Trace),
+            .with_max_level(log::LevelFilter::Trace),
     );
     debug!("Starting program.");
     info!("Things are going fine.");


### PR DESCRIPTION
This is part of #2398.
