### PR TITLE
Fix speaker notes header and link contrast in Rust theme

### DIFF
--- a/theme/css/speaker-notes.css
+++ b/theme/css/speaker-notes.css
@@ -5,6 +5,10 @@
   padding: 0.25em;
 }
 
+.content details a:link, .content details a:visited {
+  color: var(--sidebar-fg) !important;
+}
+
 .content details summary h4 {
   display: inline-block;
   list-style: none;


### PR DESCRIPTION
Despite the !important in the .content details style, links were showing up in the link color and headers were showing up in the (main) foreground color, which in the Rust theme has poor and no contrast, respectively.

Fix this by explicitly forcing both to the sidebar foreground color instead.