### PR TITLE
chore: formalize book.js patching

### DIFF
--- a/patches/book.js.patch
+++ b/patches/book.js.patch
@@ -1,0 +1,338 @@
+--- theme/upstream_book.js	2025-12-25 17:01:51
++++ theme/book.js	2025-12-25 16:02:41
+@@ -3,6 +3,16 @@
+ // Fix back button cache problem
+ window.onunload = function () { };
+ 
++function isPlaygroundModified(playground) {
++    let code_block = playground.querySelector("code");
++    if (window.ace && code_block.classList.contains("editable")) {
++      let editor = window.ace.edit(code_block);
++      return editor.getValue() != editor.originalCode;
++    } else {
++      return false;
++    }
++}
++
+ // Global variable, shared between modules
+ function playground_text(playground, hidden = true) {
+     let code_block = playground.querySelector("code");
+@@ -18,7 +28,7 @@
+ }
+ 
+ (function codeSnippets() {
+-    function fetch_with_timeout(url, options, timeout = 6000) {
++    function fetch_with_timeout(url, options, timeout = 15000) {
+         return Promise.race([
+             fetch(url, options),
+             new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeout))
+@@ -34,12 +44,12 @@
+             method: 'POST',
+             mode: 'cors',
+         })
+-            .then(response => response.json())
+-            .then(response => {
+-                // get list of crates available in the rust playground
+-                let playground_crates = response.crates.map(item => item["id"]);
+-                playgrounds.forEach(block => handle_crate_list_update(block, playground_crates));
+-            });
++        .then(response => response.json())
++        .then(response => {
++            // get list of crates available in the rust playground
++            let playground_crates = response.crates.map(item => item["id"]);
++            playgrounds.forEach(block => handle_crate_list_update(block, playground_crates));
++        });
+     }
+ 
+     function handle_crate_list_update(playground_block, playground_crates) {
+@@ -100,36 +110,63 @@
+     }
+ 
+     function run_rust_code(code_block) {
+-        var result_block = code_block.querySelector(".result");
++        var result_stderr_block = code_block.querySelector(".result.stderr");
++        if (!result_stderr_block) {
++            result_stderr_block = document.createElement('code');
++            result_stderr_block.className = 'result stderr hljs nohighlight hidden';
++
++            code_block.append(result_stderr_block);
++        }
++        var result_block = code_block.querySelector(".result.stdout");
+         if (!result_block) {
+             result_block = document.createElement('code');
+-            result_block.className = 'result hljs language-bash';
++            result_block.className = 'result stdout hljs nohighlight';
+ 
+             code_block.append(result_block);
+         }
+ 
+         let text = playground_text(code_block);
+         let classes = code_block.querySelector('code').classList;
++        // Unless the code block has `warnunused`, allow all "unused" lints to avoid cluttering
++        // the output.
++        if(!classes.contains("warnunused")) {
++            text = '#![allow(unused)] ' + text;
++        }
+         let edition = "2015";
+-        if (classes.contains("edition2018")) {
++        if(classes.contains("edition2018")) {
+             edition = "2018";
+-        } else if (classes.contains("edition2021")) {
++        } else if(classes.contains("edition2021")) {
+             edition = "2021";
++        } else if(classes.contains("edition2024")) {
++            edition = "2024";
+         }
+         var params = {
+-            version: "stable",
+-            optimize: "0",
++            backtrace: true,
++            channel: "stable",
+             code: text,
+-            edition: edition
++            edition: edition,
++            mode: "debug",
++            tests: false,
++            crateType: "bin",
+         };
+ 
++        // If the code block has no `main` but does have tests, run those.
++        if (text.indexOf("fn main") === -1 && text.indexOf("#[test]") !== -1) {
++            params.tests = true;
++        }
++
+         if (text.indexOf("#![feature") !== -1) {
+             params.version = "nightly";
+         }
+ 
+         result_block.innerText = "Running...";
++        // hide stderr block while running
++        result_stderr_block.innerText = "";
++        result_stderr_block.classList.add("hidden");
+ 
+-        fetch_with_timeout("https://play.rust-lang.org/evaluate.json", {
++        const playgroundModified = isPlaygroundModified(code_block);
++        const startTime = window.performance.now();
++        fetch_with_timeout("https://play.rust-lang.org/execute", {
+             headers: {
+                 'Content-Type': "application/json",
+             },
+@@ -137,17 +174,52 @@
+             mode: 'cors',
+             body: JSON.stringify(params)
+         })
+-            .then(response => response.json())
+-            .then(response => {
+-                if (response.result.trim() === '') {
+-                    result_block.innerText = "No output";
+-                    result_block.classList.add("result-no-output");
+-                } else {
+-                    result_block.innerText = response.result;
+-                    result_block.classList.remove("result-no-output");
+-                }
+-            })
+-            .catch(error => result_block.innerText = "Playground Communication: " + error.message);
++        .then(response => response.json())
++        .then(response => {
++            const endTime = window.performance.now();
++            gtag("event", "playground", {
++                "modified": playgroundModified,
++                "error": (response.error == null) ? null : 'compilation_error',
++                "latency": (endTime - startTime) / 1000,
++            });
++
++            if (response.error != null && response.error != '') {
++                // output the error if there's any. e.g. timeout
++                result_block.innerText = response.error;
++                result_block.classList.remove("result-no-output");
++                return;
++            }
++
++            if (response.stdout.trim() === '') {
++                result_block.innerText = "No output";
++                result_block.classList.add("result-no-output");
++            } else {
++                result_block.innerText = response.stdout;
++                result_block.classList.remove("result-no-output");
++            }
++
++            // trim compile message
++            // ====================
++            // Compiling playground v0.0.1 (/playground)
++            // Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.60s
++            // Running `target/debug/playground`
++            // ====================
++            const compileMsgRegex = /^\s+Compiling(.+)\s+Finished(.+)\s+Running(.+)\n/;
++            response.stderr = response.stderr.replace(compileMsgRegex, "");
++            if (response.stderr.trim() !== '') {
++                result_stderr_block.classList.remove("hidden");
++                result_stderr_block.innerText = response.stderr;
++            }
++        })
++        .catch(error => {
++            const endTime = window.performance.now();
++            gtag("event", "playground", {
++                "modified": playgroundModified,
++                "error": error.message,
++                "latency": (endTime - startTime) / 1000,
++            });
++            result_block.innerText = "Playground Communication: " + error.message
++        });
+     }
+ 
+     // Syntax highlighting Configuration
+@@ -159,17 +231,17 @@
+     let code_nodes = Array
+         .from(document.querySelectorAll('code'))
+         // Don't highlight `inline code` blocks in headers.
+-        .filter(function (node) { return !node.parentElement.classList.contains("header"); });
++        .filter(function (node) {return !node.parentElement.classList.contains("header"); });
+ 
+     if (window.ace) {
+         // language-rust class needs to be removed for editable
+         // blocks or highlightjs will capture events
+         code_nodes
+-            .filter(function (node) { return node.classList.contains("editable"); })
++            .filter(function (node) {return node.classList.contains("editable"); })
+             .forEach(function (block) { block.classList.remove('language-rust'); });
+ 
+         code_nodes
+-            .filter(function (node) { return !node.classList.contains("editable"); })
++            .filter(function (node) {return !node.classList.contains("editable"); })
+             .forEach(function (block) { hljs.highlightBlock(block); });
+     } else {
+         code_nodes.forEach(function (block) { hljs.highlightBlock(block); });
+@@ -225,7 +297,7 @@
+                 }
+ 
+                 var clipButton = document.createElement('button');
+-                clipButton.className = 'fa fa-copy clip-button';
++                clipButton.className = 'clip-button';
+                 clipButton.title = 'Copy to clipboard';
+                 clipButton.setAttribute('aria-label', clipButton.title);
+                 clipButton.innerHTML = '<i class=\"tooltiptext\"></i>';
+@@ -258,8 +330,8 @@
+ 
+         if (window.playground_copyable) {
+             var copyCodeClipboardButton = document.createElement('button');
+-            copyCodeClipboardButton.className = 'fa fa-copy clip-button';
+-            copyCodeClipboardButton.innerHTML = '<i class=\"tooltiptext\"></i>';
++            copyCodeClipboardButton.className = 'clip-button';
++            copyCodeClipboardButton.innerHTML = '<i class="tooltiptext"></i>';
+             copyCodeClipboardButton.title = 'Copy to clipboard';
+             copyCodeClipboardButton.setAttribute('aria-label', copyCodeClipboardButton.title);
+ 
+@@ -289,6 +361,10 @@
+     var themeToggleButton = document.getElementById('theme-toggle');
+     var themePopup = document.getElementById('theme-list');
+     var themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
++    var themeIds = [];
++    themePopup.querySelectorAll('button.theme').forEach(function (el) {
++        themeIds.push(el.id);
++    });
+     var stylesheets = {
+         ayuHighlight: document.querySelector("[href$='ayu-highlight.css']"),
+         tomorrowNight: document.querySelector("[href$='tomorrow-night.css']"),
+@@ -317,7 +393,7 @@
+     function get_theme() {
+         var theme;
+         try { theme = localStorage.getItem('mdbook-theme'); } catch (e) { }
+-        if (theme === null || theme === undefined) {
++        if (theme === null || theme === undefined || !themeIds.includes(theme)) {
+             return default_theme;
+         } else {
+             return theme;
+@@ -391,7 +467,7 @@
+         set_theme(theme);
+     });
+ 
+-    themePopup.addEventListener('focusout', function (e) {
++    themePopup.addEventListener('focusout', function(e) {
+         // e.relatedTarget is null in Safari and Firefox on macOS (see workaround below)
+         if (!!e.relatedTarget && !themeToggleButton.contains(e.relatedTarget) && !themePopup.contains(e.relatedTarget)) {
+             hideThemes();
+@@ -399,7 +475,7 @@
+     });
+ 
+     // Should not be needed, but it works around an issue on macOS & iOS: https://github.com/rust-lang/mdBook/issues/628
+-    document.addEventListener('click', function (e) {
++    document.addEventListener('click', function(e) {
+         if (themePopup.style.display === 'block' && !themeToggleButton.contains(e.target) && !themePopup.contains(e.target)) {
+             hideThemes();
+         }
+@@ -445,6 +521,7 @@
+     var sidebar = document.getElementById("sidebar");
+     var sidebarLinks = document.querySelectorAll('#sidebar a');
+     var sidebarToggleButton = document.getElementById("sidebar-toggle");
++    var sidebarToggleAnchor = document.getElementById("sidebar-toggle-anchor");
+     var sidebarResizeHandle = document.getElementById("sidebar-resize-handle");
+     var firstContact = null;
+ 
+@@ -459,17 +536,6 @@
+         try { localStorage.setItem('mdbook-sidebar', 'visible'); } catch (e) { }
+     }
+ 
+-
+-    var sidebarAnchorToggles = document.querySelectorAll('#sidebar a.toggle');
+-
+-    function toggleSection(ev) {
+-        ev.currentTarget.parentElement.classList.toggle('expanded');
+-    }
+-
+-    Array.from(sidebarAnchorToggles).forEach(function (el) {
+-        el.addEventListener('click', toggleSection);
+-    });
+-
+     function hideSidebar() {
+         body.classList.remove('sidebar-visible')
+         body.classList.add('sidebar-hidden');
+@@ -482,22 +548,16 @@
+     }
+ 
+     // Toggle sidebar
+-    sidebarToggleButton.addEventListener('click', function sidebarToggle() {
+-        if (body.classList.contains("sidebar-hidden")) {
++    sidebarToggleAnchor.addEventListener('change', function sidebarToggle() {
++        if (sidebarToggleAnchor.checked) {
+             var current_width = parseInt(
+                 document.documentElement.style.getPropertyValue('--sidebar-width'), 10);
+             if (current_width < 150) {
+                 document.documentElement.style.setProperty('--sidebar-width', '150px');
+             }
+             showSidebar();
+-        } else if (body.classList.contains("sidebar-visible")) {
+-            hideSidebar();
+         } else {
+-            if (getComputedStyle(sidebar)['transform'] === 'none') {
+-                hideSidebar();
+-            } else {
+-                showSidebar();
+-            }
++            hideSidebar();
+         }
+     });
+ 
+@@ -597,12 +657,12 @@
+ 
+     function hideTooltip(elem) {
+         elem.firstChild.innerText = "";
+-        elem.className = 'fa fa-copy clip-button';
++        elem.className = 'clip-button';
+     }
+ 
+     function showTooltip(elem, msg) {
+         elem.firstChild.innerText = msg;
+-        elem.className = 'fa fa-copy tooltipped';
++        elem.className = 'clip-button tooltipped';
+     }
+ 
+     var clipboardSnippets = new ClipboardJS('.clip-button', {
+@@ -629,7 +689,7 @@
+     });
+ })();
+ 
+-(function scrollToTop() {
++(function scrollToTop () {
+     var menuTitle = document.querySelector('.menu-title');
+ 
+     menuTitle.addEventListener('click', function () {

--- a/third_party/mdbook/book.js
+++ b/third_party/mdbook/book.js
@@ -1,1 +1,697 @@
-../../theme/book.js
+"use strict";
+
+// Fix back button cache problem
+window.onunload = function () { };
+
+// Global variable, shared between modules
+function playground_text(playground, hidden = true) {
+    let code_block = playground.querySelector("code");
+
+    if (window.ace && code_block.classList.contains("editable")) {
+        let editor = window.ace.edit(code_block);
+        return editor.getValue();
+    } else if (hidden) {
+        return code_block.textContent;
+    } else {
+        return code_block.innerText;
+    }
+}
+
+(function codeSnippets() {
+    function fetch_with_timeout(url, options, timeout = 6000) {
+        return Promise.race([
+            fetch(url, options),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeout))
+        ]);
+    }
+
+    var playgrounds = Array.from(document.querySelectorAll(".playground"));
+    if (playgrounds.length > 0) {
+        fetch_with_timeout("https://play.rust-lang.org/meta/crates", {
+            headers: {
+                'Content-Type': "application/json",
+            },
+            method: 'POST',
+            mode: 'cors',
+        })
+            .then(response => response.json())
+            .then(response => {
+                // get list of crates available in the rust playground
+                let playground_crates = response.crates.map(item => item["id"]);
+                playgrounds.forEach(block => handle_crate_list_update(block, playground_crates));
+            });
+    }
+
+    function handle_crate_list_update(playground_block, playground_crates) {
+        // update the play buttons after receiving the response
+        update_play_button(playground_block, playground_crates);
+
+        // and install on change listener to dynamically update ACE editors
+        if (window.ace) {
+            let code_block = playground_block.querySelector("code");
+            if (code_block.classList.contains("editable")) {
+                let editor = window.ace.edit(code_block);
+                editor.addEventListener("change", function (e) {
+                    update_play_button(playground_block, playground_crates);
+                });
+                // add Ctrl-Enter command to execute rust code
+                editor.commands.addCommand({
+                    name: "run",
+                    bindKey: {
+                        win: "Ctrl-Enter",
+                        mac: "Ctrl-Enter"
+                    },
+                    exec: _editor => run_rust_code(playground_block)
+                });
+            }
+        }
+    }
+
+    // updates the visibility of play button based on `no_run` class and
+    // used crates vs ones available on https://play.rust-lang.org
+    function update_play_button(pre_block, playground_crates) {
+        var play_button = pre_block.querySelector(".play-button");
+
+        // skip if code is `no_run`
+        if (pre_block.querySelector('code').classList.contains("no_run")) {
+            play_button.classList.add("hidden");
+            return;
+        }
+
+        // get list of `extern crate`'s from snippet
+        var txt = playground_text(pre_block);
+        var re = /extern\s+crate\s+([a-zA-Z_0-9]+)\s*;/g;
+        var snippet_crates = [];
+        var item;
+        while (item = re.exec(txt)) {
+            snippet_crates.push(item[1]);
+        }
+
+        // check if all used crates are available on play.rust-lang.org
+        var all_available = snippet_crates.every(function (elem) {
+            return playground_crates.indexOf(elem) > -1;
+        });
+
+        if (all_available) {
+            play_button.classList.remove("hidden");
+        } else {
+            play_button.classList.add("hidden");
+        }
+    }
+
+    function run_rust_code(code_block) {
+        var result_block = code_block.querySelector(".result");
+        if (!result_block) {
+            result_block = document.createElement('code');
+            result_block.className = 'result hljs language-bash';
+
+            code_block.append(result_block);
+        }
+
+        let text = playground_text(code_block);
+        let classes = code_block.querySelector('code').classList;
+        let edition = "2015";
+        if (classes.contains("edition2018")) {
+            edition = "2018";
+        } else if (classes.contains("edition2021")) {
+            edition = "2021";
+        }
+        var params = {
+            version: "stable",
+            optimize: "0",
+            code: text,
+            edition: edition
+        };
+
+        if (text.indexOf("#![feature") !== -1) {
+            params.version = "nightly";
+        }
+
+        result_block.innerText = "Running...";
+
+        fetch_with_timeout("https://play.rust-lang.org/evaluate.json", {
+            headers: {
+                'Content-Type': "application/json",
+            },
+            method: 'POST',
+            mode: 'cors',
+            body: JSON.stringify(params)
+        })
+            .then(response => response.json())
+            .then(response => {
+                if (response.result.trim() === '') {
+                    result_block.innerText = "No output";
+                    result_block.classList.add("result-no-output");
+                } else {
+                    result_block.innerText = response.result;
+                    result_block.classList.remove("result-no-output");
+                }
+            })
+            .catch(error => result_block.innerText = "Playground Communication: " + error.message);
+    }
+
+    // Syntax highlighting Configuration
+    hljs.configure({
+        tabReplace: '    ', // 4 spaces
+        languages: [],      // Languages used for auto-detection
+    });
+
+    let code_nodes = Array
+        .from(document.querySelectorAll('code'))
+        // Don't highlight `inline code` blocks in headers.
+        .filter(function (node) { return !node.parentElement.classList.contains("header"); });
+
+    if (window.ace) {
+        // language-rust class needs to be removed for editable
+        // blocks or highlightjs will capture events
+        code_nodes
+            .filter(function (node) { return node.classList.contains("editable"); })
+            .forEach(function (block) { block.classList.remove('language-rust'); });
+
+        code_nodes
+            .filter(function (node) { return !node.classList.contains("editable"); })
+            .forEach(function (block) { hljs.highlightBlock(block); });
+    } else {
+        code_nodes.forEach(function (block) { hljs.highlightBlock(block); });
+    }
+
+    // Adding the hljs class gives code blocks the color css
+    // even if highlighting doesn't apply
+    code_nodes.forEach(function (block) { block.classList.add('hljs'); });
+
+    Array.from(document.querySelectorAll("code.hljs")).forEach(function (block) {
+
+        var lines = Array.from(block.querySelectorAll('.boring'));
+        // If no lines were hidden, return
+        if (!lines.length) { return; }
+        block.classList.add("hide-boring");
+
+        var buttons = document.createElement('div');
+        buttons.className = 'buttons';
+        buttons.innerHTML = "<button class=\"fa fa-eye\" title=\"Show hidden lines\" aria-label=\"Show hidden lines\"></button>";
+
+        // add expand button
+        var pre_block = block.parentNode;
+        pre_block.insertBefore(buttons, pre_block.firstChild);
+
+        pre_block.querySelector('.buttons').addEventListener('click', function (e) {
+            if (e.target.classList.contains('fa-eye')) {
+                e.target.classList.remove('fa-eye');
+                e.target.classList.add('fa-eye-slash');
+                e.target.title = 'Hide lines';
+                e.target.setAttribute('aria-label', e.target.title);
+
+                block.classList.remove('hide-boring');
+            } else if (e.target.classList.contains('fa-eye-slash')) {
+                e.target.classList.remove('fa-eye-slash');
+                e.target.classList.add('fa-eye');
+                e.target.title = 'Show hidden lines';
+                e.target.setAttribute('aria-label', e.target.title);
+
+                block.classList.add('hide-boring');
+            }
+        });
+    });
+
+    if (window.playground_copyable) {
+        Array.from(document.querySelectorAll('pre code')).forEach(function (block) {
+            var pre_block = block.parentNode;
+            if (!pre_block.classList.contains('playground')) {
+                var buttons = pre_block.querySelector(".buttons");
+                if (!buttons) {
+                    buttons = document.createElement('div');
+                    buttons.className = 'buttons';
+                    pre_block.insertBefore(buttons, pre_block.firstChild);
+                }
+
+                var clipButton = document.createElement('button');
+                clipButton.className = 'fa fa-copy clip-button';
+                clipButton.title = 'Copy to clipboard';
+                clipButton.setAttribute('aria-label', clipButton.title);
+                clipButton.innerHTML = '<i class=\"tooltiptext\"></i>';
+
+                buttons.insertBefore(clipButton, buttons.firstChild);
+            }
+        });
+    }
+
+    // Process playground code blocks
+    Array.from(document.querySelectorAll(".playground")).forEach(function (pre_block) {
+        // Add play button
+        var buttons = pre_block.querySelector(".buttons");
+        if (!buttons) {
+            buttons = document.createElement('div');
+            buttons.className = 'buttons';
+            pre_block.insertBefore(buttons, pre_block.firstChild);
+        }
+
+        var runCodeButton = document.createElement('button');
+        runCodeButton.className = 'fa fa-play play-button';
+        runCodeButton.hidden = true;
+        runCodeButton.title = 'Run this code';
+        runCodeButton.setAttribute('aria-label', runCodeButton.title);
+
+        buttons.insertBefore(runCodeButton, buttons.firstChild);
+        runCodeButton.addEventListener('click', function (e) {
+            run_rust_code(pre_block);
+        });
+
+        if (window.playground_copyable) {
+            var copyCodeClipboardButton = document.createElement('button');
+            copyCodeClipboardButton.className = 'fa fa-copy clip-button';
+            copyCodeClipboardButton.innerHTML = '<i class=\"tooltiptext\"></i>';
+            copyCodeClipboardButton.title = 'Copy to clipboard';
+            copyCodeClipboardButton.setAttribute('aria-label', copyCodeClipboardButton.title);
+
+            buttons.insertBefore(copyCodeClipboardButton, buttons.firstChild);
+        }
+
+        let code_block = pre_block.querySelector("code");
+        if (window.ace && code_block.classList.contains("editable")) {
+            var undoChangesButton = document.createElement('button');
+            undoChangesButton.className = 'fa fa-history reset-button';
+            undoChangesButton.title = 'Undo changes';
+            undoChangesButton.setAttribute('aria-label', undoChangesButton.title);
+
+            buttons.insertBefore(undoChangesButton, buttons.firstChild);
+
+            undoChangesButton.addEventListener('click', function () {
+                let editor = window.ace.edit(code_block);
+                editor.setValue(editor.originalCode);
+                editor.clearSelection();
+            });
+        }
+    });
+})();
+
+(function themes() {
+    var html = document.querySelector('html');
+    var themeToggleButton = document.getElementById('theme-toggle');
+    var themePopup = document.getElementById('theme-list');
+    var themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
+    var stylesheets = {
+        ayuHighlight: document.querySelector("[href$='ayu-highlight.css']"),
+        tomorrowNight: document.querySelector("[href$='tomorrow-night.css']"),
+        highlight: document.querySelector("[href$='highlight.css']"),
+    };
+
+    function showThemes() {
+        themePopup.style.display = 'block';
+        themeToggleButton.setAttribute('aria-expanded', true);
+        themePopup.querySelector("button#" + get_theme()).focus();
+    }
+
+    function updateThemeSelected() {
+        themePopup.querySelectorAll('.theme-selected').forEach(function (el) {
+            el.classList.remove('theme-selected');
+        });
+        themePopup.querySelector("button#" + get_theme()).classList.add('theme-selected');
+    }
+
+    function hideThemes() {
+        themePopup.style.display = 'none';
+        themeToggleButton.setAttribute('aria-expanded', false);
+        themeToggleButton.focus();
+    }
+
+    function get_theme() {
+        var theme;
+        try { theme = localStorage.getItem('mdbook-theme'); } catch (e) { }
+        if (theme === null || theme === undefined) {
+            return default_theme;
+        } else {
+            return theme;
+        }
+    }
+
+    function set_theme(theme, store = true) {
+        let ace_theme;
+
+        if (theme == 'coal' || theme == 'navy') {
+            stylesheets.ayuHighlight.disabled = true;
+            stylesheets.tomorrowNight.disabled = false;
+            stylesheets.highlight.disabled = true;
+
+            ace_theme = "ace/theme/tomorrow_night";
+        } else if (theme == 'ayu') {
+            stylesheets.ayuHighlight.disabled = false;
+            stylesheets.tomorrowNight.disabled = true;
+            stylesheets.highlight.disabled = true;
+            ace_theme = "ace/theme/tomorrow_night";
+        } else {
+            stylesheets.ayuHighlight.disabled = true;
+            stylesheets.tomorrowNight.disabled = true;
+            stylesheets.highlight.disabled = false;
+            ace_theme = "ace/theme/dawn";
+        }
+
+        setTimeout(function () {
+            themeColorMetaTag.content = getComputedStyle(document.documentElement).backgroundColor;
+        }, 1);
+
+        if (window.ace && window.editors) {
+            window.editors.forEach(function (editor) {
+                editor.setTheme(ace_theme);
+            });
+        }
+
+        var previousTheme = get_theme();
+
+        if (store) {
+            try { localStorage.setItem('mdbook-theme', theme); } catch (e) { }
+        }
+
+        html.classList.remove(previousTheme);
+        html.classList.add(theme);
+        updateThemeSelected();
+    }
+
+    // Set theme
+    var theme = get_theme();
+
+    set_theme(theme, false);
+
+    themeToggleButton.addEventListener('click', function () {
+        if (themePopup.style.display === 'block') {
+            hideThemes();
+        } else {
+            showThemes();
+        }
+    });
+
+    themePopup.addEventListener('click', function (e) {
+        var theme;
+        if (e.target.className === "theme") {
+            theme = e.target.id;
+        } else if (e.target.parentElement.className === "theme") {
+            theme = e.target.parentElement.id;
+        } else {
+            return;
+        }
+        set_theme(theme);
+    });
+
+    themePopup.addEventListener('focusout', function (e) {
+        // e.relatedTarget is null in Safari and Firefox on macOS (see workaround below)
+        if (!!e.relatedTarget && !themeToggleButton.contains(e.relatedTarget) && !themePopup.contains(e.relatedTarget)) {
+            hideThemes();
+        }
+    });
+
+    // Should not be needed, but it works around an issue on macOS & iOS: https://github.com/rust-lang/mdBook/issues/628
+    document.addEventListener('click', function (e) {
+        if (themePopup.style.display === 'block' && !themeToggleButton.contains(e.target) && !themePopup.contains(e.target)) {
+            hideThemes();
+        }
+    });
+
+    document.addEventListener('keydown', function (e) {
+        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) { return; }
+        if (!themePopup.contains(e.target)) { return; }
+
+        switch (e.key) {
+            case 'Escape':
+                e.preventDefault();
+                hideThemes();
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                var li = document.activeElement.parentElement;
+                if (li && li.previousElementSibling) {
+                    li.previousElementSibling.querySelector('button').focus();
+                }
+                break;
+            case 'ArrowDown':
+                e.preventDefault();
+                var li = document.activeElement.parentElement;
+                if (li && li.nextElementSibling) {
+                    li.nextElementSibling.querySelector('button').focus();
+                }
+                break;
+            case 'Home':
+                e.preventDefault();
+                themePopup.querySelector('li:first-child button').focus();
+                break;
+            case 'End':
+                e.preventDefault();
+                themePopup.querySelector('li:last-child button').focus();
+                break;
+        }
+    });
+})();
+
+(function sidebar() {
+    var body = document.querySelector("body");
+    var sidebar = document.getElementById("sidebar");
+    var sidebarLinks = document.querySelectorAll('#sidebar a');
+    var sidebarToggleButton = document.getElementById("sidebar-toggle");
+    var sidebarResizeHandle = document.getElementById("sidebar-resize-handle");
+    var firstContact = null;
+
+    function showSidebar() {
+        body.classList.remove('sidebar-hidden')
+        body.classList.add('sidebar-visible');
+        Array.from(sidebarLinks).forEach(function (link) {
+            link.setAttribute('tabIndex', 0);
+        });
+        sidebarToggleButton.setAttribute('aria-expanded', true);
+        sidebar.setAttribute('aria-hidden', false);
+        try { localStorage.setItem('mdbook-sidebar', 'visible'); } catch (e) { }
+    }
+
+
+    var sidebarAnchorToggles = document.querySelectorAll('#sidebar a.toggle');
+
+    function toggleSection(ev) {
+        ev.currentTarget.parentElement.classList.toggle('expanded');
+    }
+
+    Array.from(sidebarAnchorToggles).forEach(function (el) {
+        el.addEventListener('click', toggleSection);
+    });
+
+    function hideSidebar() {
+        body.classList.remove('sidebar-visible')
+        body.classList.add('sidebar-hidden');
+        Array.from(sidebarLinks).forEach(function (link) {
+            link.setAttribute('tabIndex', -1);
+        });
+        sidebarToggleButton.setAttribute('aria-expanded', false);
+        sidebar.setAttribute('aria-hidden', true);
+        try { localStorage.setItem('mdbook-sidebar', 'hidden'); } catch (e) { }
+    }
+
+    // Toggle sidebar
+    sidebarToggleButton.addEventListener('click', function sidebarToggle() {
+        if (body.classList.contains("sidebar-hidden")) {
+            var current_width = parseInt(
+                document.documentElement.style.getPropertyValue('--sidebar-width'), 10);
+            if (current_width < 150) {
+                document.documentElement.style.setProperty('--sidebar-width', '150px');
+            }
+            showSidebar();
+        } else if (body.classList.contains("sidebar-visible")) {
+            hideSidebar();
+        } else {
+            if (getComputedStyle(sidebar)['transform'] === 'none') {
+                hideSidebar();
+            } else {
+                showSidebar();
+            }
+        }
+    });
+
+    sidebarResizeHandle.addEventListener('mousedown', initResize, false);
+
+    function initResize(e) {
+        window.addEventListener('mousemove', resize, false);
+        window.addEventListener('mouseup', stopResize, false);
+        body.classList.add('sidebar-resizing');
+    }
+    function resize(e) {
+        var pos = (e.clientX - sidebar.offsetLeft);
+        if (pos < 20) {
+            hideSidebar();
+        } else {
+            if (body.classList.contains("sidebar-hidden")) {
+                showSidebar();
+            }
+            pos = Math.min(pos, window.innerWidth - 100);
+            document.documentElement.style.setProperty('--sidebar-width', pos + 'px');
+        }
+    }
+    //on mouseup remove windows functions mousemove & mouseup
+    function stopResize(e) {
+        body.classList.remove('sidebar-resizing');
+        window.removeEventListener('mousemove', resize, false);
+        window.removeEventListener('mouseup', stopResize, false);
+    }
+
+    document.addEventListener('touchstart', function (e) {
+        firstContact = {
+            x: e.touches[0].clientX,
+            time: Date.now()
+        };
+    }, { passive: true });
+
+    document.addEventListener('touchmove', function (e) {
+        if (!firstContact)
+            return;
+
+        var curX = e.touches[0].clientX;
+        var xDiff = curX - firstContact.x,
+            tDiff = Date.now() - firstContact.time;
+
+        if (tDiff < 250 && Math.abs(xDiff) >= 150) {
+            if (xDiff >= 0 && firstContact.x < Math.min(document.body.clientWidth * 0.25, 300))
+                showSidebar();
+            else if (xDiff < 0 && curX < 300)
+                hideSidebar();
+
+            firstContact = null;
+        }
+    }, { passive: true });
+})();
+
+(function chapterNavigation() {
+    document.addEventListener('keydown', function (e) {
+        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) { return; }
+        if (window.search && window.search.hasFocus()) { return; }
+        var html = document.querySelector('html');
+
+        function next() {
+            var nextButton = document.querySelector('.nav-chapters.next');
+            if (nextButton) {
+                window.location.href = nextButton.href;
+            }
+        }
+        function prev() {
+            var previousButton = document.querySelector('.nav-chapters.previous');
+            if (previousButton) {
+                window.location.href = previousButton.href;
+            }
+        }
+        switch (e.key) {
+            case 'ArrowRight':
+                e.preventDefault();
+                if (html.dir == 'rtl') {
+                    prev();
+                } else {
+                    next();
+                }
+                break;
+            case 'ArrowLeft':
+                e.preventDefault();
+                if (html.dir == 'rtl') {
+                    next();
+                } else {
+                    prev();
+                }
+                break;
+        }
+    });
+})();
+
+(function clipboard() {
+    var clipButtons = document.querySelectorAll('.clip-button');
+
+    function hideTooltip(elem) {
+        elem.firstChild.innerText = "";
+        elem.className = 'fa fa-copy clip-button';
+    }
+
+    function showTooltip(elem, msg) {
+        elem.firstChild.innerText = msg;
+        elem.className = 'fa fa-copy tooltipped';
+    }
+
+    var clipboardSnippets = new ClipboardJS('.clip-button', {
+        text: function (trigger) {
+            hideTooltip(trigger);
+            let playground = trigger.closest("pre");
+            return playground_text(playground, false);
+        }
+    });
+
+    Array.from(clipButtons).forEach(function (clipButton) {
+        clipButton.addEventListener('mouseout', function (e) {
+            hideTooltip(e.currentTarget);
+        });
+    });
+
+    clipboardSnippets.on('success', function (e) {
+        e.clearSelection();
+        showTooltip(e.trigger, "Copied!");
+    });
+
+    clipboardSnippets.on('error', function (e) {
+        showTooltip(e.trigger, "Clipboard error!");
+    });
+})();
+
+(function scrollToTop() {
+    var menuTitle = document.querySelector('.menu-title');
+
+    menuTitle.addEventListener('click', function () {
+        document.scrollingElement.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+})();
+
+(function controllMenu() {
+    var menu = document.getElementById('menu-bar');
+
+    (function controllPosition() {
+        var scrollTop = document.scrollingElement.scrollTop;
+        var prevScrollTop = scrollTop;
+        var minMenuY = -menu.clientHeight - 50;
+        // When the script loads, the page can be at any scroll (e.g. if you reforesh it).
+        menu.style.top = scrollTop + 'px';
+        // Same as parseInt(menu.style.top.slice(0, -2), but faster
+        var topCache = menu.style.top.slice(0, -2);
+        menu.classList.remove('sticky');
+        var stickyCache = false; // Same as menu.classList.contains('sticky'), but faster
+        document.addEventListener('scroll', function () {
+            scrollTop = Math.max(document.scrollingElement.scrollTop, 0);
+            // `null` means that it doesn't need to be updated
+            var nextSticky = null;
+            var nextTop = null;
+            var scrollDown = scrollTop > prevScrollTop;
+            var menuPosAbsoluteY = topCache - scrollTop;
+            if (scrollDown) {
+                nextSticky = false;
+                if (menuPosAbsoluteY > 0) {
+                    nextTop = prevScrollTop;
+                }
+            } else {
+                if (menuPosAbsoluteY > 0) {
+                    nextSticky = true;
+                } else if (menuPosAbsoluteY < minMenuY) {
+                    nextTop = prevScrollTop + minMenuY;
+                }
+            }
+            if (nextSticky === true && stickyCache === false) {
+                menu.classList.add('sticky');
+                stickyCache = true;
+            } else if (nextSticky === false && stickyCache === true) {
+                menu.classList.remove('sticky');
+                stickyCache = false;
+            }
+            if (nextTop !== null) {
+                menu.style.top = nextTop + 'px';
+                topCache = nextTop;
+            }
+            prevScrollTop = scrollTop;
+        }, { passive: true });
+    })();
+    (function controllBorder() {
+        function updateBorder() {
+            if (menu.offsetTop === 0) {
+                menu.classList.remove('bordered');
+            } else {
+                menu.classList.add('bordered');
+            }
+        }
+        updateBorder();
+        document.addEventListener('scroll', updateBorder, { passive: true });
+    })();
+})();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -86,6 +86,8 @@ enum Task {
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
+    /// Patches the assets (e.g. book.js) with local changes.
+    PatchAssets,
 }
 
 fn execute_task() -> Result<()> {
@@ -97,6 +99,7 @@ fn execute_task() -> Result<()> {
         Task::RustTests => run_rust_tests(),
         Task::Serve { language, output } => start_web_server(language, output),
         Task::Build { language, output } => build(language, output),
+        Task::PatchAssets => patch_assets(),
     }
 }
 
@@ -168,6 +171,8 @@ fn install_tools(binstall: bool) -> Result<()> {
 
     // Uninstall original linkcheck if currently installed (see issue no 2773)
     uninstall_mdbook_linkcheck()?;
+
+    patch_assets()?;
 
     Ok(())
 }
@@ -384,4 +389,22 @@ fn get_output_dir(language: Option<String>, output_arg: Option<PathBuf>) -> Path
     } else {
         Path::new("book").join(language.unwrap_or("".to_string()))
     }
+}
+
+fn patch_assets() -> Result<()> {
+    let workspace_dir = Path::new(env!("CARGO_WORKSPACE_DIR"));
+    let patch = workspace_dir.join("patches/book.js.patch");
+    let original = workspace_dir.join("third_party/mdbook/book.js");
+    let target = workspace_dir.join("theme/book.js");
+
+    println!("Patching {} with {}...", target.display(), patch.display());
+
+    fs::copy(&original, &target).with_context(|| {
+        format!("Failed to copy {} to {}", original.display(), target.display())
+    })?;
+
+    // Apply the patch to `theme/book.js`
+    let mut cmd = Command::new("patch");
+    cmd.arg(&target).arg(&patch);
+    run_command(&mut cmd)
 }


### PR DESCRIPTION
# Formalize `book.js` Patching

## Description
This PR formalizes the process of patching `book.js`.

Previously, `theme/book.js` contained custom modifications (Google Analytics) but there was no clear separation from the upstream `mdBook` code, and `third_party/mdbook/book.js` was a symlink to this modified file.

This change:
1.  Restores `third_party/mdbook/book.js` to its pristine upstream state (matching `mdBook` version used).
2.  Adds a `patches/book.js.patch` file containing the custom Google Analytics integration.
3.  Adds a new `xtask patch-assets` command to automatically apply this patch.
4.  Updates `xtask install-tools` to run `patch-assets`, ensuring the environment is always correctly set up.

## Verification
- Run `cargo xtask patch-assets` to verify the patch applies cleanly.
- Inspect `theme/book.js` to confirm `gtag` calls are present.
- Run `cargo xtask serve` to verify the book builds and serves correctly.

Fixes #2924
