### PR TITLE
Add `main` method to code snippet

### DIFF
--- a/src/iterators/helpers.md
+++ b/src/iterators/helpers.md
@@ -10,12 +10,12 @@ customized iterators.
 
 ```rust,editable
 fn main() {
-  let result: i32 = (1..=10) // Create a range from 1 to 10
-      .filter(|x| x % 2 == 0) // Keep only even numbers
-      .map(|x| x * x) // Square each number
-      .sum(); // Sum up all the squared numbers
+    let result: i32 = (1..=10) // Create a range from 1 to 10
+        .filter(|x| x % 2 == 0) // Keep only even numbers
+        .map(|x| x * x) // Square each number
+        .sum(); // Sum up all the squared numbers
 
-  println!("The sum of squares of even numbers from 1 to 10 is: {}", result);
+    println!("The sum of squares of even numbers from 1 to 10 is: {}", result);
 }
 ```
 

--- a/src/iterators/helpers.md
+++ b/src/iterators/helpers.md
@@ -9,12 +9,14 @@ In addition to the `next` method that defines how an iterator behaves, the
 customized iterators.
 
 ```rust,editable
-let result: i32 = (1..=10) // Create a range from 1 to 10
-    .filter(|&x| x % 2 == 0) // Keep only even numbers
-    .map(|x| x * x) // Square each number
-    .sum(); // Sum up all the squared numbers
+fn main() {
+  let result: i32 = (1..=10) // Create a range from 1 to 10
+      .filter(|x| x % 2 == 0) // Keep only even numbers
+      .map(|x| x * x) // Square each number
+      .sum(); // Sum up all the squared numbers
 
-println!("The sum of squares of even numbers from 1 to 10 is: {}", result);
+  println!("The sum of squares of even numbers from 1 to 10 is: {}", result);
+}
 ```
 
 <details>


### PR DESCRIPTION
The code snippet wouldn't compile/run directly because of a missing `main` method.

Also remove unnecessary `&`.