### PR TITLE
Fix the use of `minutes` frontmatter

### DIFF
--- a/src/generics/generic-traits.md
+++ b/src/generics/generic-traits.md
@@ -1,5 +1,5 @@
 ---
-Minutes: 5
+minutes: 5
 ---
 
 # Generic Traits


### PR DESCRIPTION
This file was inconsistent with the other files in our course.

I don’t actually know if both work, but if not, we should consider
erroring out to ensure consistency going forward.
