### PR TITLE
Use `jni_libs` for JNI dependency

### DIFF
--- a/src/android/interoperability/java/Android.bp
+++ b/src/android/interoperability/java/Android.bp
@@ -12,6 +12,6 @@ java_binary {
     name: "helloworld_jni",
     srcs: ["HelloWorld.java"],
     main_class: "HelloWorld",
-    required: ["libhello_jni"],
+    jni_libs: ["libhello_jni"],
 }
 // ANCHOR_END: helloworld_jni


### PR DESCRIPTION
It looks like the module type used for adding a JNI dependency to a Java binary has changed to `jni_libs`. This gets our various Android examples building again, since currently the incorrect dependency causes Soong errors even if you're trying to build a different module.