### PR TITLE
Correcting a little error on pt-BR.po

### DIFF
--- a/po/pt-BR.po
+++ b/po/pt-BR.po
@@ -2571,10 +2571,10 @@ msgstr ""
 #: src/welcome-day-1.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 5 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve durar cerca de 2 horas e 5 "
-"minutos"
+"minutos. Possui:"
 
 #: src/welcome-day-1.md
 msgid "Please remind the students that:"
@@ -2673,7 +2673,7 @@ msgstr "[Playground](./hello-world/playground.md) (2 minutos)"
 
 #: src/hello-world.md src/concurrency/send-sync.md
 msgid "This segment should take about 15 minutes. It contains:"
-msgstr "Este segmento deve durar cerca de 15 minutos. E possui:"
+msgstr "Este segmento deve durar cerca de 15 minutos. Possui:"
 
 #: src/hello-world/what-is-rust.md
 msgid ""
@@ -2977,8 +2977,8 @@ msgid "[Exercise: Fibonacci](./types-and-values/exercise.md) (15 minutes)"
 msgstr "[Exercício: Fibonacci](./types-and-values/exercise.md) (15 minutos)"
 
 #: src/types-and-values.md src/control-flow-basics.md src/modules.md
-msgid "This segment should take about 40 minutes"
-msgstr "Este segmento deve levar cerca de 40 minutos"
+msgid "This segment should take about 40 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 40 minutos. Possui:""
 
 #: src/types-and-values/hello-world.md
 msgid ""
@@ -3978,10 +3978,10 @@ msgstr ""
 #: src/welcome-day-1-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 35 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve levar cerca de 2 horas e 35 "
-"minutos"
+"minutos. Possui:"
 
 #: src/tuples-and-arrays.md
 msgid "[Arrays](./tuples-and-arrays/arrays.md) (5 minutes)"
@@ -4008,8 +4008,8 @@ msgstr ""
 "[Exercício: Matrizes Aninhadas](./tuples-and-arrays/exercise.md) (15 minutos)"
 
 #: src/tuples-and-arrays.md
-msgid "This segment should take about 35 minutes"
-msgstr "Este segmento deve levar cerca de 35 minutos"
+msgid "This segment should take about 35 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 35 minutos. Possui:"
 
 #: src/tuples-and-arrays/arrays.md
 msgid ""
@@ -4233,8 +4233,8 @@ msgstr "[Exercício: Geometria](./references/exercise.md) (15 minutos)"
 
 #: src/references.md src/smart-pointers.md src/borrowing.md
 #: src/concurrency/async-pitfalls.md
-msgid "This segment should take about 55 minutes"
-msgstr "Este segmento deve levar cerca de 55 minutos"
+msgid "This segment should take about 55 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 55 minutos. Possui:"
 
 #: src/references/shared.md
 msgid ""
@@ -4660,8 +4660,8 @@ msgstr ""
 "minutos)"
 
 #: src/user-defined-types.md src/methods-and-traits.md src/lifetimes.md
-msgid "This segment should take about 50 minutes"
-msgstr "Este segmento deve levar cerca de 50 minutos"
+msgid "This segment should take about 50 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 50 minutos. Possui:"
 
 #: src/user-defined-types/named-structs.md
 msgid "Like C and C++, Rust has support for custom structs:"
@@ -5251,10 +5251,10 @@ msgstr "[Métodos e Traits](./methods-and-traits.md) (50 minutos)"
 #: src/welcome-day-2.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 10 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve levar cerca de 2 horas e 10 "
-"minutos"
+"minutos. Possui:"
 
 #: src/pattern-matching.md
 msgid "[Matching Values](./pattern-matching/match.md) (10 minutes)"
@@ -5291,8 +5291,8 @@ msgstr ""
 
 #: src/pattern-matching.md src/std-types.md src/memory-management.md
 #: src/error-handling.md
-msgid "This segment should take about 1 hour"
-msgstr "Este segmento deve levar cerca de 1 hora"
+msgid "This segment should take about 1 hour. It contains:"
+msgstr "Este segmento deve levar cerca de 1 hora. Possui:"
 
 #: src/pattern-matching/match.md
 msgid ""
@@ -6247,10 +6247,10 @@ msgstr "[_Traits_ da Biblioteca Padrão](./std-traits.md) (1 hora e 10 minutos)"
 #: src/welcome-day-2-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 3 hours and 15 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve durar cerca de 3 horas e 15 "
-"minutos"
+"minutos. Possui:"
 
 #: src/generics.md
 msgid "[Generic Functions](./generics/generic-functions.md) (5 minutes)"
@@ -6277,8 +6277,8 @@ msgid "[Exercise: Generic min](./generics/exercise.md) (10 minutes)"
 msgstr "[Exercício: Mínimo Genérico](./generics/exercise.md) (10 minutos)"
 
 #: src/generics.md src/iterators.md src/testing.md
-msgid "This segment should take about 45 minutes"
-msgstr "Este segmento deve durar cerca de 45 minutos"
+msgid "This segment should take about 45 minutes. It contains:"
+msgstr "Este segmento deve durar cerca de 45 minutos. Possui:"
 
 #: src/generics/generic-functions.md
 msgid ""
