### PR TITLE
Update AIDL intermediates path

### DIFF
--- a/src/android/aidl/example-service/service-bindings.md
+++ b/src/android/aidl/example-service/service-bindings.md
@@ -9,7 +9,7 @@ _birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:
 }
 ```
 
-_out/soong/.intermediates/.../birthdayservice/IBirthdayService.rs_:
+_out/soong/.intermediates/comprehensive-rust/.../com_example_birthdayservice.rs_:
 
 <!-- The example below is a cleaned up and simplified version of the real code. -->
 

--- a/src/android/aidl/example-service/service-bindings.md
+++ b/src/android/aidl/example-service/service-bindings.md
@@ -9,7 +9,7 @@ _birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:
 }
 ```
 
-_out/soong/.intermediates/comprehensive-rust/.../com_example_birthdayservice.rs_:
+_out/soong/.intermediates/.../com_example_birthdayservice.rs_:
 
 <!-- The example below is a cleaned up and simplified version of the real code. -->
 


### PR DESCRIPTION
The path to the generated Rust code for AIDL definitions seems to have changed, this updates the slide to reflect the current location. This also assumes that the CompRust repo is checked out at the root of an AOSP checkout.