### PR TITLE
Update exercise.md

### DIFF
--- a/src/methods-and-traits/exercise.md
+++ b/src/methods-and-traits/exercise.md
@@ -15,8 +15,7 @@ messages above a maximum verbosity.
 
 This is a common pattern: a struct wrapping a trait implementation and
 implementing that same trait, adding behavior in the process. In the "Generics"
-segment this afternoon, we will see how to make the wrapper generic over the
-wrapped type.
+segment, we will see how to make the wrapper generic over the wrapped type.
 
 ```rust,compile_fail,editable
 {{#include exercise.rs:setup}}


### PR DESCRIPTION
The point at which the generics segment will be covered has changed multiple times. After the last change, the 'logger trait' section was not updated to reflect when it will now be covered. To keep it more general, I suggest not specifying when it will be covered.