### PR TITLE
ci: parallelize the mdbook build <language> process

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -15,6 +15,19 @@ set -Eeuo pipefail
 book_lang=${1:?"Usage: $0 <book-lang> <dest-dir>"}
 dest_dir=${2:?"Usage: $0 <book-lang> <dest-dir>"}
 
+# ensure source dir exists
+mkdir -p source
+# clean previous build artifacts
+SOURCE_DIR="source/${book_lang}"
+rm -rf "$SOURCE_DIR"
+mkdir "$SOURCE_DIR"
+
+# clone the current state into the source directory
+git clone . "$SOURCE_DIR"
+
+# now work from that new directory as the base directory
+cd "$SOURCE_DIR"
+
 if [ "$book_lang" = "en" ]; then
     echo "::group::Building English course"
 else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,12 +53,10 @@ jobs:
         run: .github/workflows/build.sh en book
 
       - name: Build all translations
+        # note: build.sh here uses the given book path relative to source/{language}
         run: |
-          for po_lang in ${{ env.LANGUAGES }}; do
-              .github/workflows/build.sh $po_lang book/$po_lang
-              mv book/$po_lang/html book/html/$po_lang
-          done
-
+          parallel -i .github/workflows/build.sh {} book/{} -- ${{ env.LANGUAGES }}
+          parallel -i mv source/{}/book/{}/html book/html/{} -- ${{ env.LANGUAGES }}
       - name: Build translation report
         run: i18n-report report book/html/translation-report.html po/*.po
 


### PR DESCRIPTION
Make the mdbook build process parallel. This is a simple approach by just cloning the entire repository into new directories and running the process in parallel. This is a demonstration for #2767.

The process appears to be mostly CPU bound and not memory or disk heavy so the amount of cores on the CI runner matter.
mdbook build does not seem to use more than 1 core and a typical github CI machine [has 4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). So the expected speedup would be 4x.

Currently 30 minutes are used for publish, 25 minutes of this is build process, this would be reduced to 5 + 6.25 = ~12 minutes, thus more than halving the process.