### PR TITLE
Put “Bye!” message on its own line

### DIFF
--- a/src/bare-metal/aps/examples/src/main_improved.rs
+++ b/src/bare-metal/aps/examples/src/main_improved.rs
@@ -50,7 +50,7 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
         }
     }
 
-    writeln!(uart, "Bye!").unwrap();
+    writeln!(uart, "\n\nBye!").unwrap();
     system_off::<Hvc>().unwrap();
 }
 // ANCHOR_END: main


### PR DESCRIPTION
Before the message would be printed right next to the text echoed
back. We now make sure to print it after a blank line.
