### PR TITLE
Call out that `self` receivers are covered later

### DIFF
--- a/src/methods-and-traits/methods.md
+++ b/src/methods-and-traits/methods.md
@@ -33,7 +33,7 @@ impl Race {
         }
     }
 
-    // Exclusive ownership of self
+    // Exclusive ownership of self (covered later)
     fn finish(self) {
         let total: i32 = self.laps.iter().sum();
         println!("Race {} is finished, total lap time: {}", self.name, total);


### PR DESCRIPTION
We have not formally introduced ownership at this point, so the
exercise can be confusing for students.

Alternatively, we could consider removing the `finish` method since
it’s not essential for a first encounter with methods.
