### PR TITLE
Delete empty and unused slide

### DIFF
--- a/src/android/interoperability/with-c/calling-rust.md
+++ b/src/android/interoperability/with-c/calling-rust.md
@@ -1,1 +1,0 @@
-# Calling Rust from C


### PR DESCRIPTION
The page is not mentioned in the `SUMMARY.md` file and has apparently been forgotten.

We could consider adding a check for this situation, but since I don't think it occurs very often, I don't consider it high priority.