### PR TITLE
fix(docs): remove stray/trailing s>

### DIFF
--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -71,4 +71,3 @@ fn main() {
   may be heap allocated by default.
 
 </details>
-s>


### PR DESCRIPTION
It looks like changes from the last commit (`085b534`) to the `<details>...</details>` block had a stray `s>` included.