### PR TITLE
Make nested array example editable

### DIFF
--- a/src/tuples-and-arrays/exercise.md
+++ b/src/tuples-and-arrays/exercise.md
@@ -6,7 +6,7 @@ minutes: 15
 
 Arrays can contain other arrays:
 
-```rust
+```rust,editable
 let array = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
 ```
 


### PR DESCRIPTION
I always want to edit this block to show the correct array type after students have answered, so it'd be helpful if it were editable so I don't have to copy/paste into a new window.