### PR TITLE
uk: avoid translating fixed strings in protobufs

### DIFF
--- a/po/uk.po
+++ b/po/uk.po
@@ -9950,11 +9950,11 @@ msgstr "\"\""
 
 #: src/lifetimes/solution.md
 msgid "\"beautiful name\""
-msgstr "\"красиве ім'я\""
+msgstr "\"beautiful name\""
 
 #: src/lifetimes/solution.md
 msgid "\"Evan\""
-msgstr "\"Еван\""
+msgstr "\"Evan\""
 
 #: src/lifetimes/solution.md
 msgid "\"+1234-777-9090\""
@@ -9962,7 +9962,7 @@ msgstr ""
 
 #: src/lifetimes/solution.md
 msgid "\"home\""
-msgstr "\"дім\""
+msgstr "\"home\""
 
 #: src/welcome-day-4.md
 msgid "Welcome to Day 4"


### PR DESCRIPTION
The protobuf exercise asks people to decode a few fixed byte slices:

  https://google.github.io/comprehensive-rust/uk/lifetimes/exercise.html

Some of the messages in the slices are fixed English strings, such as “home”. They should thus not be translated into other languages.

This should fix the CI. I guess it wasn’t caught before merging because of a parallel update.