### PR TITLE
Type Aliases before const and static

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -65,9 +65,9 @@
   - [Named Structs](user-defined-types/named-structs.md)
   - [Tuple Structs](user-defined-types/tuple-structs.md)
   - [Enums](user-defined-types/enums.md)
+  - [Type Aliases](user-defined-types/aliases.md)
   - [Const](user-defined-types/const.md)
   - [Static](user-defined-types/static.md)
-  - [Type Aliases](user-defined-types/aliases.md)
   - [Exercise: Elevator Events](user-defined-types/exercise.md)
     - [Solution](user-defined-types/solution.md)
 


### PR DESCRIPTION
Admittedly, const and static are a weird fit in this segment, but don't really fit anywhere else either. However, type aliases fit more closely with structs and enums than with const and static.