### PR TITLE
Fix missing text in exposed-unsafe

### DIFF
--- a/src/unsafe-deep-dive/rules-of-the-game/copying-memory/exposed-unsafe.md
+++ b/src/unsafe-deep-dive/rules-of-the-game/copying-memory/exposed-unsafe.md
@@ -35,7 +35,7 @@ fn main() {
 
 <details>
 
-onality of copying bytes from one place to the next remains the same.
+The functionality of copying bytes from one place to the next remains the same.
 
 “However, we need to manually create a slice. To do that, we first need to find
 the end of the data.


### PR DESCRIPTION
I'm guessing the first characters of that sentence got somehow deleted. I filled them with what I believe is the most probable option.