### PR TITLE
Move struct update syntax to speaker notes

### DIFF
--- a/src/user-defined-types/named-structs.md
+++ b/src/user-defined-types/named-structs.md
@@ -58,10 +58,8 @@ Key Points:
 - It allows us to copy the majority of the fields from the old struct without
   having to explicitly type it all out. It must always be the last element.
 
-- It is mainly used in combination with the `Default` trait.
-
-- We will talk about struct update syntax in more detail on the slide on the
-  `Default` trait, so we don't need to talk about it here unless students ask
-  about it.
+- It is mainly used in combination with the `Default` trait. We will talk about
+  struct update syntax in more detail on the slide on the `Default` trait, so we
+  don't need to talk about it here unless students ask about it.
 
 </details>

--- a/src/user-defined-types/named-structs.md
+++ b/src/user-defined-types/named-structs.md
@@ -27,9 +27,6 @@ fn main() {
     let age = 39;
     let avery = Person { name, age };
     describe(&avery);
-
-    let jackie = Person { name: String::from("Jackie"), ..avery };
-    describe(&jackie);
 }
 ```
 
@@ -49,8 +46,22 @@ Key Points:
     not important.
 - If you already have variables with the right names, then you can create the
   struct using a shorthand.
-- The syntax `..avery` allows us to copy the majority of the fields from the old
-  struct without having to explicitly type it all out. It must always be the
-  last element.
+
+## More to Explore
+
+- You can also demonstrate the struct update syntax here:
+
+  ```rust,ignore
+  let jackie = Person { name: String::from("Jackie"), ..avery };
+  ```
+
+- It allows us to copy the majority of the fields from the old struct without
+  having to explicitly type it all out. It must always be the last element.
+
+- It is mainly used in combination with the `Default` trait.
+
+- We will talk about struct update syntax in more detail on the slide on the
+  `Default` trait, so we don't need to talk about it here unless students ask
+  about it.
 
 </details>


### PR DESCRIPTION
I don't think we need to cover struct update syntax in the slide on structs. The `Default` trait slide covers this later on, and in a context that makes more sense, i.e. using it in combination with `Default`, which is the main usage of the syntax. This would give us a little more breathing room in day 1. I've instead moved it to the speaker notes, so we can still talk about it if students ask.