### PR TITLE
memory-management: remove weasel words

### DIFF
--- a/src/memory-management/drop.md
+++ b/src/memory-management/drop.md
@@ -45,7 +45,7 @@ fn main() {
   significance is that it takes ownership of the value, so at the end of its
   scope it gets dropped. This makes it a convenient way to explicitly drop
   values earlier than they would otherwise go out of scope.
-  - This can be useful for objects that do some work on `drop`: releasing locks,
+  - This is useful for objects that do some work on `drop`: releasing locks,
     closing files, etc.
 
 Discussion points:


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*