### PR TITLE
ja: update summary translations

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -190,7 +190,7 @@ msgstr "配列のイテレート"
 #: src/SUMMARY.md src/tuples-and-arrays.md
 #: src/tuples-and-arrays/destructuring.md
 msgid "Patterns and Destructuring"
-msgstr "パターンと分配"
+msgstr "パターンとデストラクト"
 
 #: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/exercise.md
 msgid "Exercise: Nested Arrays"
@@ -272,11 +272,11 @@ msgstr ""
 
 #: src/SUMMARY.md src/pattern-matching.md
 msgid "Destructuring Structs"
-msgstr "構造体編"
+msgstr "構造体のデストラクト"
 
 #: src/SUMMARY.md src/pattern-matching.md
 msgid "Destructuring Enums"
-msgstr "列挙型の分配"
+msgstr "列挙型のデストラクト"
 
 #: src/SUMMARY.md src/pattern-matching.md
 #: src/pattern-matching/let-control-flow.md
@@ -339,7 +339,7 @@ msgstr "ジェネリックデータ型"
 
 #: src/SUMMARY.md src/generics/generic-traits.md
 msgid "Generic Traits"
-msgstr "ジェネリクトレイト"
+msgstr "ジェネリックトレイト"
 
 #: src/SUMMARY.md src/generics.md src/generics/trait-bounds.md
 msgid "Trait Bounds"
@@ -360,7 +360,7 @@ msgstr "演習: ジェネリックな `min`"
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/welcome-day-2-afternoon.md src/std-types.md
 msgid "Standard Library Types"
-msgstr "標準ライブラリ型"
+msgstr "標準ライブラリ内の型"
 
 #: src/SUMMARY.md src/std-types.md src/std-types/std.md
 msgid "Standard Library"
@@ -398,7 +398,7 @@ msgstr "演習: カウンター"
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/welcome-day-2-afternoon.md src/std-traits.md
 msgid "Standard Library Traits"
-msgstr "標準ライブラリトレイト"
+msgstr "標準ライブラリ内のトレイト"
 
 #: src/SUMMARY.md src/std-traits.md src/std-traits/comparisons.md
 #: src/concurrency/welcome-async.md
@@ -490,7 +490,7 @@ msgstr "`Rc`"
 
 #: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/trait-objects.md
 msgid "Owned Trait Objects"
-msgstr "所有トレイトオブジェクト"
+msgstr "所有されたトレイトオブジェクト"
 
 #: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/exercise.md
 msgid "Exercise: Binary Tree"
@@ -511,7 +511,7 @@ msgstr "値の借用"
 
 #: src/SUMMARY.md src/borrowing.md src/borrowing/borrowck.md
 msgid "Borrow Checking"
-msgstr "借用に関するチェック"
+msgstr "借用チェック"
 
 #: src/SUMMARY.md src/borrowing.md src/borrowing/examples.md
 msgid "Borrow Errors"
@@ -709,7 +709,7 @@ msgstr "AIDL（Androidインターフェイス定義言語）"
 
 #: src/SUMMARY.md src/android/aidl/birthday-service.md
 msgid "Birthday Service Tutorial"
-msgstr "誕生日サービスのインターフェース"
+msgstr "誕生日サービスのチュートリアル"
 
 #: src/SUMMARY.md
 msgid "Interface"
@@ -761,7 +761,7 @@ msgstr "オブジェクトの送信"
 
 #: src/SUMMARY.md src/android/aidl/types/parcelables.md
 msgid "Parcelables"
-msgstr "パーセラブル"
+msgstr "Parcelables"
 
 #: src/SUMMARY.md src/android/aidl/types/file-descriptor.md
 msgid "Sending Files"

--- a/po/ja.po
+++ b/po/ja.po
@@ -120,7 +120,6 @@ msgid "Control Flow Basics"
 msgstr "制御フローの基本"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "`if` Expressions"
 msgstr "`if` 式"
 
@@ -190,9 +189,8 @@ msgstr "配列のイテレート"
 
 #: src/SUMMARY.md src/tuples-and-arrays.md
 #: src/tuples-and-arrays/destructuring.md
-#, fuzzy
 msgid "Patterns and Destructuring"
-msgstr "列挙型編"
+msgstr "パターンと分配"
 
 #: src/SUMMARY.md src/tuples-and-arrays.md src/tuples-and-arrays/exercise.md
 msgid "Exercise: Nested Arrays"
@@ -230,9 +228,8 @@ msgstr "ユーザー定義型"
 
 #: src/SUMMARY.md src/user-defined-types.md
 #: src/user-defined-types/named-structs.md
