### PR TITLE
bare-metal: remove weasel words

### DIFF
--- a/src/bare-metal/aps/entry-point.md
+++ b/src/bare-metal/aps/entry-point.md
@@ -9,8 +9,8 @@ Before we can start running Rust code, we need to do some initialization.
 <details>
 
 This code is in `src/bare-metal/aps/examples/src/entry.S`. It's not necessary to
-understand this in detail -- the takeaway is that typically some low-level setup
-is needed to meet Rust's expectations of the system.
+understand this in detail -- the takeaway is that some low-level setup is needed
+to meet Rust's expectations of the system.
 
 - This is the same as it would be for C: initializing the processor state,
   zeroing the BSS, and setting up the stack pointer.

--- a/src/bare-metal/aps/mmio.md
+++ b/src/bare-metal/aps/mmio.md
@@ -24,9 +24,9 @@ unsafe {
 
 - Volatile access: read or write operations may have side-effects, so prevent
   the compiler or hardware from reordering, duplicating or eliding them.
-  - Usually if you write and then read, e.g. via a mutable reference, the
-    compiler may assume that the value read is the same as the value just
-    written, and not bother actually reading memory.
+  - If you write and then read, e.g. via a mutable reference, the compiler may
+    assume that the value read is the same as the value just written, and not
+    bother actually reading memory.
 - Some existing crates for volatile access to hardware do hold references, but
   this is unsound. Whenever a reference exists, the compiler may choose to
   dereference it.

--- a/src/bare-metal/microcontrollers/embedded-hal.md
+++ b/src/bare-metal/microcontrollers/embedded-hal.md
@@ -17,7 +17,7 @@ accelerometer driver might need an I2C or SPI device instance.
 <details>
 
 - The traits cover using the peripherals but not initializing or configuring
-  them, as initialization and configuration is usually highly platform-specific.
+  them, as initialization and configuration is highly platform-specific.
 - There are implementations for many microcontrollers, as well as other
   platforms such as Linux on Raspberry Pi.
 - [`embedded-hal-async`] provides async versions of the traits.

--- a/src/bare-metal/microcontrollers/pacs.md
+++ b/src/bare-metal/microcontrollers/pacs.md
@@ -14,8 +14,9 @@ wrappers for memory-mapped peripherals from
   silicon vendors that describe the memory map of the device.
   - They are organized by peripheral, register, field and value, with names,
     descriptions, addresses and so on.
-  - SVD files are often buggy and incomplete, so there are various projects that
-    patch the mistakes, add missing details, and publish the generated crates.
+  - SVD files are frequently buggy and incomplete, so there are various projects
+    that patch the mistakes, add missing details, and publish the generated
+    crates.
 - `cortex-m-rt` provides the vector table, among other things.
 - If you `cargo install cargo-binutils` then you can run
   `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*