### PR TITLE
Fix bug where speaker notes are not connected to regular window

### DIFF
--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -25,7 +25,6 @@
     Regular: "regular",
     RegularWithSpeakerNotes: "regular-speaker-notes",
     SpeakerNotes: "speaker-notes",
-    SpeakerNotesDefunct: "speaker-notes-defunct",
     PrintPage: "print-page",
   };
 
@@ -35,8 +34,6 @@
       return WindowMode.SpeakerNotes;
     } else if (window.location.hash == "#speaker-notes") {
       return WindowMode.RegularWithSpeakerNotes;
-    } else if (window.location.hash == "#speaker-notes-defunct") {
-      return WindowMode.SpeakerNotesDefunct;
     } else if (window.location.pathname.endsWith("/print.html")) {
       return WindowMode.PrintPage;
     } else {
@@ -70,14 +67,14 @@
         if (getState() == NotesState.Popup) {
           // Reset to Inline if we have been in Popup mode
           setState(NotesState.Inline);
-          applyState();
+          applyInlinePopupStyle();
         }
       } else {
         // Received a pong from a speaker notes window
         if (getState() != NotesState.Popup) {
           // but we are not in Popup mode, reset to Popup mode
           setState(NotesState.Popup);
-          applyState();
+          applyInlinePopupStyle();
         }
       }
     }, 500);
@@ -110,16 +107,9 @@
   }
   let popIn = document.createElement("button");
 
-  // Apply the correct style for the speaker notes in the
-  // regular window - not on speaker notes page
-  function applyState() {
-    if (detectWindowMode() == WindowMode.SpeakerNotes) {
-      if (getState() != NotesState.Popup) {
-        markDefunct();
-      }
-      return;
-    }
-
+  // Apply the correct style for the inline speaker notes in the
+  // regular window - do not use on speaker notes page
+  function applyInlinePopupStyle() {
     switch (getState()) {
       case NotesState.Popup:
         popIn.classList.remove("hidden");
@@ -143,8 +133,8 @@
     return window.localStorage["speakerNotes"] || NotesState.Closed;
   }
 
-  // Set the state of the speaker note window. Call applyState as needed
-  // afterwards.
+  // Set the state of the speaker note window. Call applyInlinePopupStyle
+  // as needed afterwards.
   function setState(state) {
     window.localStorage["speakerNotes"] = state;
   }
@@ -169,7 +159,7 @@
       speakerNotesChannel.postMessage(BroadcastMessage.CloseNotes);
       // Switch to Inline popup mode
       setState(NotesState.Inline);
-      applyState();
+      applyInlinePopupStyle();
     });
     document.querySelector(".left-buttons").append(popIn);
 
@@ -204,7 +194,7 @@
       );
       if (popup) {
         setState(NotesState.Popup);
-        applyState();
+        applyInlinePopupStyle();
       } else {
         window.alert(
           "Could not open popup, please check your popup blocker settings."
@@ -293,9 +283,6 @@
 
   // apply the correct state for the window
   switch (detectWindowMode()) {
-    case WindowMode.SpeakerNotesDefunct:
-      // mark the window defunct then fall-through into speaker notes
-      markDefunct();
     case WindowMode.SpeakerNotes:
       setupSpeakerNotes();
       break;
@@ -306,7 +293,7 @@
       // Regular page with inline speaker notes, set state then fall-through
       setState(NotesState.Inline);
     case WindowMode.Regular:
-      applyState();
+      applyInlinePopupStyle();
       setupRegularPage();
       break;
   }

--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -13,6 +13,13 @@
 // limitations under the License.
 
 (function () {
+  // Valid speaker notes states
+  const NotesState = {
+    Popup: "popup",
+    Inline: "inline-open",
+    Closed: "inline-closed",
+  };
+
   let notes = document.querySelector("details");
   // Create an unattached DOM node for the code below.
   if (!notes) {
@@ -34,23 +41,23 @@
   // speaker note pages.
   function applyState() {
     if (window.location.hash == "#speaker-notes-open") {
-      if (getState() != "popup") {
+      if (getState() != NotesState.Popup) {
         markDefunct();
       }
       return;
     }
 
     switch (getState()) {
-      case "popup":
+      case NotesState.Popup:
         popIn.classList.remove("hidden");
         notes.classList.add("hidden");
         break;
-      case "inline-open":
+      case NotesState.Inline:
         popIn.classList.add("hidden");
         notes.open = true;
         notes.classList.remove("hidden");
         break;
-      case "inline-closed":
+      case NotesState.Closed:
         popIn.classList.add("hidden");
         notes.open = false;
         notes.classList.remove("hidden");
@@ -58,10 +65,9 @@
     }
   }
 
-  // Get the state of the speaker note window: "inline-open", "inline-closed",
-  // or "popup".
+  // Get the state of the speaker note window.
   function getState() {
-    return window.localStorage["speakerNotes"] || "inline-closed";
+    return window.localStorage["speakerNotes"] || NotesState.Closed;
   }
 
   // Set the state of the speaker note window. Call applyState as needed
@@ -82,14 +88,14 @@
     popInIcon.classList.add("fa", "fa-window-close-o");
     popIn.append(popInIcon);
     popIn.addEventListener("click", (event) => {
-      setState("inline-open");
+      setState(NotesState.Inline);
       applyState();
     });
     document.querySelector(".left-buttons").append(popIn);
 
     // Create speaker notes.
     notes.addEventListener("toggle", (event) => {
-      setState(notes.open ? "inline-open" : "inline-closed");
+      setState(notes.open ? NotesState.Inline : NotesState.Closed);
     });
 
     let summary = document.createElement("summary");
@@ -111,14 +117,18 @@
     let popOut = document.createElement("button");
     popOut.classList.add("icon-button", "pop-out");
     popOut.addEventListener("click", (event) => {
-      let popup = window.open(popOutLocation.href, "speakerNotes", "popup");
+      let popup = window.open(
+        popOutLocation.href,
+        "speakerNotes",
+        NotesState.Popup,
+      );
       if (popup) {
-        setState("popup");
+        setState(NotesState.Popup);
         applyState();
         // bind the popup to reset the speaker note state on close of the popup
         popup.onload = () => {
           popup.onbeforeunload = () => {
-            setState("inline-open");
+            setState(NotesState.Inline);
             applyState();
           };
         };
@@ -200,7 +210,7 @@
   window.addEventListener("storage", (event) => {
     switch (event.key) {
       case "currentPage":
-        if (getState() == "popup") {
+        if (getState() == NotesState.Popup) {
           // We link all windows when we are showing speaker notes.
           window.location.pathname = event.newValue;
         }
@@ -246,10 +256,10 @@
         return;
       }
 
-      // We are on a regular page. We force the state to "inline-open" if this
+      // We are on a regular page. We force the state to Inline if this
       // looks like a direct link to the speaker notes.
       if (window.location.hash == "#speaker-notes") {
-        setState("inline-open");
+        setState(NotesState.Inline);
       }
       applyState();
       setupRegularPage();


### PR DESCRIPTION
Fixes bug #2004.
Refactored the communication between the speaker notes window and the regular window by using a Broadcast channel - this is now self-recovering(!) even if speaker notes are closed and manually re-opened!

For better readability and maintainability refactored some string-based states into enum style code and refactored detection of the type of windows (print, speaker note, regular window)

Manually tested the new code and the speaker notes window does not disconnect from the regular window anymore.
This now works way more reliable, even if there are (still) some UI glitches that have been there before already.