### PR TITLE
Add speaker notes to instructor-focused slides

### DIFF
--- a/src/running-the-course.md
+++ b/src/running-the-course.md
@@ -55,3 +55,29 @@ better. Your students are also very welcome to [send us feedback][2]!
 [1]: https://github.com/google/comprehensive-rust/discussions/86
 [2]: https://github.com/google/comprehensive-rust/discussions/100
 [3]: https://github.com/google/comprehensive-rust#building
+
+<details>
+
+### Instructor Preparation
+
+- **Go through all the material:** Before teaching the course, make sure you
+  have gone through all the slides and exercises yourself. This will help you
+  anticipate questions and potential difficulties.
+- **Prepare for live coding:** The course involves a lot of live coding.
+  Practice the examples and exercises beforehand to ensure you can type them out
+  smoothly during the class. Have the solutions ready in case you get stuck.
+- **Familiarize yourself with `mdbook`:** The course is presented using
+  `mdbook`. Knowing how to navigate, search, and use its features will make the
+  presentation smoother.
+
+### Creating a Good Learning Environment
+
+- **Encourage questions:** Reiterate that there are no "stupid" questions. A
+  welcoming atmosphere for questions is crucial for learning.
+- **Manage time effectively:** Keep an eye on the schedule, but be flexible.
+  It's more important that students understand the concepts than sticking
+  rigidly to the timeline.
+- **Facilitate group work:** During exercises, encourage students to work
+  together. This can help them learn from each other and feel less stuck.
+
+</details>

--- a/src/running-the-course/keyboard-shortcuts.md
+++ b/src/running-the-course/keyboard-shortcuts.md
@@ -6,3 +6,15 @@ There are several useful keyboard shortcuts in mdBook:
 - <kbd>Arrow-Right</kbd>: Navigate to the next page.
 - <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.
 - <kbd>s</kbd>: Activate the search bar.
+
+<details>
+
+- Mention that these shortcuts are standard for `mdbook` and can be useful when
+  navigating any `mdbook`-generated site.
+- You can demonstrate each shortcut live to the students.
+- The <kbd>s</kbd> key for search is particularly useful for quickly finding
+  topics that have been discussed earlier.
+- <kbd>Ctrl + Enter</kbd> will be super important for you since you'll do a lot
+  of live coding.
+
+</details>

--- a/src/running-the-course/translations.md
+++ b/src/running-the-course/translations.md
@@ -97,3 +97,15 @@ get going. Translations are coordinated on the [issue tracker].
 [synced-translation-report]: https://google.github.io/comprehensive-rust/synced-translation-report.html
 [our instructions]: https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md
 [issue tracker]: https://github.com/google/comprehensive-rust/issues/282
+
+<details>
+
+- This is a good opportunity to thank the volunteers who have contributed to the
+  translations.
+- If there are students in the class who speak any of the listed languages, you
+  can encourage them to check out the translated versions and even contribute if
+  they find any issues.
+- Highlight that the project is open source and contributions are welcome, not
+  just for translations but for the course content itself.
+
+</details>


### PR DESCRIPTION
Following the style guide, these notes provide additional context for
instructors and self-learners. The notes focus on practical tips for
running the course and highlighting key information for students.