-#, fuzzy
 msgid "Named Structs"
-msgstr "構造体（structs）"
+msgstr "名前付き構造体"
 
 #: src/SUMMARY.md src/user-defined-types.md
 #: src/user-defined-types/tuple-structs.md
@@ -245,7 +242,6 @@ msgid "Enums"
 msgstr "列挙型（enums）"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Const"
 msgstr "定数"
 
@@ -279,15 +275,13 @@ msgid "Destructuring Structs"
 msgstr "構造体編"
 
 #: src/SUMMARY.md src/pattern-matching.md
-#, fuzzy
 msgid "Destructuring Enums"
-msgstr "列挙型編"
+msgstr "列挙型の分配"
 
 #: src/SUMMARY.md src/pattern-matching.md
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "Let Control Flow"
-msgstr "制御フロー"
+msgstr "Let制御フロー"
 
 #: src/SUMMARY.md src/pattern-matching.md src/pattern-matching/exercise.md
 msgid "Exercise: Expression Evaluation"
@@ -307,24 +301,20 @@ msgid "Traits"
 msgstr "トレイト（trait）"
 
 #: src/SUMMARY.md src/methods-and-traits/traits/implementing.md
-#, fuzzy
 msgid "Implementing Traits"
-msgstr "Unsafeなトレイトの実装"
+msgstr "トレイトの実装"
 
 #: src/SUMMARY.md src/methods-and-traits/traits/supertraits.md
-#, fuzzy
 msgid "Supertraits"
-msgstr "他のトレイト"
+msgstr "スーパートレイト"
 
 #: src/SUMMARY.md src/methods-and-traits/traits/associated-types.md
-#, fuzzy
 msgid "Associated Types"
-msgstr "共有の型"
+msgstr "関連型"
 
 #: src/SUMMARY.md src/methods-and-traits.md src/methods-and-traits/deriving.md
-#, fuzzy
 msgid "Deriving"
-msgstr "トレイトの導出"
+msgstr "導出"
 
 #: src/SUMMARY.md src/methods-and-traits.md
 msgid "Exercise: Generic Logger"
@@ -340,18 +330,16 @@ msgid "Generics"
 msgstr "ジェネリクス（generics）"
 
 #: src/SUMMARY.md src/generics.md src/generics/generic-functions.md
-#, fuzzy
 msgid "Generic Functions"
-msgstr "Extern関数"
+msgstr "ジェネリック関数"
 
 #: src/SUMMARY.md src/generics.md src/generics/generic-data.md
 msgid "Generic Data Types"
 msgstr "ジェネリックデータ型"
 
 #: src/SUMMARY.md src/generics/generic-traits.md
-#, fuzzy
 msgid "Generic Traits"
-msgstr "ジェネリクス（generics）"
+msgstr "ジェネリクトレイト"
 
 #: src/SUMMARY.md src/generics.md src/generics/trait-bounds.md
 msgid "Trait Bounds"
@@ -362,9 +350,8 @@ msgid "`impl Trait`"
 msgstr "`impl Trait`"
 
 #: src/SUMMARY.md src/generics/dyn-trait.md
-#, fuzzy
 msgid "`dyn Trait`"
-msgstr "`impl Trait`"
+msgstr "`dyn Trait`"
 
 #: src/SUMMARY.md src/generics/exercise.md
 msgid "Exercise: Generic `min`"
@@ -372,9 +359,8 @@ msgstr "演習: ジェネリックな `min`"
 
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/welcome-day-2-afternoon.md src/std-types.md
-#, fuzzy
 msgid "Standard Library Types"
-msgstr "標準ライブラリ"
+msgstr "標準ライブラリ型"
 
 #: src/SUMMARY.md src/std-types.md src/std-types/std.md
 msgid "Standard Library"
@@ -411,9 +397,8 @@ msgstr "演習: カウンター"
 
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/welcome-day-2-afternoon.md src/std-traits.md
-#, fuzzy
 msgid "Standard Library Traits"
-msgstr "標準ライブラリ"
+msgstr "標準ライブラリトレイト"
 
 #: src/SUMMARY.md src/std-traits.md src/std-traits/comparisons.md
 #: src/concurrency/welcome-async.md
@@ -421,18 +406,16 @@ msgid "Comparisons"
 msgstr "他の言語との比較"
 
 #: src/SUMMARY.md src/std-traits.md src/std-traits/operators.md
-#, fuzzy
 msgid "Operators"
-msgstr "イテレータ"
+msgstr "演算子"
 
 #: src/SUMMARY.md src/std-traits/from-and-into.md
 msgid "`From` and `Into`"
 msgstr "`From` と `Into`"
 
 #: src/SUMMARY.md src/std-traits.md src/std-traits/casting.md
