### PR TITLE
Fix typo in `es.po`

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -1540,7 +1540,7 @@ msgstr ""
 
 #: src/running-the-course.md
 msgid "Before you run the course, you will want to:"
-msgstr "Antes de impartir el curso, te recomdamos hacer lo siguiente:"
+msgstr "Antes de impartir el curso, te recomendamos hacer lo siguiente:"
 
 #: src/running-the-course.md
 msgid ""


### PR DESCRIPTION
Fix typo in `es.po`.
Arreglo de error ortográfico en `es.po`.