### PR TITLE
unsafe-rust: remove weasel words

### DIFF
--- a/src/unsafe-rust/mutable-static.md
+++ b/src/unsafe-rust/mutable-static.md
@@ -49,7 +49,7 @@ fn main() {
   behavior to access a mutable static from multiple threads.
 - The 2024 Rust edition goes further and makes accessing a mutable static by
   reference an error by default.
-- Using a mutable static is almost always a bad idea, you should use interior
+- Using a mutable static is rarely a good idea, you should use interior
   mutability instead.
 - There are some cases where it might be necessary in low-level `no_std` code,
   such as implementing a heap allocator or working with some C APIs. In this

--- a/src/unsafe-rust/unions.md
+++ b/src/unsafe-rust/unions.md
@@ -22,8 +22,8 @@ fn main() {
 
 <details>
 
-Unions are very rarely needed in Rust as you can usually use an enum. They are
-occasionally needed for interacting with C library APIs.
+Unions are rarely needed in Rust as enums provide a superior alternative. They
+are occasionally needed for interacting with C library APIs.
 
 If you just want to reinterpret bytes as a different type, you probably want
 [`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html)

--- a/src/unsafe-rust/unsafe-functions/calling.md
+++ b/src/unsafe-rust/unsafe-functions/calling.md
@@ -39,8 +39,8 @@ Key points:
   prerequisites to avoid undefined behaviour. A safe function which can cause
   undefined behaviour is said to be `unsound`. What should its safety
   documentation say?
-- The standard library contains many low-level unsafe functions. Prefer the safe
-  alternatives when possible!
+- The standard library contains a number of low-level unsafe functions. Prefer
+  the safe alternatives when possible!
 - If you use an unsafe function as an optimization, make sure to add a benchmark
   to demonstrate the gain.
 

--- a/src/unsafe-rust/unsafe-functions/extern-c.md
+++ b/src/unsafe-rust/unsafe-functions/extern-c.md
@@ -35,9 +35,9 @@ fn main() {
 - Rust used to consider all extern functions unsafe, but this changed in Rust
   1.82 with `unsafe extern` blocks.
 - `abs` must be explicitly marked as `safe` because it is an external function
-  (FFI). Calling external functions is usually only a problem when those
-  functions do things with pointers which might violate Rust's memory model, but
-  in general any C function might have undefined behaviour under any arbitrary
+  (FFI). Calling external functions is only a problem when those functions do
+  things with pointers which might violate Rust's memory model, but in general
+  any C function might have undefined behaviour under any arbitrary
   circumstances.
 - The `"C"` in this example is the ABI;
   [other ABIs are available too](https://doc.rust-lang.org/reference/items/external-blocks.html).

--- a/src/unsafe-rust/unsafe.md
+++ b/src/unsafe-rust/unsafe.md
@@ -12,8 +12,8 @@ The Rust language has two parts:
 We saw mostly safe Rust in this course, but it's important to know what Unsafe
 Rust is.
 
-Unsafe code is usually small and isolated, and its correctness should be
-carefully documented. It is usually wrapped in a safe abstraction layer.
+Unsafe code should be small and isolated, and its correctness should be
+carefully documented. It should be wrapped in a safe abstraction layer.
 
 Unsafe Rust gives you access to five new capabilities:
 


### PR DESCRIPTION
This PR removes imprecise language ('weasel words') to align with the new precision guidelines in #3029.

---
*Note: This PR was generated using Gemini. Please review the changes accordingly. If the new style is not desired for this section, feel free to close this PR.*