### PR TITLE
Add comma in auto-referencing explanation for methods

### DIFF
--- a/src/references/shared.md
+++ b/src/references/shared.md
@@ -39,7 +39,7 @@ value.
   will recognize references as pointers. Later parts of the course will cover
   how Rust prevents the memory-safety bugs that come from using raw pointers.
 
-- Explicit referencing with `&` is required, except when invoking methods where
+- Explicit referencing with `&` is required, except when invoking methods, where
   Rust performs automatic referencing and dereferencing.
 
 - Rust will auto-dereference in some cases, in particular when invoking methods


### PR DESCRIPTION
Since Rust does auto-referencing for all methods, the "where" clause is an explanation and not a qualifier. Hence, a comma is required.