### PR TITLE
Move `use` statements to beginning of `widgets.rs`

### DIFF
--- a/src/modules/solution.md
+++ b/src/modules/solution.md
@@ -28,13 +28,13 @@ src
 
 ```rust,ignore
 // ---- src/widgets.rs ----
-mod button;
-mod label;
-mod window;
-
 pub use button::Button;
 pub use label::Label;
 pub use window::Window;
+
+mod button;
+mod label;
+mod window;
 
 pub trait Widget {
     /// Natural width of `self`.

--- a/src/modules/solution.md
+++ b/src/modules/solution.md
@@ -32,6 +32,10 @@ mod button;
 mod label;
 mod window;
 
+pub use button::Button;
+pub use label::Label;
+pub use window::Window;
+
 pub trait Widget {
     /// Natural width of `self`.
     fn width(&self) -> usize;
@@ -46,10 +50,6 @@ pub trait Widget {
         println!("{buffer}");
     }
 }
-
-pub use button::Button;
-pub use label::Label;
-pub use window::Window;
 ```
 
 ```rust,ignore


### PR DESCRIPTION
I think the convention is to put `use` statements (including `pub use`) towards the top of the file under the `mod` statements.