### PR TITLE
Change tests for pattern-matching exercise

### DIFF
--- a/src/pattern-matching/exercise.rs
+++ b/src/pattern-matching/exercise.rs
@@ -97,7 +97,7 @@ fn test_recursion() {
         left: Box::new(Expression::Op {
             op: Operation::Sub,
             left: Box::new(Expression::Value(3)),
-            right: Box::new(Expression::Value(4)),
+            right: Box::new(Expression::Value(0)),
         }),
         right: Box::new(Expression::Value(5)),
     };
@@ -107,7 +107,7 @@ fn test_recursion() {
             left: Box::new(term1),
             right: Box::new(term2),
         }),
-        Ok(85)
+        Ok(105)
     );
 }
 

--- a/src/pattern-matching/exercise.rs
+++ b/src/pattern-matching/exercise.rs
@@ -97,7 +97,7 @@ fn test_recursion() {
         left: Box::new(Expression::Op {
             op: Operation::Sub,
             left: Box::new(Expression::Value(3)),
-            right: Box::new(Expression::Value(0)),
+            right: Box::new(Expression::Value(4)),
         }),
         right: Box::new(Expression::Value(5)),
     };
@@ -107,7 +107,7 @@ fn test_recursion() {
             left: Box::new(term1),
             right: Box::new(term2),
         }),
-        Ok(105)
+        Ok(85)
     );
 }
 

--- a/src/pattern-matching/exercise.rs
+++ b/src/pattern-matching/exercise.rs
@@ -112,6 +112,34 @@ fn test_recursion() {
 }
 
 #[test]
+fn test_zeros() {
+    assert_eq!(
+        eval(Expression::Op {
+            op: Operation::Add,
+            left: Box::new(Expression::Value(0)),
+            right: Box::new(Expression::Value(0))
+        }),
+        Ok(0)
+    );
+    assert_eq!(
+        eval(Expression::Op {
+            op: Operation::Mul,
+            left: Box::new(Expression::Value(0)),
+            right: Box::new(Expression::Value(0))
+        }),
+        Ok(0)
+    );
+    assert_eq!(
+        eval(Expression::Op {
+            op: Operation::Sub,
+            left: Box::new(Expression::Value(0)),
+            right: Box::new(Expression::Value(0))
+        }),
+        Ok(0)
+    );
+}
+
+#[test]
 fn test_error() {
     assert_eq!(
         eval(Expression::Op {


### PR DESCRIPTION
to catch wrong `right == 0` checks.

To change the number like this catches for example a wrong implementation only looking if `right_result` is zero, but not checking if we are doing a division.
````
fn eval(e: Expression) -> Result<i64, String> {
    match e {
        Expression::Op { op, left, right } => {
            let left_result = eval(*left)?;
            let right_result = eval(*right)?;
            // Correct line commented out. (Or even better match inside the match below)
            //if (right_result == 0) && (matches!(op, Operation::Div)) {
            if right_result == 0 {
                return Err(String::from("division by zero"));
            }
            Ok(match op {
                Operation::Add => left_result + right_result,
                Operation::Sub => left_result - right_result,
                Operation::Mul => left_result * right_result,
                Operation::Div => left_result / right_result
                })
        }
        Expression::Value(value) => Ok(value),
    }
}
```