### PR TITLE
Remove type annotations in move.md

### DIFF
--- a/src/memory-management/move.md
+++ b/src/memory-management/move.md
@@ -8,8 +8,8 @@ An assignment will transfer _ownership_ between variables:
 
 ```rust,editable
 fn main() {
-    let s1: String = String::from("Hello!");
-    let s2: String = s1;
+    let s1 = String::from("Hello!");
+    let s2 = s1;
     dbg!(s2);
     // dbg!(s1);
 }


### PR DESCRIPTION
At this point I don't think we need the type annotation, and I think the example is a bit clearer without them, so I usually delete these as I'm explaining in class.