### PR TITLE
Remove needless imports from inheritance slide

### DIFF
--- a/src/idiomatic/polymorphism/from-oop-to-rust/inheritance.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/inheritance.md
@@ -10,9 +10,6 @@ SPDX-License-Identifier: CC-BY-4.0
 # Inheritance in OOP languages
 
 ```cpp
-#include <iostream>
-using namespace std;
-
 // Base class
 class Vehicle {
 public:
@@ -28,7 +25,7 @@ public:
 
 int main() {
     Car myCar;                  // Create a Car object
-    myCar.accelerate();        // Inherited method
+    myCar.accelerate();         // Inherited method
     myCar.honk();               // Car's own method
     myCar.brake();              // Inherited method
     return 0;


### PR DESCRIPTION
There's no need to bring the `std` namespace into scope since it's not used anywhere. While we're at it, let's also fix the indentation of one comment.