### PR TITLE
Make install-tools command work from any directory in the workspace.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,8 @@
 # We use this alias for task automation in the project.
 # See README in xtask directory.
 xtask = "run --package xtask --"
+
+[env]
+# To provide an anchor to the root of the workspace when working with paths.
+# See https://github.com/rust-lang/cargo/issues/3946#issuecomment-973132993
+CARGO_WORKSPACE_DIR = { value = "", relative = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -54,6 +54,11 @@ fn execute_task() -> Result<()> {
 fn install_tools() -> Result<()> {
     println!("Installing project tools...");
 
+    let path_to_mdbook_exerciser =
+        format!("{}mdbook-exerciser", env!("CARGO_WORKSPACE_DIR"));
+    let path_to_mdbook_course =
+        format!("{}mdbook-course", env!("CARGO_WORKSPACE_DIR"));
+
     let install_args = vec![
         // The --locked flag is important for reproducible builds. It also
         // avoids breakage due to skews between mdbook and mdbook-svgbob.
@@ -62,9 +67,11 @@ fn install_tools() -> Result<()> {
         vec!["mdbook-pandoc", "--locked", "--version", "0.9.3"],
         vec!["mdbook-i18n-helpers", "--locked", "--version", "0.3.5"],
         vec!["i18n-report", "--locked", "--version", "0.2.0"],
-        // These packages are located in this repository
-        vec!["--path", "mdbook-exerciser", "--locked"],
-        vec!["--path", "mdbook-course", "--locked"],
+        // Mdbook-exerciser and mdbook-course are located in this repository.
+        // To make it possible to install them from any directory we need to 
+        // specify their path from the workspace root.
+        vec!["--path", &path_to_mdbook_exerciser, "--locked"],
+        vec!["--path", &path_to_mdbook_course, "--locked"],
     ];
 
     for args in &install_args {


### PR DESCRIPTION
This fixes #2708 by creating a CARGO_WORKSPACE_DIR env variable to act as an anchor path, allowing the installation of mdbook-exerciser and mdbook-course to succeed from any directory within the repository. Based on the approach mentioned here: https://github.com/rust-lang/cargo/issues/3946#issuecomment-973132993