### PR TITLE
Improve slide on lifetimes for external resources

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/phantomdata-03-lifetimes.md
+++ b/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/phantomdata-03-lifetimes.md
@@ -22,6 +22,7 @@ mod ffi {
 }
 
 struct DatabaseConnection(ffi::DatabaseHandle);
+
 struct Transaction<'a>(&'a mut DatabaseConnection);
 
 impl DatabaseConnection {
@@ -72,17 +73,19 @@ fn main() {}
 - Demonstrate: change `Transaction` to the following:
 
   ```rust,compile_fail
-  pub struct Transaction<'a> {
+  struct Transaction<'a> {
       connection: DatabaseConnection,
-      _phantom: PhantomData<&mut 'a ()>,
+      _phantom: PhantomData<&'a mut DatabaseConnection>,
   }
   ```
 
   Update the `DatabaseConnection::new_transaction()` method:
 
   ```rust,compile_fail
-  fn new_transaction<'a>(&'a mut self) -> Transaction<'a> {
-      Transaction { connection: DatabaseConnection(self.0), _phantom: PhantomData }
+  impl DatabaseConnection {
+      fn new_transaction<'a>(&'a mut self) -> Transaction<'a> {
+          Transaction { connection: DatabaseConnection(self.0), _phantom: PhantomData }
+      }
   }
   ```
 


### PR DESCRIPTION
The main change is to use `&'a mut DatabaseConnection` instead of `&'a mut ()` as the type argument of `PhantomData`. This style makes it clearer what the unused lifetime parameter `'a` represents. In fact, the
[example in the documentation for `PhantomData`](https://doc.rust-lang.org/stable/std/marker/struct.PhantomData.html#unused-lifetime-parameters) uses the same style.

The rest are cosmetic changes to make it easier to copy and paste from the notes to the code snippet.