### PR TITLE
Make refresher on traits clearer

### DIFF
--- a/src/idiomatic/polymorphism/refresher/traits.md
+++ b/src/idiomatic/polymorphism/refresher/traits.md
@@ -9,13 +9,11 @@ trait Receiver {
     fn send(&self, message: &str);
 }
 
-struct Email {
-    email: String,
-}
+struct EmailAddress(String);
 
-impl Receiver for Email {
+impl Receiver for EmailAddress {
     fn send(&self, message: &str) {
-        println!("Email to {}: {}", self.email, message);
+        println!("Email to {}: {}", self.0, message);
     }
 }
 


### PR DESCRIPTION
The `Email` type represents an email address and not email (message). Let's make this clearer by renaming it to `EmailAddress`. We also make it a newtype since there's no obviously good field name for a regular struct.