### PR TITLE
Format filenames consistently

### DIFF
--- a/src/android/aidl/types/file-descriptor.md
+++ b/src/android/aidl/types/file-descriptor.md
@@ -3,7 +3,7 @@
 Files can be sent between Binder clients/servers using the
 `ParcelFileDescriptor` type:
 
-**birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl**:
+_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:
 
 ```java
 interface IBirthdayService {
@@ -11,7 +11,7 @@ interface IBirthdayService {
 }
 ```
 
-**birthday_service/src/client.rs**:
+_birthday_service/src/client.rs_:
 
 ```rust,ignore
 fn main() {
@@ -21,7 +21,7 @@ fn main() {
 }
 ```
 
-**birthday_service/src/lib.rs**:
+_birthday_service/src/lib.rs_:
 
 ```rust,ignore
 impl IBirthdayService for BirthdayService {

--- a/src/android/aidl/types/objects.md
+++ b/src/android/aidl/types/objects.md
@@ -3,13 +3,13 @@
 AIDL objects can be sent either as a concrete AIDL type or as the type-erased
 `IBinder` interface:
 
-**birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider.aidl**:
+_birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider.aidl_:
 
 ```java
 {{#include ../birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider.aidl:IBirthdayInfoProvider}}
 ```
 
-**birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl**:
+_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:
 
 ```java
 import com.example.birthdayservice.IBirthdayInfoProvider;
@@ -19,7 +19,7 @@ interface IBirthdayService {
 }
 ```
 
-**birthday_service/src/client.rs**:
+_birthday_service/src/client.rs_:
 
 ```rust,ignore
 {{#include ../birthday_service/src/client.rs:InfoProvider}}

--- a/src/android/aidl/types/parcelables.md
+++ b/src/android/aidl/types/parcelables.md
@@ -2,13 +2,13 @@
 
 Binder for Rust supports sending parcelables directly:
 
-**birthday_service/aidl/com/example/birthdayservice/BirthdayInfo.aidl**:
+_birthday_service/aidl/com/example/birthdayservice/BirthdayInfo.aidl_:
 
 ```java
 {{#include ../birthday_service/aidl/com/example/birthdayservice/BirthdayInfo.aidl}}
 ```
 
-**birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl**:
+_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:
 
 ```java
 import com.example.birthdayservice.BirthdayInfo;
@@ -18,7 +18,7 @@ interface IBirthdayService {
 }
 ```
 
-**birthday_service/src/client.rs**:
+_birthday_service/src/client.rs_:
 
 ```rust,ignore
 fn main() {


### PR DESCRIPTION
The style used in the rest of the course is _italic_ filenames, so we
should be careful to not suddenly use **bold** names.

The style is of course up for debate, but we need to ensure
consistency first.
