### PR TITLE
Fix referencing issue on trait method conflicts

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/extension-traits/trait-method-conflicts.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits/trait-method-conflicts.md
@@ -71,9 +71,8 @@ fn main() {
   [fully-qualified syntax][1].
 
 - Demonstrate: replace `"dad".is_palindrome()` with
-  `<&str as Ext1>::is_palindrome("dad")` or
-  `<&str as
-  Ext2>::is_palindrome("dad")`.
+  `<str as Ext1>::is_palindrome("dad")` or
+  `<str as Ext2>::is_palindrome("dad")`.
 
 </details>
 


### PR DESCRIPTION
Since `str` (and not `&str`) implements `Ext1`, we need to disambiguate using `<str as Ext1>::is_palindrome` (rather than `<&str as Ext1>`). Same for `Ext2`.