### PR TITLE
ci: add rustfmt check to formatting workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - fix-2794
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - fix-2794
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
           rustup default nightly
           rustup component add rustfmt
 
+      - name: Check Rust formatting (rustfmt --check)
+        run: cargo fmt --all -- --check
+
       - name: Check formatting
         uses: dprint/check@v2.3
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,9 +21,9 @@
 
 use anyhow::{Ok, Result, anyhow};
 use clap::{Parser, Subcommand};
+use std::env;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::{env, process::Command};
+use std::process::{Command, Stdio};
 
 fn main() -> Result<()> {
     if let Err(e) = execute_task() {
@@ -49,7 +49,8 @@ enum Task {
     InstallTools,
     /// Runs the web driver tests in the tests directory.
     WebTests {
-        /// Optional 'book html' directory - if set, will also refresh the list of slides used by slide size test.
+        /// Optional 'book html' directory - if set, will also refresh the list
+        /// of slides used by slide size test.
         #[arg(short, long)]
         dir: Option<PathBuf>,
     },
@@ -61,7 +62,8 @@ enum Task {
         #[arg(short, long)]
         language: Option<String>,
 
-        /// Directory to place the build. If not provided, defaults to the book/ directory (or the book/xx directory if a language is provided).
+        /// Directory to place the build. If not provided, defaults to the book/
+        /// directory (or the book/xx directory if a language is provided).
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
@@ -71,7 +73,8 @@ enum Task {
         #[arg(short, long)]
         language: Option<String>,
 
-        /// Directory to place the build. If not provided, defaults to the book/ directory (or the book/xx directory if a language is provided).
+        /// Directory to place the build. If not provided, defaults to the book/
+        /// directory (or the book/xx directory if a language is provided).
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
@@ -286,8 +289,9 @@ fn build(language: Option<String>, output_arg: Option<PathBuf>) -> Result<()> {
 }
 
 fn get_output_dir(language: Option<String>, output_arg: Option<PathBuf>) -> PathBuf {
-    // If the 'output' arg is specified by the caller, use that, otherwise output to the 'book/' directory
-    // (or the 'book/xx' directory if a language was specified).
+    // If the 'output' arg is specified by the caller, use that, otherwise output to
+    // the 'book/' directory (or the 'book/xx' directory if a language was
+    // specified).
     if let Some(d) = output_arg {
         d
     } else {


### PR DESCRIPTION
## What does this PR do?

This PR extends the existing `format` job in `.github/workflows/build.yml` to
**check Rust formatting with nightly `rustfmt`**:

```yaml
- name: Check Rust formatting (rustfmt --check)
  run: cargo fmt --all -- --check
  ```

## Why?

•	The repository already defines a rustfmt.toml with nightly-only settings (imports_granularity, use_small_heuristics = "Max", etc.).
•	The CI installs nightly rustfmt but wasn’t actually using it.
•	Currently, dprint/check verifies formatting for Markdown/PO/JS/etc., but not Rust code.
This PR makes sure PRs fail if Rust code is not formatted according to rustfmt.toml.

## How was it tested?

•	Ran locally with:
```bash
rustup default nightly
rustup component add rustfmt
cargo fmt --all -- --check
dprint fmt --check
```
Both checks pass on a clean branch.

•	CI workflow updated accordingly.
If Rust code is unformatted, the format job will now fail.

**Closes #2794**