### PR TITLE
Make const slide less silly

### DIFF
--- a/src/user-defined-types/const.md
+++ b/src/user-defined-types/const.md
@@ -7,10 +7,18 @@ they are used:
 
 ```rust,editable
 const DIGEST_SIZE: usize = 3;
-const ZERO: Option<u8> = Some(42);
+const FILL_VALUE: u8 = calculate_fill_value();
+
+const fn calculate_fill_value() -> u8 {
+    if DIGEST_SIZE < 10 {
+        42
+    } else {
+        13
+    }
+}
 
 fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {
-    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];
+    let mut digest = [FILL_VALUE; DIGEST_SIZE];
     for (idx, &b) in text.as_bytes().iter().enumerate() {
         digest[idx % DIGEST_SIZE] = digest[idx % DIGEST_SIZE].wrapping_add(b);
     }


### PR DESCRIPTION
A constant named ZERO that does not contain zero seems pretty silly!

This also shows an example of a const fn.