-#, fuzzy
 msgid "Casting"
-msgstr "テスト"
+msgstr "キャスト"
 
 #: src/SUMMARY.md src/std-traits/read-and-write.md
 msgid "`Read` and `Write`"
@@ -464,9 +447,8 @@ msgid "Review of Program Memory"
 msgstr "プログラム メモリの見直し"
 
 #: src/SUMMARY.md src/memory-management.md src/memory-management/approaches.md
-#, fuzzy
 msgid "Approaches to Memory Management"
-msgstr "Rustのメモリ管理"
+msgstr "メモリ管理のアプローチ"
 
 #: src/SUMMARY.md src/memory-management.md src/memory-management/ownership.md
 msgid "Ownership"
@@ -507,9 +489,8 @@ msgid "`Rc`"
 msgstr "`Rc`"
 
 #: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/trait-objects.md
-#, fuzzy
 msgid "Owned Trait Objects"
-msgstr "トレイトオブジェクト"
+msgstr "所有トレイトオブジェクト"
 
 #: src/SUMMARY.md src/smart-pointers.md src/smart-pointers/exercise.md
 msgid "Exercise: Binary Tree"
@@ -525,14 +506,12 @@ msgid "Borrowing"
 msgstr "借用"
 
 #: src/SUMMARY.md src/borrowing.md src/borrowing/shared.md
-#, fuzzy
 msgid "Borrowing a Value"
-msgstr "借用"
+msgstr "値の借用"
 
 #: src/SUMMARY.md src/borrowing.md src/borrowing/borrowck.md
-#, fuzzy
 msgid "Borrow Checking"
-msgstr "借用"
+msgstr "借用に関するチェック"
 
 #: src/SUMMARY.md src/borrowing.md src/borrowing/examples.md
 msgid "Borrow Errors"
@@ -548,7 +527,6 @@ msgstr "演習: 健康に関する統計"
 
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/welcome-day-3-afternoon.md src/lifetimes.md
-#, fuzzy
 msgid "Lifetimes"
 msgstr "ライフタイム"
 
@@ -557,14 +535,12 @@ msgid "Lifetime Annotations"
 msgstr "関数とライフタイム"
 
 #: src/SUMMARY.md src/lifetimes.md
-#, fuzzy
 msgid "Lifetime Elision"
-msgstr "ライフタイム"
+msgstr "ライフタイムの省略"
 
 #: src/SUMMARY.md src/lifetimes.md
-#, fuzzy
 msgid "Struct Lifetimes"
-msgstr "ライフタイム"
+msgstr "構造体のライフタイム"
 
 #: src/SUMMARY.md src/lifetimes.md src/lifetimes/exercise.md
 msgid "Exercise: Protobuf Parsing"
@@ -597,9 +573,8 @@ msgstr "演習: イテレータのメソッドチェーン"
 
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/welcome-day-4.md src/modules.md src/modules/modules.md
-#, fuzzy
 msgid "Modules"
-msgstr "モジュール タイプ"
+msgstr "モジュール"
 
 #: src/SUMMARY.md src/modules.md src/modules/filesystem.md
 msgid "Filesystem Hierarchy"
@@ -614,9 +589,8 @@ msgid "`use`, `super`, `self`"
 msgstr "`use`、`super`、`self`"
 
 #: src/SUMMARY.md src/modules.md src/modules/exercise.md
-#, fuzzy
 msgid "Exercise: Modules for a GUI Library"
-msgstr "[演習: GUI ライブラリのモジュール](./modules/exercise.md)（15 分）"
+msgstr "演習: GUI ライブラリのモジュール"
 
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/welcome-day-4.md src/testing.md src/chromium/testing.md
@@ -628,18 +602,16 @@ msgid "Test Modules"
 msgstr "テストモジュール"
 
 #: src/SUMMARY.md src/testing.md src/testing/other.md
-#, fuzzy
 msgid "Other Types of Tests"
-msgstr "他のプロジェクト"
+msgstr "他のタイプのテスト"
 
 #: src/SUMMARY.md src/testing.md src/testing/lints.md
 msgid "Compiler Lints and Clippy"
 msgstr "コンパイラの Lints と Clippy"
 
 #: src/SUMMARY.md src/testing.md src/testing/exercise.md
-#, fuzzy
 msgid "Exercise: Luhn Algorithm"
-msgstr "Luhnアルゴリズム"
+msgstr "演習: Luhnアルゴリズム"
 
 #: src/SUMMARY.md
 msgid "Day 4: Afternoon"
