### PR TITLE
Idiomatic Rust: Improve section on extension traits

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/extension-traits.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits.md
@@ -10,9 +10,9 @@ method-calling syntax: `s.is_palindrome()`.
 
 It might feel natural to reach out for an `impl` block:
 
-```rust,compile_fail
+```rust,editable,compile_fail
 // 🛠️❌
-impl &'_ str {
+impl str {
     pub fn is_palindrome(&self) -> bool {
         self.chars().eq(self.chars().rev())
     }

--- a/src/idiomatic/leveraging-the-type-system/extension-traits/extending-foreign-types.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits/extending-foreign-types.md
@@ -7,24 +7,26 @@ minutes: 10
 An **extension trait** is a local trait definition whose primary purpose is to
 attach new methods to foreign types.
 
-```rust
+```rust,editable
 mod ext {
     pub trait StrExt {
         fn is_palindrome(&self) -> bool;
     }
 
-    impl StrExt for &str {
+    impl StrExt for str {
         fn is_palindrome(&self) -> bool {
             self.chars().eq(self.chars().rev())
         }
     }
 }
 
-// Bring the extension trait into scope...
-pub use ext::StrExt as _;
-// ...then invoke its methods as if they were inherent methods
-assert!("dad".is_palindrome());
-assert!(!"grandma".is_palindrome());
+fn main() {
+    // Bring the extension trait into scope...
+    pub use ext::StrExt as _;
+    // ...then invoke its methods as if they were inherent methods
+    assert!("dad".is_palindrome());
+    assert!(!"grandma".is_palindrome());
+}
 ```
 
 <details>

--- a/src/idiomatic/leveraging-the-type-system/extension-traits/should-i-define-an-extension-trait.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits/should-i-define-an-extension-trait.md
@@ -6,7 +6,7 @@ minutes: 5
 
 In what scenarios should you prefer an extension trait over a free function?
 
-```rust
+```rust,editable
 pub trait StrExt {
     fn is_palindrome(&self) -> bool;
 }

--- a/src/idiomatic/leveraging-the-type-system/extension-traits/trait-method-conflicts.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits/trait-method-conflicts.md
@@ -19,13 +19,13 @@ mod ext {
         fn is_palindrome(&self) -> bool;
     }
 
-    impl Ext1 for &str {
+    impl Ext1 for str {
         fn is_palindrome(&self) -> bool {
             self.chars().eq(self.chars().rev())
         }
     }
 
-    impl Ext2 for &str {
+    impl Ext2 for str {
         fn is_palindrome(&self) -> bool {
             self.chars().eq(self.chars().rev())
         }
@@ -56,16 +56,16 @@ fn main() {
 
   To resolve this conflict, you must specify which trait you want to use.
 
-  Demonstrate: call `Ext1::is_palindrome(&"dad")` or
-  `Ext2::is_palindrome(&"dad")` instead of `"dad".is_palindrome()`.
+  Demonstrate: call `Ext1::is_palindrome("dad")` or `Ext2::is_palindrome("dad")`
+  instead of `"dad".is_palindrome()`.
 
   For methods with more complex signatures, you may need to use a more explicit
   [fully-qualified syntax][1].
 
 - Demonstrate: replace `"dad".is_palindrome()` with
-  `<&str as Ext1>::is_palindrome(&"dad")` or
+  `<&str as Ext1>::is_palindrome("dad")` or
   `<&str as
-  Ext2>::is_palindrome(&"dad")`.
+  Ext2>::is_palindrome("dad")`.
 
 </details>
 


### PR DESCRIPTION
We make 3 changes:
1.  We make all code snippets editable. This makes it easier to play around with students' ideas.
2.  We add a `main` function to make the code exectable where it makes sense
3.  We move extension traits for `str` from `&str` to `str`. There is no need for the reference if the methods take `&self`.