### PR TITLE
Split complex enum initialization

### DIFF
--- a/src/user-defined-types/enums.md
+++ b/src/user-defined-types/enums.md
@@ -22,7 +22,8 @@ enum PlayerMove {
 }
 
 fn main() {
-    let player_move: PlayerMove = PlayerMove::Run(Direction::Left);
+    let dir = Direction::Left;
+    let player_move: PlayerMove = PlayerMove::Run(dir);
     println!("On this turn: {player_move:?}");
 }
 ```


### PR DESCRIPTION
I find that the combined expression `PlayerMove::Run(Direction::Left)` is hard to parse and makes it hard to talk about `Direction` in isolation before getting to `PlayerMove`. I think splitting out a `dir` variable would make it easier read and easier to walk through in class.