### PR TITLE
Remove unnecessary type cast in C ffi example

### DIFF
--- a/src/android/interoperability/with-c/bindgen/main.rs
+++ b/src/android/interoperability/with-c/bindgen/main.rs
@@ -25,6 +25,6 @@ fn main() {
     // remains valid. `print_card` doesn't store either pointer to use later
     // after it returns.
     unsafe {
-        print_card(&card as *const card);
+        print_card(&card);
     }
 }


### PR DESCRIPTION
A `&T` can automatically coerce to a `*const T`, so the manual cast isn't necessary here.