### PR TITLE
unsafe: mutable-static: do not create reference

### DIFF
--- a/src/unsafe-rust/mutable-static.md
+++ b/src/unsafe-rust/mutable-static.md
@@ -32,7 +32,7 @@ fn main() {
 
     // SAFETY: There are no other threads which could be accessing `COUNTER`.
     unsafe {
-        println!("COUNTER: {COUNTER}");
+        dbg!(COUNTER);
     }
 }
 ```


### PR DESCRIPTION
`println!` adds references (&) to its arguments, to avoid moving them.

This is undesirable here, because it is extremely error-prone to take references to `static mut`s. We could `println!("{}", {counter})`, but this is somewhat exotic syntax and just sticking with `dbg!` also avoids this problem as it does not add references.