### PR TITLE
chromium: remove weasel words

### DIFF
--- a/src/chromium/adding-third-party-crates/configuring-cargo-toml.md
+++ b/src/chromium/adding-third-party-crates/configuring-cargo-toml.md
@@ -12,10 +12,10 @@ cxx = "1"
 ```
 
 As with any other `Cargo.toml`, you can specify
-[more details about the dependencies][1] --- most commonly, you'll want to
-specify the `features` that you wish to enable in the crate.
+[more details about the dependencies][1] --- typically, you'll want to specify
+the `features` that you wish to enable in the crate.
 
-When adding a crate to Chromium, you'll often need to provide some extra
+When adding a crate to Chromium, you'll frequently need to provide additional
 information in an additional file, `gnrt_config.toml`, which we'll meet next.
 
 [0]: https://source.chromium.org/chromium/chromium/src/+/main:third_party/rust/chromium_crates_io/Cargo.toml

--- a/src/chromium/adding-third-party-crates/reviews-and-audits.md
+++ b/src/chromium/adding-third-party-crates/reviews-and-audits.md
@@ -2,9 +2,9 @@
 
 Adding new libraries is subject to Chromium's standard [policies][0], but of
 course also subject to security review. As you may be bringing in not just a
-single crate but also transitive dependencies, there may be a lot of code to
-review. On the other hand, safe Rust code can have limited negative side
-effects. How should you review it?
+single crate but also transitive dependencies, there may be a substantial amount
+of code to review. On the other hand, safe Rust code can have limited negative
+side effects. How should you review it?
 
 Over time Chromium aims to move to a process based around [cargo vet][1].
 
@@ -22,7 +22,7 @@ Meanwhile, for each new crate addition, we are checking for the following:
 - Check for any use of `fs` or `net` APIs
 - Read all the code at a sufficient level to look for anything out of place that
   might have been maliciously inserted. (You can't realistically aim for 100%
-  perfection here: there's often just too much code.)
+  perfection here: there is often too much code.)
 
 These are just guidelines --- work with reviewers from `security@chromium.org`
 to work out the right way to become confident of the crate.

--- a/src/chromium/build-rules.md
+++ b/src/chromium/build-rules.md
@@ -1,8 +1,8 @@
 # Build rules
 
-Rust code is usually built using `cargo`. Chromium builds with `gn` and `ninja`
-for efficiency --- its static rules allow maximum parallelism. Rust is no
-exception.
+Rust code is typically built using `cargo`. Chromium builds with `gn` and
+`ninja` for efficiency --- its static rules allow maximum parallelism. Rust is
+no exception.
 
 ## Adding Rust code to Chromium
 

--- a/src/chromium/cargo.md
+++ b/src/chromium/cargo.md
@@ -37,7 +37,7 @@ may offer an advantage"):
 
 - It's fantastic that when writing a tool, or prototyping a part of Chromium,
   one has access to the rich ecosystem of crates.io libraries. There is a crate
-  for almost anything and they are usually quite pleasant to use. (`clap` for
+  for almost anything and they are typically quite pleasant to use. (`clap` for
   command-line parsing, `serde` for serializing/deserializing to/from various
   formats, `itertools` for working with iterators, etc.).
 
@@ -66,7 +66,7 @@ may offer an advantage"):
   - Participating in the Rust ecosystem requires using standard Rust tools like
     Cargo. Libraries that want to get external contributions, and want to be
     used outside of Chromium (e.g. in Bazel or Android/Soong build environments)
-    should probably use Cargo.
+    should use Cargo.
 
 - Examples of Chromium-related projects that are `cargo`-based:
   - `serde_json_lenient` (experimented with in other parts of Google which

--- a/src/chromium/interoperability-with-cpp.md
+++ b/src/chromium/interoperability-with-cpp.md
@@ -4,7 +4,7 @@ The Rust community offers multiple options for C++/Rust interop, with new tools
 being developed all the time. At the moment, Chromium uses a tool called CXX.
 
 You describe your whole language boundary in an interface definition language
-(which looks a lot like Rust) and then CXX tools generate declarations for
+(which closely resembles Rust) and then CXX tools generate declarations for
 functions and types in both Rust and C++.
 
 <img src="../android/interoperability/cpp/overview.svg" alt="Overview diagram of cxx, showing that the same interface definition is used to create both C++ and Rust side code which then communicate via a lowest common denominator C API">

--- a/src/chromium/policy.md
+++ b/src/chromium/policy.md
@@ -21,9 +21,9 @@ Using Rust for pure first-party code looks like this:
 `- - - - - - - - - -'           `- - - - - - - - - - -'
 ```
 
-The third-party case is also common. It's likely that you'll also need a small
-amount of first-party glue code, because very few Rust libraries directly expose
-a C/C++ API.
+The third-party case is also common. You will typically also need a small amount
+of first-party glue code, because very few Rust libraries directly expose a
+C/C++ API.
 
 ```bob
 "C++"                           Rust


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*