### PR TITLE
Use dbg! instead of println! in day 3 & 4.

### DIFF
--- a/src/borrowing/borrowck.md
+++ b/src/borrowing/borrowck.md
@@ -15,7 +15,7 @@ fn main() {
         let x = 10;
         &x
     };
-    println!("x: {x_ref}");
+    dbg!(x_ref);
 }
 ```
 
@@ -37,8 +37,8 @@ fn main() {
         *c = 20;
     }
 
-    println!("a: {a}");
-    println!("b: {b}");
+    dbg!(a);
+    dbg!(b);
 }
 ```
 
@@ -57,8 +57,8 @@ fn main() {
     conflict. Replace `c` with a direct mutation of `a` and demonstrate that
     this produces a similar error. This is because direct mutation of a value
     effectively creates a temporary mutable reference.
-- Move the `println!` statement for `b` before the scope that introduces `c` to
-  make the code compile.
+- Move the `dbg!` statement for `b` before the scope that introduces `c` to make
+  the code compile.
   - After that change, the compiler realizes that `b` is only ever used before
     the new mutable borrow of `a` through `c`. This is a feature of the borrow
     checker called "non-lexical lifetimes".

--- a/src/borrowing/examples.md
+++ b/src/borrowing/examples.md
@@ -13,7 +13,7 @@ fn main() {
     let mut vec = vec![1, 2, 3, 4, 5];
     let elem = &vec[2];
     vec.push(6);
-    println!("{elem}");
+    dbg!(elem);
 }
 ```
 

--- a/src/borrowing/interior-mutability/cell.md
+++ b/src/borrowing/interior-mutability/cell.md
@@ -12,7 +12,7 @@ fn main() {
     let cell = Cell::new(5);
 
     cell.set(123);
-    println!("{}", cell.get());
+    dbg!(cell.get());
 }
 ```
 

--- a/src/error-handling/panics.md
+++ b/src/error-handling/panics.md
@@ -11,7 +11,7 @@ Rust will trigger a panic if a fatal error happens at runtime:
 ```rust,editable,should_panic
 fn main() {
     let v = vec![10, 20, 30];
-    println!("v[100]: {}", v[100]);
+    dbg!(v[100]);
 }
 ```
 
@@ -33,12 +33,12 @@ use std::panic;
 
 fn main() {
     let result = panic::catch_unwind(|| "No problem here!");
-    println!("{result:?}");
+    dbg!(result);
 
     let result = panic::catch_unwind(|| {
         panic!("oh no!");
     });
-    println!("{result:?}");
+    dbg!(result);
 }
 ```
 

--- a/src/iterators/iterator.md
+++ b/src/iterators/iterator.md
@@ -32,7 +32,7 @@ fn main() {
     let slice = &[2, 4, 6, 8];
     let iter = SliceIter { slice, i: 0 };
     for elem in iter {
-        println!("elem: {elem}");
+        dbg!(elem);
     }
 }
 ```

--- a/src/lifetimes/lifetime-annotations.md
+++ b/src/lifetimes/lifetime-annotations.md
@@ -40,7 +40,7 @@ fn main() {
     let p1: Point = Point(10, 10);
     let p2: Point = Point(20, 20);
     let p3 = left_most(&p1, &p2); // What is the lifetime of p3?
-    println!("p3: {p3:?}");
+    dbg!(p3);
 }
 ```
 

--- a/src/lifetimes/struct-lifetimes.md
+++ b/src/lifetimes/struct-lifetimes.md
@@ -24,8 +24,8 @@ fn main() {
     let noun = Highlight { slice: &doc[16..19], color: HighlightColor::Yellow };
     let verb = Highlight { slice: &doc[20..25], color: HighlightColor::Pink };
     // drop(doc);
-    println!("{noun:?}");
-    println!("{verb:?}");
+    dbg!(noun);
+    dbg!(verb);
 }
 ```
 

--- a/src/memory-management/copy-types.md
+++ b/src/memory-management/copy-types.md
@@ -12,8 +12,8 @@ While move semantics are the default, certain types are copied by default:
 fn main() {
     let x = 42;
     let y = x;
-    println!("x: {x}"); // would not be accessible if not Copy
-    println!("y: {y}");
+    dbg!(x); // would not be accessible if not Copy
+    dbg!(y);
 }
 ```
 

--- a/src/memory-management/exercise.rs
+++ b/src/memory-management/exercise.rs
@@ -113,16 +113,16 @@ impl PackageBuilder {
 // ANCHOR: main
 fn main() {
     let base64 = PackageBuilder::new("base64").version("0.13").build();
-    println!("base64: {base64:?}");
+    dbg!(&base64);
     let log =
         PackageBuilder::new("log").version("0.4").language(Language::Rust).build();
-    println!("log: {log:?}");
+    dbg!(&log);
     let serde = PackageBuilder::new("serde")
         .authors(vec!["djmitche".into()])
         .version(String::from("4.0"))
         .dependency(base64.as_dependency())
         .dependency(log.as_dependency())
         .build();
-    println!("serde: {serde:?}");
+    dbg!(serde);
 }
 // ANCHOR_END: main

--- a/src/memory-management/move.md
+++ b/src/memory-management/move.md
@@ -10,8 +10,8 @@ An assignment will transfer _ownership_ between variables:
 fn main() {
     let s1: String = String::from("Hello!");
     let s2: String = s1;
-    println!("s2: {s2}");
-    // println!("s1: {s1}");
+    dbg!(s2);
+    // dbg!(s1);
 }
 ```
 

--- a/src/memory-management/ownership.md
+++ b/src/memory-management/ownership.md
@@ -15,9 +15,9 @@ struct Point(i32, i32);
 fn main() {
     {
         let p = Point(3, 4);
-        println!("x: {}", p.0);
+        dbg!(p.0);
     }
-    println!("y: {}", p.1);
+    dbg!(p.1);
 }
 ```
 

--- a/src/smart-pointers/rc.md
+++ b/src/smart-pointers/rc.md
@@ -14,8 +14,8 @@ fn main() {
     let a = Rc::new(10);
     let b = Rc::clone(&a);
 
-    println!("a: {a}");
-    println!("b: {b}");
+    dbg!(a);
+    dbg!(b);
 }
 ```
 


### PR DESCRIPTION
Part of #2478 to clean up code blocks when all that is needed is a trivial debug print statement.