### PR TITLE
Use dbg! instead of println! in deep dive sessions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,11 @@ match ANCHOR comments in the `exercise.rs` file. Each segment also has a
 `Cargo.toml`. The result is that `exercise.rs` is built and tested by
 `cargo test`.
 
-For segments on day 1, exercises should use `fn main() { .. }` and `println!`,
-with students visually verifying the correct output. On subsequent days, prefer
-tests and omit `fn main() { .. }`. However, where tests would be difficult and
-visual verification is more natural (such as in the Logger exercise), using
-`fn main { .. }` is OK.
+For segments on day 1, exercises should use `fn main() { .. }` and `dbg!` or
+`println!`, with students visually verifying the correct output. On subsequent
+days, prefer tests and omit `fn main() { .. }`. However, where tests would be
+difficult and visual verification is more natural (such as in the Logger
+exercise), using `fn main { .. }` is OK.
 
 Especially for exercises without tests, consider including tests in
 `exercise.rs` that do not appear in either `exercise.md` or `solution.md`, as

--- a/src/bare-metal/useful-crates/spin.md
+++ b/src/bare-metal/useful-crates/spin.md
@@ -15,9 +15,9 @@ use spin::mutex::SpinMutex;
 static COUNTER: SpinMutex<u32> = SpinMutex::new(0);
 
 fn main() {
-    println!("count: {}", COUNTER.lock());
+    dbg!(COUNTER.lock());
     *COUNTER.lock() += 2;
-    println!("count: {}", COUNTER.lock());
+    dbg!(COUNTER.lock());
 }
 ```
 

--- a/src/concurrency/threads/scoped.md
+++ b/src/concurrency/threads/scoped.md
@@ -12,7 +12,7 @@ use std::thread;
 fn foo() {
     let s = String::from("Hello");
     thread::spawn(|| {
-        println!("Length: {}", s.len());
+        dbg!(s.len());
     });
 }
 
@@ -30,7 +30,7 @@ fn foo() {
     let s = String::from("Hello");
     thread::scope(|scope| {
         scope.spawn(|| {
-            println!("Length: {}", s.len());
+            dbg!(s.len());
         });
     });
 }


### PR DESCRIPTION
Part of #2478 to clean up code blocks when all that is needed is a trivial debug print statement. The deep dive sessions didn't have that many occurrences of trivial println! statements.

I believe this can close #2478.