### PR TITLE
Add speaker note regarding passing slices instead

### DIFF
--- a/src/references/solution.md
+++ b/src/references/solution.md
@@ -10,4 +10,9 @@
   element. This is because we're iterating using a mutable reference to an
   array, which causes the `for` loop to give mutable references to each element.
 
+- It is also possible to take slice references here, e.g.,
+  `fn
+  magnitude(vector: &[f64]) -> f64`. This makes the function more general,
+  at the cost of a runtime length check.
+
 </details>


### PR DESCRIPTION
This section covers both references and slices, but the exercise focuses on references. This speaker note briefly discusses the option to use slices instead, and a cost of doing so.