### PR TITLE
Replace `unimplemented` with `todo`

### DIFF
--- a/src/iterators/exercise.md
+++ b/src/iterators/exercise.md
@@ -13,7 +13,7 @@ return value.
 
 ```rust
 {{#include exercise.rs:offset_differences}}
-    unimplemented!()
+    todo!()
 }
 
 {{#include exercise.rs:unit-tests}}

--- a/src/tuples-and-arrays/exercise.md
+++ b/src/tuples-and-arrays/exercise.md
@@ -31,7 +31,7 @@ This function only operates on 3x3 matrices.
 #![allow(unused_variables, dead_code)]
 
 {{#include exercise.rs:transpose}}
-    unimplemented!()
+    todo!()
 }
 
 {{#include exercise.rs:tests}}

--- a/src/unsafe-rust/exercise.md
+++ b/src/unsafe-rust/exercise.md
@@ -58,17 +58,17 @@ functions and methods:
 {{#include exercise.rs:ffi}}
 
 {{#include exercise.rs:DirectoryIterator}}
-        unimplemented!()
+        todo!()
     }
 }
 
 {{#include exercise.rs:Iterator}}
-        unimplemented!()
+        todo!()
     }
 }
 
 {{#include exercise.rs:Drop}}
-        unimplemented!()
+        todo!()
     }
 }
 


### PR DESCRIPTION
At some point we started using `todo` instead of `unimplemented`, but a couple places still use the old macro. May as well normalize on `todo` everywhere, since `unimplemented` is baaaaaaasically deprecated.