### PR TITLE
Remove explicit derefs from shared ref slide

### DIFF
--- a/src/references/shared.md
+++ b/src/references/shared.md
@@ -14,10 +14,10 @@ fn main() {
     let b = 'B';
 
     let mut r: &char = &a;
-    dbg!(*r);
+    dbg!(r);
 
     r = &b;
-    dbg!(*r);
+    dbg!(r);
 }
 ```
 


### PR DESCRIPTION
When teaching I generally remove these. I emphasize that a reference can generally be used as if you have the referenced value directly, since in most cases you don't have to explicitly dereference a reference. On the next slide we show mutable references, and we need to use a deref when writing through a mutable reference, so I think that's the better place to point out the deref operator.