### PR TITLE
Make spelling of "Rust" consistent

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -538,7 +538,7 @@
     - [Inheritance](idiomatic/polymorphism/from-oop-to-rust/inheritance.md)
     - [Why no Inheritance in Rust?](idiomatic/polymorphism/from-oop-to-rust/why-no-inheritance.md)
     - [Inheritance from Rust's Perspective](idiomatic/polymorphism/from-oop-to-rust/switch-perspective.md)
-    - ["Inheritance" in rust and Supertraits](idiomatic/polymorphism/from-oop-to-rust/supertraits.md)
+    - ["Inheritance" in Rust and Supertraits](idiomatic/polymorphism/from-oop-to-rust/supertraits.md)
     - [Composition over Inheritance](idiomatic/polymorphism/from-oop-to-rust/composition.md)
     - [Trait Objects and Dynamic Dispatch](idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-trait.md)
     - [Dyn Compatibility](idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-compatible.md)

--- a/src/idiomatic/foundations-api-design/predictable-api/naming-conventions.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/naming-conventions.md
@@ -14,7 +14,7 @@ cases of a method.
 Rust's community developed naming conventions early, making them mostly
 consistent in places like the standard library.
 
-- Here we'll learn common components of rust method names, giving examples from
+- Here we'll learn common components of Rust method names, giving examples from
   the standard library and some context to go with them.
 
 </details>

--- a/src/idiomatic/foundations-api-design/predictable-api/naming-conventions/new.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/naming-conventions/new.md
@@ -20,7 +20,7 @@ impl <T> Box<T> {
 
 <details>
 
-- There's no `new` keyword for rust to initialize a new value, only functions
+- There's no `new` keyword for Rust to initialize a new value, only functions
   you call or values you directly populate.
 
   `new` is conventional for the "default" constructor function for a type. It

--- a/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/generalizing-ownership.md
+++ b/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/generalizing-ownership.md
@@ -41,7 +41,7 @@ fn demo_denied() {
 
   Nothing is being mutated, nothing is being sent across threads.
 
-- In rust's borrow checker we have access to three different ways of "taking" a
+- In Rust's borrow checker we have access to three different ways of "taking" a
   value:
 
   - Owned value `T`. Value is dropped when the scope ends, unless it is not

--- a/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/phantomdata-04-borrowedfd.md
+++ b/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/phantomdata-04-borrowedfd.md
@@ -10,7 +10,7 @@ minutes: 10
   This code has to define a fake libc module even though libc works fine on
   rust playground because the CI does not currently support dependencies.
 
-  TODO: Once we can use libc as a dependency in rust tests, replace the
+  TODO: Once we can use libc as a dependency in Rust tests, replace the
   faux libc code with appropriate imports & `O_WRONLY | O_CREAT` permissions.
 -->
 

--- a/src/idiomatic/leveraging-the-type-system/token-types/branded-02-phantomdata.md
+++ b/src/idiomatic/leveraging-the-type-system/token-types/branded-02-phantomdata.md
@@ -57,7 +57,7 @@ fn main() {
   distinguish values so we say that a token only applies to a single variable
   without having to create a newtype for every single variable we declare.
 
-- **Goal**: We want two lifetimes that the rust compiler cannot determine if one
+- **Goal**: We want two lifetimes that the Rust compiler cannot determine if one
   outlives the other.
 
   We are using `try_coerce_lifetimes` as a compile-time check to see if the
@@ -77,7 +77,7 @@ fn main() {
   possible lifetimes.
 
   What this also does is remove some ability of the compiler to make assumptions
-  about that specific lifetime for the function argument, as it must meet rust's
+  about that specific lifetime for the function argument, as it must meet Rust's
   borrow checking rules regardless of the "real" lifetime its arguments are
   going to have. The caller is substituting in actual lifetime, the function
   itself cannot.
@@ -129,7 +129,7 @@ fn main() {
   <!-- Note: We've been using "invariants" in this module in a specific way, but subtyping introduces _invariant_, _covariant_, and _contravariant_ as specific terms. -->
 
 - Ask: How can we make it more restrictive? How do we make a reference type more
-  restrictive in rust?
+  restrictive in Rust?
 
   Expect or demonstrate: Making it `&'id mut ()` instead. This will not be
   enough!
@@ -154,7 +154,7 @@ fn main() {
 
   Reason: `*mut` means
   [mutable raw pointer](https://doc.rust-lang.org/reference/types/pointer.html#r-type.pointer.raw).
-  Rust has mutable pointers! But you cannot reason about them in safe rust.
+  Rust has mutable pointers! But you cannot reason about them in safe Rust.
   Making this a mutable raw pointer to a reference that has a lifetime
   complicates the compiler's ability subtype because it cannot reason about
   mutable raw pointers within the borrow checker.

--- a/src/idiomatic/polymorphism/from-oop-to-rust.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust.md
@@ -8,11 +8,11 @@ minutes: 2
   software engineering has been done with Inheritance as a core part of business
   logic.
 
-- So why did rust avoid inheritance?
+- So why did Rust avoid inheritance?
 
-- How do we move from inheritance-based problem solving to rust's approach?
+- How do we move from inheritance-based problem solving to Rust's approach?
 
-- How do you represent heterogeneous collections in rust?
+- How do you represent heterogeneous collections in Rust?
 
 <details>
 
@@ -20,8 +20,8 @@ minutes: 2
   polymorphic problem solving with types in OOP languages like java, C++ etc. to
   Rust's trait-based approach to Polymorphism.
 
-- There will be differences, but there are also plenty of areas in common
-  – especially with modern standards of OOP development. Remember to keep an
-  open mind.
+- There will be differences, but there are also plenty of areas in common –
+  especially with modern standards of OOP development. Remember to keep an open
+  mind.
 
 </details>

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-trait.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-trait.md
@@ -25,7 +25,7 @@ fn main() {
   In OOP languages, dynamic dispatch is often an _implicit_ process and not
   something you can opt out of.
 
-  In rust, we use `dyn Trait`: an opt-in form of dynamic dispatch.
+  In Rust, we use `dyn Trait`: an opt-in form of dynamic dispatch.
 
 - For any trait that is _dyn compatible_ we can coerce a reference to a value of
   that trait into a `dyn Trait` value.

--- a/src/idiomatic/polymorphism/from-oop-to-rust/problem-solving.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/problem-solving.md
@@ -66,7 +66,7 @@ things.
 
   Does a trait already exist for this use case? If so, use it!
 
-- If you really do need heterogeneous collections, use them! They exist in rust
+- If you really do need heterogeneous collections, use them! They exist in Rust
   as a tool for a reason.
 
   Be aware of the XY problem: a problem may seem most easily addressable by one

--- a/src/idiomatic/polymorphism/from-oop-to-rust/switch-perspective.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/switch-perspective.md
@@ -42,7 +42,7 @@ impl Named for Data {
 
   A class is a combination of data, behavior, and overrides to that behavior.
 
-- Coming from rust, an inheritable class looks like a type that is also a trait.
+- Coming from Rust, an inheritable class looks like a type that is also a trait.
 
 - This is not an upside, as we can no longer reason about concrete types.
 

--- a/src/idiomatic/polymorphism/from-oop-to-rust/why-no-inheritance.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/why-no-inheritance.md
@@ -13,14 +13,14 @@ impl Id {
     // methods
 }
 
-// 🔨❌, rust does not have inheritance!
+// 🔨❌, Rust does not have inheritance!
 pub struct Data: Id {
     // Inherited "id" field
     pub name: String,
 }
 
 impl Data {
-    // methods, but also includes Id's methods, or maybe overrides to 
+    // methods, but also includes Id's methods, or maybe overrides to
     // those methods.
 }
 

--- a/src/idiomatic/polymorphism/refresher/orphan-rule.md
+++ b/src/idiomatic/polymorphism/refresher/orphan-rule.md
@@ -38,7 +38,7 @@ impl DbConnection for PostgresqlConn {} // ❌🔨
 
 - We can prevent this within a crate by detecting if there are multiple
   definitions and disallowing it, but what about between crates in the entire
-  rust ecosystem?
+  Rust ecosystem?
 
 - Types are either _local_ to a crate, they are defined there, or they're not.
 

--- a/src/modules/filesystem.md
+++ b/src/modules/filesystem.md
@@ -59,7 +59,7 @@ pub fn harvest(garden: &mut Garden) {
       └── sub_module.rs
   ```
 
-- The place rust will look for modules can be changed with a compiler directive:
+- The place Rust will look for modules can be changed with a compiler directive:
 
   ```rust,ignore
   #[path = "some/path.rs"]


### PR DESCRIPTION
In various places in the course, the name of the programming language "Rust" is spelled with a lowercase "r". The official spelling is with an uppercase "R" however. So, let's fix this and make it consistent across the course.