### PR TITLE
Remove the phrase "third-party"

### DIFF
--- a/src/bare-metal/alloc.md
+++ b/src/bare-metal/alloc.md
@@ -9,9 +9,9 @@ To use `alloc` you must implement a
 
 <details>
 
-- `buddy_system_allocator` is a third-party crate implementing a basic buddy
-  system allocator. Other crates are available, or you can write your own or
-  hook into your existing allocator.
+- `buddy_system_allocator` is a crate implementing a basic buddy system
+  allocator. Other crates are available, or you can write your own or hook into
+  your existing allocator.
 - The const parameter of `LockedHeap` is the max order of the allocator; i.e. in
   this case it can allocate regions of up to 2**32 bytes.
 - If any crate in your dependency tree depends on `alloc` then you must have

--- a/src/bare-metal/useful-crates/buddy_system_allocator.md
+++ b/src/bare-metal/useful-crates/buddy_system_allocator.md
@@ -1,7 +1,7 @@
 # `buddy_system_allocator`
 
-[`buddy_system_allocator`][1] is a third-party crate implementing a basic buddy
-system allocator. It can be used both for [`LockedHeap`][2] implementing
+[`buddy_system_allocator`][1] is a crate implementing a basic buddy system
+allocator. It can be used both for [`LockedHeap`][2] implementing
 [`GlobalAlloc`][3] so you can use the standard `alloc` crate (as we saw
 [before][4]), or for allocating other address space. For example, we might want
 to allocate MMIO space for PCI BARs:

--- a/src/memory-management/approaches.md
+++ b/src/memory-management/approaches.md
@@ -46,7 +46,7 @@ Rust's ownership and borrowing model can, in many cases, get the performance of
 C, with alloc and free operations precisely where they are required -- zero
 cost. It also provides tools similar to C++'s smart pointers. When required,
 other options such as reference counting are available, and there are even
-third-party crates available to support runtime garbage collection (not covered
-in this class).
+crates available to support runtime garbage collection (not covered in this
+class).
 
 </details>


### PR DESCRIPTION
"Third-party" is a Googleism that doesn't make much sense otherwise. Most references to crates just say "crate", implying that they are open-source packages available on https://crates.io, so this updates a few additional locations to do the same.