### PR TITLE
Optimize `apt update` calls

### DIFF
--- a/.github/workflows/apt-get-install/action.yml
+++ b/.github/workflows/apt-get-install/action.yml
@@ -1,0 +1,44 @@
+name: Setup Apt and Install Packages
+description: Configures apt, runs update once per job, and installs packages.
+
+inputs:
+  packages:
+    description: A space-separated list of packages to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure dpkg and apt for CI
+      shell: bash
+      run: |
+        # Avoid time-consuming man-db updates.
+        sudo tee /etc/dpkg/dpkg.cfg.d/99-no-doc > /dev/null <<EOF
+        path-exclude /usr/share/doc/*
+        path-exclude /usr/share/man/*
+        path-exclude /usr/share/info/*
+        EOF
+
+        # Exclude translations.
+        sudo tee /etc/apt/apt.conf.d/99-no-translations > /dev/null <<EOF
+        Acquire::Languages "none";
+        EOF
+
+        # Exclude command-not-found utility.
+        sudo rm -f /etc/apt/apt.conf.d/50command-not-found
+
+        # Remove unnecessary repository lists (we don't install Azure
+        # utilities)
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/azure-cli.*
+
+    - name: Run apt-get update
+      if: env.APT_UPDATED != 'true'
+      shell: bash
+      run: |
+        sudo apt-get update
+        echo "APT_UPDATED=true" >> $GITHUB_ENV
+
+    - name: Installing ${{ inputs.packages }}
+      shell: bash
+      run: |
+        sudo apt-get install --quiet --yes ${{ inputs.packages }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,9 @@ jobs:
         uses: ./.github/workflows/setup-rust-cache
 
       - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu
+        uses: ./.github/workflows/apt-get-install
+        with:
+          packages: gcc-aarch64-linux-gnu
 
       - name: Build Rust code
         working-directory: ${{ matrix.directory }}
@@ -113,10 +113,10 @@ jobs:
         with:
           key: ${{ contains(fromJSON(env.LINK_CHECKED_LANGUAGES), matrix.language) }}
 
-      - name: Install Gettext
-        run: |
-          sudo apt update
-          sudo apt install gettext
+      - name: Install dependencies
+        uses: ./.github/workflows/apt-get-install
+        with:
+          packages: gettext
 
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook

--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -12,10 +12,13 @@ runs:
       run: cargo xtask install-tools --binstall
       shell: bash
 
-    - name: Install dependencies for mdbook-pandoc
+    - name: Install mdbook-pandoc dependencies
+      uses: ./.github/workflows/apt-get-install
+      with:
+        packages: texlive texlive-luatex texlive-lang-cjk texlive-lang-arabic librsvg2-bin fonts-noto
+
+    - name: Install mdbook-pandoc
       run: |
-        sudo apt-get update
-        sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk texlive-lang-arabic librsvg2-bin fonts-noto
         curl -LsSf https://github.com/jgm/pandoc/releases/download/3.7.0.1/pandoc-3.7.0.1-linux-amd64.tar.gz | tar zxf -
         echo "$PWD/pandoc-3.7.0.1/bin" >> $GITHUB_PATH
       shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install formatting dependencies
-        run: |
-          sudo apt update
-          sudo apt install gettext yapf3
+        uses: ./.github/workflows/apt-get-install
+        with:
+          packages: gettext yapf3
 
       - name: Install pinned nightly for rustfmt
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,9 +42,9 @@ jobs:
         uses: ./.github/workflows/setup-rust-cache
 
       - name: Install Gettext
-        run: |
-          sudo apt update
-          sudo apt install gettext
+        uses: ./.github/workflows/apt-get-install
+        with:
+          packages: gettext
 
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -80,6 +80,16 @@ list of options.
 - **Contributions:** Refer to `CONTRIBUTING.md` for guidelines on contributing
   to the project.
 - **Style:** Refer to `STYLE.md` for style guidelines.
+- **GitHub Actions:** The project uses composite GitHub Actions to simplify CI
+  workflows. These actions should be preferred over hand-written commands.
+  - **`apt-get-install`:** This action efficiently installs Debian packages. It
+    configures `dpkg` and `apt` to skip documentation and translations, and
+    ensures that `apt-get update` is run only once per job. This significantly
+    speeds up CI runs.
+  - **`install-mdbook`:** A composite action to install `mdbook` and its
+    dependencies, including `pandoc` and `texlive`.
+  - **`setup-rust-cache`:** A composite action that configures the
+    `Swatinem/rust-cache` action.
 
 ## Markdown Conventions
 


### PR DESCRIPTION
This introduces a new local GitHub action for installing Debian packages. I noticed that it often takes several minutes to install a few small packages, and a large part of that time is spent updating the man page database:

    2025-09-20T11:39:25.3001853Z Setting up yapf3 (0.33.0-1) ...
    2025-09-20T11:39:25.3045329Z Processing triggers for libc-bin (2.39-0ubuntu8.5) ...
    2025-09-20T11:39:25.4420933Z Processing triggers for man-db (2.12.0-4build2) ...
    2025-09-20T11:41:42.8522570Z Processing triggers for install-info (7.1-3build2) ...

Excluding the documentation files should make the man-db run much faster. Compare these two runs:

* [Before](https://github.com/google/comprehensive-rust/actions/runs/17879390708/job/50845084995): 2m 41s.
* [After](https://github.com/google/comprehensive-rust/actions/runs/17880418155/job/50847334471): 11s.