### PR TITLE
Make slide on drop option consistent wrt unwrap

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/raii/drop_option.md
+++ b/src/idiomatic/leveraging-the-type-system/raii/drop_option.md
@@ -13,10 +13,8 @@ impl File {
     }
 
     fn write(&mut self, data: &str) -> std::io::Result<()> {
-        match &mut self.0 {
-            Some(handle) => println!("write '{data}' to file '{}'", handle.path),
-            None => unreachable!(),
-        }
+        let handle = self.0.as_ref().unwrap();
+        println!("write '{data}' to file '{}'", handle.path);
         Ok(())
     }
 


### PR DESCRIPTION
The slide unwraps an `Option` that is known to be some in two different ways. Let's make this consistent by always using `.unwrap()`.