### PR TITLE
Create install-mdbook.sh and lock to the current versions used in the CI

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -5,37 +5,14 @@ description: Install mdbook with the dependencies we need.
 runs:
   using: composite
   steps:
-    # The --locked flag is important for reproducible builds. It also
-    # avoids breakage due to skews between mdbook and mdbook-svgbob.
     - name: Install mdbook
-      run: cargo install mdbook --locked --version 0.4.37
+      run: ./install-mdbook.sh
       shell: bash
 
-    - name: Install mdbook-svgbob
-      run: cargo install mdbook-svgbob --locked --version 0.2.1
-      shell: bash
-
-    - name: Install mdbook-pandoc and related dependencies
+    - name: Install dependencies for mdbook-pandoc
       run: |
-        cargo install mdbook-pandoc --locked --version 0.9.3
         sudo apt-get update
         sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk texlive-lang-arabic librsvg2-bin fonts-noto
         curl -LsSf https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-linux-amd64.tar.gz | tar zxf -
         echo "$PWD/pandoc-3.6.2/bin" >> $GITHUB_PATH
-      shell: bash
-
-    - name: Install mdbook-i18n-helpers
-      run: cargo install mdbook-i18n-helpers --locked --version 0.3.3
-      shell: bash
-
-    - name: Install i18n-report
-      run: cargo install i18n-report --locked --version 0.2.0
-      shell: bash
-
-    - name: Install mdbook-exerciser
-      run: cargo install --path mdbook-exerciser --locked
-      shell: bash
-
-    - name: Install mdbook-course
-      run: cargo install --path mdbook-course --locked
       shell: bash

--- a/README.md
+++ b/README.md
@@ -71,13 +71,7 @@ cd comprehensive-rust
 Then install these tools with:
 
 ```shell
-cargo install mdbook
-cargo install --locked mdbook-svgbob
-cargo install --locked mdbook-i18n-helpers
-cargo install --locked i18n-report
-cargo install --locked mdbook-linkcheck
-cargo install --locked --path mdbook-exerciser
-cargo install --locked --path mdbook-course
+bash install-mdbook.sh
 ```
 
 Run

--- a/install-mdbook.sh
+++ b/install-mdbook.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# The --locked flag is important for reproducible builds. It also
+# avoids breakage due to skews between mdbook and mdbook-svgbob.
+cargo install mdbook --locked --version 0.4.37
+cargo install mdbook-svgbob --locked --version 0.2.1
+cargo install mdbook-pandoc --locked --version 0.9.3
+cargo install mdbook-i18n-helpers --locked --version 0.3.3
+cargo install i18n-report --locked --version 0.2.0
+# these packages are located in this repository
+cargo install --path mdbook-exerciser --locked
+cargo install --path mdbook-course --locked


### PR DESCRIPTION
Move mdbook installation into a script and use exact versions from the CI.
Update README.md to instruct developers to use the same versions as the CI to sync both environments.
This is related to #2620 and it fixes #2588 