### PR TITLE
Add speaker note that arrays go on the stack

### DIFF
--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -65,4 +65,9 @@ fn main() {
 - Adding `#`, eg `{a:#?}`, invokes a "pretty printing" format, which can be
   easier to read.
 
+- Arrays are not heap-allocated. They are regular values with a fixed size known
+  at compile time, meaning they go on the stack. This can be different from what
+  students expect if they come from a garbage collected language, where arrays
+  may be heap allocated by default.
+
 </details>


### PR DESCRIPTION
I like to mention this here because students coming from garbage collected languages may be used to arrays being automatically heap allocated, and at this point we haven't covered memory layout yet.