### PR TITLE
Reorder CXX build steps to show genrules first

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -272,8 +272,8 @@
     - [Rust Error Handling](android/interoperability/cpp/rust-result.md)
     - [C++ Error Handling](android/interoperability/cpp/cpp-exception.md)
     - [Additional Types](android/interoperability/cpp/type-mapping.md)
-    - [Building for Android: C++](android/interoperability/cpp/android-build-cpp.md)
     - [Building for Android: Genrules](android/interoperability/cpp/android-cpp-genrules.md)
+    - [Building for Android: C++](android/interoperability/cpp/android-build-cpp.md)
     - [Building for Android: Rust](android/interoperability/cpp/android-build-rust.md)
   - [With Java](android/interoperability/java.md)
 


### PR DESCRIPTION
The genrules are inputs to the `cc_library_static`, which we're currently showing first. I think showing the genrules first, then showing how they're used in `cc_library_static`, makes more sense (and that's how I always teach it in class).