### PR TITLE
Rework generic fn examples to show monomorphized versions

### DIFF
--- a/src/generics/generic-functions.md
+++ b/src/generics/generic-functions.md
@@ -24,7 +24,6 @@ fn pick_char(cond: bool, left: char, right: char) -> char {
     }
 }
 
-/// Pick `left` or `right` depending on the value of `n`.
 fn pick<T>(cond: bool, left: T, right: T) -> T {
     if cond {
         left

--- a/src/generics/generic-functions.md
+++ b/src/generics/generic-functions.md
@@ -8,18 +8,34 @@ Rust supports generics, which lets you abstract algorithms or data structures
 (such as sorting or a binary tree) over the types used or stored.
 
 ```rust,editable
-/// Pick `even` or `odd` depending on the value of `n`.
-fn pick<T>(n: i32, even: T, odd: T) -> T {
-    if n % 2 == 0 {
-        even
+fn pick_i32(cond: bool, left: i32, right: i32) -> i32 {
+    if cond {
+        left
     } else {
-        odd
+        right
+    }
+}
+
+fn pick_char(cond: bool, left: char, right: char) -> char {
+    if cond {
+        left
+    } else {
+        right
+    }
+}
+
+/// Pick `left` or `right` depending on the value of `n`.
+fn pick<T>(cond: bool, left: T, right: T) -> T {
+    if cond {
+        left
+    } else {
+        right
     }
 }
 
 fn main() {
-    println!("picked a number: {:?}", pick(97, 222, 333));
-    println!("picked a string: {:?}", pick(28, "dog", "cat"));
+    println!("picked a number: {:?}", pick(true, 222, 333));
+    println!("picked a string: {:?}", pick(false, 'L', 'R'));
 }
 ```
 

--- a/src/generics/generic-functions.md
+++ b/src/generics/generic-functions.md
@@ -8,22 +8,6 @@ Rust supports generics, which lets you abstract algorithms or data structures
 (such as sorting or a binary tree) over the types used or stored.
 
 ```rust,editable
-fn pick_i32(cond: bool, left: i32, right: i32) -> i32 {
-    if cond {
-        left
-    } else {
-        right
-    }
-}
-
-fn pick_char(cond: bool, left: char, right: char) -> char {
-    if cond {
-        left
-    } else {
-        right
-    }
-}
-
 fn pick<T>(cond: bool, left: T, right: T) -> T {
     if cond {
         left
@@ -40,9 +24,32 @@ fn main() {
 
 <details>
 
+- It can be helpful to show the monomorphized versions of `pick`, either before
+  talking about the generic `pick` in order to show how generics can reduce code
+  duplication, or after talking about generics to show how monomorphization
+  works.
+
+  ```rust
+  fn pick_i32(cond: bool, left: i32, right: i32) -> i32 {
+      if cond {
+          left
+      } else {
+          right
+      }
+  }
+
+  fn pick_char(cond: bool, left: char, right: char) -> char {
+      if cond {
+          left
+      } else {
+          right
+      }
+  }
+  ```
+
 - Rust infers a type for T based on the types of the arguments and return value.
 
-- In this example we only use the primitive types `i32` and `&str` for `T`, but
+- In this example we only use the primitive types `i32` and `char` for `T`, but
   we can use any type here, including user-defined types:
 
   ```rust,ignore


### PR DESCRIPTION
Something I always do when covering generic fns is I like to show the monomorphized versions of `pick` to make it clear to students what generics are doing behind the scenes. In my most recent class I tried going the other way around, showing the monomorphized versions first to more clearly motivate what generics are used for, and I liked the way it went. I think motivating generics by first showing code duplication and then showing how generics allow us to de-duplicate makes for a good teaching flow, and I think it also helps make things clearer to students coming from more dynamic languages that don't have an equivalent to generics.

I also changed the `pick` fns to take a `bool` as the first argument because I think that makes things slightly clearer/cleaner, but I'm not married to that change either.