### PR TITLE
Make scoped thread examples consistent

### DIFF
--- a/src/concurrency/threads/scoped.md
+++ b/src/concurrency/threads/scoped.md
@@ -26,14 +26,17 @@ However, you can use a [scoped thread][1] for this:
 ```rust,editable
 use std::thread;
 
-fn main() {
+fn foo() {
     let s = String::from("Hello");
-
     thread::scope(|scope| {
         scope.spawn(|| {
             println!("Length: {}", s.len());
         });
     });
+}
+
+fn main() {
+    foo();
 }
 ```
 


### PR DESCRIPTION
This is a followup to #1020.
