### PR TITLE
Add more prominent references to `cargo xtask`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,10 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-Make sure you can build the book, and that `mdbook serve` works. Please follow
-the [instructions in the README].
+Make sure you can build the book with `mdbook build`, that `mdbook serve` works,
+and that `dprint fmt` formats the code. Please use `cargo xtask install-tools`
+to install the necessary dependencies, following the
+[instructions in the README].
 
 [instructions in the README]: README.md#building
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,6 +36,8 @@ tests, and managing translations.
    ```bash
    cargo xtask install-tools
    ```
+   This is a necessary first step for working with this repository. It will
+   install the correct versions of all tools used by the project.
 
 ## Commands
 
@@ -72,6 +74,9 @@ list of options.
   development tasks.
 - **Course Content:** Markdown files in the `src/` directory, structured
   according to `src/SUMMARY.md`.
+- **Code Formatting:** `dprint fmt` is used to format all source files according
+  to `rustfmt.toml` and `dprint.json`. Note that you must first install the
+  project tools with `cargo xtask install-tools`.
 - **Contributions:** Refer to `CONTRIBUTING.md` for guidelines on contributing
   to the project.
 - **Style:** Refer to `STYLE.md` for style guidelines.

--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ git clone https://github.com/google/comprehensive-rust/
 cd comprehensive-rust
 ```
 
-Then install these tools with:
+Then run the following command to install the correct versions of all tools
+mentioned above:
 
 ```shell
 cargo xtask install-tools
 ```
 
-> **Note** We use `xtask` for task automation within the project (e.g.
-> installing required tools). Xtask is not a package that you should install.
-> Visit https://github.com/matklad/cargo-xtask for more information.
+This uses `cargo install` to install the tools, so you will find them in your
+`~/.cargo/bin/` directory afterwards.
 
 ## Commands
 


### PR DESCRIPTION
I found that Gemini didn’t know how to install the necessary tools
make `dprint fmt` work, so I’m adding more references to `cargo xtask`
in our documentation.
