### PR TITLE
Reorder struct pattern examples

### DIFF
--- a/third_party/rust-by-example/destructuring-structs.rs
+++ b/third_party/rust-by-example/destructuring-structs.rs
@@ -7,8 +7,8 @@ struct Foo {
 fn main() {
     let foo = Foo { x: (1, 2), y: 3 };
     match foo {
-        Foo { x: (1, b), y } => println!("x.0 = 1, b = {b}, y = {y}"),
         Foo { y: 2, x: i }   => println!("y = 2, x = {i:?}"),
+        Foo { x: (1, b), y } => println!("x.0 = 1, b = {b}, y = {y}"),
         Foo { y, .. }        => println!("y = {y}, other fields were ignored"),
     }
 }


### PR DESCRIPTION
I generally like to start with that second case since imo it's the simplest one before going on to the case that uses a tuple sub-pattern to break up the `x` field.