### PR TITLE
Use dbg! instead of println! in Day 1 aft session

### DIFF
--- a/src/references/dangling.md
+++ b/src/references/dangling.md
@@ -9,15 +9,13 @@ use. One rule is that references can never be `null`, making them safe to use
 without `null` checks. The other rule we'll look at for now is that references
 can't _outlive_ the data they point to.
 
-<!-- mdbook-xgettext: skip -->
-
 ```rust,editable,compile_fail
 fn main() {
     let x_ref = {
         let x = 10;
         &x
     };
-    println!("x: {x_ref}");
+    dbg!(x_ref);
 }
 ```
 

--- a/src/references/shared.md
+++ b/src/references/shared.md
@@ -8,18 +8,16 @@ A reference provides a way to access another value without taking ownership of
 the value, and is also called "borrowing". Shared references are read-only, and
 the referenced data cannot change.
 
-<!-- mdbook-xgettext: skip -->
-
 ```rust,editable
 fn main() {
     let a = 'A';
     let b = 'B';
 
     let mut r: &char = &a;
-    println!("r: {}", *r);
+    dbg!(*r);
 
     r = &b;
-    println!("r: {}", *r);
+    dbg!(*r);
 }
 ```
 

--- a/src/tuples-and-arrays/exercise.rs
+++ b/src/tuples-and-arrays/exercise.rs
@@ -33,9 +33,9 @@ fn main() {
         [301, 302, 303],
     ];
 
-    println!("matrix: {:#?}", matrix);
+    dbg!(matrix);
     let transposed = transpose(matrix);
-    println!("transposed: {:#?}", transposed);
+    dbg!(transposed);
 }
 // ANCHOR_END: main
 // ANCHOR_END: solution

--- a/src/tuples-and-arrays/tuples.md
+++ b/src/tuples-and-arrays/tuples.md
@@ -9,8 +9,8 @@ minutes: 5
 ```rust,editable
 fn main() {
     let t: (i8, bool) = (7, true);
-    println!("t.0: {}", t.0);
-    println!("t.1: {}", t.1);
+    dbg!(t.0);
+    dbg!(t.1);
 }
 ```
 


### PR DESCRIPTION
Part of #2478 to clean up code blocks when all that is needed is a trivial debug print statement.

In certain slides (8.1, 9.2, 9.3, 10.5) I've opted to retain the use of println! because dbg! makes it less readable. The
dbg! macro uses pretty-printing by default and this results in a simple array such as the one in 8.1 being printed vertically instead of a cleaner one-liner.