### PR TITLE
Use explicit range when slicing into string

### DIFF
--- a/src/references/strings.md
+++ b/src/references/strings.md
@@ -27,7 +27,7 @@ fn main() {
     s2.push_str(s1);
     println!("s2: {s2}");
 
-    let s3: &str = &s2[s2.len() - s1.len()..];
+    let s3: &str = &s2[2..9];
     println!("s3: {s3}");
 }
 ```


### PR DESCRIPTION
I don't like the `&s2[s2.len() - s1.len()..]` index operation because it's always hard for me to scan and explain, and I don't want to be focusing on the math, I want to focus on the slice operation. I think it would be better to use an explicit range so we can keep things simple and clear for students. I also never liked that `s3` is "World", since that's also what `s1` was, so I don't feel it clearly enough demonstrates that `s3` is coming from `s2`. I think pulling a weird range out of the middle of `s2` would better show that we're indeed looking at part of the full string. Now `s3` is "llo Wor".