### PR TITLE
Use Vec::new instead of vec!

### DIFF
--- a/src/memory-management/exercise.rs
+++ b/src/memory-management/exercise.rs
@@ -65,8 +65,8 @@ impl PackageBuilder {
         Self(Package {
             name: name.into(),
             version: "0.1".into(),
-            authors: vec![],
-            dependencies: vec![],
+            authors: Vec::new(),
+            dependencies: Vec::new(),
             language: None,
         })
     }


### PR DESCRIPTION
Using the `vec!` macro to create an empty `Vec` is a bit weird imo, generally I only see the macro used when you actually want to initialize the `Vec` with some values (like is done in the examples for this exercise). Students are more likely to use `Vec::new`, and I think that's the more idiomatic approach, so I think using `Vec::new` here would be better.