### PR TITLE
Avoid uppercase “HINT”

### DIFF
--- a/src/error-handling/exercise.md
+++ b/src/error-handling/exercise.md
@@ -9,9 +9,9 @@ However, it handles errors by panicking. Rewrite it to instead use idiomatic
 error handling and propagate errors to a return from `main`. Feel free to use
 `thiserror` and `anyhow`.
 
-HINT: start by fixing error handling in the `parse` function. Once that is
-working correctly, update `Tokenizer` to implement
-`Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser.
+> **Hint:** start by fixing error handling in the `parse` function. Once that is
+> working correctly, update `Tokenizer` to implement
+> `Iterator<Item=Result<Token, TokenizerError>>` and handle that in the parser.
 
 ```rust,editable
 {{#include exercise.rs:types}}


### PR DESCRIPTION
We don’t have a convention of all-capital headings. However, we can
have do a similar convention with a block quotes (see README and
TRANSLATIONS).

Reviewed-by: Martin Geisler <mgeisler@google.com>
