### PR TITLE
Add missing docstring to birthday server implementation

### DIFF
--- a/src/android/aidl/example-service/service.md
+++ b/src/android/aidl/example-service/service.md
@@ -5,6 +5,7 @@ We can now implement the AIDL service:
 _birthday_service/src/lib.rs_:
 
 ```rust,ignore
+//! Implementation of the `IBirthdayService` AIDL interface.
 use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;
 use com_example_birthdayservice::binder;
 


### PR DESCRIPTION
Without this, compilation fails. The comment *is* in the included Rust file — but we only include a fraction of the file to keep the example short. This makes it cumbersome to both show something that works in the slides while also making it possible for the instructor to show more complex examples.

@randomPoison, we need to make our examples simpler here: the complexity here makes it hard to modify the files and I feel it's hard to show during class. I would suggest splitting this up into a very basic example (what the birthday service was) and then add 1-2 slides with more complex samples (if necessary). Last I taught the class, I had a hard time a) making every example compile and b) finding time to cover everything.

I would err on the side of makings things simple and clear.