### PR TITLE
Upgrade `mdbook-pandoc` to fix missing images in PDFs

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -17,11 +17,11 @@ runs:
 
     - name: Install mdbook-pandoc and related dependencies
       run: |
-        cargo install mdbook-pandoc --locked --version 0.7.0
+        cargo install mdbook-pandoc --locked --version 0.8.0
         sudo apt-get update
         sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
-        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.2.1/pandoc-3.2.1-linux-amd64.tar.gz | tar zxf -
-        echo "$PWD/pandoc-3.2.1/bin" >> $GITHUB_PATH
+        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.6.1/pandoc-3.6.1-linux-amd64.tar.gz | tar zxf -
+        echo "$PWD/pandoc-3.6.1/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: Install mdbook-i18n-helpers


### PR DESCRIPTION
`mdbook-pandoc` 0.8 now supports `<img>` elements in raw HTML, fixing a few missing images in the PDF versions of the course.