### PR TITLE
cxx: fix build with CARGO_TARGET_DIR set

### DIFF
--- a/third_party/cxx/blobstore/build.rs
+++ b/third_party/cxx/blobstore/build.rs
@@ -1,9 +1,13 @@
 fn main() {
+    // Find target directory, either from CARGO_TARGET_DIR or in-tree if unset.
+    let mut src_dir = std::env::var_os("CARGO_TARGET_DIR").unwrap_or("../../../target".into());
+    src_dir.push("/cxxbridge/demo/src");
+
     cxx_build::bridge("src/main.rs")
         .file("src/blobstore.cc")
         .flag_if_supported("-std=c++14")
         .include(".")
-        .include("../../../target/cxxbridge/demo/src")
+        .include(src_dir)
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");


### PR DESCRIPTION
Fixes #2335. This `build.rs` file is already ours rather than matching the [upstream one](https://github.com/dtolnay/cxx/blob/master/demo/build.rs), so I think further changes are fine--stop me if not!