### PR TITLE
Add a picture to Rc

### DIFF
--- a/src/smart-pointers/rc.md
+++ b/src/smart-pointers/rc.md
@@ -19,6 +19,22 @@ fn main() {
 }
 ```
 
+Each `Rc` points to the same shared data structure, containing strong and weak
+pointers and the value:
+
+```bob
+ Stack                     Heap
+.- - - - - - - -.     .- - - - - - - - - - - - - - - - -.
+:               :     :                                 :
+:     +-----+   :     :   +-----------+-------------+   :
+:  a: | o---|---:--+--:-->|  count: 2 |  value: 10  |   :
+:     +-----+   :  |  :   +-----------+-------------+   :
+:  b: | o---|---:--+  :                                 :
+:     +-----+   :     `- - - - - - - - - - - - - - - - -'
+:               :     
+`- - - - - - - -'
+```
+
 - See [`Arc`][2] and [`Mutex`][3] if you are in a multi-threaded context.
 - You can _downgrade_ a shared pointer into a [`Weak`][4] pointer to create
   cycles that will get dropped.


### PR DESCRIPTION
I suppose my `svgbob` skills leave a bit to be desired, but I think the meaning is clear:

![image](https://github.com/user-attachments/assets/09fa2ebd-7364-4d23-bc97-6e7e81a9c82e)

Now that I look through the `Rc` implementation, there's a weak count for every strong count, so the `weak: 0` here is inaccurate. But, maybe this is too much of an implementation detail? Should I just concentrate on strong refs? I suppose I could put a `...` in that upper-right box, to suggest there's more going on here?