### PR TITLE
Preserve line numbers by not injecting a newline

### DIFF
--- a/theme/book.js
+++ b/theme/book.js
@@ -130,7 +130,7 @@ function playground_text(playground, hidden = true) {
         // Unless the code block has `warnunused`, allow all "unused" lints to avoid cluttering
         // the output.
         if(!classes.contains("warnunused")) {
-            text = '#![allow(unused)]\n' + text;
+            text = '#![allow(unused)] ' + text;
         }
         let edition = "2015";
         if(classes.contains("edition2018")) {


### PR DESCRIPTION
The `dbg!` macro, being deployed more widely in #2478, shows the line number. But if we inject `#![allow(..)]\n` then the printed numbers do not match those in the textarea. It turns out that `\n` is not required!

cc @egithinji