### PR TITLE
docs(gemini): Add kbd tag formatting rule

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -141,7 +141,9 @@ list of options.
 
 - **HTML Tags:**
   - **`<details>`:** Used for collapsible "speaker notes".
-  - **`<kbd>`:** Used to denote keyboard keys.
+  - **`<kbd>`:** Used to denote keyboard keys. Key combinations must be
+    formatted as `<kbd>Ctrl + S</kbd>`, wrapping the entire combination in one
+    tag.
   - **`<style>`:** Used rarely for targeted custom CSS.
   - **`<img>`:** Used to embed images.
 


### PR DESCRIPTION
Adds a specific style convention to GEMINI.md for formatting keyboard key combinations using the `<kbd>` tag.

The required format is `<kbd>Ctrl + S</kbd>`, which is consistent with existing usage in the course. This rule will be enforced by the AI assistant to ensure uniformity.