### PR TITLE
Fix vendored crates path

### DIFF
--- a/src/android/build-rules/library.md
+++ b/src/android/build-rules/library.md
@@ -6,9 +6,9 @@ Here we declare a dependency on two libraries:
 
 - `libgreeting`, which we define below,
 - `libtextwrap`, which is a crate already vendored in
-  [`external/rust/crates/`][crates].
+  [`external/rust/android-crates-io/crates/`][crates].
 
-[crates]: https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/
+[crates]: https://cs.android.com/android/platform/superproject/main/+/main:external/rust/android-crates-io/crates/
 
 _hello_rust/Android.bp_:
 


### PR DESCRIPTION
In Android vendored crates now live under `external/rust/android-crates-io/crates`.