### PR TITLE
Fix leftover in encapsulated-unsafe

### DIFF
--- a/src/unsafe-deep-dive/rules-of-the-game/copying-memory/encapsulated-unsafe.md
+++ b/src/unsafe-deep-dive/rules-of-the-game/copying-memory/encapsulated-unsafe.md
@@ -18,10 +18,6 @@ pub fn copy(dest: &mut [u8], source: &[u8]) {
         *old = *new;
         i += 1;
     }
-
-    for (dest, src) in dest.iter_mut().zip(source) {
-        *dest = *src;
-    }
 }
 
 fn main() {


### PR DESCRIPTION
This seems to be a leftover of a copy/paste from the safe version. This is redundant with the unsafe implementation.