### PR TITLE
Remove misplaced `extern "C"`

### DIFF
--- a/src/android/interoperability/with-c/rust/libanalyze/analyze.h
+++ b/src/android/interoperability/with-c/rust/libanalyze/analyze.h
@@ -18,8 +18,6 @@
 #ifndef ANALYSE_H
 #define ANALYSE_H
 
-extern "C" {
 void analyze_numbers(int x, int y);
-}
 
 #endif


### PR DESCRIPTION
I think something changed: I now get a compilation error with these
lines (and it works fine without).
