### PR TITLE
Fix incorrectly hidden lines in Rust code blocks in PDFs

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - name: Install mdbook-pandoc and related dependencies
       run: |
-        cargo install mdbook-pandoc --locked --version 0.9.0
+        cargo install mdbook-pandoc --locked --version 0.9.3
         sudo apt-get update
         sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk texlive-lang-arabic librsvg2-bin fonts-noto
         curl -LsSf https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-linux-amd64.tar.gz | tar zxf -


### PR DESCRIPTION
Upgrades `mdbook-pandoc` to pull in a fix relating to hidden lines in Rust code blocks. The bug was causing lines like `#[test]` to be hidden when they should not have been.

## HTML
<img width="500" alt="Screenshot 2025-01-18 at 12 50 26 PM" src="https://github.com/user-attachments/assets/c3363696-6ab6-4537-8285-fad047cb384f" />

## PDF (before)
<img width="500" alt="Screenshot 2025-01-18 at 12 51 25 PM" src="https://github.com/user-attachments/assets/19539a9b-db24-41c5-98be-87d5a6228423" />

## PDF (after)
<img width="500" alt="Screenshot 2025-01-18 at 12 52 25 PM" src="https://github.com/user-attachments/assets/b19f1e6c-d717-449e-8799-c56d9b5401ca" />
