### PR TITLE
Use `*const c_char` like the `extern "C"` block does

### DIFF
--- a/src/unsafe-rust/exercise.md
+++ b/src/unsafe-rust/exercise.md
@@ -27,8 +27,8 @@ You will convert between all these types:
 
 - `&str` to `CString`: you need to allocate space for a trailing `\0` character,
 - `CString` to `*const c_char`: you need a pointer to call C functions,
-- `*const c_char` to `&CStr`: you need something which can find the trailing `\0`
-  character,
+- `*const c_char` to `&CStr`: you need something which can find the trailing
+  `\0` character,
 - `&CStr` to `&[u8]`: a slice of bytes is the universal interface for "some
   unknown data",
 - `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use


### PR DESCRIPTION
The mismatch between `c_char` and `i8` here is a bit unfortunate. With this change, the page becomes internally consistent, but I noticed that [`CString::as_ptr`](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr) is documented to return `*const i8` on std.rs right now. This is because of a type alias which Rustdoc "helpfully" resolves for us.