### PR TITLE
docs: improve language in references section

### DIFF
--- a/src/references/exclusive.md
+++ b/src/references/exclusive.md
@@ -28,8 +28,8 @@ Key points:
   making an `&point.0` or changing `point.0` while `x_coord` is alive.
 
 - Be sure to note the difference between `let mut x_coord: &i32` and
-  `let x_coord: &mut i32`. The first one is a shared reference that can
-  be bound to different values, while the second is an exclusive
-  reference to a mutable value.
+  `let x_coord: &mut i32`. The first one is a shared reference that can be bound
+  to different values, while the second is an exclusive reference to a mutable
+  value.
 
 </details>

--- a/src/references/slices.md
+++ b/src/references/slices.md
@@ -45,9 +45,9 @@ fn main() {
 - You can't "grow" a slice once it's created:
   - You can't append elements of the slice, since it doesn't own the backing
     buffer.
-  - You can't grow a slice to point to a larger section of the backing buffer.
-    A slice does not have information about the length of the underlying buffer and so you can't
-    know how large the slice can be grown.
+  - You can't grow a slice to point to a larger section of the backing buffer. A
+    slice does not have information about the length of the underlying buffer
+    and so you can't know how large the slice can be grown.
   - To get a larger slice you have to back to the original buffer and create a
     larger slice from there.
 


### PR DESCRIPTION
I asked Gemini to review the English for inconsistencies and grammar mistakes. This is the result and I hope it's useful!

As a non-native speaker, it is hard for me to evaluate the finer details, so let me know if you would like to see changes (or even better: make them directly in the PR with the suggestion function).
