### PR TITLE
Better demonstrate imports in modules exercise

### DIFF
--- a/src/modules/solution.md
+++ b/src/modules/solution.md
@@ -181,8 +181,7 @@ use widgets::{Button, Label, Widget, Window};
 
 fn main() {
     let mut window = Window::new("Rust GUI Demo 1.23");
-    window
-        .add_widget(Box::new(Label::new("This is a small text GUI demo.")));
+    window.add_widget(Box::new(Label::new("This is a small text GUI demo.")));
     window.add_widget(Box::new(Button::new("Click me!")));
     window.draw();
 }

--- a/src/modules/solution.md
+++ b/src/modules/solution.md
@@ -177,13 +177,13 @@ impl Widget for Window {
 // ---- src/main.rs ----
 mod widgets;
 
-use widgets::Widget;
+use widgets::{Button, Label, Widget, Window};
 
 fn main() {
-    let mut window = widgets::Window::new("Rust GUI Demo 1.23");
+    let mut window = Window::new("Rust GUI Demo 1.23");
     window
-        .add_widget(Box::new(widgets::Label::new("This is a small text GUI demo.")));
-    window.add_widget(Box::new(widgets::Button::new("Click me!")));
+        .add_widget(Box::new(Label::new("This is a small text GUI demo.")));
+    window.add_widget(Box::new(Button::new("Click me!")));
     window.draw();
 }
 ```


### PR DESCRIPTION
The solution to the modules exercise changes how `Button`, `Window`, and `Label` are referenced, adding a `widgets::` prefix to them. This seems weird to me because the more idiomatic thing to do would be to import those types at the top of the file. Unless I'm missing a reason why the solutions is written the way it is, I think this is a good simplification.