### PR TITLE
Add speaker note with manual derive example

### DIFF
--- a/src/methods-and-traits/deriving.md
+++ b/src/methods-and-traits/deriving.md
@@ -47,7 +47,7 @@ fn main() {
   ```
 
   Not all of the `.clone()`s in the above are necessary in this case, but this
-  demonstrates the generaly boilerplate-y pattern that manual impls would
+  demonstrates the generally boilerplate-y pattern that manual impls would
   follow, which should help make the use of `derive` clear to students.
 
 </details>

--- a/src/methods-and-traits/deriving.md
+++ b/src/methods-and-traits/deriving.md
@@ -26,8 +26,28 @@ fn main() {
 
 <details>
 
-Derivation is implemented with macros, and many crates provide useful derive
-macros to add useful functionality. For example, `serde` can derive
-serialization support for a struct using `#[derive(Serialize)]`.
+- Derivation is implemented with macros, and many crates provide useful derive
+  macros to add useful functionality. For example, `serde` can derive
+  serialization support for a struct using `#[derive(Serialize)]`.
+
+- Derivation is usually provided for traits that have a common boilerplate-y
+  implementation that is correct for most cases. For example, demonstrate how a
+  manual `Clone` impl can be repetitive compared to deriving the trait:
+
+  ```rust,skip
+  impl Clone for Player {
+      fn clone(&self) -> Self {
+          Player {
+              name: self.name.clone(),
+              strength: self.strength.clone(),
+              hit_points: self.hit_points.clone(),
+          }
+      }
+  }
+  ```
+
+  Not all of the `.clone()`s in the above are necessary in this case, but this
+  demonstrates the generaly boilerplate-y pattern that manual impls would
+  follow, which should help make the use of `derive` clear to students.
 
 </details>

--- a/src/methods-and-traits/deriving.md
+++ b/src/methods-and-traits/deriving.md
@@ -34,7 +34,7 @@ fn main() {
   implementation that is correct for most cases. For example, demonstrate how a
   manual `Clone` impl can be repetitive compared to deriving the trait:
 
-  ```rust,skip
+  ```rust,ignore
   impl Clone for Player {
       fn clone(&self) -> Self {
           Player {


### PR DESCRIPTION
I often end up typing this example out manually to help motivate using `derive` instead of a manual implementation. I don't think it needs to be in the main slide, but having the example at hand would save a minute or two of awkward typing.