### PR TITLE
Minor whitespace changes

### DIFF
--- a/src/references/shared.md
+++ b/src/references/shared.md
@@ -14,8 +14,10 @@ the referenced data cannot change.
 fn main() {
     let a = 'A';
     let b = 'B';
+
     let mut r: &char = &a;
     println!("r: {}", *r);
+
     r = &b;
     println!("r: {}", *r);
 }

--- a/src/references/strings.md
+++ b/src/references/strings.md
@@ -23,6 +23,7 @@ fn main() {
 
     let mut s2: String = String::from("Hello ");
     println!("s2: {s2}");
+
     s2.push_str(s1);
     println!("s2: {s2}");
 

--- a/src/user-defined-types/named-structs.md
+++ b/src/user-defined-types/named-structs.md
@@ -17,7 +17,10 @@ fn describe(person: &Person) {
 }
 
 fn main() {
-    let mut peter = Person { name: String::from("Peter"), age: 27 };
+    let mut peter = Person {
+        name: String::from("Peter"),
+        age: 27,
+    };
     describe(&peter);
 
     peter.age = 28;

--- a/src/user-defined-types/named-structs.md
+++ b/src/user-defined-types/named-structs.md
@@ -6,6 +6,8 @@ minutes: 10
 
 Like C and C++, Rust has support for custom structs:
 
+<!-- dprint-ignore-start -->
+
 ```rust,editable
 struct Person {
     name: String,
@@ -35,6 +37,8 @@ fn main() {
     describe(&jackie);
 }
 ```
+
+<!-- dprint-ignore-end -->
 
 <details>
 


### PR DESCRIPTION
* Add extra lines in a couple places to make code examples more readable. In both these cases I'm trying to break the code into more logical groups, generally some statement followed by a `println` showing the result of that operation.
* Split the first example of struct initialization across a couple of lines for readability. I personally struggle to read that statement when it's all one line, so I expect it'd be hard for students, and I always break it up like this in class.