### PR TITLE
std-types: remove weasel words

### DIFF
--- a/src/std-types/option.md
+++ b/src/std-types/option.md
@@ -31,7 +31,7 @@ fn main() {
   - It's common to `unwrap`/`expect` all over the place when hacking something
     together, but production code typically handles `None` in a nicer fashion.
 
-- The "niche optimization" means that `Option<T>` often has the same size in
+- The "niche optimization" means that `Option<T>` typically has the same size in
   memory as `T`, if there is some representation that is not a valid value of T.
   For example, a reference cannot be NULL, so `Option<&T>` automatically uses
   NULL to represent the `None` variant, and thus can be stored in the same

--- a/src/std-types/result.md
+++ b/src/std-types/result.md
@@ -37,8 +37,8 @@ fn main() {
   case where an error should never happen, `unwrap()` or `expect()` can be
   called, and this is a signal of the developer intent too.
 - `Result` documentation is a recommended read. Not during the course, but it is
-  worth mentioning. It contains a lot of convenience methods and functions that
-  help functional-style programming.
+  worth mentioning. It contains many convenience methods and functions that help
+  functional-style programming.
 - `Result` is the standard type to implement error handling as we will see on
   Day 4.
 

--- a/src/std-types/std.md
+++ b/src/std-types/std.md
@@ -15,4 +15,4 @@ and `std`.
   `libc`, allocator or even the presence of an operating system.
 - `alloc` includes types that require a global heap allocator, such as `Vec`,
   `Box` and `Arc`.
-- Embedded Rust applications often only use `core`, and sometimes `alloc`.
+- Embedded Rust applications typically only use `core`, and sometimes `alloc`.


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*