### PR TITLE
borrowing: add explanatory commentary to solution

### DIFF
--- a/src/borrowing/solution.md
+++ b/src/borrowing/solution.md
@@ -4,24 +4,28 @@
 {{#include ../../third_party/rust-on-exercism/health-statistics.rs:solution}}
 ```
 
-- **Lifetimes in Structs:** `HealthReport` has a lifetime parameter `'a` because
-  it contains a reference `patient_name: &'a str`. This ensures that the report
-  cannot outlive the `User` it refers to.
-- **Mutable Reference (`&mut self`):** `visit_doctor` modifies the `User`
-  struct, so it must take `&mut self`.
-- **Lifetime Elision:** The return type `HealthReport<'_>` indicates that the
-  output lifetime is tied to the input lifetime of `self`. Explicitly, this
-  would be `fn visit_doctor<'a>(&'a mut self, ...) -> HealthReport<'a>`.
-- **Option combinators:** We use `self.last_blood_pressure.map(...)` to
-  convenienty calculate the blood pressure change if the previous measurement
-  exists.
+The solution explores how structs can capture references and how lifetimes tie
+related data structures together:
+
+- **Lifetimes in Structs:** `HealthReport` contains a reference
+  `patient_name: &'a str`, which necessitates a lifetime parameter `'a`. This
+  guarantees that a report cannot outlive the `User` it was created from.
+- **Mutable Borrows:** `visit_doctor` takes `&mut self` to update the user's
+  stats. Because it returns a `HealthReport` that borrows from `self`, the
+  report's lifetime is tied to the duration of this borrow.
+- **Idiomatic `Option` Handling:** `self.last_blood_pressure.map(...)` is used
+  to concisely compute the change in blood pressure only when a prior value is
+  available.
 
 <details>
 
-- Explain that `HealthReport` borrows from `User`. While `report` exists, `User`
-  is borrowed (mutably, because it came from `visit_doctor`), so we cannot use
-  `User` for anything else until `report` is dropped.
-- Note the cast to `i32` for blood pressure calculation to allow for negative
-  changes.
+- **Lifetime Elision:** The signature
+  `fn visit_doctor(&mut self, ...) -> HealthReport<'_>` uses anonymous
+  lifetimes. The compiler expands this to indicate that the returned report
+  borrows from `self`, effectively making the user inaccessible while the report
+  is in scope.
+- **Borrows and Mutation:** Inside `visit_doctor`, the report must be created
+  _before_ the user's fields are updated, as creating a reference to `self.name`
+  borrows `self`. In Rust, you cannot modify a value while it is borrowed.
 
 </details>

--- a/src/borrowing/solution.md
+++ b/src/borrowing/solution.md
@@ -3,3 +3,25 @@
 ```rust,editable
 {{#include ../../third_party/rust-on-exercism/health-statistics.rs:solution}}
 ```
+
+- **Lifetimes in Structs:** `HealthReport` has a lifetime parameter `'a` because
+  it contains a reference `patient_name: &'a str`. This ensures that the report
+  cannot outlive the `User` it refers to.
+- **Mutable Reference (`&mut self`):** `visit_doctor` modifies the `User`
+  struct, so it must take `&mut self`.
+- **Lifetime Elision:** The return type `HealthReport<'_>` indicates that the
+  output lifetime is tied to the input lifetime of `self`. Explicitly, this
+  would be `fn visit_doctor<'a>(&'a mut self, ...) -> HealthReport<'a>`.
+- **Option combinators:** We use `self.last_blood_pressure.map(...)` to
+  convenienty calculate the blood pressure change if the previous measurement
+  exists.
+
+<details>
+
+- Explain that `HealthReport` borrows from `User`. While `report` exists, `User`
+  is borrowed (mutably, because it came from `visit_doctor`), so we cannot use
+  `User` for anything else until `report` is dropped.
+- Note the cast to `i32` for blood pressure calculation to allow for negative
+  changes.
+
+</details>


### PR DESCRIPTION
This commentary, written by Gemini, focuses on aspects of the solution that differ from the baseline languages (C/Java/Python), highlighting Rust-specific idioms and concepts.
