### PR TITLE
Briefly touch on match ergonomics

### DIFF
--- a/src/pattern-matching/destructuring-structs.md
+++ b/src/pattern-matching/destructuring-structs.md
@@ -14,6 +14,12 @@ Like tuples, Struct can also be destructured by matching:
 
 - Change the literal values in `foo` to match with the other patterns.
 - Add a new field to `Foo` and make changes to the pattern as needed.
+- Try `match &foo` and check the type of captures. The pattern syntax remains
+  the same, but the captures become shared references. This is
+  [match ergonomics](https://rust-lang.github.io/rfcs/2005-match-ergonomics.html)
+  and is often useful with `match self` when implementing methods on an enum.
+  - The same effect occurs with `match &mut foo`: the captures become exclusive
+    references.
 - The distinction between a capture and a constant expression can be hard to
   spot. Try changing the `2` in the second arm to a variable, and see that it
   subtly doesn't work. Change it to a `const` and see it working again.


### PR DESCRIPTION
This is done in the speaker notes as it's a relatively minor point, but one that students should have in the back of their mind when they wonder, "hey, how does a `&Foo` match against `Foo` patterns??"