### PR TITLE
Remove `unreachable!` from macros slide

### DIFF
--- a/src/control-flow-basics/macros.md
+++ b/src/control-flow-basics/macros.md
@@ -44,4 +44,19 @@ especially critical.
 The course does not cover defining macros, but a later section will describe use
 of derive macros.
 
+## More To Explore
+
+There are a number of other useful macros provided by the standard library. Some
+other examples you can share with students if they want to know more:
+
+- [`assert!`] and related macros can be used to add assertions to your code.
+  These are used heavily in writing tests.
+- [`unreachable!`] is used to mark a branch of control flow that should never be
+  hit.
+- [`eprintln!`] allows you to print to stderr.
+
 </details>
+
+[`assert!`]: https://doc.rust-lang.org/stable/std/macro.assert.html
+[`unreachable!`]: https://doc.rust-lang.org/stable/std/macro.unreachable.html
+[`eprintln!`]: https://doc.rust-lang.org/stable/std/macro.eprintln.html

--- a/src/control-flow-basics/macros.md
+++ b/src/control-flow-basics/macros.md
@@ -15,8 +15,6 @@ standard library includes an assortment of useful macros.
 - `dbg!(expression)` logs the value of the expression and returns it.
 - `todo!()` marks a bit of code as not-yet-implemented. If executed, it will
   panic.
-- `unreachable!()` marks a bit of code as unreachable. If executed, it will
-  panic.
 
 ```rust,editable
 fn factorial(n: u32) -> u32 {


### PR DESCRIPTION
After #2594 we no longer use `unimplemented!` in the course, so I don't think we need to mention it in the macros slide.