### PR TITLE
Reduce wdio verbosity

### DIFF
--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -83,7 +83,10 @@ export const config: WebdriverIO.Config = {
   //     webdriver: 'info',
   //     '@wdio/appium-service': 'info'
   // },
-  //
+  logLevels: {
+    // Webdriverio outputs several lines per test, in the success case.
+    webdriverio: "error",
+  },
   // If you only want to run your tests until a specific amount of tests have failed use
   // bail (default is 0 - don't bail, run all tests).
   bail: 0,


### PR DESCRIPTION
This avoids the need to scroll through pages of useless warnings to find an actual test failure.