### PR TITLE
Avoid debug printing error in thiserror.md

### DIFF
--- a/src/error-handling/thiserror.md
+++ b/src/error-handling/thiserror.md
@@ -42,7 +42,7 @@ fn main() {
     //fs::write("config.dat", "").unwrap();
     match read_username("config.dat") {
         Ok(username) => println!("Username: {username}"),
-        Err(err) => println!("Error: {err:?}"),
+        Err(err) => println!("Error: {err}"),
     }
 }
 ```


### PR DESCRIPTION
One point about Rust error handling is that errors should know how to `Display` print themselves, not just `Debug` print. So the example here and elsewhere should avoid debug printing the error and thus show that we use the format string from `#[error(...)]`.