### PR TITLE
es: add and improve Spanish translations in `Testing in Android` section

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -13653,34 +13653,32 @@ msgid ""
 msgstr ""
 
 #: src/android/testing.md
-#, fuzzy
 msgid "Testing in Android"
-msgstr "Rust en Android"
+msgstr "Pruebas en Android"
 
 #: src/android/testing.md
 msgid ""
 "Building on [Testing](../testing.md), we will now look at how unit tests "
 "work in AOSP. Use the `rust_test` module for your unit tests:"
 msgstr ""
+"Basándonos en [Pruebas](../testing.md), ahora veremos cómo funcionan las pruebas "
+"unitarias en AOSP. Usa el módulo `rust_test` para tus pruebas unitarias:"
 
 #: src/android/testing.md
-#, fuzzy
 msgid "_testing/Android.bp_:"
-msgstr "_hello_rust/Android.bp_:"
+msgstr "_testing/Android.bp_:"
 
 #: src/android/testing.md
-#, fuzzy
 msgid "\"libleftpad\""
-msgstr "\"libtextwrap\""
+msgstr "\"libleftpad\""
 
 #: src/android/testing.md
 msgid "\"leftpad\""
 msgstr ""
 
 #: src/android/testing.md
-#, fuzzy
 msgid "\"libleftpad_test\""
-msgstr "\"libbirthday_bindgen_test\""
+msgstr "\"libleftpad_test\""
 
 #: src/android/testing.md
 msgid "\"leftpad_test\""
@@ -13691,43 +13689,36 @@ msgid "\"general-tests\""
 msgstr "\"general-tests\""
 
 #: src/android/testing.md
-#, fuzzy
 msgid "_testing/src/lib.rs_:"
-msgstr "_hello_rust/src/lib.rs_:"
+msgstr "_testing/src/lib.rs_:"
 
 #: src/android/testing.md
-#, fuzzy
 msgid "//! Left-padding library.\n"
-msgstr "//! Biblioteca de saludos.\n"
+msgstr "//! Biblioteca de relleno a la izquierda.\n"
 
 #: src/android/testing.md
 msgid "/// Left-pad `s` to `width`.\n"
-msgstr ""
+msgstr "/// Rellena `s` a la izquierda hasta `width`.\n"
 
 #: src/android/testing.md
-#, fuzzy
 msgid "\"{s:>width$}\""
-msgstr "\"|{:^width$}|\""
+msgstr "\"{s:>width$}\""
 
 #: src/android/testing.md
-#, fuzzy
 msgid "\"  foo\""
-msgstr "\"foo\""
+msgstr "\"  foo\""
 
 #: src/android/testing.md
-#, fuzzy
 msgid "\"foobar\""
-msgstr "\"foo\""
+msgstr "\"foobar\""
 
 #: src/android/testing.md
-#, fuzzy
 msgid "You can now run the test with"
-msgstr "Ahora puedes generar automáticamente los enlaces:"
+msgstr "Ahora puedes ejecutar la prueba con"
 
 #: src/android/testing.md
-#, fuzzy
 msgid "The output looks like this:"
-msgstr "El enfoque general es el siguiente:"
+msgstr "La salida se ve así:"
 
 #: src/android/testing.md
 msgid ""
@@ -13748,15 +13739,16 @@ msgid ""
 "Notice how you only mention the root of the library crate. Tests are found "
 "recursively in nested modules."
 msgstr ""
+"Observa que solo mencionas la raíz del crate de la biblioteca. Las pruebas se "
+"encuentran de forma recursiva en módulos anidados."
 
 #: src/android/testing/googletest.md
-#, fuzzy
 msgid ""
 "The [GoogleTest](https://docs.rs/googletest/) crate allows for flexible test "
 "assertions using _matchers_:"
 msgstr ""
-"[googletest](https://docs.rs/googletest): biblioteca completa de aserción de "
-"pruebas en la tradición de GoogleTest para C++."
+"El crate [GoogleTest](https://docs.rs/googletest/) permite realizar aserciones de "
+"prueba flexibles utilizando _matchers_:"
 
 #: src/android/testing/googletest.md
 msgid "\"baz\""
@@ -13804,13 +13796,12 @@ msgid ""
 msgstr ""
 
 #: src/android/testing/googletest.md
-#, fuzzy
 msgid ""
 "A particularly nice feature is that mismatches in multi-line strings are "
 "shown as a diff:"
 msgstr ""
-"Una característica muy interesante es que las discrepancias en las cadenas "
-"que contienen varias líneas se muestran como un diff:"
+"Una característica especialmente útil es que las discrepancias en cadenas de "
+"varias líneas se muestran como un diff:"
 
 #: src/android/testing/googletest.md
 msgid ""
@@ -13855,7 +13846,6 @@ msgstr ""
 "podrás hacer simulaciones:"
 
 #: src/android/testing/mocking.md
-#, fuzzy
 msgid ""
 "Mockall is the recommended mocking library in Android (AOSP). There are "
 "other [mocking libraries available on crates.io](https://crates.io/keywords/"
@@ -13863,13 +13853,12 @@ msgid ""
 "libraries work in a similar fashion as Mockall, meaning that they make it "
 "easy to get a mock implementation of a given trait."
 msgstr ""
-"Estos consejos son útiles para Android (AOSP), donde Mockall es la "
-"biblioteca de simulaciones recomendada. Hay otras [bibliotecas de simulación "
-"disponibles en crates.io](https://crates.io/keywords/mock), especialmente en "
-"el área de servicios de simulación de HTTP. Las demás bibliotecas de "
-"simulación funcionan de forma similar a Mockall, lo que significa que "
-"facilitan la obtención de una implementación simulada de un trait "
-"determinado."
+"Mockall es la biblioteca de simulación recomendada en Android (AOSP). Hay "
+"otras [bibliotecas de simulación disponibles en crates.io](https://crates.io/keywords/mock), "
+"particularmente en el área de simulación de servicios HTTP. Las demás "
+"bibliotecas de simulación funcionan de manera similar a Mockall, lo que "
+"significa que facilitan la obtención de una implementación simulada de un "
+"trait determinado."
 
 #: src/android/testing/mocking.md
 msgid ""


### PR DESCRIPTION
Fixes and improves the Spanish translations in the `Testing in Android` section (src/android/testing.md)