### PR TITLE
Fix typo in Matching Values section

### DIFF
--- a/src/pattern-matching/match.md
+++ b/src/pattern-matching/match.md
@@ -43,7 +43,7 @@ Key Points:
   wish to concisely express more complex ideas than patterns alone would allow.
 - They are not the same as separate `if` expression inside of the match arm. An
   `if` expression inside of the branch block (after `=>`) happens after the
-  match arm is selected. Failing the `if` condition inside of that block won't
+  match arm is selected. Failing the `if` condition inside of that block will
   result in other arms of the original `match` expression being considered.
 - The condition defined in the guard applies to every expression in a pattern
   with an `|`.


### PR DESCRIPTION
Given 

```
#[rustfmt::skip]
fn main() {
    let input = '1';
    match input {
        key if key.is_lowercase() => println!("Lowercase: {key}"),
        'q'                       => println!("Quitting"),
        'a' | 's' | 'w' | 'd'     => println!("Moving around"),
        '0'..='9'                 => println!("Number input"),
        _                         => println!("Something else"),
    }
}
```

the output will be

```
Number input
```

So in practice, failing the condition does result to the other arms if the other arms are after that (if I'm reading this correctly).