### PR TITLE
Remove unnecessary deref operation in refcell.md

### DIFF
--- a/src/borrowing/interior-mutability/refcell.md
+++ b/src/borrowing/interior-mutability/refcell.md
@@ -23,7 +23,7 @@ fn main() {
 
         // This triggers an error at runtime.
         // let other = cell.borrow();
-        // println!("{}", *other);
+        // println!("{}", other);
     }
 
     println!("{cell:?}");


### PR DESCRIPTION
This is another place where we were explicitly doing a deref in a situation where it's not necessary, so I think removing it makes the code a bit more idiomatic and readable.