### PR TITLE
references: remove weasel words

### DIFF
--- a/src/references/shared.md
+++ b/src/references/shared.md
@@ -39,8 +39,8 @@ value.
   will recognize references as pointers. Later parts of the course will cover
   how Rust prevents the memory-safety bugs that come from using raw pointers.
 
-- Explicit referencing with `&` is usually required. However, Rust performs
-  automatic referencing and dereferencing when invoking methods.
+- Explicit referencing with `&` is required, except when invoking methods where
+  Rust performs automatic referencing and dereferencing.
 
 - Rust will auto-dereference in some cases, in particular when invoking methods
   (try `r.is_ascii()`). There is no need for an `->` operator like in C++.


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*