### PR TITLE
Make string construction explicit in dyn slide

### DIFF
--- a/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-trait.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/dynamic-dispatch/dyn-trait.md
@@ -20,7 +20,7 @@ impl Trait for String {}
 
 fn main() {
     let int: &dyn Trait = &42i32;
-    let string: &dyn Trait = &("Hello dyn!".to_owned());
+    let string: &dyn Trait = &String::from("Hello dyn!");;
 }
 ```
 


### PR DESCRIPTION
Let's make it crystal clear that we're taking a reference to a `String` instead of hiding it behind a call to the overloaded `to_owned` method.