### PR TITLE
Allow the 'unused' category of lints

### DIFF
--- a/src/generics/trait-bounds.md
+++ b/src/generics/trait-bounds.md
@@ -14,7 +14,7 @@ fn duplicate<T: Clone>(a: T) -> (T, T) {
     (a.clone(), a.clone())
 }
 
-// struct NotCloneable;
+struct NotCloneable;
 
 fn main() {
     let foo = String::from("foo");

--- a/src/testing/lints.md
+++ b/src/testing/lints.md
@@ -8,10 +8,10 @@ The Rust compiler produces fantastic error messages, as well as helpful built-in
 lints. [Clippy](https://doc.rust-lang.org/clippy/) provides even more lints,
 organized into groups that can be enabled per-project.
 
-```rust,editable,should_panic
+```rust,editable,should_panic,warnunused
 #[deny(clippy::cast_possible_truncation)]
 fn main() {
-    let x = 3;
+    let mut x = 3;
     while (x < 70000) {
         x *= 2;
     }
@@ -21,13 +21,9 @@ fn main() {
 
 <details>
 
-Run the code sample and examine the error message. There are also lints visible
-here, but those will not be shown once the code compiles. Switch to the
-Playground site to show those lints.
-
-After resolving the lints, run `clippy` on the playground site to show clippy
-warnings. Clippy has extensive documentation of its lints, and adds new lints
-(including default-deny lints) all the time.
+There are compiler lints visible here, but not clippy lints. Run `clippy` on the
+playground site to show clippy warnings. Clippy has extensive documentation of
+its lints, and adds new lints (including default-deny lints) all the time.
 
 Note that errors or warnings with `help: ...` can be fixed with `cargo fix` or
 via your editor.

--- a/src/types-and-values/variables.md
+++ b/src/types-and-values/variables.md
@@ -7,7 +7,7 @@ minutes: 5
 Rust provides type safety via static typing. Variable bindings are made with
 `let`:
 
-```rust,editable
+```rust,editable,warnunused
 fn main() {
     let x: i32 = 10;
     println!("x: {x}");
@@ -20,6 +20,10 @@ fn main() {
 
 - Uncomment the `x = 20` to demonstrate that variables are immutable by default.
   Add the `mut` keyword to allow changes.
+
+- Warnings are enabled for this slide, such as for unused variables or
+  unnecessary `mut`. These are omitted in most slides to avoid distracting
+  warnings. Try removing the mutation but leaving the `mut` keyword in place.
 
 - The `i32` here is the type of the variable. This must be known at compile
   time, but type inference (covered later) allows the programmer to omit it in

--- a/theme/book.js
+++ b/theme/book.js
@@ -127,6 +127,11 @@ function playground_text(playground, hidden = true) {
 
         let text = playground_text(code_block);
         let classes = code_block.querySelector('code').classList;
+        // Unless the code block has `warnunused`, allow all "unused" lints to avoid cluttering
+        // the output.
+        if(!classes.contains("warnunused")) {
+            text = '#![allow(unused)]\n' + text;
+        }
         let edition = "2015";
         if(classes.contains("edition2018")) {
             edition = "2018";


### PR DESCRIPTION
These sort of warnings can be distracting when commenting out a few lines of code or demonstrating some other concept. They can be re-enabled for a code block with `warnunused`.

I filed https://github.com/rust-lang/mdBook/issues/2527 to get behavior like this upstream.