### PR TITLE
docs: improve language in error-handling section

### DIFF
--- a/src/error-handling/panics.md
+++ b/src/error-handling/panics.md
@@ -4,9 +4,7 @@ minutes: 3
 
 # Panics
 
-Rust handles fatal errors with a "panic".
-
-Rust will trigger a panic if a fatal error happens at runtime:
+Rust handles fatal errors with a "panic", which happens at runtime:
 
 ```rust,editable,should_panic
 fn main() {
@@ -17,8 +15,8 @@ fn main() {
 
 - Panics are for unrecoverable and unexpected errors.
   - Panics are symptoms of bugs in the program.
-  - Runtime failures like failed bounds checks can panic
-  - Assertions (such as `assert!`) panic on failure
+  - Runtime failures like failed bounds checks can panic.
+  - Assertions (such as `assert!`) panic on failure.
   - Purpose-specific panics can use the `panic!` macro.
 - A panic will "unwind" the stack, dropping values just as if the functions had
   returned.

--- a/src/error-handling/panics.md
+++ b/src/error-handling/panics.md
@@ -4,7 +4,7 @@ minutes: 3
 
 # Panics
 
-Rust handles fatal errors with a "panic", which happens at runtime:
+In case of a fatal runtime error, Rust triggers a "panic":
 
 ```rust,editable,should_panic
 fn main() {


### PR DESCRIPTION
I asked Gemini to review the English for inconsistencies and grammar mistakes. This is the result and I hope it's useful!

As a non-native speaker, it is hard for me to evaluate the finer details, so let me know if you would like to see changes (or even better: make them directly in the PR with the suggestion function).
