### PR TITLE
Fix the unit testing docs referring to integration tests

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -183,7 +183,7 @@
   - [Exercise: Modules for a GUI Library](modules/exercise.md)
     - [Solution](modules/solution.md)
 - [Testing](testing.md)
-  - [Test Modules](testing/unit-tests.md)
+  - [Unit Tests](testing/unit-tests.md)
   - [Other Types of Tests](testing/other.md)
   - [Compiler Lints and Clippy](testing/lints.md)
   - [Exercise: Luhn Algorithm](testing/exercise.md)

--- a/src/testing/unit-tests.md
+++ b/src/testing/unit-tests.md
@@ -4,15 +4,9 @@ minutes: 5
 
 # Unit Tests
 
-Rust and Cargo come with a simple unit test framework:
-
-- Unit tests are supported throughout your code.
-
-- Integration tests are supported via the `tests/` directory.
-
-Tests are marked with `#[test]`. Unit tests are often put in a nested `tests`
-module, using `#[cfg(test)]` to conditionally compile them only when building
-tests.
+Rust and Cargo come with a simple unit test framework. Tests are marked with
+`#[test]`. Unit tests are often put in a nested `tests` module, using
+`#[cfg(test)]` to conditionally compile them only when building tests.
 
 ```rust,editable,ignore
 fn first_word(text: &str) -> &str {


### PR DESCRIPTION
The side bar is out of date, and also the the unit testing docs are talking about integration tests. These tests are discussed on the next slide in "Other Types of Tests".