### PR TITLE
Use `.iter()` instead of `(&values).into_iter()`

### DIFF
--- a/src/iterators/exercise.rs
+++ b/src/iterators/exercise.rs
@@ -22,8 +22,8 @@
 /// Element `n` of the result is `values[(n+offset)%len] - values[n]`.
 fn offset_differences(offset: usize, values: Vec<i32>) -> Vec<i32> {
     // ANCHOR_END: offset_differences
-    let a = (&values).into_iter();
-    let b = (&values).into_iter().cycle().skip(offset);
+    let a = values.iter();
+    let b = values.iter().cycle().skip(offset);
     a.zip(b).map(|(a, b)| *b - *a).collect()
 }
 


### PR DESCRIPTION
The `(&values).into_iter()` construct used in the solution to the iterators exercise is kind of awkward and always gets questions from students. I think the better thing would be to use the `iter` method to get the initial iterator, as that's the more idiomatic way to. It's also an opportunity to point out that there are helper methods for getting an iterator for a collection.