### PR TITLE
Use clamp in bare-metal compass solution

### DIFF
--- a/src/exercises/bare-metal/compass/src/main.rs
+++ b/src/exercises/bare-metal/compass/src/main.rs
@@ -22,7 +22,6 @@ extern crate panic_halt as _;
 use core::fmt::Write;
 use cortex_m_rt::entry;
 // ANCHOR_END: top
-use core::cmp::{max, min};
 use embedded_hal::digital::InputPin;
 use lsm303agr::{
     AccelMode, AccelOutputDataRate, Lsm303agr, MagMode, MagOutputDataRate,
@@ -163,9 +162,6 @@ impl Mode {
 fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -> i32 {
     let range_in = max_in - min_in;
     let range_out = max_out - min_out;
-    cap(min_out + range_out * (value - min_in) / range_in, min_out, max_out)
-}
-
-fn cap(value: i32, min_value: i32, max_value: i32) -> i32 {
-    max(min_value, min(value, max_value))
+    let scaled = min_out + range_out * (value - min_in) / range_in;
+    scaled.clamp(min_out, max_out)
 }


### PR DESCRIPTION
The custom function `cap` does the same as `Ord::clamp`, which was introduced in Rust 1.50. Let's use the latter instead.

I've flashed the new program onto my microbit and can confirm it still works as intended.