### PR TITLE
Remove unnecessary null check in FFI exercise

### DIFF
--- a/src/unsafe-rust/exercise.rs
+++ b/src/unsafe-rust/exercise.rs
@@ -123,11 +123,9 @@ impl Drop for DirectoryIterator {
     fn drop(&mut self) {
         // Call closedir as needed.
         // ANCHOR_END: Drop
-        if !self.dir.is_null() {
-            // SAFETY: self.dir is not NULL.
-            if unsafe { ffi::closedir(self.dir) } != 0 {
-                panic!("Could not close {:?}", self.path);
-            }
+        // SAFETY: self.dir is never NULL.
+        if unsafe { ffi::closedir(self.dir) } != 0 {
+            panic!("Could not close {:?}", self.path);
         }
     }
 }


### PR DESCRIPTION
We only assign `self.dir` once and we only assign it if the pointer is
non-null. We can therefore simplify the drop implementation a little.
