### PR TITLE
web tests: run style guide compliance check only for modified markdown files

### DIFF
--- a/tests/src/slides/create-slide.list.sh
+++ b/tests/src/slides/create-slide.list.sh
@@ -24,19 +24,52 @@ if [[ ! -f "${TEST_BOOK_DIR}/index.html" ]]; then
   exit 1
 fi
 
-pushd "${TEST_BOOK_DIR}"
-# exclude special pages that should never be tested
-SLIDES=$(grep -L "Redirecting to..."  -R --include "*.html" \
-    --exclude "exercise.html" \
-    --exclude "solution.html" \
-    --exclude "toc.html" \
-    --exclude "print.html" \
-    --exclude "404.html" \
-    --exclude "glossary.html" \
-    --exclude "index.html" \
-    --exclude "course-structure.html"
-    )
-popd
+# These special pages should never be tested for slide size.
+EXCLUDE_FILES=(
+  "exercise.html"
+  "solution.html"
+  "toc.html"
+  "print.html"
+  "404.html"
+  "glossary.html"
+  "index.html"
+  "course-structure.html"
+)
+
+CANDIDATE_SLIDES=""
+if [[ -n "${CI}" ]]; then
+  echo "CI environment detected, checking only changed slides."
+  # Find changed markdown files in src/ and map them to their html output.
+  # GITHUB_BASE_REF is available in PRs. Default to 'main' for other CI contexts.
+  CANDIDATE_SLIDES=$(git diff --name-only "origin/${GITHUB_BASE_REF:-main}"... \
+    | grep '^src/.*\.md$' \
+    | sed 's|^src/||; s|\.md$|.html|' \
+    || true)
+else
+  # TODO: Limit the amount of files to check: Figure out what a good local diff base is.
+  echo "Local environment, checking all slides."
+  # Find all .html files recursively.
+  CANDIDATE_SLIDES=$(find "${TEST_BOOK_DIR}" -name "*.html" -printf "%P\n")
+fi
+
+SLIDES=""
+if [[ -n "${CANDIDATE_SLIDES}" ]]; then
+  # From the candidate slides, filter out:
+  # - Files that are just redirects.
+  # - Files that are in the EXCLUDE_FILES list.
+  # - Files that do not exist in the TEST_BOOK_DIR (by using ls)
+  pushd "${TEST_BOOK_DIR}" > /dev/null
+  EXCLUDE_PATTERN=$(IFS="|" ; echo "${EXCLUDE_FILES[*]}")
+  SLIDES=$(echo "${CANDIDATE_SLIDES}" | grep -v -E "${EXCLUDE_PATTERN}" \
+    | xargs ls 2>/dev/null \
+    | xargs -r grep -L "Redirecting to...") || true
+  popd > /dev/null
+fi
+
+if [[ -n "${CI}" ]]; then
+  echo "The following slides will be checked:"
+  echo "${SLIDES}"
+fi
 OUTPUT="${BASEDIR}/slides.list.ts"
 
 # create a ts module that can be imported in the tests


### PR DESCRIPTION
In the CI environment, only changes in the current PR are taken into account.
This speeds up the test process and reduces failure potential if no Markdown files have been changed.

Mitigates #2941 but does not fix the root cause