### PR TITLE
workflow: enable npm caching and update node to LTS version 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,12 +182,14 @@ jobs:
         run: mdbook test
 
       - name: Setup Node
+        if: matrix.language == 'en'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "npm"
           cache-dependency-path: "tests/package-lock.json"
       - name: Install test framework
+        if: matrix.language == 'en'
         run: npm install
         working-directory: ./tests
       - name: Test Javascript

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: "tests/package-lock.json"
       - name: Install test framework
         run: npm install
         working-directory: ./tests


### PR DESCRIPTION
node version 18 is EOL  https://nodejs.org/en/about/previous-releases
node version 22 is the new LTS release 
The caching is done to make the tests less brittle in addition to only setup for the english translation
There have been failed tests because npm install encountered network issues while downloading packages.