### PR TITLE
Update speaker notes for arrays.md with clarification on runtime check optimization

### DIFF
--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -27,7 +27,7 @@ fn main() {
   later.
 
 - Try accessing an out-of-bounds array element. Array accesses are checked at
-  runtime. Rust can usually optimize these checks away, and they can be avoided
+  compile time. Rust can usually optimize these checks away, and they can be avoided
   using unsafe Rust.
 
 - We can use literals to assign values to arrays.

--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -27,8 +27,8 @@ fn main() {
   later.
 
 - Try accessing an out-of-bounds array element. Array accesses are checked at
-  compile time. Rust can usually optimize these checks away, and they can be avoided
-  using unsafe Rust.
+  compile time. Rust can usually optimize these checks away, and they can be
+  avoided using unsafe Rust.
 
 - We can use literals to assign values to arrays.
 

--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -26,7 +26,8 @@ fn main() {
   different types. Slices, which have a size determined at runtime, are covered
   later.
 
-- Try accessing an out-of-bounds array element. The compiler is able to determine that the index is unsafe, and will not compile the code:
+- Try accessing an out-of-bounds array element. The compiler is able to
+  determine that the index is unsafe, and will not compile the code:
 
 ```rust,editable,compile_fail
 fn main() {
@@ -35,7 +36,12 @@ fn main() {
     println!("a: {a:?}");
 }
 ```
-* Array accesses are checked at runtime. Rust can usually optimize these checks away; meaning if the compiler can prove the access is safe, it removes the runtime check for better performance. They can be avoided using unsafe Rust. The optimization is so good that it's hard to give an example of runtime checks failing. The following code will compile but panic at runtime:
+
+- Array accesses are checked at runtime. Rust can usually optimize these checks
+  away; meaning if the compiler can prove the access is safe, it removes the
+  runtime check for better performance. They can be avoided using unsafe Rust.
+  The optimization is so good that it's hard to give an example of runtime
+  checks failing. The following code will compile but panic at runtime:
 
 ```rust,editable,should_panic
 fn get_index() -> usize {

--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -26,19 +26,25 @@ fn main() {
   different types. Slices, which have a size determined at runtime, are covered
   later.
 
-- Try accessing an out-of-bounds array element. Array accesses are checked at
-  compile time. Rust can usually optimize these checks away, and they can be
-  avoided using unsafe Rust.
+- Try accessing an out-of-bounds array element. The compiler is able to determine that the index is unsafe, and will not compile the code:
 
-```rust,editable
+```rust,editable,compile_fail
+fn main() {
+    let mut a: [i8; 5] = [5, 4, 3, 2, 1];
+    a[6] = 0;
+    println!("a: {a:?}");
+}
+```
+* Array accesses are checked at runtime. Rust can usually optimize these checks away; meaning if the compiler can prove the access is safe, it removes the runtime check for better performance. They can be avoided using unsafe Rust. The optimization is so good that it's hard to give an example of runtime checks failing. The following code will compile but panic at runtime:
+
+```rust,editable,should_panic
 fn get_index() -> usize {
-    10
+    6
 }
 
 fn main() {
     let mut a: [i8; 5] = [5, 4, 3, 2, 1];
-    a[2] = 0;
-    a[get_index()];
+    a[get_index()] = 0;
     println!("a: {a:?}");
 }
 ```

--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -30,6 +30,19 @@ fn main() {
   compile time. Rust can usually optimize these checks away, and they can be
   avoided using unsafe Rust.
 
+```rust,editable
+fn get_index() -> usize {
+    10
+}
+
+fn main() {
+    let mut a: [i8; 5] = [5, 4, 3, 2, 1];
+    a[2] = 0;
+    a[get_index()];
+    println!("a: {a:?}");
+}
+```
+
 - We can use literals to assign values to arrays.
 
 - The `println!` macro asks for the debug implementation with the `?` format


### PR DESCRIPTION
According to the error I got from trying out-of-bound index, array accesses seem to be checked at compile time.

```
   Compiling playground v0.0.1 (/playground)
error: this operation will panic at runtime
 --> src/main.rs:3:5
  |
3 |     a[7] = 0;
  |     ^^^^ index out of bounds: the length is 5 but the index is 7
  |
  = note: `#[deny(unconditional_panic)]` on by default

error: could not compile `playground` (bin "playground") due to 1 previous error
```

