### PR TITLE
Remove `pub` from traits exercise

### DIFF
--- a/src/methods-and-traits/exercise.rs
+++ b/src/methods-and-traits/exercise.rs
@@ -14,7 +14,7 @@
 
 // ANCHOR: solution
 // ANCHOR: setup
-pub trait Logger {
+trait Logger {
     /// Log a message at the given verbosity level.
     fn log(&self, verbosity: u8, message: &str);
 }


### PR DESCRIPTION
We haven't talked about visibility at this point and the new keyword sometimes confuses students.