### PR TITLE
tuples-and-arrays: remove weasel words

### DIFF
--- a/src/tuples-and-arrays/arrays.md
+++ b/src/tuples-and-arrays/arrays.md
@@ -37,8 +37,8 @@ fn main() {
 }
 ```
 
-- Array accesses are checked at runtime. Rust can usually optimize these checks
-  away; meaning if the compiler can prove the access is safe, it removes the
+- Array accesses are checked at runtime. Rust optimizes these checks away when
+  possible; meaning if the compiler can prove the access is safe, it removes the
   runtime check for better performance. They can be avoided using unsafe Rust.
   The optimization is so good that it's hard to give an example of runtime
   checks failing. The following code will compile but panic at runtime:


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*