### PR TITLE
Reduce permissions for Github actions by reducing to minimal permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/check-msgid-changes.yml
+++ b/.github/workflows/check-msgid-changes.yml
@@ -1,4 +1,6 @@
 name: Prevent unintended msgid changes
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
This is increasing the security of this repository. A standard GITHUB_TOKEN currently has these permissions.

Setting only `contents: read` permission has the effect of removing Packages permission. Metadata is added automatically.

GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  Packages: read

fixes #2958 