### PR TITLE
Add `Android.bp` entries for googletest and mockall example tests

### DIFF
--- a/src/android/testing/Android.bp
+++ b/src/android/testing/Android.bp
@@ -11,3 +11,19 @@ rust_test {
     host_supported: true,
     test_suites: ["general-tests"],
 }
+
+rust_test {
+    name: "libgoogletest_example",
+    crate_name: "googletest_example",
+    srcs: ["googletest.rs"],
+    rustlibs: ["libgoogletest_rust"],
+    host_supported: true,
+}
+
+rust_test {
+    name: "libmockall_example",
+    crate_name: "mockall_example",
+    srcs: ["mockall.rs"],
+    rustlibs: ["libmockall"],
+    host_supported: true,
+}

--- a/src/android/testing/mockall.rs
+++ b/src/android/testing/mockall.rs
@@ -10,7 +10,7 @@ pub trait Pet {
 fn test_robot_dog() {
     let mut mock_dog = MockPet::new();
     mock_dog.expect_is_hungry().return_const(true);
-    assert_eq!(mock_dog.is_hungry(Duration::from_secs(10)), true);
+    assert!(mock_dog.is_hungry(Duration::from_secs(10)));
 }
 // ANCHOR_END: simple_example
 
@@ -23,7 +23,7 @@ fn test_robot_cat() {
         .with(mockall::predicate::gt(Duration::from_secs(3 * 3600)))
         .return_const(true);
     mock_cat.expect_is_hungry().return_const(false);
-    assert_eq!(mock_cat.is_hungry(Duration::from_secs(1 * 3600)), false);
-    assert_eq!(mock_cat.is_hungry(Duration::from_secs(5 * 3600)), true);
+    assert!(mock_cat.is_hungry(Duration::from_secs(5 * 3600)));
+    assert!(!mock_cat.is_hungry(Duration::from_secs(5)));
 }
 // ANCHOR_END: extended_example


### PR DESCRIPTION
This makes the googletest and mockall examples buildable and runnable in an AOSP checkout. To make this work I had to slightly modify the examples to fix linter warnings that were resulting in errors in the build.