### PR TITLE
mdbook-exerciser: ensure all code block bytes of the examples are written to the file

### DIFF
--- a/mdbook-exerciser/src/lib.rs
+++ b/mdbook-exerciser/src/lib.rs
@@ -58,7 +58,7 @@ pub fn process(output_directory: &Path, input_contents: &str) -> anyhow::Result<
             Event::Text(text) => {
                 info!("Text: {:?}", text);
                 if let Some(output_file) = &mut current_file {
-                    output_file.write(text.as_bytes())?;
+                    output_file.write_all(text.as_bytes())?;
                 }
             }
             Event::End(TagEnd::CodeBlock) => {


### PR DESCRIPTION
- write() attempts to write the entire buffer does not guarantee this.
  Not writing all bytes is not considered an error.
  It just returns the number of bytes.
- write_all() ensures that everything is written or throws an error