### PR TITLE
Remove trait bound on `VerbosityFilter` in the generic data types slide

### DIFF
--- a/src/generics/generic-data.md
+++ b/src/generics/generic-data.md
@@ -53,5 +53,8 @@ fn main() {
     - `VerbosityFilter` is still generic and you can use `VerbosityFilter<f64>`,
       but methods in this block will only be available for
       `Point<StderrLogger>`.
+- Note that we don't put a trait bound on the `VerbosityFilter` type itself. You
+  can put bounds there as well, but generally in Rust we only put the trait
+  bounds on the impl blocks.
 
 </details>

--- a/src/generics/generic-data.md
+++ b/src/generics/generic-data.md
@@ -22,7 +22,7 @@ impl Logger for StderrLogger {
 }
 
 /// Only log messages up to the given verbosity level.
-struct VerbosityFilter<L: Logger> {
+struct VerbosityFilter<L> {
     max_verbosity: u8,
     inner: L,
 }


### PR DESCRIPTION
It's generally more idiomatic in Rust to not have trait bounds on the data type itself. I think we better demonstrate how trait bounds are used in impl blocks with generic data types in the impl block below the struct definition. I've also added a speaker note to call this out if students ask.