### PR TITLE
Simplify type cast and remove error handling in protobuf exercise

### DIFF
--- a/src/lifetimes/exercise.rs
+++ b/src/lifetimes/exercise.rs
@@ -127,10 +127,7 @@ fn parse_field(data: &[u8]) -> (Field, &[u8]) {
         }
         WireType::Len => {
             let (len, remainder) = parse_varint(remainder);
-            let len: usize = len.try_into().expect("len not a valid `usize`");
-            if remainder.len() < len {
-                panic!("Unexpected EOF");
-            }
+            let len = len as usize;
             let (value, remainder) = remainder.split_at(len);
             (FieldValue::Len(value), remainder)
         }


### PR DESCRIPTION
While using `.try_into().expect()` is the more robust solution, I think it's more complex than we want here. We don't really care about error handling in this exercise, so I think a simple `as` cast is clearer here. I think we should also remove the logic for checking if there are enough bytes left, since it simplifies things and makes the solution easier to read.