### PR TITLE
Revert "Exercise: method and traits: change output"

### DIFF
--- a/src/methods-and-traits/exercise.md
+++ b/src/methods-and-traits/exercise.md
@@ -9,7 +9,7 @@ method. Code which might log its progress can then take an `&impl Logger`. In
 testing, this might put messages in the test logfile, while in a production
 build it would send messages to a log server.
 
-However, the `StdoutLogger` given below logs all messages, regardless of
+However, the `StderrLogger` given below logs all messages, regardless of
 verbosity. Your task is to write a `VerbosityFilter` type that will ignore
 messages above a maximum verbosity.
 

--- a/src/methods-and-traits/exercise.rs
+++ b/src/methods-and-traits/exercise.rs
@@ -19,11 +19,11 @@ pub trait Logger {
     fn log(&self, verbosity: u8, message: &str);
 }
 
-struct StdoutLogger;
+struct StderrLogger;
 
-impl Logger for StdoutLogger {
+impl Logger for StderrLogger {
     fn log(&self, verbosity: u8, message: &str) {
-        println!("verbosity={verbosity}: {message}");
+        eprintln!("verbosity={verbosity}: {message}");
     }
 }
 // ANCHOR_END: setup
@@ -31,7 +31,7 @@ impl Logger for StdoutLogger {
 /// Only log messages up to the given verbosity level.
 struct VerbosityFilter {
     max_verbosity: u8,
-    inner: StdoutLogger,
+    inner: StderrLogger,
 }
 
 impl Logger for VerbosityFilter {
@@ -44,7 +44,7 @@ impl Logger for VerbosityFilter {
 
 // ANCHOR: main
 fn main() {
-    let logger = VerbosityFilter { max_verbosity: 3, inner: StdoutLogger };
+    let logger = VerbosityFilter { max_verbosity: 3, inner: StderrLogger };
     logger.log(5, "FYI");
     logger.log(2, "Uhoh");
 }


### PR DESCRIPTION
Reverts google/comprehensive-rust#2383

Since #2397 is merged, to align the goal in #2478, rollback this temp workaround.