### PR TITLE
build: add SPDX-License-Identifier to Apache 2.0 licensed files

### DIFF
--- a/.github/workflows/check-msgid-changes.py
+++ b/.github/workflows/check-msgid-changes.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mdbook-course/src/bin/course-content.rs
+++ b/mdbook-course/src/bin/course-content.rs
@@ -1,4 +1,5 @@
 // Copyright 2024 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/bin/course-schedule.rs
+++ b/mdbook-course/src/bin/course-schedule.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/bin/mdbook-course.rs
+++ b/mdbook-course/src/bin/mdbook-course.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/course.rs
+++ b/mdbook-course/src/course.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/frontmatter.rs
+++ b/mdbook-course/src/frontmatter.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/lib.rs
+++ b/mdbook-course/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/markdown.rs
+++ b/mdbook-course/src/markdown.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/replacements.rs
+++ b/mdbook-course/src/replacements.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-course/src/timing_info.rs
+++ b/mdbook-course/src/timing_info.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-exerciser/src/lib.rs
+++ b/mdbook-exerciser/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mdbook-exerciser/src/main.rs
+++ b/mdbook-exerciser/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/aidl/birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider.aidl
+++ b/src/android/aidl/birthday_service/aidl/com/example/birthdayservice/IBirthdayInfoProvider.aidl
@@ -1,4 +1,5 @@
 // Copyright 2024 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/aidl/birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl
+++ b/src/android/aidl/birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/aidl/birthday_service/src/client.rs
+++ b/src/android/aidl/birthday_service/src/client.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/aidl/birthday_service/src/lib.rs
+++ b/src/android/aidl/birthday_service/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/aidl/birthday_service/src/server.rs
+++ b/src/android/aidl/birthday_service/src/server.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/bpfmt.sh
+++ b/src/android/bpfmt.sh
@@ -1,5 +1,6 @@
 #!/bin/zsh
 # Copyright 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/android/build-rules/binary/src/main.rs
+++ b/src/android/build-rules/binary/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/build-rules/library/src/lib.rs
+++ b/src/android/build-rules/library/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/build-rules/library/src/main.rs
+++ b/src/android/build-rules/library/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/build_all.sh
+++ b/src/android/build_all.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/android/interoperability/java/HelloWorld.java
+++ b/src/android/interoperability/java/HelloWorld.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/android/interoperability/java/src/lib.rs
+++ b/src/android/interoperability/java/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/interoperability/with-c/bindgen/libbirthday.c
+++ b/src/android/interoperability/with-c/bindgen/libbirthday.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/android/interoperability/with-c/bindgen/libbirthday.h
+++ b/src/android/interoperability/with-c/bindgen/libbirthday.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/android/interoperability/with-c/bindgen/libbirthday_wrapper.h
+++ b/src/android/interoperability/with-c/bindgen/libbirthday_wrapper.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/android/interoperability/with-c/bindgen/main.rs
+++ b/src/android/interoperability/with-c/bindgen/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/interoperability/with-c/rust/analyze/main.c
+++ b/src/android/interoperability/with-c/rust/analyze/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/android/interoperability/with-c/rust/libanalyze/analyze.h
+++ b/src/android/interoperability/with-c/rust/libanalyze/analyze.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/android/interoperability/with-c/rust/libanalyze/analyze.rs
+++ b/src/android/interoperability/with-c/rust/libanalyze/analyze.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/logging/src/main.rs
+++ b/src/android/logging/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/testing/src/lib.rs
+++ b/src/android/testing/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2024 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/alloc-example/src/main.rs
+++ b/src/bare-metal/alloc-example/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/Makefile
+++ b/src/bare-metal/aps/examples/Makefile
@@ -1,4 +1,5 @@
 # Copyright 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/image.ld
+++ b/src/bare-metal/aps/examples/image.ld
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/asm.rs
+++ b/src/bare-metal/aps/examples/src/asm.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/entry.S
+++ b/src/bare-metal/aps/examples/src/entry.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/exceptions.S
+++ b/src/bare-metal/aps/examples/src/exceptions.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/exceptions.rs
+++ b/src/bare-metal/aps/examples/src/exceptions.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/exceptions_rt.rs
+++ b/src/bare-metal/aps/examples/src/exceptions_rt.rs
@@ -1,4 +1,5 @@
 // Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/idmap.S
