### PR TITLE
Provide shorter Cargo aliases for xtool subcommands (fixes #2803)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,12 @@
 [alias]
-# We use this alias for task automation in the project.
-# See README in xtask directory.
+# WARNING: Using the `xtask` alias is deprecated and will be unsupported in a
+# future version of Cargo. See https://github.com/rust-lang/cargo/issues/10049.
 xtask = "run --package xtask --"
+install-tools = "run --package xtask -- install-tools"
+web-tests = "run --package xtask -- web-tests"
+rust-tests = "run --package xtask -- rust-tests"
+serve = "run --package xtask -- serve"
+build-book = "run --package xtask -- build"
 
 [env]
 # To provide an anchor to the root of the workspace when working with paths.

--- a/README.md
+++ b/README.md
@@ -77,14 +77,29 @@ Here is a summary of the various commands you can run in the project.
 
 | Command                     | Description                                                                                                                                                                                                                                                                                                                                                                                                   |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cargo xtask install-tools` | Install all the tools the project depends on.                                                                                                                                                                                                                                                                                                                                                                 |
-| `cargo xtask serve`         | Start a web server with the course. You'll find the content on http://localhost:3000.                                                                                                                                                                                                                                                                                                                         |
-| `cargo xtask rust-tests`    | Test the included Rust snippets.                                                                                                                                                                                                                                                                                                                                                                              |
-| `cargo xtask web-tests`     | Run the web driver tests in the tests directory.                                                                                                                                                                                                                                                                                                                                                              |
-| `cargo xtask build`         | Create a static version of the course in the `book/` directory. Note that you have to separately build and zip exercises and add them to book/html. To build any of the translated versions of the course, run MDBOOK_BOOK__LANGUAGE=xx mdbook build -d book/xx where xx is the ISO 639 language code (e.g. da for the Danish translation). [TRANSLATIONS.md](TRANSLATIONS.md) contains further instructions. |
+| `cargo install-tools` | Install all the tools the project depends on.                                                                                                                                                                                                                                                                                                                                                                 |
+| `cargo serve`         | Start a web server with the course. You'll find the content on http://localhost:3000.                                                                                                                                                                                                                                                                                                                         |
+| `cargo rust-tests`    | Test the included Rust snippets.                                                                                                                                                                                                                                                                                                                                                                              |
+| `cargo web-tests`     | Run the web driver tests in the tests directory.                                                                                                                                                                                                                                                                                                                                                              |
+| `cargo build-book`         | Create a static version of the course in the `book/` directory. Note that you have to separately build and zip exercises and add them to book/html. To build any of the translated versions of the course, run MDBOOK_BOOK__LANGUAGE=xx mdbook build -d book/xx where xx is the ISO 639 language code (e.g. da for the Danish translation). [TRANSLATIONS.md](TRANSLATIONS.md) contains further instructions. |
 
 > **Note** On Windows, you need to enable symlinks
 > (`git config --global core.symlinks true`) and Developer Mode.
+
+> **Note** Previous versions this README recommended that you use 
+> `cargo xpath <tool>`, i.e. `cargo xpath install-tools`. This causes issues 
+> with pre-existing installations of `cargo-xpath` and is now deprecated.
+>
+> The new syntax is almost a 1:1 mapping, although `cargo xpath build` has 
+> become `cargo build-book` to avoid conflicting with the built-in Cargo 
+> subcommand.
+>
+> - `cargo xpath build` -> `cargo build-book`
+> - `cargo xpath install-tools` -> `cargo install-tools`
+> - `cargo xpath serve` -> `cargo serve`
+> - `cargo xpath run-tests` -> `cargo run-tests`
+> - `cargo xpath web-tests` -> `cargo web-tests`
+
 
 ## Contributing
 


### PR DESCRIPTION
Fixes #2803 