### PR TITLE
docs: clarify license coverage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ details.
 This project is licensed under a mix of the Apache License 2.0 and the Creative
 Commons Attribution 4.0 International License.
 
-- **Source Code:** All source code files are licensed under the
-  [Apache License, Version 2.0](LICENSE).
+- **Source Code:** All source code files and code examples embedded in the
+  documentation are licensed under the [Apache License, Version 2.0](LICENSE).
 
 - **Documentation & Content:** All non-source code assets—specifically Markdown
-  (`.md`) files and documentation—are licensed under the
+  (`.md`) files, documentation, and images—are licensed under the
   [Creative Commons Attribution 4.0 International License](LICENSE-CC-BY).
 
 ## Contact


### PR DESCRIPTION
Explicitly state that:
- All source code, including examples embedded in documentation, is licensed under Apache 2.0.
- Documentation, including images, is licensed under CC-BY 4.0.