### PR TITLE
GitHub actions separate web tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,20 +149,28 @@ jobs:
           MDBOOK_BOOK__LANGUAGE: ${{ matrix.language }}
         run: mdbook test
 
+  web-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
       - name: Setup Node
-        if: matrix.language == 'en'
         uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: "npm"
           cache-dependency-path: "tests/package-lock.json"
       - name: Install test framework
-        if: matrix.language == 'en'
         run: npm install
         working-directory: ./tests
+      - name: Download english book
+        uses: actions/download-artifact@v6
+        with:
+          name: comprehensive-rust-en
+          path: book/
       - name: Test Javascript
-        if: matrix.language == 'en'
-        run: cargo xtask web-tests --dir book/comprehensive-rust-${{ matrix.language }}/html
+        run: cargo xtask web-tests --dir book/comprehensive-rust-en/html
 
   po-diff:
     name: Translation diff


### PR DESCRIPTION
Separating the web-tests from building the tests makes it more easy to spot and override failing web-tests.

This is still testing only the English translation.

There are legitimate warnings coming out of the web-test infrastructure and should be blocking. But sometimes the tests fail and need to be overridden.