### PR TITLE
Consistently use `**Note:**` instead of `**Note**:`

### DIFF
--- a/src/chromium/adding-third-party-crates/checking-in.md
+++ b/src/chromium/adding-third-party-crates/checking-in.md
@@ -11,7 +11,7 @@ Please also add an `OWNERS` file in the latter location.
 You should land all this, along with your `Cargo.toml` and `gnrt_config.toml`
 changes, into the Chromium repo.
 
-**Important**: you need to use `git add -f` because otherwise `.gitignore` files
+**Important:** you need to use `git add -f` because otherwise `.gitignore` files
 may result in some files being skipped.
 
 As you do so, you might find presubmit checks fail because of non-inclusive

--- a/src/chromium/interoperability-with-cpp/example-bindings.md
+++ b/src/chromium/interoperability-with-cpp/example-bindings.md
@@ -20,7 +20,7 @@ Point out:
 - Calls from C++ to Rust, and Rust types (in the top part)
 - Calls from Rust to C++, and C++ types (in the bottom part)
 
-**Common misconception**: It _looks_ like a C++ header is being parsed by Rust,
+**Common misconception:** It _looks_ like a C++ header is being parsed by Rust,
 but this is misleading. This header is never interpreted by Rust, but simply
 `#include`d in the generated C++ code for the benefit of C++ compilers.
 

--- a/src/exercises/chromium/build-rules.md
+++ b/src/exercises/chromium/build-rules.md
@@ -11,7 +11,7 @@ pub extern "C" fn hello_from_rust() {
 }
 ```
 
-**Important**: note that `no_mangle` here is considered a type of unsafety by
+**Important:** note that `no_mangle` here is considered a type of unsafety by
 the Rust compiler, so you'll need to allow unsafe code in your `gn` target.
 
 Add this new Rust target as a dependency of `//ui/base:base`. Declare this


### PR DESCRIPTION
I think the former is slightly nicer: I see `:` as belonging to the
poor-mans heading we create with the bold text.
