### PR TITLE
Remove reqwest's rustls-tls feature in link checker exercise

### DIFF
--- a/src/concurrency/sync-exercises/link-checker.md
+++ b/src/concurrency/sync-exercises/link-checker.md
@@ -18,7 +18,7 @@ Create a new Cargo project and `reqwest` it as a dependency with:
 ```shell
 cargo new link-checker
 cd link-checker
-cargo add --features blocking,rustls-tls reqwest
+cargo add --features blocking reqwest
 cargo add scraper
 cargo add thiserror
 ```


### PR DESCRIPTION
As of version 0.13 of `reqwest`, the `rustls-tls` feature does not exist anymore. The feature has been renamed to `rustls` and is turned on by default. See https://github.com/seanmonstar/reqwest/releases/tag/v0.13.0 for details.

Thus, we remove the feature from the exercise to avoid students running into issues.