### PR TITLE
Fix inclusion of `PhoneNumber` in exercise

### DIFF
--- a/src/lifetimes/exercise.rs
+++ b/src/lifetimes/exercise.rs
@@ -154,7 +154,7 @@ fn parse_message<'a, T: ProtoMessage<'a>>(mut data: &'a [u8]) -> T {
 // ANCHOR_END: parse_message
 
 #[derive(PartialEq)]
-// ANCHOR: message_message_phone_number_type
+// ANCHOR: message_phone_number_type
 #[derive(Debug, Default)]
 struct PhoneNumber<'a> {
     number: &'a str,


### PR DESCRIPTION
The anchor used the wrong name. This was not caught by our tests
because the code isn’t expected to compile, even when this is
included.
