### PR TITLE
Make code in Idiomatic Rust course editable

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/extension-traits/extending-other-traits.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits/extending-other-traits.md
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC-BY-4.0
 As with types, it may be desirable to **extend foreign traits**. In particular,
 to attach new methods to _all_ implementors of a given trait.
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/newtype-pattern/is-it-encapsulated.md
+++ b/src/idiomatic/leveraging-the-type-system/newtype-pattern/is-it-encapsulated.md
@@ -14,7 +14,7 @@ invariants are indeed bullet-proof. It is crucial to consider all possible
 interactions, including trait implementations, that may allow users to bypass
 validation checks.
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/newtype-pattern/parse-don-t-validate.md
+++ b/src/idiomatic/leveraging-the-type-system/newtype-pattern/parse-don-t-validate.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 The newtype pattern can be leveraged to enforce _invariants_.
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/newtype-pattern/semantic-confusion.md
+++ b/src/idiomatic/leveraging-the-type-system/newtype-pattern/semantic-confusion.md
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC-BY-4.0
 When a function takes multiple arguments of the same type, call sites are
 unclear:
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
@@ -31,7 +31,7 @@ login(password, username);
 
 The newtype pattern can prevent this class of errors at compile time:
 
-```rust,compile_fail
+```rust,editable,compile_fail
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/raii/drop_guards.md
+++ b/src/idiomatic/leveraging-the-type-system/raii/drop_guards.md
@@ -13,7 +13,7 @@ A **drop guard** in Rust is a temporary object that performs some kind of
 cleanup when it goes out of scope. In the case of `Mutex`, the `lock` method
 returns a `MutexGuard` that automatically unlocks the mutex on `drop`:
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/raii/mutex.md
+++ b/src/idiomatic/leveraging-the-type-system/raii/mutex.md
@@ -14,7 +14,7 @@ descriptors. With a `Mutex`, the "resource" is mutable access to a value. You
 access the value by calling `lock`, which then returns a `MutexGuard` which will
 unlock the `Mutex` automatically when dropped.
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/token-types/branded-03-impl.md
+++ b/src/idiomatic/leveraging-the-type-system/token-types/branded-03-impl.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 Constructing branded types is different to how we construct non-branded types.
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
@@ -37,10 +37,10 @@ impl<'id> Bytes<'id> {
         if ix < self.0.len() { Some(ProvenIndex(ix, InvariantLifetime::default())) }
         else { None }
     }
-    
+
     fn get_proven(&self, ix: &ProvenIndex<'id>) -> u8 {
         debug_assert!(ix.0 < self.0.len());
-        unsafe { *self.0.get_unchecked(ix.0) } 
+        unsafe { *self.0.get_unchecked(ix.0) }
     }
 }
 ```

--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/property.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/property.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ## Serializer: implement Property
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/root.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/root.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ## Serializer: implement Root
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/struct.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics/struct.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ## Serializer: implement Struct
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/composition.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/composition.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Composition over Inheritance
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/any-trait.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/any-trait.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Any Trait and Downcasting
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-compatible.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-compatible.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Dyn-compatible traits
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-trait.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-trait.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # `dyn Trait` for Dynamic Dispatch in Rust
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-vs-generics.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-vs-generics.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 We have two means of writing polymorphic functions, how do they compare?
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/heterogeneous.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/heterogeneous.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Heterogeneous data with `dyn trait`
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/limits.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/limits.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Limits of Trait Objects
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/pitfalls.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/pitfalls.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Pitfall: Reaching too quickly for `dyn Trait`
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/problem-solving.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/problem-solving.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Problem solving: Break Down the Problem
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/sealed-traits.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/sealed-traits.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Sealed traits for Polymorphism users cannot extend
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/sealing-with-enums.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/sealing-with-enums.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Sealing with Enums
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/sticking-with-traits.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/sticking-with-traits.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Traits for Polymorphism users can extend
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/supertraits.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/supertraits.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # "Inheritance" in Rust: Supertraits
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/switch-perspective.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/switch-perspective.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Inheritance from Rust's Perspective
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/from-oop-to-rust/why-no-inheritance.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/why-no-inheritance.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Why no Inheritance in Rust?
 
-```rust,compile_fail
+```rust,editable,compile_fail
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/blanket-impls.md
+++ b/src/idiomatic/polymorphism/refresher/blanket-impls.md
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC-BY-4.0
 When a trait is local, we can implement it for as many types as we like. How far
 can we take this?
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/conditional-methods.md
+++ b/src/idiomatic/polymorphism/refresher/conditional-methods.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Conditional Method Implementations
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/default-impls.md
+++ b/src/idiomatic/polymorphism/refresher/default-impls.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Default Method Implementations
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/deriving-traits.md
+++ b/src/idiomatic/polymorphism/refresher/deriving-traits.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Deriving Traits
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/monomorphization.md
+++ b/src/idiomatic/polymorphism/refresher/monomorphization.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Monomorphization and Binary Size
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/orphan-rule.md
+++ b/src/idiomatic/polymorphism/refresher/orphan-rule.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 What prevents users from writing arbitrary trait implementations for any type?
 
-```rust,compile_fail
+```rust,editable,compile_fail
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/sized.md
+++ b/src/idiomatic/polymorphism/refresher/sized.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Statically Sized and Dynamically Sized Types
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/supertraits.md
+++ b/src/idiomatic/polymorphism/refresher/supertraits.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 Traits can be extended by new traits.
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/trait-bounds.md
+++ b/src/idiomatic/polymorphism/refresher/trait-bounds.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Trait Bounds on Generics
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/src/idiomatic/polymorphism/refresher/traits.md
+++ b/src/idiomatic/polymorphism/refresher/traits.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Traits, Protocols, Interfaces
 
-```rust
+```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
The students tend to have questions in all parts of the course. So, it's always convenient to be able to edit the code examples. Here, for all code blocks in the Idiomatic Rust course, which is what I'm teaching right now.