@@ -655,14 +627,12 @@ msgid "Panics"
 msgstr "パニック（panic）"
 
 #: src/SUMMARY.md src/error-handling.md src/error-handling/try.md
-#, fuzzy
 msgid "Try Operator"
-msgstr "Iterator"
+msgstr "Try演算子"
 
 #: src/SUMMARY.md src/error-handling.md src/error-handling/try-conversions.md
-#, fuzzy
 msgid "Try Conversions"
-msgstr "暗黙的な型変換"
+msgstr "Try変換"
 
 #: src/SUMMARY.md
 msgid "`Error` Trait"
@@ -686,9 +656,8 @@ msgid "Unsafe Rust"
 msgstr "Unsafe Rust"
 
 #: src/SUMMARY.md src/unsafe-rust.md
-#, fuzzy
 msgid "Unsafe"
-msgstr "Unsafe Rust"
+msgstr "アンセーフ"
 
 #: src/SUMMARY.md src/unsafe-rust.md src/unsafe-rust/dereferencing.md
 msgid "Dereferencing Raw Pointers"
@@ -739,9 +708,8 @@ msgid "AIDL"
 msgstr "AIDL（Androidインターフェイス定義言語）"
 
 #: src/SUMMARY.md src/android/aidl/birthday-service.md
-#, fuzzy
 msgid "Birthday Service Tutorial"
-msgstr "/** 誕生日サービスのインターフェース。*/"
+msgstr "誕生日サービスのインターフェース"
 
 #: src/SUMMARY.md
 msgid "Interface"
@@ -752,9 +720,8 @@ msgid "Service API"
 msgstr ""
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Service"
-msgstr "サーバ"
+msgstr "サービス"
 
 #: src/SUMMARY.md
 msgid "Server"
@@ -773,33 +740,28 @@ msgid "Changing API"
 msgstr "APIの変更"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Updating Implementations"
-msgstr "実装"
+msgstr "実装の更新"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "AIDL Types"
-msgstr "型"
+msgstr "AIDL型"
 
 #: src/SUMMARY.md src/android/aidl/types/primitives.md
 msgid "Primitive Types"
 msgstr ""
 
 #: src/SUMMARY.md src/android/aidl/types/arrays.md
-#, fuzzy
 msgid "Array Types"
-msgstr "配列"
+msgstr "配列型"
 
 #: src/SUMMARY.md src/android/aidl/types/objects.md
-#, fuzzy
 msgid "Sending Objects"
-msgstr "トレイトオブジェクト"
+msgstr "オブジェクトの送信"
 
 #: src/SUMMARY.md src/android/aidl/types/parcelables.md
-#, fuzzy
 msgid "Parcelables"
-msgstr "変数"
+msgstr "パーセラブル"
 
 #: src/SUMMARY.md src/android/aidl/types/file-descriptor.md
 msgid "Sending Files"
@@ -838,9 +800,8 @@ msgid "With C++"
 msgstr "C++"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/bridge.md
-#, fuzzy
 msgid "The Bridge Module"
-msgstr "テストモジュール"
+msgstr "ブリッジモジュール"
 
 #: src/SUMMARY.md
 msgid "Rust Bridge"
@@ -863,14 +824,12 @@ msgid "Shared Enums"
 msgstr "共有の列挙型"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/rust-result.md
-#, fuzzy
 msgid "Rust Error Handling"
-msgstr "エラー処理"
+msgstr "Rustのエラー処理"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/cpp-exception.md
-#, fuzzy
 msgid "C++ Error Handling"
-msgstr "エラー処理"
+msgstr "C++のエラー処理"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/type-mapping.md
 msgid "Additional Types"
@@ -905,9 +864,8 @@ msgid "Policy"
 msgstr "ポリシー"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Unsafe Code"
-msgstr "Unsafe Rust"
+msgstr "アンセーフなコード"
 
 #: src/SUMMARY.md src/chromium/build-rules/depending.md
 msgid "Depending on Rust Code from Chromium C++"
@@ -934,33 +892,28 @@ msgid "`chromium::import!` Macro"
 msgstr "`chromium::import!` マクロ"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp.md
-#, fuzzy
 msgid "Interoperability with C++"
-msgstr "C との相互運用性"
+msgstr "C++との相互運用性"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/example-bindings.md
-#, fuzzy
 msgid "Example Bindings"
-msgstr "例"
+msgstr "バインディングの例"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/limitations-of-cxx.md
 msgid "Limitations of CXX"
 msgstr "CXXの限界"
 
 #: src/SUMMARY.md src/chromium/interoperability-with-cpp/error-handling.md
-#, fuzzy
 msgid "CXX Error Handling"
