### PR TITLE
closures/exercise.rs: drop trait bounds from struct definition

### DIFF
--- a/src/closures/exercise.rs
+++ b/src/closures/exercise.rs
@@ -29,11 +29,7 @@ impl Logger for StderrLogger {
 // ANCHOR_END: setup
 
 /// Only log messages matching a filtering predicate.
-struct Filter<L, P>
-where
-    L: Logger,
-    P: Fn(u8, &str) -> bool,
-{
+struct Filter<L, P> {
     inner: L,
     predicate: P,
 }


### PR DESCRIPTION
This is more idiomatic than what we had before.

We keep the trait bounds for the inherent impl, because the new method can use them to guide inference of unannotated closure arguments.