### PR TITLE
Add division example to expression exercise

### DIFF
--- a/src/pattern-matching/exercise.rs
+++ b/src/pattern-matching/exercise.rs
@@ -126,4 +126,16 @@ fn test_zeros() {
         0
     );
 }
+
+#[test]
+fn test_div() {
+    assert_eq!(
+        eval(Expression::Op {
+            op: Operation::Div,
+            left: Box::new(Expression::Value(10)),
+            right: Box::new(Expression::Value(2)),
+        }),
+        5
+    )
+}
 // ANCHOR_END: tests


### PR DESCRIPTION
[I'm having deja vu](https://github.com/google/comprehensive-rust/pull/2605). Fixes a warning about an unused enum variant in the expression evaluation exercise.