### PR TITLE
Update "Solutions" in Rust-in-Chromium guide.

### DIFF
--- a/src/exercises/chromium/solutions.md
+++ b/src/exercises/chromium/solutions.md
@@ -2,4 +2,9 @@
 
 Solutions to the Chromium exercises can be found in [this series of CLs][0].
 
+Or, if you'd prefer "standalone" solutions that don't require applying patchsets
+or integration with core Chromium code, you can find them in the
+[`//chromium/src/codelabs/rust` subdirectory in Chromium][1].
+
 [0]: https://chromium-review.googlesource.com/c/chromium/src/+/5096560
+[1]: https://source.chromium.org/chromium/chromium/src/+/main:codelabs/rust/


### PR DESCRIPTION
Previously the guide only listed a series of abandoned patches for the solutions for this part of the guide.

However, we've moved some of these exercises into the Chromium tree as standalone build targets to make it more convenient for Rust learners.

So, let's make sure they're linked in this guide.