### PR TITLE
Add direct call to `talk` in trait implementation slide

### DIFF
--- a/src/methods-and-traits/traits/implementing.md
+++ b/src/methods-and-traits/traits/implementing.md
@@ -22,6 +22,7 @@ impl Pet for Dog {
 
 fn main() {
     let fido = Dog { name: String::from("Fido"), age: 5 };
+    dbg!(fido.talk());
     fido.greet();
 }
 ```


### PR DESCRIPTION
I think it'd be helpful to also show a direct call to `talk`, so that it's clear that both trait methods can be called directly.