### PR TITLE
Simplify ownership/borrowing refresher slide

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/generalizing-ownership.md
+++ b/src/idiomatic/leveraging-the-type-system/borrow-checker-invariants/generalizing-ownership.md
@@ -22,7 +22,7 @@ fn demo_exclusive() {
     let mut value = Data(Internal);
     let shared = shared_use(&value);
     // let exclusive = exclusive_use(&mut value); // ❌🔨
-    let shared_again = &shared;
+    let shared_again = shared;
 }
 
 fn demo_denied() {


### PR DESCRIPTION
We can drop one reference since the only thing we care about is to keep a variable alive.