### PR TITLE
Fix note about undefined behavior

### DIFF
--- a/src/unsafe-rust/unsafe-functions/calling.md
+++ b/src/unsafe-rust/unsafe-functions/calling.md
@@ -33,9 +33,8 @@ Key points:
 - The second argument to `slice::from_raw_parts` is the number of _elements_,
   not bytes! This example demonstrates unexpected behavior by reading past the
   end of one array and into another.
-- This is not actually undefined behaviour, as `KeyPair` has a defined
-  representation (due to `repr(C)`) and no padding, so the contents of the
-  second array is also valid to read through the same pointer.
+- This is undefined behavior because we're reading past the end of the array
+  that the pointer was derived from.
 - `log_public_key` should be unsafe, because `pk_ptr` must meet certain
   prerequisites to avoid undefined behaviour. A safe function which can cause
   undefined behaviour is said to be `unsound`. What should its safety


### PR DESCRIPTION
So turns out this example **does** trigger undefined behavior. It's undefined behavior to use a pointer to read past the end of the object from which the pointer was originally created. So even though we know there's another array past the end of the first one, it's still undefined behavior to read past the end of the array if we created the initial pointer from the first array. You can see this if you [run miri in the playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=8e464b10e3386d2a8755d6de9acb93b4). If we tweak the example to instead [take a pointer to the struct as a whole](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=792bb4d96a376bb730b1c058aec86dc5) it runs through miri with no errors, since now we're allowed to read the full contents of the struct.

Isn't undefined behavior fun? 🙃 