### PR TITLE
Remove outdated note about showing type of future

### DIFF
--- a/src/concurrency/async/async-await.md
+++ b/src/concurrency/async/async-await.md
@@ -31,9 +31,6 @@ Key points:
 - Note that this is a simplified example to show the syntax. There is no long
   running operation or any real concurrency in it!
 
-- What is the return type of an async call?
-  - Use `let future: () = async_main(10);` in `main` to see the type.
-
 - The "async" keyword is syntactic sugar. The compiler replaces the return type
   with a future.
 


### PR DESCRIPTION
Modern Rust just says “note: calling an async function returns a
future” and hides the `Future` type.
