### PR TITLE
feat(docs): Update and apply kbd tag style guide

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -141,9 +141,8 @@ list of options.
 
 - **HTML Tags:**
   - **`<details>`:** Used for collapsible "speaker notes".
-  - **`<kbd>`:** Used to denote keyboard keys. Key combinations must be
-    formatted as `<kbd>Ctrl + S</kbd>`, wrapping the entire combination in one
-    tag.
+  - **`<kbd>`:** Used to denote keyboard keys. Each key in a combination must be
+    wrapped in its own tag, e.g., `<kbd>Ctrl</kbd> + <kbd>S</kbd>`.
   - **`<style>`:** Used rarely for targeted custom CSS.
   - **`<img>`:** Used to embed images.
 

--- a/src/cargo/code-samples.md
+++ b/src/cargo/code-samples.md
@@ -16,8 +16,8 @@ fn main() {
 }
 ```
 
-You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in the
-text box.
+You can use <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to execute the code when focus is
+in the text box.
 
 <details>
 

--- a/src/running-the-course/keyboard-shortcuts.md
+++ b/src/running-the-course/keyboard-shortcuts.md
@@ -4,7 +4,7 @@ There are several useful keyboard shortcuts in mdBook:
 
 - <kbd>Arrow-Left</kbd>: Navigate to the previous page.
 - <kbd>Arrow-Right</kbd>: Navigate to the next page.
-- <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.
+- <kbd>Ctrl</kbd> + <kbd>Enter</kbd>: Execute the code sample that has focus.
 - <kbd>s</kbd>: Activate the search bar.
 
 <details>
@@ -14,7 +14,7 @@ There are several useful keyboard shortcuts in mdBook:
 - You can demonstrate each shortcut live to the students.
 - The <kbd>s</kbd> key for search is particularly useful for quickly finding
   topics that have been discussed earlier.
-- <kbd>Ctrl + Enter</kbd> will be super important for you since you'll do a lot
-  of live coding.
+- <kbd>Ctrl</kbd> + <kbd>Enter</kbd> will be super important for you since
+  you'll do a lot of live coding.
 
 </details>


### PR DESCRIPTION
- Based on feed back from @mgeisler, update the kbd tag guidance in GEMINI.md to require wrapping each key in its own tag (e.g., `<kbd>Ctrl</kbd> + <kbd>S</kbd>`).
- Apply this new convention to existing content in the `src` directory to ensure consistency.