### PR TITLE
Add slide reviewing irrefutable patterns

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -77,6 +77,7 @@
 
 - [Welcome](welcome-day-2.md)
 - [Pattern Matching](pattern-matching.md)
+  - [Irrefutable Patterns](pattern-matching/infallible.md)
   - [Matching Values](pattern-matching/match.md)
   - [Destructuring Structs](pattern-matching/destructuring-structs.md)
   - [Destructuring Enums](pattern-matching/destructuring-enums.md)

--- a/src/pattern-matching/infallible.md
+++ b/src/pattern-matching/infallible.md
@@ -34,6 +34,9 @@ fn main() {
 - All of the demonstrated patterns are _irrefutable_, meaning that they will
   always match the value on the right hand side.
 
+- Patterns are type-specific, including irrefutable patterns. Try adding or
+  removing an element to the tuple and look at the resulting compiler errors.
+
 - Variable names are patterns that always match and which bind the matched value
   into a new variable with that name.
 

--- a/src/pattern-matching/infallible.md
+++ b/src/pattern-matching/infallible.md
@@ -1,0 +1,63 @@
+---
+minutes: 5
+---
+
+# Irrefutable Patterns
+
+In day 1 we briefly saw how patterns can be used to _destructure_ compound
+values. Let's review that and talk about a few other things patterns can
+express:
+
+```rust,editable
+fn takes_tuple(tuple: (char, i32, bool)) {
+    let a = tuple.0;
+    let b = tuple.1;
+    let c = tuple.2;
+
+    // This does the same thing as above.
+    let (a, b, c) = tuple;
+
+    // Ignore the first element, only bind the second and third.
+    let (_, b, c) = tuple;
+
+    // Ignore everything but the last element.
+    let (.., c) = tuple;
+}
+
+fn main() {
+    takes_tuple(('a', 777, true));
+}
+```
+
+<details>
+
+- All of the demonstrated patterns are _irrefutable_, meaning that they will
+  always match the value on the right hand side.
+
+- Variable names are patterns that always match and which bind the matched value
+  into a new variable with that name.
+
+- `_` is a pattern that always matches any value, discarding the matched value.
+
+- `..` alows you to ignore multiple values at once.
+
+## More to Explore
+
+- You can also demonstrate more advanced usages of `..`, such as ignoring the
+  middle elements of a tuple.
+
+  ```rust
+  fn takes_tuple(tuple: (char, i32, bool, u8)) {
+      let (first, .., last) = tuple;
+  }
+  ```
+
+- All of these patterns work with arrays as well:
+
+  ```rust
+  fn takes_array(array: [u8; 5]) {
+      let [first, .., last] = array;
+  }
+  ```
+
+</details>

--- a/src/pattern-matching/infallible.md
+++ b/src/pattern-matching/infallible.md
@@ -39,7 +39,7 @@ fn main() {
 
 - `_` is a pattern that always matches any value, discarding the matched value.
 
-- `..` alows you to ignore multiple values at once.
+- `..` allows you to ignore multiple values at once.
 
 ## More to Explore
 


### PR DESCRIPTION
We already talk about irrefutable patterns in day 1, but only briefly. I always review the concept at the beginning of the pattern matching section to refresh students' memories, so this is just formalizing that review into a slide at the beginning of the section. I also use this opportunity to introduce `_` and `..`, which should help students understand that patterns can do more than just directly destructure values.