### PR TITLE
Split off function call to make pattern match clearer

### DIFF
--- a/src/pattern-matching/let-control-flow/if-let.md
+++ b/src/pattern-matching/let-control-flow/if-let.md
@@ -8,7 +8,9 @@ lets you execute different code depending on whether a value matches a pattern:
 use std::time::Duration;
 
 fn sleep_for(secs: f32) {
-    if let Ok(duration) = Duration::try_from_secs_f32(secs) {
+    let result = Duration::try_from_secs_f32(secs);
+
+    if let Ok(duration) = result {
         std::thread::sleep(duration);
         println!("slept for {duration:?}");
     }


### PR DESCRIPTION
I think doing the call to `Duration::try_from_secs_f32` in the pattern match is a bit verbose since the function name is so long. I usually split this off into a separate variable so that it's easier to see the pattern match syntax.