### PR TITLE
Convert dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,18 @@ po/uk.po @dyeroshenko
 po/vi.po @daivinhtran @qu-ngx
 po/zh-CN.po @wnghl @anlunx @kongy @noahdragon @superwhd @emmali01 @candysonya @AgainstEntropy
 po/zh-TW.po @edong @hueich @kuanhungchen @victorhsieh @mingyc @johnathan79717
+
+# Dependency changes (mostly dependabot PRs)
+Cargo.toml @djmitche @mgeisler @qwandor
+Cargo.lock @djmitche @mgeisler @qwandor
+src/bare-metal/alloc-example/Cargo.toml @djmitche @mgeisler @qwandor
+src/bare-metal/alloc-example/Cargo.lock @djmitche @mgeisler @qwandor
+src/bare-metal/aps/examples/Cargo.toml @djmitche @mgeisler @qwandor
+src/bare-metal/aps/examples/Cargo.lock @djmitche @mgeisler @qwandor
+src/bare-metal/microcontrollers/examples/Cargo.toml @djmitche @mgeisler @qwandor
+src/bare-metal/microcontrollers/examples/Cargo.lock @djmitche @mgeisler @qwandor
+src/exercises/bare-metal/compass/Cargo.toml @djmitche @mgeisler @qwandor
+src/exercises/bare-metal/compass/Cargo.lock @djmitche @mgeisler @qwandor
+src/exercises/bare-metal/rtc/Cargo.toml @djmitche @mgeisler @qwandor
+src/exercises/bare-metal/rtc/Cargo.lock @djmitche @mgeisler @qwandor
+.github/workflows @djmitche @mgeisler @qwandor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    reviewers:
-      - djmitche
-      - mgeisler
-      - qwandor
     commit-message:
       prefix: cargo
     groups:
@@ -24,10 +20,6 @@ updates:
     directory: /src/bare-metal/alloc-example/
     schedule:
       interval: monthly
-    reviewers:
-      - djmitche
-      - mgeisler
-      - qwandor
     commit-message:
       prefix: cargo
     groups:
@@ -41,10 +33,6 @@ updates:
     directory: /src/bare-metal/aps/examples/
     schedule:
       interval: monthly
-    reviewers:
-      - djmitche
-      - mgeisler
-      - qwandor
     commit-message:
       prefix: cargo
     groups:
@@ -58,10 +46,6 @@ updates:
     directory: /src/bare-metal/microcontrollers/examples/
     schedule:
       interval: monthly
-    reviewers:
-      - djmitche
-      - mgeisler
-      - qwandor
     commit-message:
       prefix: cargo
     groups:
@@ -75,10 +59,6 @@ updates:
     directory: /src/exercises/bare-metal/compass/
     schedule:
       interval: monthly
-    reviewers:
-      - djmitche
-      - mgeisler
-      - qwandor
     commit-message:
       prefix: cargo
     groups:
@@ -92,10 +72,6 @@ updates:
     directory: /src/exercises/bare-metal/rtc/
     schedule:
       interval: monthly
-    reviewers:
-      - djmitche
-      - mgeisler
-      - qwandor
     commit-message:
       prefix: cargo
     groups:
@@ -109,7 +85,3 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    reviewers:
-      - djmitche
-      - mgeisler
-      - qwandor


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/.