### PR TITLE
Add more tools to install instructions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,12 +161,6 @@ jobs:
           MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' mdbook build -d po
           msgfmt -o /dev/null --statistics po/messages.pot
 
-      - name: Install mdbook-linkcheck2
-        if: contains(fromJSON(env.LINK_CHECKED_LANGUAGES), matrix.language)
-        run: |
-          cargo uninstall mdbook-linkcheck || true
-          cargo install mdbook-linkcheck2 --locked --version 0.9.1
-
       - name: Build ${{ matrix.language }} translation
         run: |
           .github/workflows/build.sh ${{ matrix.language }} book/comprehensive-rust-${{ matrix.language }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,10 +59,12 @@ Install `dprint` using their
 [installation instructions](https://dprint.dev/install/) and install `rustfmt`
 via `rustup`.
 
+Install [pandoc 3.7.0.1](https://github.com/jgm/pandoc/releases/tag/3.7.0.1).
+
 On Debian, you can install the other tools using:
 
 ```sh
-sudo apt install yapf3 gettext
+sudo apt install yapf3 gettext texlive texlive-luatex texlive-lang-cjk texlive-lang-arabic librsvg2-bin fonts-noto
 ```
 
 ### MacOS

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -84,6 +84,7 @@ fn install_tools() -> Result<()> {
         vec!["mdbook-pandoc", "--locked", "--version", "0.10.4"],
         vec!["mdbook-i18n-helpers", "--locked", "--version", "0.3.6"],
         vec!["i18n-report", "--locked", "--version", "0.2.0"],
+        vec!["mdbook-linkcheck2", "--locked", "--version", "0.9.1"],
         // Mdbook-exerciser and mdbook-course are located in this repository.
         // To make it possible to install them from any directory we need to
         // specify their path from the workspace root.


### PR DESCRIPTION
Install mdbook-linkcheck2 via xtask, rather than separate step.