### PR TITLE
Speed up rust crate installs in workflow by using cargo-binstall

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -5,8 +5,11 @@ description: Install mdbook with the dependencies we need.
 runs:
   using: composite
   steps:
+    - name: Ensure cargo-binstall is installed
+      uses: cargo-bins/cargo-binstall@main
+
     - name: Install mdbook
-      run: cargo xtask install-tools
+      run: cargo xtask install-tools --binstall
       shell: bash
 
     - name: Install dependencies for mdbook-pandoc


### PR DESCRIPTION
When cargo xtask install-tools --binstall is used, precompiled binaries are fetched if available.
Triggers a regular (compilation) install if binary releases do not exist.

This is now configured to be used by the CI to speed up the build and deploy workflows where possible.

Currently binary packages exist for:
- mdbook
- mdbook-pandoc