### PR TITLE
Replace closure `map` example with direct calls

### DIFF
--- a/src/closures/capturing.md
+++ b/src/closures/capturing.md
@@ -16,10 +16,12 @@ fn main() {
             v
         }
     };
-    println!(
-        "clamped values at {max_value}: {:?}",
-        (0..10).map(clamp).collect::<Vec<_>>()
-    );
+
+    dbg!(clamp(1));
+    dbg!(clamp(3));
+    dbg!(clamp(5));
+    dbg!(clamp(7));
+    dbg!(clamp(10));
 }
 ```
 


### PR DESCRIPTION
At this point we haven't talked about iterators or `map`, so I think this example is confusing for students. Calling `clamp` directly a few times and logging it with `dbg!` should be clearer I think.