### PR TITLE
iterators: remove weasel words

### DIFF
--- a/src/iterators/collect.md
+++ b/src/iterators/collect.md
@@ -39,7 +39,7 @@ There are two ways to specify the generic type `B` for this method:
   `Result<Vec<V>, E>`.
 - The reason type annotations are often needed with `collect` is because it's
   generic over its return type. This makes it harder for the compiler to infer
-  the correct type in a lot of cases.
+  the correct type in many cases.
 
 </details>
 


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*