### PR TITLE
Move `From` definition into code block

### DIFF
--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -40,8 +40,8 @@ fn main() {
 
 <details>
 
-- The `From` trait will be covered later in the course, but its [definition in
-  the `std` docs][from] is simple, and copied here for reference.
+- The `From` trait will be covered later in the course, but its
+  [definition in the `std` docs][from] is simple, and copied here for reference.
 
 - Implementations of the trait do not need to cover all possible type
   parameters. Here, `Foo::from("hello")` would not compile because there is no

--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -5,18 +5,18 @@ Minutes: 5
 # Generic Traits
 
 Traits can also be generic, just like types and functions. A trait's parameters
-get concrete types when it is used.
+get concrete types when it is used. For example the [`From<T>`][from] trait is
+used to define type conversions:
+
+```rust
+pub trait From<T>: Sized {
+    fn from(value: T) -> Self;
+}
+```
 
 ```rust,editable
 #[derive(Debug)]
 struct Foo(String);
-
-/* https://doc.rust-lang.org/stable/std/convert/trait.From.html
- *
- * pub trait From<T>: Sized {
- *   fn from(value: T) -> Self;
- * }
- */
 
 impl From<u32> for Foo {
     fn from(from: u32) -> Foo {
@@ -40,9 +40,8 @@ fn main() {
 
 <details>
 
-- The `From` trait will be covered later in the course, but its
-  [definition in the `std` docs](https://doc.rust-lang.org/std/convert/trait.From.html)
-  is simple, and copied here for reference.
+- The `From` trait will be covered later in the course, but its [definition in
+  the `std` docs][from] is simple, and copied here for reference.
 
 - Implementations of the trait do not need to cover all possible type
   parameters. Here, `Foo::from("hello")` would not compile because there is no
@@ -58,3 +57,5 @@ fn main() {
   [specialization](https://rust-lang.github.io/rfcs/1210-impl-specialization.html).
 
 </details>
+
+[from]: https://doc.rust-lang.org/std/convert/trait.From.html


### PR DESCRIPTION
Having the `From` definition in the slide for quick reference is useful, but having it in a comment makes it a bit hard to read, but also we can't directly include it in the same code block as the example code because it causes errors. Moving it into its own block makes it easier to read without interfering with the example code.