### PR TITLE
Improve speaker notes and exercise in tuples and arrays section

### DIFF
--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -57,6 +57,15 @@ fn main() {
 
 - We can use literals to assign values to arrays.
 
+- Arrays are not heap-allocated. They are regular values with a fixed size known
+  at compile time, meaning they go on the stack. This can be different from what
+  students expect if they come from a garbage-collected language, where arrays
+  may be heap allocated by default.
+
+- There is no way to remove elements from an array, nor add elements to an
+  array. The length of an array is fixed at compile-time, and so its length
+  cannot change at runtime.
+
 - The `println!` macro asks for the debug implementation with the `?` format
   parameter: `{}` gives the default output, `{:?}` gives the debug output. Types
   such as integers and strings implement the default output, but arrays only
@@ -64,10 +73,5 @@ fn main() {
 
 - Adding `#`, eg `{a:#?}`, invokes a "pretty printing" format, which can be
   easier to read.
-
-- Arrays are not heap-allocated. They are regular values with a fixed size known
-  at compile time, meaning they go on the stack. This can be different from what
-  students expect if they come from a garbage-collected language, where arrays
-  may be heap allocated by default.
 
 </details>

--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -66,6 +66,8 @@ fn main() {
   array. The length of an array is fixed at compile-time, and so its length
   cannot change at runtime.
 
+## Debug Printing
+
 - The `println!` macro asks for the debug implementation with the `?` format
   parameter: `{}` gives the default output, `{:?}` gives the debug output. Types
   such as integers and strings implement the default output, but arrays only

--- a/src/tuples-and-arrays/exercise.rs
+++ b/src/tuples-and-arrays/exercise.rs
@@ -33,9 +33,17 @@ fn main() {
         [301, 302, 303],
     ];
 
-    dbg!(matrix);
+    println!("Original:");
+    for row in &matrix {
+        println!("{:?}", row);
+    }
+
     let transposed = transpose(matrix);
-    dbg!(transposed);
+
+    println!("\nTransposed:");
+    for row in &transposed {
+        println!("{:?}", row);
+    }
 }
 // ANCHOR_END: main
 // ANCHOR_END: solution

--- a/src/tuples-and-arrays/tuples.md
+++ b/src/tuples-and-arrays/tuples.md
@@ -26,4 +26,11 @@ fn main() {
 - The empty tuple `()` is referred to as the "unit type" and signifies absence
   of a return value, akin to `void` in other languages.
 
+- Unlike arrays, tuples cannot be used in a `for` loop. This is because a `for`
+  loop requires all the elements to have the same type, which may not be the
+  case for a tuple.
+
+- There is no way to add or remove elements from a tuple. The number of elements
+  and their types are fixed at compile time and cannot be changed at runtime.
+
 </details>


### PR DESCRIPTION
A couple of small changes to the tuples and arrays section that I'm lumping together for convenience.

- Add speaker notes about not being able to add/remove from arrays/tuples. This is a thing I try to remember to mention, and sometimes students as questions along these lines.
- Add section to arrays speaker note for debug printing. I found the order of the speaker notes a bit confusing because we have a bunch of notes about arrays, then a couple about debug printing, then another one about arrays (at least once I added the above note). Since the debug printing stuff is pretty tangential to the rest of the slide (this is just the first time we happen to encounter debug printing), I think breaking it out into its own header will help with clarity and organization.
- Print matrices in the array exercise in a more readable way. We're currently printing the matrices in the exercise with `dbg!`, which is very verbose and makes it hard to compare the start and end matrices, and students sometimes ask about how to format the output in a more readable way.