### PR TITLE
drop: avoid confusing names

### DIFF
--- a/src/memory-management/drop.md
+++ b/src/memory-management/drop.md
@@ -25,9 +25,9 @@ fn main() {
         {
             let c = Droppable { name: "c" };
             let d = Droppable { name: "d" };
-            println!("Exiting block B");
+            println!("Exiting innermost block");
         }
-        println!("Exiting block A");
+        println!("Exiting next block");
     }
     drop(a);
     println!("Exiting main");


### PR DESCRIPTION
The Droppables are already named with letters, so hopefully referencing the nesting order of blocks instead of giving them names is clearer.