### PR TITLE
tests: fix the includes in test/tsconfig.json and switch to modern node18 module

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
-    "module": "ESNext",
-    "target": "es2022",
+    // This implicitly sets moduleResolution to "node16"
+    // https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution-is-host-defined
+    "module": "Node18",
+    "target": "ES2024",
     "lib": [
-      "es2022",
-      "dom"
+      // https://www.typescriptlang.org/tsconfig/#lib
+      // include APIs that are enabled by ES2024
+      "ES2024",
+      // DOM definitions, window, document, etc.
+      "DOM"
     ],
     "types": [
       "node",
@@ -24,7 +28,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "test",
+    "src/**/*.ts",
     "wdio.conf.ts"
   ]
 }


### PR DESCRIPTION
- typescript checking was not properly working before in src/ directory
- https://www.typescriptlang.org/tsconfig/#node16node18nodenext: node18 is the up-to-date module. This picks the module resolution "node16"
- https://www.typescriptlang.org/tsconfig/#moduleResolution recommends not using node (node10) in modern code
- Update target to ES2024