### PR TITLE
Use surface syntax in type state diagrams

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/complete.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/complete.md
@@ -28,31 +28,31 @@ serializer --> structure --> property --> list +-+
 We can now see this reflected directly in the types of our serializer:
 
 ```bob
-                                                         +------+
-                                                 finish  |      |
-                           serialize             struct  V      |
-                           struct
-+---------------------+ --------------> +-----------------------------+ <---------------+
-| Serializer [ Root ] |                 | Serializer [ Struct [ S ] ] |                 |
-+---------------------+ <-------------- +-----------------------------+ <-----------+   |
-                          finish struct                                             |   |
-         |                                  |     serialize   |                     |   |
-         |                       +----------+     property    V          serialize  |   |
-         |                       |                                       string or  |   |
-finish   |                       |    +-------------------------------+  struct     |   |
-         V                       |    | Serializer [ Property [ S ] ] | ------------+   |
-                         finish  |    +-------------------------------+                 |
-     +--------+          struct  |                                                      |
-     | String |                  |                serialize   |                         |
-     +--------+                  |                list        V                         |
-                                 |                                         finish       |
-                                 |        +---------------------------+    list         |
-                                 +------> | Serializer [ List [ S ] ] | ----------------+
-                                          +---------------------------+
-                                                  serialize
-                                                  list or string  ^
-                                              |   or finish list  |
-                                              +-------------------+
+                                                     +------+
+                                             finish  |      |
+                          serialize          struct  V      |
+                          struct
++--------------------+ --------------> +-------------------------+ <---------------+
+| "Serializer<Root>" |                 | "Serializer<Struct<S>>" |                 |
++--------------------+ <-------------- +-------------------------+ <-----------+   |
+                         finish struct                                         |   |
+         |                                  |  serialize   |                   |   |
+         |                       +----------+  property    V        serialize  |   |
+         |                       |                                  string or  |   |
+finish   |                       |   +---------------------------+  struct     |   |
+         V                       |   | "Serializer<Property<S>>" | ------------+   |
+                         finish  |   +---------------------------+                 |
+     +--------+          struct  |                                                 |
+     | String |                  |             serialize   |                       |
+     +--------+                  |             list        V                       |
+                                 |                                    finish       |
+                                 |       +-----------------------+    list         |
+                                 +-----> | "Serializer<List<S>>" | ----------------+
+                                         +-----------------------+
+                                              serialize
+                                            | list or string  ^
+                                            | or finish list  |
+                                            +-----------------+
 ```
 
 The code for the full implementation of the `Serializer` and all its states can

--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/property.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/property.md
@@ -27,27 +27,27 @@ With the addition of the Property state methods, our diagram is now nearly
 complete:
 
 ```bob
-                                                         +------+
-                                                 finish  |      |
-                           serialize             struct  V      |
-                           struct
-+---------------------+ --------------> +-----------------------------+
-| Serializer [ Root ] |                 | Serializer [ Struct [ S ] ] |
-+---------------------+ <-------------- +-----------------------------+ <-----------+
-                          finish struct                                             |
-         |                                        serialize   |                     |
-         |                                        property    V          serialize  |
-         |                                                               string or  |
-finish   |                            +-------------------------------+  struct     |
-         V                            | Serializer [ Property [ S ] ] | ------------+
-                                      +-------------------------------+
+                                                     +------+
+                                             finish  |      |
+                          serialize          struct  V      |
+                          struct
++--------------------+ --------------> +-------------------------+
+| "Serializer<Root>" |                 | "Serializer<Struct<S>>" |
++--------------------+ <-------------- +-------------------------+ <-----------+
+                         finish struct                                         |
+         |                                     serialize   |                   |
+         |                                     property    V        serialize  |
+         |                                                          string or  |
+finish   |                           +---------------------------+  struct     |
+         V                           | "Serializer<Property<S>>" | ------------+
+                                     +---------------------------+
      +--------+
-     | String |                                   serialize   |
-     +--------+                                   list        V
+     | String |                                serialize   |
+     +--------+                                list        V
 
-                                          +---------------------------+
-                                          | Serializer [ List [ S ] ] |
-                                          +---------------------------+
+                                         +-----------------------+
+                                         | "Serializer<List<S>>" |
+                                         +-----------------------+
 ```
 
 <details>

--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/root.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/root.md
@@ -26,12 +26,12 @@ Referring back to our original diagram of valid transitions, we can visualize
 the beginning of our implementation as follows:
 
 ```bob
-                           serialize
-                           struct
-+---------------------+ --------------> +--------------------------------+
-| Serializer [ Root ] |                 | Serializer [ Struct [ Root ] ] |
-+---------------------+ <-------------- +--------------------------------+
-                          finish struct
+                          serialize
+                          struct
++--------------------+ --------------> +----------------------------+
+| "Serializer<Root>" |                 | "Serializer<Struct<Root>>" |
++--------------------+ <-------------- +----------------------------+
+                         finish struct
          |
          |
          |

--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/struct.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/struct.md
@@ -25,20 +25,20 @@ SPDX-License-Identifier: CC-BY-4.0
 The diagram can now be expanded as follows:
 
 ```bob
-                                                         +------+
-                                                 finish  |      |
-                           serialize             struct  V      |
-                           struct
-+---------------------+ --------------> +-----------------------------+
-| Serializer [ Root ] |                 | Serializer [ Struct [ S ] ] |
-+---------------------+ <-------------- +-----------------------------+
-                          finish struct
-         |                                        serialize   |
-         |                                        property    V
+                                                     +------+
+                                             finish  |      |
+                          serialize          struct  V      |
+                          struct
++--------------------+ --------------> +-------------------------+
+| "Serializer<Root>" |                 | "Serializer<Struct<S>>" |
++--------------------+ <-------------- +-------------------------+
+                         finish struct
+         |                                     serialize   |
+         |                                     property    V
          |
-finish   |                            +------------------------------------------+
-         V                            | Serializer [ Property [ Struct [ S ] ] ] |
-                                      +------------------------------------------+
+finish   |                           +-----------------------------------+
+         V                           | "Serializer<Property<Struct<S>>>" |
+                                     +-----------------------------------+
      +--------+
      | String |
      +--------+


### PR DESCRIPTION
For some reason the diagrams in the section for the type state pattern do not use Rust's surface syntax but rather spell
`Serializer<Struct<S>>` as `Serializer [ Struct [ S ] ]`. I guess this is because the `<` and `>` are somewhat tricky in bob diagrams.

However, this can be fixed by quoting phrases containing these tricky symbols. This is what we do here. This also requires a little realigning of arrows in order to keep the overall visual appearance of the diagrams.