### PR TITLE
Avoid unnecessary borrow in exercise.rs

### DIFF
--- a/src/tuples-and-arrays/exercise.rs
+++ b/src/tuples-and-arrays/exercise.rs
@@ -36,15 +36,15 @@ fn main() {
     ];
 
     println!("Original:");
-    for row in &matrix {
-        println!("{:?}", row);
+    for row in matrix {
+        println!("{row:?}");
     }
 
     let transposed = transpose(matrix);
 
     println!("\nTransposed:");
-    for row in &transposed {
-        println!("{:?}", row);
+    for row in transposed {
+        println!("{row:?}");
     }
 }
 // ANCHOR_END: main


### PR DESCRIPTION
We haven't talked about copy types yet, but the rows are infact `Copy`. So we can avoid the borrow syntax, which hasn't yet been introduced.

Also inline the variable in the format string like elsewhere in the course.