### PR TITLE
docs: improve language in user-defined-types section

### DIFF
--- a/src/user-defined-types/exercise.md
+++ b/src/user-defined-types/exercise.md
@@ -47,7 +47,6 @@ out of these structures.
 - If students ask about `#![allow(dead_code)]` at the top of the exercise, it's
   necessary because the only thing we do with the `Event` type is print it out.
   Due to a nuance of how the compiler checks for dead code this causes it to
-  think that the code is unused. They can ignore it for the purpose of this
-  exercise.
+  think the code is unused. They can ignore it for the purpose of this exercise.
 
 </details>

--- a/src/user-defined-types/tuple-structs.md
+++ b/src/user-defined-types/tuple-structs.md
@@ -47,9 +47,10 @@ fn main() {
   ["Idiomatic Rust" module](../idiomatic/leveraging-the-type-system/newtype-pattern.md).
 - Demonstrate how to add a `f64` value to a `Newtons` type by accessing the
   single field in the newtype.
-  - Rust generally doesn’t like inexplicit things, like automatic unwrapping or
-    for instance using booleans as integers.
-  - Operator overloading is discussed on Day 3 (generics).
+  - Rust generally avoids implicit conversions, like automatic unwrapping or
+    using booleans as integers.
+    - Operator overloading is discussed on Day 2
+      ([Standard Library Traits](../std-traits.md)).
 - When a tuple struct has zero fields, the `()` can be omitted. The result is a
   zero-sized type (ZST), of which there is only one value (the name of the
   type).


### PR DESCRIPTION
I asked Gemini to review the English for inconsistencies and grammar
mistakes. This is the result.

As a non-native speaker, it is hard for me to evaluate the finer details
of this, so let me know if you would like to see changes (or even better:
make them directly in the PR with the suggestion function).