### PR TITLE
Remove speaker note on "runtime evaluated constants"

### DIFF
--- a/src/user-defined-types/const.md
+++ b/src/user-defined-types/const.md
@@ -31,8 +31,6 @@ values. `const` functions can however be called at runtime.
 <details>
 
 - Mention that `const` behaves semantically similar to C++'s `constexpr`
-- It isn't super common that one would need a runtime evaluated constant, but it
-  is helpful and safer than using a static.
 
 </details>
 


### PR DESCRIPTION
It's unclear what this would mean! It was introduced in 89ddb2c19.