### PR TITLE
docs: improve language in pattern-matching section

### DIFF
--- a/src/pattern-matching/destructuring-structs.md
+++ b/src/pattern-matching/destructuring-structs.md
@@ -4,7 +4,7 @@ minutes: 4
 
 # Structs
 
-Like tuples, Struct can also be destructured by matching:
+Like tuples, structs can also be destructured by matching:
 
 ```rust,editable
 {{#include ../../third_party/rust-by-example/destructuring-structs.rs}}

--- a/src/pattern-matching/exercise.md
+++ b/src/pattern-matching/exercise.md
@@ -22,7 +22,7 @@ to `30`. We can represent the expression as a tree:
 ```
 
 A bigger and more complex expression would be `(10 * 9) + ((3 - 4) * 5)`, which
-evaluate to `85`. We represent this as a much bigger tree:
+evaluates to `85`. We represent this as a much bigger tree:
 
 <!-- mdbook-xgettext: skip -->
 

--- a/src/pattern-matching/infallible.md
+++ b/src/pattern-matching/infallible.md
@@ -37,8 +37,8 @@ fn main() {
 - Patterns are type-specific, including irrefutable patterns. Try adding or
   removing an element to the tuple and look at the resulting compiler errors.
 
-- Variable names are patterns that always match and bind the matched
-  value into a new variable with that name.
+- Variable names are patterns that always match and bind the matched value into
+  a new variable with that name.
 
 - `_` is a pattern that always matches any value, discarding the matched value.
 

--- a/src/pattern-matching/infallible.md
+++ b/src/pattern-matching/infallible.md
@@ -37,8 +37,8 @@ fn main() {
 - Patterns are type-specific, including irrefutable patterns. Try adding or
   removing an element to the tuple and look at the resulting compiler errors.
 
-- Variable names are patterns that always match and which bind the matched value
-  into a new variable with that name.
+- Variable names are patterns that always match, and which bind the matched
+  value into a new variable with that name.
 
 - `_` is a pattern that always matches any value, discarding the matched value.
 

--- a/src/pattern-matching/infallible.md
+++ b/src/pattern-matching/infallible.md
@@ -37,7 +37,7 @@ fn main() {
 - Patterns are type-specific, including irrefutable patterns. Try adding or
   removing an element to the tuple and look at the resulting compiler errors.
 
-- Variable names are patterns that always match, and which bind the matched
+- Variable names are patterns that always match and bind the matched
   value into a new variable with that name.
 
 - `_` is a pattern that always matches any value, discarding the matched value.

--- a/src/pattern-matching/let-control-flow.md
+++ b/src/pattern-matching/let-control-flow.md
@@ -4,7 +4,7 @@ minutes: 10
 
 # Let Control Flow
 
-Rust has a few control flow constructs, which differ from other languages. They
+Rust has a few control flow constructs that differ from other languages. They
 are used for pattern matching:
 
 - `if let` expressions

--- a/src/pattern-matching/let-control-flow.md
+++ b/src/pattern-matching/let-control-flow.md
@@ -4,7 +4,7 @@ minutes: 10
 
 # Let Control Flow
 
-Rust has a few control flow constructs which differ from other languages. They
+Rust has a few control flow constructs, which differ from other languages. They
 are used for pattern matching:
 
 - `if let` expressions

--- a/src/pattern-matching/let-control-flow/while-let.md
+++ b/src/pattern-matching/let-control-flow/while-let.md
@@ -2,7 +2,7 @@
 
 Like with `if let`, there is a
 [`while let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops)
-variant, which repeatedly tests a value against a pattern:
+variant that repeatedly tests a value against a pattern:
 
 ```rust,editable
 fn main() {

--- a/src/pattern-matching/let-control-flow/while-let.md
+++ b/src/pattern-matching/let-control-flow/while-let.md
@@ -2,7 +2,7 @@
 
 Like with `if let`, there is a
 [`while let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops)
-variant which repeatedly tests a value against a pattern:
+variant, which repeatedly tests a value against a pattern:
 
 ```rust,editable
 fn main() {

--- a/src/pattern-matching/match.md
+++ b/src/pattern-matching/match.md
@@ -35,7 +35,7 @@ Key Points:
 - You might point out how some specific characters are being used when in a
   pattern
   - `|` as an `or`
-  - `..` can expand as much as it needs to be
+  - `..` matches any number of items
   - `1..=5` represents an inclusive range
   - `_` is a wild card
 


### PR DESCRIPTION
I asked Gemini to review the English for inconsistencies and grammar mistakes. This is the result and I hope it's useful!

As a non-native speaker, it is hard for me to evaluate the finer details, so let me know if you would like to see changes (or even better: make them directly in the PR with the suggestion function).
