### PR TITLE
Add missing `static_libs` dep for libbirthday example

### DIFF
--- a/src/android/interoperability/with-c/bindgen/Android.bp
+++ b/src/android/interoperability/with-c/bindgen/Android.bp
@@ -32,5 +32,6 @@ rust_binary {
     name: "print_birthday_card",
     srcs: ["main.rs"],
     rustlibs: ["libbirthday_bindgen"],
+    static_libs: ["libbirthday"],
 }
 // ANCHOR_END: print_birthday_card


### PR DESCRIPTION
Turns out it's not enough to just depend on the bindgen module, we also need a direct `static_libs` dependency on the C module.