### PR TITLE
Remove nesting from `let else` example

### DIFF
--- a/src/pattern-matching/let-control-flow/let-else.md
+++ b/src/pattern-matching/let-control-flow/let-else.md
@@ -49,4 +49,12 @@ fn hex_or_die_trying(maybe_string: Option<String>) -> Result<u32, String> {
 }
 ```
 
+## More to Explore
+
+- This early return-based control flow is common in Rust error handling code,
+  where you try to get a value out of a `Result`, returning an error if the
+  `Result` was `Err`.
+- If students ask, you can also demonstrate how real error handling code would
+  be written with `?`.
+
 </details>

--- a/src/pattern-matching/let-control-flow/let-else.md
+++ b/src/pattern-matching/let-control-flow/let-else.md
@@ -7,19 +7,19 @@ off the end of the block).
 
 ```rust,editable
 fn hex_or_die_trying(maybe_string: Option<String>) -> Result<u32, String> {
-    // TODO: The structure of this code is difficult to follow -- rewrite it with let-else!
-    if let Some(s) = maybe_string {
-        if let Some(first_byte_char) = s.chars().next() {
-            if let Some(digit) = first_byte_char.to_digit(16) {
-                Ok(digit)
-            } else {
-                Err(String::from("not a hex digit"))
-            }
-        } else {
-            Err(String::from("got empty string"))
-        }
-    } else {
-        Err(String::from("got None"))
+    let s = match maybe_string {
+        Some(s) => s,
+        None => return Err(String::from("got None")),
+    };
+
+    let first_byte_char = match s.chars().next() {
+        Some(first) => first,
+        None => return Err(String::from("got empty string")),
+    };
+
+    match first_byte_char.to_digit(16) {
+        Some(digit) => Ok(digit),
+        None => Err(String::from("not a hex digit")),
     }
 }
 
@@ -29,11 +29,6 @@ fn main() {
 ```
 
 <details>
-
-`if-let`s can pile up, as shown. The `let-else` construct supports flattening
-this nested code. Rewrite the awkward version for students, so they can see the
-transformation.
-
 The rewritten version is:
 
 ```rust

--- a/src/pattern-matching/let-control-flow/let-else.md
+++ b/src/pattern-matching/let-control-flow/let-else.md
@@ -7,20 +7,25 @@ off the end of the block).
 
 ```rust,editable
 fn hex_or_die_trying(maybe_string: Option<String>) -> Result<u32, String> {
-    let s = match maybe_string {
-        Some(s) => s,
-        None => return Err(String::from("got None")),
+    let s = if let Some(s) = maybe_string {
+        s
+    } else {
+        return Err(String::from("got None"));
     };
 
-    let first_byte_char = match s.chars().next() {
-        Some(first) => first,
-        None => return Err(String::from("got empty string")),
+    let first_byte_char = if let Some(first) = s.chars().next() {
+        first
+    } else {
+        return Err(String::from("got empty string"));
     };
 
-    match first_byte_char.to_digit(16) {
-        Some(digit) => Ok(digit),
-        None => Err(String::from("not a hex digit")),
-    }
+    let digit = if let Some(digit) = first_byte_char.to_digit(16) {
+        digit
+    } else {
+        return Err(String::from("not a hex digit"));
+    };
+
+    Ok(digit)
 }
 
 fn main() {


### PR DESCRIPTION
I think focusing on deeply nested control on this slide distracts from the main point of the slide. The slide frames `let else` as the solution to deep nesting, when it's really the early returns that allow for the simplification (at least in this example). This makes it harder to explain `let else` to students because we're simultaneously changing the control flow structure and introducing a new language construct. I think if we started with a `match`-based example that's already using early returns it'd be clearer to students how `let else` can be a more concise version of `match` in cases like this.

If this seems like a bad idea to others I can change this to move the `match`-based version into the speaker notes. That'd at least make it easier to first show the nested code, then an unnested version using `match`, and then finally an unnested version using `let else`.