+++ b/src/bare-metal/aps/examples/src/idmap.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/logger.rs
+++ b/src/bare-metal/aps/examples/src/logger.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/main_improved.rs
+++ b/src/bare-metal/aps/examples/src/main_improved.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/main_logger.rs
+++ b/src/bare-metal/aps/examples/src/main_logger.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/main_minimal.rs
+++ b/src/bare-metal/aps/examples/src/main_minimal.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/main_psci.rs
+++ b/src/bare-metal/aps/examples/src/main_psci.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/main_rt.rs
+++ b/src/bare-metal/aps/examples/src/main_rt.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/main_safemmio.rs
+++ b/src/bare-metal/aps/examples/src/main_safemmio.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/pl011.rs
+++ b/src/bare-metal/aps/examples/src/pl011.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/pl011_minimal.rs
+++ b/src/bare-metal/aps/examples/src/pl011_minimal.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/aps/examples/src/pl011_struct.rs
+++ b/src/bare-metal/aps/examples/src/pl011_struct.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/microcontrollers/examples/src/bin/board_support.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/board_support.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/microcontrollers/examples/src/bin/hal.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/hal.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/microcontrollers/examples/src/bin/interrupts/mod.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/interrupts/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/microcontrollers/examples/src/bin/minimal.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/minimal.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/microcontrollers/examples/src/bin/mmio.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/mmio.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/microcontrollers/examples/src/bin/pac.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/pac.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/microcontrollers/examples/src/bin/typestate.rs
+++ b/src/bare-metal/microcontrollers/examples/src/bin/typestate.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/useful-crates/allocator-example/src/main.rs
+++ b/src/bare-metal/useful-crates/allocator-example/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bare-metal/useful-crates/zerocopy-example/src/main.rs
+++ b/src/bare-metal/useful-crates/zerocopy-example/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/borrowing/exercise.rs
+++ b/src/borrowing/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/closures/exercise.rs
+++ b/src/closures/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2024 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/concurrency/async-exercises/chat-async/src/bin/client.rs
+++ b/src/concurrency/async-exercises/chat-async/src/bin/client.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/concurrency/async-exercises/chat-async/src/bin/server.rs
+++ b/src/concurrency/async-exercises/chat-async/src/bin/server.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/concurrency/async-exercises/dining-philosophers.rs
+++ b/src/concurrency/async-exercises/dining-philosophers.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/concurrency/sync-exercises/dining-philosophers.rs
+++ b/src/concurrency/sync-exercises/dining-philosophers.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/concurrency/sync-exercises/link-checker.rs
+++ b/src/concurrency/sync-exercises/link-checker.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/control-flow-basics/exercise.rs
+++ b/src/control-flow-basics/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/error-handling/exercise.rs
+++ b/src/error-handling/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/compass/src/main.rs
+++ b/src/exercises/bare-metal/compass/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/rtc/Makefile
+++ b/src/exercises/bare-metal/rtc/Makefile
@@ -1,4 +1,5 @@
 # Copyright 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/rtc/build.rs
+++ b/src/exercises/bare-metal/rtc/build.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/rtc/memory.ld
+++ b/src/exercises/bare-metal/rtc/memory.ld
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/rtc/src/exceptions.rs
+++ b/src/exercises/bare-metal/rtc/src/exceptions.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/rtc/src/logger.rs
+++ b/src/exercises/bare-metal/rtc/src/logger.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/rtc/src/main.rs
+++ b/src/exercises/bare-metal/rtc/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/exercises/bare-metal/rtc/src/pl031.rs
+++ b/src/exercises/bare-metal/rtc/src/pl031.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/generics/exercise.rs
+++ b/src/generics/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/iterators/exercise.rs
+++ b/src/iterators/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/lifetimes/exercise.rs
+++ b/src/lifetimes/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/memory-management/exercise.rs
+++ b/src/memory-management/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/methods-and-traits/exercise.rs
+++ b/src/methods-and-traits/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2024 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/modules/exercise.rs
+++ b/src/modules/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/modules/solution.md
+++ b/src/modules/solution.md
@@ -2,6 +2,7 @@
 
 <!--
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/pattern-matching/exercise.rs
+++ b/src/pattern-matching/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/references/exercise.rs
+++ b/src/references/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/smart-pointers/exercise.rs
+++ b/src/smart-pointers/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/std-traits/exercise.rs
+++ b/src/std-traits/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/std-types/exercise.rs
+++ b/src/std-types/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/testing/exercise.rs
+++ b/src/testing/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/tuples-and-arrays/exercise.rs
+++ b/src/tuples-and-arrays/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/types-and-values/exercise.rs
+++ b/src/types-and-values/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/unsafe-rust/exercise.rs
+++ b/src/unsafe-rust/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/user-defined-types/exercise.rs
+++ b/src/user-defined-types/exercise.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit adds the `SPDX-License-Identifier: Apache-2.0` header to all source files that currently contain the Apache 2.0 license boilerplate. This makes the licensing information machine-readable and compliant with SPDX standards.