### PR TITLE
Fix spelling of UTF-8 and UTF-16

### DIFF
--- a/src/chromium.md
+++ b/src/chromium.md
@@ -9,6 +9,6 @@ Rust is supported for third-party libraries in Chromium, with first-party glue
 code to connect between Rust and existing Chromium C++ code.
 
 > Today, we'll call into Rust to do something silly with strings. If you've got
-> a corner of the code where you're displaying a UTF8 string to the user, feel
+> a corner of the code where you're displaying a UTF-8 string to the user, feel
 > free to follow this recipe in your part of the codebase instead of the exact
 > part we talk about.

--- a/src/chromium/interoperability-with-cpp.md
+++ b/src/chromium/interoperability-with-cpp.md
@@ -40,7 +40,7 @@ following benefits:
     memory-safety risks.
   - `rust::String` and `CxxString` types understand and maintain differences in
     string representation across the languages (e.g. `rust::String::lossy` can
-    build a Rust string from non-UTF8 input and `rust::String::c_str` can
+    build a Rust string from non-UTF-8 input and `rust::String::c_str` can
     NUL-terminate a string).
 
 </details>

--- a/src/exercises/chromium/bringing-it-together.md
+++ b/src/exercises/chromium/bringing-it-together.md
@@ -33,8 +33,8 @@ should have created Chrome for pixies!
 <details>
 Students will likely need some hints here. Hints include:
 
-- UTF16 vs UTF8. Students should be aware that Rust strings are always UTF8, and
-  will probably decide that it's better to do the conversion on the C++ side
+- UTF-16 vs UTF-8. Students should be aware that Rust strings are always UTF-8,
+  and will probably decide that it's better to do the conversion on the C++ side
   using `base::UTF16ToUTF8` and back again.
 - If students decide to do the conversion on the Rust side, they'll need to
   consider [`String::from_utf16`][1], consider error handling, and consider


### PR DESCRIPTION
This should always be written with a hyphen in running text.
