### PR TITLE
change imports_granularity value to 'Module'

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 # Please use a nightly rustfmt for these settings.
 unstable_features = true
-imports_granularity = "module"
+imports_granularity = "Module"
 wrap_comments = true
 
 # The code blocks get a scrollbar if they are wider than this.


### PR DESCRIPTION
rustsc 1.89.0 says that the values are in PascalCase and will error out otherwise. Specfic message:

`"module" is not one of ["Preserve","Crate","Module","Item","One"]`