### PR TITLE
Use dbg! instead of println! in Day 2. 

### DIFF
--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -33,7 +33,8 @@ impl From<bool> for Foo {
 fn main() {
     let from_int = Foo::from(123);
     let from_bool = Foo::from(true);
-    println!("{from_int:?}, {from_bool:?}");
+    dbg!(from_int);
+    dbg!(from_bool);
 }
 ```
 

--- a/src/generics/impl-trait.md
+++ b/src/generics/impl-trait.md
@@ -20,11 +20,11 @@ fn pair_of(x: u32) -> impl std::fmt::Debug {
 
 fn main() {
     let many = add_42_millions(42_i8);
-    println!("{many}");
+    dbg!(many);
     let many_more = add_42_millions(10_000_000);
-    println!("{many_more}");
+    dbg!(many_more);
     let debuggable = pair_of(27);
-    println!("debuggable: {debuggable:?}");
+    dbg!(debuggable);
 }
 ```
 

--- a/src/pattern-matching/let-control-flow/while-let.md
+++ b/src/pattern-matching/let-control-flow/while-let.md
@@ -4,13 +4,11 @@ Like with `if let`, there is a
 [`while let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops)
 variant which repeatedly tests a value against a pattern:
 
-<!-- mdbook-xgettext: skip -->
-
 ```rust,editable
 fn main() {
     let mut name = String::from("Comprehensive Rust 🦀");
     while let Some(c) = name.pop() {
-        println!("character: {c}");
+        dbg!(c);
     }
     // (There are more efficient ways to reverse a string!)
 }

--- a/src/std-traits/default.md
+++ b/src/std-traits/default.md
@@ -25,14 +25,14 @@ impl Default for Implemented {
 
 fn main() {
     let default_struct = Derived::default();
-    println!("{default_struct:#?}");
+    dbg!(default_struct);
 
     let almost_default_struct =
         Derived { y: "Y is set!".into(), ..Derived::default() };
-    println!("{almost_default_struct:#?}");
+    dbg!(almost_default_struct);
 
     let nothing: Option<Derived> = None;
-    println!("{:#?}", nothing.unwrap_or_default());
+    dbg!(nothing.unwrap_or_default());
 }
 ```
 

--- a/src/std-types/hashmap.md
+++ b/src/std-types/hashmap.md
@@ -35,7 +35,7 @@ fn main() {
         *page_count += 1;
     }
 
-    println!("{page_counts:#?}");
+    dbg!(page_counts);
 }
 ```
 

--- a/src/std-types/option.md
+++ b/src/std-types/option.md
@@ -13,10 +13,10 @@ returns an `Option<usize>`.
 fn main() {
     let name = "Löwe 老虎 Léopard Gepardi";
     let mut position: Option<usize> = name.find('é');
-    println!("find returned {position:?}");
+    dbg!(position);
     assert_eq!(position.unwrap(), 14);
     position = name.find('Z');
-    println!("find returned {position:?}");
+    dbg!(position);
     assert_eq!(position.expect("Character not found"), 0);
 }
 ```


### PR DESCRIPTION
Part of #2478 to clean up code blocks when all that is needed is a trivial debug print statement.

As mentioned in previous related PRs, in some places I've opted to retain the use of println! because dbg! makes it less readable.