### PR TITLE
Remove unneeded .iter() calls in channel examples

### DIFF
--- a/src/concurrency/channels/bounded.md
+++ b/src/concurrency/channels/bounded.md
@@ -24,7 +24,7 @@ fn main() {
     });
     thread::sleep(Duration::from_millis(100));
 
-    for msg in rx.iter() {
+    for msg in rx {
         println!("Main: got {msg}");
     }
 }

--- a/src/concurrency/channels/unbounded.md
+++ b/src/concurrency/channels/unbounded.md
@@ -24,7 +24,7 @@ fn main() {
     });
     thread::sleep(Duration::from_millis(100));
 
-    for msg in rx.iter() {
+    for msg in rx {
         println!("Main: got {msg}");
     }
 }


### PR DESCRIPTION
The two calls to `.iter()` are not needed since the desugaring of `for`-loops adds them anyway.