### PR TITLE
Use dbg! instead of println! in Day 1 mng session

### DIFF
--- a/src/control-flow-basics/blocks-and-scopes.md
+++ b/src/control-flow-basics/blocks-and-scopes.md
@@ -27,7 +27,8 @@ A variable's scope is limited to the enclosing block.
 
 <details>
 
-- You can explain that dbg! is a Rust macro that prints and returns the value of a given expression for quick and dirty debugging.
+- You can explain that dbg! is a Rust macro that prints and returns the value of
+  a given expression for quick and dirty debugging.
 
 - You can show how the value of the block changes by changing the last line in
   the block. For instance, adding/removing a semicolon or using a `return`.

--- a/src/control-flow-basics/blocks-and-scopes.md
+++ b/src/control-flow-basics/blocks-and-scopes.md
@@ -13,11 +13,11 @@ fn main() {
     let z = 13;
     let x = {
         let y = 10;
-        println!("y: {y}");
+        dbg!(y);
         z - y
     };
-    println!("x: {x}");
-    // println!("y: {y}");
+    dbg!(x);
+    // dbg!(y);
 }
 ```
 
@@ -26,6 +26,8 @@ If the last expression ends with `;`, then the resulting value and type is `()`.
 A variable's scope is limited to the enclosing block.
 
 <details>
+
+- You can explain that dbg! is a Rust macro that prints and returns the value of a given expression for quick and dirty debugging.
 
 - You can show how the value of the block changes by changing the last line in
   the block. For instance, adding/removing a semicolon or using a `return`.

--- a/src/control-flow-basics/break-continue.md
+++ b/src/control-flow-basics/break-continue.md
@@ -23,7 +23,7 @@ fn main() {
         if i % 2 == 0 {
             continue;
         }
-        println!("{}", i);
+        dbg!(i);
     }
 }
 ```

--- a/src/control-flow-basics/break-continue/labels.md
+++ b/src/control-flow-basics/break-continue/labels.md
@@ -16,7 +16,7 @@ fn main() {
             }
         }
     }
-    print!("elements searched: {elements_searched}");
+    dbg!(elements_searched);
 }
 ```
 

--- a/src/control-flow-basics/functions.md
+++ b/src/control-flow-basics/functions.md
@@ -16,7 +16,7 @@ fn gcd(a: u32, b: u32) -> u32 {
 }
 
 fn main() {
-    println!("gcd: {}", gcd(143, 52));
+    dbg!(gcd(143, 52));
 }
 ```
 

--- a/src/control-flow-basics/loops.md
+++ b/src/control-flow-basics/loops.md
@@ -19,6 +19,6 @@ fn main() {
     while x >= 10 {
         x = x / 2;
     }
-    println!("Final x: {x}");
+    dbg!(x);
 }
 ```

--- a/src/control-flow-basics/loops/for.md
+++ b/src/control-flow-basics/loops/for.md
@@ -6,11 +6,11 @@ ranges of values or the items in a collection:
 ```rust,editable
 fn main() {
     for x in 1..5 {
-        println!("x: {x}");
+        dbg!(x);
     }
 
     for elem in [2, 4, 8, 16, 32] {
-        println!("elem: {elem}");
+        dbg!(elem);
     }
 }
 ```

--- a/src/control-flow-basics/loops/loop.md
+++ b/src/control-flow-basics/loops/loop.md
@@ -8,7 +8,7 @@ fn main() {
     let mut i = 0;
     loop {
         i += 1;
-        println!("{i}");
+        dbg!(i);
         if i > 100 {
             break;
         }


### PR DESCRIPTION
As mentioned in #2478, this cleans up the code blocks when all that is needed is a trivial debug print statement.
Only making changes to Day 1 morning session so that I can get feedback before proceeding with the rest of the course.