-msgstr "エラー処理"
+msgstr "CXXにおけるエラー処理"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Error Handling: QR Example"
-msgstr "エラー処理"
+msgstr "エラー処理: QRの例"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Error Handling: PNG Example"
-msgstr "エラー処理"
+msgstr "エラー処理: PNGの例"
 
 #: src/SUMMARY.md
 msgid "Using CXX in Chromium"
@@ -1024,14 +977,12 @@ msgid "Bringing It Together - Exercise"
 msgstr "まとめ - 演習"
 
 #: src/SUMMARY.md src/exercises/chromium/solutions.md
-#, fuzzy
 msgid "Exercise Solutions"
-msgstr "演習: 式の評価"
+msgstr "演習の解答"
 
 #: src/SUMMARY.md
-#, fuzzy
 msgid "Bare Metal: Morning"
-msgstr "ベアメタル Rust：午前の講座"
+msgstr "ベアメタル：午前"
 
 #: src/SUMMARY.md src/bare-metal/no_std.md
 msgid "`no_std`"
@@ -1074,9 +1025,8 @@ msgid "`embedded-hal`"
 msgstr "`embedded-hal`"
 
 #: src/SUMMARY.md src/bare-metal/microcontrollers/probe-rs.md
-#, fuzzy
 msgid "`probe-rs` and `cargo-embed`"
-msgstr "probe-rs, cargo-embed"
+msgstr "`probe-rs`と`cargo-embed`"
 
 #: src/SUMMARY.md src/bare-metal/microcontrollers/debugging.md
 msgid "Debugging"
@@ -1182,9 +1132,8 @@ msgid "`spin`"
 msgstr "`spin`"
 
 #: src/SUMMARY.md src/bare-metal/android.md
-#, fuzzy
 msgid "Bare-Metal on Android"
-msgstr "ベアメタル Rust：午前の講座"
+msgstr "Android上のベアメタル"
 
 #: src/SUMMARY.md
 msgid "`vmbase`"
@@ -1204,9 +1153,8 @@ msgid "Threads"
 msgstr "スレッド"
 
 #: src/SUMMARY.md src/concurrency/threads.md src/concurrency/threads/plain.md
-#, fuzzy
 msgid "Plain Threads"
-msgstr "スレッド"
+msgstr "プレーンなスレッド"
 
 #: src/SUMMARY.md src/concurrency/threads.md src/concurrency/threads/scoped.md
 msgid "Scoped Threads"
@@ -1219,9 +1167,8 @@ msgstr "チャネル"
 
 #: src/SUMMARY.md src/concurrency/channels.md
 #: src/concurrency/channels/senders-receivers.md
-#, fuzzy
 msgid "Senders and Receivers"
-msgstr "メソッドレシーバ"
+msgstr "送信側(Senders)と受信側(Receivers)"
 
 #: src/SUMMARY.md src/concurrency/channels.md
 #: src/concurrency/channels/unbounded.md
@@ -1239,9 +1186,8 @@ msgstr "`Send`と`Sync`"
 
 #: src/SUMMARY.md src/concurrency/send-sync.md
 #: src/concurrency/send-sync/marker-traits.md
-#, fuzzy
 msgid "Marker Traits"
-msgstr "他のトレイト"
+msgstr "マーカートレイト"
 
 #: src/SUMMARY.md src/concurrency/send-sync/send.md
 msgid "`Send`"
@@ -1320,9 +1266,8 @@ msgstr "タスク"
 
 #: src/SUMMARY.md src/running-the-course/course-structure.md
 #: src/concurrency/welcome-async.md src/concurrency/async-control-flow.md
-#, fuzzy
 msgid "Channels and Control Flow"
-msgstr "制御フロー"
+msgstr "チャネルと制御フロー"
 
 #: src/SUMMARY.md src/concurrency/async-control-flow.md
 #: src/concurrency/async-control-flow/channels.md
@@ -1359,9 +1304,8 @@ msgstr "Asyncトレイト"
 
 #: src/SUMMARY.md src/concurrency/async-pitfalls.md
 #: src/concurrency/async-pitfalls/cancellation.md
-#, fuzzy
 msgid "Cancellation"
-msgstr "インストール"
+msgstr "キャンセル"
 
 #: src/SUMMARY.md src/concurrency/async-exercises.md
 #: src/concurrency/async-exercises/chat-app.md


### PR DESCRIPTION
Update translations from SUMMARY.md.

Unfortunately, poedit changes the wrapping length of the po files and I could not get it back by changing the poedit setting for line length. I believe we won't get any more of these noisy diffs for my further changes this week.

`Cancellation` is the last item I modified in this PR.