### PR TITLE
Add xtask command for running web-tests.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,9 @@ used mainly in the [CI](../github/workflows/build.yml) to serve the book on port
 `localhost:8080` such that the test runner can access it. This mode is used when
 `npm start` or `npm test` is executed.
 
+> **Tip:** Use `cargo xtask web-tests` to run the tests in this directory 
+from anywhere in the repository.
+
 For local testing and quick iterations it is possible to use `mdbook serve`
 which creates a small HTTP server on port 3000 by default. There is a special
 config that is invoked with `npm run test-mdbook` that uses

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,8 +14,8 @@ used mainly in the [CI](../github/workflows/build.yml) to serve the book on port
 `localhost:8080` such that the test runner can access it. This mode is used when
 `npm start` or `npm test` is executed.
 
-> **Tip:** Use `cargo xtask web-tests` to run the tests in this directory 
-from anywhere in the repository.
+> **Tip:** Use `cargo xtask web-tests` to run the tests in this directory from
+> anywhere in the repository.
 
 For local testing and quick iterations it is possible to use `mdbook serve`
 which creates a small HTTP server on port 3000 by default. There is a special

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,6 +45,7 @@ fn execute_task() -> Result<()> {
     let task = Args::parse().task;
     match task.as_str() {
         "install-tools" => install_tools()?,
+        "web-tests" => run_web_tests()?,
         _ => {
             return Err(anyhow!(unrecognized_task_string(task.as_str())));
         }
@@ -95,10 +96,34 @@ fn install_tools() -> Result<()> {
     Ok(())
 }
 
+fn run_web_tests() -> Result<()> {
+    println!("Running web tests...");
+
+    let path_to_tests_dir = Path::new(env!("CARGO_WORKSPACE_DIR")).join("tests");
+
+    let status = Command::new("npm")
+        .current_dir(path_to_tests_dir.to_str().unwrap())
+        .arg("test")
+        .status()
+        .expect("Failed to execute npm test");
+
+    if !status.success() {
+        let error_message = format!(
+            "Command 'cargo web-tests' exited with status code: {}",
+            status.code().unwrap()
+        );
+        return Err(anyhow!(error_message));
+    }
+
+    Ok(())
+}
+
+// TODO - https://github.com/google/comprehensive-rust/issues/2741: Replace this with Clap
 fn unrecognized_task_string(task: &str) -> String {
     format!(
         "Unrecognized task '{task}'. Available tasks:
 
-install-tools            Installs the tools the project depends on."
+install-tools            Installs the tools the project depends on.
+web-tests                Runs the web driver tests in the tests directory."
     )
 }


### PR DESCRIPTION
Currently, to run the tests that are located in the `tests` directory (the js tests), one has to navigate to the directory and run `npm test` or `npm start`. We now have a way of automating such task execution using the binary in the `xtask` directory. This pr makes use of this by introducing a new command `cargo xtask web-tests` that can be run from anywhere in the repo to run the tests in the `tests` directory.