### PR TITLE
Suppress warnings for elevator exercise

### DIFF
--- a/src/user-defined-types/exercise.md
+++ b/src/user-defined-types/exercise.md
@@ -41,3 +41,13 @@ out of these structures.
 
 {{#include exercise.rs:main}}
 ```
+
+<details>
+
+- If students ask about `#![allow(dead_code)]` at the top of the exercise, it's
+  necessary because the only thing we do with the `Event` type is print it out.
+  Due to a nuance of how the compiler checks for dead code this causes it to
+  think that the code is unused. They can ignore it for the purpose of this
+  exercise.
+
+</details>

--- a/src/user-defined-types/exercise.rs
+++ b/src/user-defined-types/exercise.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 // ANCHOR: solution
 // ANCHOR: event
+#![allow(dead_code)]
+
 #[derive(Debug)]
 /// An event in the elevator system that the controller must react to.
 enum Event {


### PR DESCRIPTION
Turns out if you don't include the `#![allow(dead_code)]` in the exercise then you get incorrect dead code warnings because, as it turns out, if all you do with a type is print it out, then the compiler thinks it's dead code because it specifically ignores `Debug` impls for the purpose of dead code checks. I think it'd be fine to include `#![allow(dead_code)]` in the exercise, but I've added a speaker note in cases students get curious.