### PR TITLE
Improve tests for BinaryTree exercise

### DIFF
--- a/src/smart-pointers/exercise.rs
+++ b/src/smart-pointers/exercise.rs
@@ -112,6 +112,8 @@ mod tests {
         assert_eq!(tree.len(), 2);
         tree.insert(2); // not a unique item
         assert_eq!(tree.len(), 2);
+        tree.insert(3);
+        assert_eq!(tree.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Current tests still pass if `len` is implemented to calculate the height of the tree (i.e. max(left.len(), right.len()) + 1 for each node). It seems this is quite a common misunderstanding when doing this course.

With the new assert height implementation will fail, which hints towards implementing `len` as a total number of nodes.