### PR TITLE
Mention that glossary is for Rust terms

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -178,6 +178,13 @@ possible, prefer terminology used in
 [the official Rust Book](https://doc.rust-lang.org/book/). If a less common but
 necessary term is used, provide a brief definition.
 
+#### Glossary
+
+The `src/glossary.md` file contains definitions for key Rust terms used
+throughout the course. When editing course content, use the glossary to anchor
+concepts and ensure consistency in terminology. Terms should be defined and used
+consistently with their glossary entries.
+
 ## Exercises
 
 At the end of some sections, learners will actively engage with the material by


### PR DESCRIPTION
This should help both humans and LLMs understand that the glossary is there to help ensure consistent terminology across the many slides in the courses.