### PR TITLE
Fix bug in speaker notes that broke navigating to next slide

### DIFF
--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -189,7 +189,7 @@
 
     // Update prev/next buttons to keep speaker note state.
     document
-      .querySelectorAll('a[rel="prev"], a[rel="next"]')
+      .querySelectorAll('a[rel~="prev"], a[rel~="next"]')
       .forEach((elem) => {
         elem.href += "#speaker-notes-open";
       });


### PR DESCRIPTION
Change this selector to use the ~= selector to test if a white space separated word "prev" or "next" is contained

Fixes a speaker notes bug that did not allow going to the next slide in the speaker notes.
The reason for that is that the "rel" attribute contained "prev" respective "next prefetch".

See: https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#attrvalue_2

This fixes part of #2004 when going to the right (containing "prefetch").