### PR TITLE
Add timing for const slide

### DIFF
--- a/src/user-defined-types/const.md
+++ b/src/user-defined-types/const.md
@@ -1,3 +1,7 @@
+---
+minutes: 10
+---
+
 # `const`
 
 Constants are evaluated at compile time and their values are inlined wherever


### PR DESCRIPTION
I think this was missed when it split from the static slide. In the last course session, we spent a fair amount of time on this slide.