### PR TITLE
Make code in expression evaluation exercise editable

### DIFF
--- a/src/pattern-matching/exercise.md
+++ b/src/pattern-matching/exercise.md
@@ -46,7 +46,7 @@ evaluate to `85`. We represent this as a much bigger tree:
 
 In code, we will represent the tree with two types:
 
-```rust
+```rust,editable
 {{#include exercise.rs:Operation}}
 
 {{#include exercise.rs:Expression}}
@@ -68,7 +68,7 @@ get the tests to pass one-by-one. You can also skip a test temporarily with
 fn test_value() { .. }
 ```
 
-```rust
+```rust,editable
 {{#include exercise.rs:Operation}}
 
 {{#include exercise.rs:Expression}}


### PR DESCRIPTION
The first code block especially benefits from being editable because then you can edit it in place to remove a `Box` in `Expression`, which allows you to demonstrate Rust erroring on recursive data types.