### PR TITLE
Add "More to Explore" section to struct patterns slide

### DIFF
--- a/src/pattern-matching/destructuring-structs.md
+++ b/src/pattern-matching/destructuring-structs.md
@@ -14,6 +14,9 @@ Like tuples, Struct can also be destructured by matching:
 
 - Change the literal values in `foo` to match with the other patterns.
 - Add a new field to `Foo` and make changes to the pattern as needed.
+
+## More to Explore
+
 - Try `match &foo` and check the type of captures. The pattern syntax remains
   the same, but the captures become shared references. This is
   [match ergonomics](https://rust-lang.github.io/rfcs/2005-match-ergonomics.html)


### PR DESCRIPTION
Talking about matching on references and interactions with constants are useful to note but not super important imo. Breaking those notes into the "More to Explore" section would at least help me remember to only go into that if students ask or there's enough extra time to cover them.