### PR TITLE
Add note about trait bound in closures exercise

### DIFF
--- a/src/closures/solution.md
+++ b/src/closures/solution.md
@@ -3,3 +3,12 @@
 ```rust,editable
 {{#include exercise.rs:solution}}
 ```
+
+<details>
+
+- Note that the `P: Fn(u8, &str) -> bool` bound on the first `Filter` impl block
+  isn't strictly necessary, but it helps with type inference when calling `new`.
+  Demonstrate removing it and showing how the compiler now needs type
+  annotations for the closure passed to `new`.
+
+</details>


### PR DESCRIPTION
I've tried removing this trait bound thinking it's unnecessary only to then be surprised that it breaks type inference. I think that's worth calling out to students, so I think a speaker note here would be appropriate.