@@ -7509,8 +7509,8 @@ msgstr "[Exercício: ROT13](./std-traits/exercise.md) (30 minutos)"
 
 #: src/std-traits.md src/concurrency/sync-exercises.md
 #: src/concurrency/async-exercises.md
-msgid "This segment should take about 1 hour and 10 minutes"
-msgstr "Este segmento deve levar cerca de 1 hora e 10 minutos"
+msgid "This segment should take about 1 hour and 10 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 1 hora e 10 minutos. Possui:"
 
 #: src/std-traits.md
 msgid ""
@@ -8075,10 +8075,10 @@ msgstr ""
 #: src/welcome-day-3.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 20 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve levar cerca de 2 horas e 20 "
-"minutos"
+"minutos. Possui:"
 
 #: src/memory-management.md
 msgid "[Review of Program Memory](./memory-management/review.md) (5 minutes)"
@@ -9512,10 +9512,10 @@ msgstr "[Tempos de Vida](./lifetimes.md) (50 minutos)"
 #: src/welcome-day-3-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 1 hour and 55 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve durar cerca de 1 hora e 55 "
-"minutos"
+"minutos. Possui:"
 
 #: src/borrowing.md
 msgid "[Borrowing a Value](./borrowing/shared.md) (10 minutes)"
@@ -10414,10 +10414,10 @@ msgstr "[Testes](./testing.md) (45 minutos)"
 #: src/welcome-day-4.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 40 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve durar cerca de 2 horas e 40 "
-"minutos"
+"minutos. Possui:"
 
 #: src/iterators.md
 msgid "[Iterator](./iterators/iterator.md) (5 minutes)"
@@ -11490,10 +11490,10 @@ msgstr "[Rust Inseguro](./unsafe-rust.md) (1 hora e 5 minutos)"
 #: src/welcome-day-4-afternoon.md
 msgid ""
 "Including 10 minute breaks, this session should take about 2 hours and 15 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve levar cerca de 2 horas e 15 "
-"minutos"
+"minutos. Possui:"
 
 #: src/error-handling.md
 msgid "[Panics](./error-handling/panics.md) (3 minutes)"
@@ -12182,8 +12182,8 @@ msgstr ""
 "minutos)"
 
 #: src/unsafe-rust.md
-msgid "This segment should take about 1 hour and 5 minutes"
-msgstr "Este segmento deve levar cerca de 1 hora e 5 minutos"
+msgid "This segment should take about 1 hour and 5 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 1 hora e 5 minutos. Possui:"
 
 #: src/unsafe-rust/unsafe.md
 msgid "The Rust language has two parts:"
@@ -21068,10 +21068,10 @@ msgstr "[Exercícios](./concurrency/sync-exercises.md) (1 hora e 10 minutos)"
 #: src/concurrency/welcome.md src/concurrency/welcome-async.md
 msgid ""
 "Including 10 minute breaks, this session should take about 3 hours and 20 "
-"minutes"
+"minutes. It contains:"
 msgstr ""
 "Incluindo pausas de 10 minutos, esta sessão deve levar cerca de 3 horas e 20 "
-"minutos"
+"minutos. Possui:"
 
 #: src/concurrency/welcome.md
 msgid ""
@@ -21108,8 +21108,8 @@ msgstr "[_Threads_ Escopadas](./concurrency/threads/scoped.md) (15 minutos)"
 
 #: src/concurrency/threads.md src/concurrency/shared-state.md
 #: src/concurrency/async.md
-msgid "This segment should take about 30 minutes"
-msgstr "Este segmento deve levar cerca de 30 minutos"
+msgid "This segment should take about 30 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 30 minutos. Possui:"
 
 #: src/concurrency/threads/plain.md
 msgid "Rust threads work similarly to threads in other languages:"
@@ -21333,8 +21333,8 @@ msgid "[Bounded Channels](./concurrency/channels/bounded.md) (10 minutes)"
 msgstr "[Canais Limitados](./concurrency/channels/bounded.md) (10 minutos)"
 
 #: src/concurrency/channels.md src/concurrency/async-control-flow.md
-msgid "This segment should take about 20 minutes"
-msgstr "Este segmento deve levar cerca de 20 minutos"
+msgid "This segment should take about 20 minutes. It contains:"
+msgstr "Este segmento deve levar cerca de 20 minutos. Possui:"
 
 #: src/concurrency/channels/senders-receivers.md
 msgid ""


### PR DESCRIPTION
Hello Everyone!
Correcting little error, that do not translate to Brazilian Portuguese in `po/pt-BR.po`, adding a sentence in the end of the string for correct translation...

```
--- msgid "This segment should take about 15 minutes"
--- msgstr "Este segmento deve durar cerca de 15 minutos"

+++ msgid "This segment should take about 15 minutes. It contains:"
+++ msgstr "Este segmento deve durar cerca de 15 minutos. E possui:"
```

The correction is related with the following issue:

https://github.com/google/comprehensive-rust/issues/2777