### PR TITLE
Remove type annotations from borrowck example

### DIFF
--- a/src/borrowing/borrowck.md
+++ b/src/borrowing/borrowck.md
@@ -29,11 +29,11 @@ rule. For a given value, at any time:
 
 ```rust,editable,compile_fail
 fn main() {
-    let mut a: i32 = 10;
-    let b: &i32 = &a;
+    let mut a = 10;
+    let b = &a;
 
     {
-        let c: &mut i32 = &mut a;
+        let c = &mut a;
         *c = 20;
     }
 


### PR DESCRIPTION
This slide is on day 3, I don't think we need the explicit type annotations at this point.