### PR TITLE
Idiomatic: Various tweaks and cleanup to common traits section

### DIFF
--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits.md
@@ -22,7 +22,10 @@ pub struct MyData {
 ```
 
 <details>
-- Traits are one of the most potent tools in the Rust language. The language and ecosystem expects you to use them, and so a big part of _predictability_ is what traits are implemented for a type!
+
+- Traits are one of the most potent tools in the Rust language. The language and
+  ecosystem expects you to use them, and so a big part of _predictability_ is
+  what traits are implemented for a type!
 
 - Traits should be liberally implemented on types you author, but there are
   caveats!

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/clone.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/clone.md
@@ -13,19 +13,10 @@ Deep-copy a type or duplicate a smart, shareable pointer.
 
 Derivable: ✅
 
-When to implement: If duplicating doesn't break invariants.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
-// pub trait Clone: Sized {
-//     // Required method
-//     fn clone(&self) -> Self;
-// 
-//     // Provided methods omitted
-// }
-
 use std::collections::BTreeSet;
 use std::rc::Rc;
 

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/copy.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/copy.md
@@ -40,7 +40,7 @@ fn main() {
 - Has the same caveat as `Clone`: If duplicating the values would break an
   invariant, the type shouldn't implement `Copy`.
 
-- Always derive `Clone` and `Copy` together! Do NOT manually implement `Clone`
+- Always derive `Clone` and `Copy` together! Do _not_ manually implement `Clone`
   when implementing `Copy`.
 
   - Copy operations do not invoke the `clone` method, so a custom `Clone` impl

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/copy.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/copy.md
@@ -50,21 +50,21 @@ fn main() {
 
 - Cannot be implemented on types with `Drop` or non-`Copy` fields.
 
-  - Ask the class: Why can't a type with heap data (`Vec`, `BTreeMap`, `Rc`, etc.) be
-    `Copy`?
+  - Ask the class: Why can't a type with heap data (`Vec`, `BTreeMap`, `Rc`,
+    etc.) be `Copy`?
 
-    Bitwise copying on these types would mean types with heap data would no longer
-    have exclusive ownership of a pointer, breaking the invariants usually upheld
-    by Rust and its ecosystem.
+    Bitwise copying on these types would mean types with heap data would no
+    longer have exclusive ownership of a pointer, breaking the invariants
+    usually upheld by Rust and its ecosystem.
 
     Multiple `Vec`s would point to the same data in memory. Adding and removing
-    data would only update individual `Vec`s length and capacity values. The same
-    for `BTreeMap`.
+    data would only update individual `Vec`s length and capacity values. The
+    same for `BTreeMap`.
 
-    Bitwise copying of `Rc`s would not update the reference counting value within
-    the pointers, meaning there could be two instances of a `Rc` value that
-    believe themselves to be the only `Rc` for that pointer. Once one of them is
-    destroyed, the reference count will become 0 on one of them and the inner
-    value dropped despite there being another `Rc` still alive.
+    Bitwise copying of `Rc`s would not update the reference counting value
+    within the pointers, meaning there could be two instances of a `Rc` value
+    that believe themselves to be the only `Rc` for that pointer. Once one of
+    them is destroyed, the reference count will become 0 on one of them and the
+    inner value dropped despite there being another `Rc` still alive.
 
 </details>

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/copy.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/copy.md
@@ -13,15 +13,10 @@ Like `Clone`, but indicates the type is can be bitwise copied.
 
 Derivable: ✅
 
-When to implement: If possible, but with caveats.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
-// Copy is just a marker trait with Clone as a supertrait.
-// pub trait Copy: Clone { }
-
 #[derive(Debug, Clone, Copy)]
 pub struct Copyable(u8, u16, u32, u64);
 
@@ -34,31 +29,42 @@ fn main() {
 ```
 
 <details>
-- Clone represents a deep clone, and so does copy, but copy suggests to the compiler that a value can be copied bitwise.
 
-- When not to implement/derive: If you do not want to implicitly create copies
-  when dereferencing values of a type, do not implement this trait.
+- `Clone` represents an explicit, user-defined copy operation. `Copy` represents
+  an implicit, bitwise copy.
 
-  Copy enables implicit duplication, so be careful about what types you're
-  implementing this on.
+- Should generally only be implemented on "plain data" types that should act
+  like primitive values. For example, primitive numeric types for a linear
+  algebra library.
 
-- Ask the class: Can a type with heap data (`Vec`, `BTreeMap`, `Rc`, etc.) be
-  copy? Should it be?
+- Has the same caveat as `Clone`: If duplicating the values would break an
+  invariant, the type shouldn't implement `Copy`.
 
-  It both cannot and should not, this is a misuse of this trait.
+- Always derive `Clone` and `Copy` together! Do NOT manually implement `Clone`
+  when implementing `Copy`.
 
-  Bitwise copying on these types would mean types with heap data would no longer
-  have exclusive ownership of a pointer, breaking the invariants usually upheld
-  by Rust and its ecosystem.
+  - Copy operations do not invoke the `clone` method, so a custom `Clone` impl
+    can have different behavior than an implicit copy operation. Deriving both
+    `Clone` and `Copy` together ensures that calling `clone` will give the same
+    result as invoking a copy.
 
-  Multiple `Vec`s would point to the same data in memory. Adding and removing
-  data would only update individual `Vec`s length and capacity values. The same
-  for `BTreeMap`.
+- Cannot be implemented on types with `Drop` or non-`Copy` fields.
 
-  Bitwise copying of `Rc`s would not update the reference counting value within
-  the pointers, meaning there could be two instances of a `Rc` value that
-  believe themselves to be the only `Rc` for that pointer. Once one of them is
-  destroyed, the reference count will become 0 on one of them and the inner
-  value dropped despite there being another `Rc` still alive.
+  - Ask the class: Why can't a type with heap data (`Vec`, `BTreeMap`, `Rc`, etc.) be
+    `Copy`?
+
+    Bitwise copying on these types would mean types with heap data would no longer
+    have exclusive ownership of a pointer, breaking the invariants usually upheld
+    by Rust and its ecosystem.
+
+    Multiple `Vec`s would point to the same data in memory. Adding and removing
+    data would only update individual `Vec`s length and capacity values. The same
+    for `BTreeMap`.
+
+    Bitwise copying of `Rc`s would not update the reference counting value within
+    the pointers, meaning there could be two instances of a `Rc` value that
+    believe themselves to be the only `Rc` for that pointer. Once one of them is
+    destroyed, the reference count will become 0 on one of them and the inner
+    value dropped despite there being another `Rc` still alive.
 
 </details>

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/debug.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/debug.md
@@ -13,16 +13,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 Derivable: ✅
 
-When to implement: Almost always
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
-// pub trait Debug {
-//     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error>;
-// }
-
 #[derive(Debug)]
 pub struct Date {
     day: u8,
@@ -68,17 +62,18 @@ fn main() {
 ```
 
 <details>
+
 - Provides trivial "write to string" functionality.
 
-- Formatting for _debug information_ for programmers during , not appearance or
-  serialization.
+- Formatting for _debug information_ for programmers during development, not
+  appearance or serialization.
 
 - Allows for use of `{:?}` and `{#?}` interpolation in string formatting macros.
 
 - When to not derive/implement: If a struct holds sensitive data, investigate if
-  you should implement Debug for it.
+  you should implement `Debug` for it.
 
-  If Debug is needed, consider manually implementing Debug rather than deriving
-  it. Omit the sensitive data from the implementation.
+  - If `Debug` is needed, consider manually implementing `Debug` rather than
+    deriving it. Omit the sensitive data from the implementation.
 
 </details>

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/display.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/display.md
@@ -58,4 +58,8 @@ fn main() {
 - Types that implement `Display` automatically have `ToString` implemented for
   them.
 
+- Compare the behavior of `Debug` and `Display` for our example error type. Show
+  that the `Debug` impl more directly represents the data as it appears in code,
+  whereas `Display` provides a more friendly message to non-programmers.
+
 </details>

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/display.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/display.md
@@ -13,9 +13,6 @@ SPDX-License-Identifier: CC-BY-4.0
 
 Derivable: ❌, without crates like `derive_more`.
 
-When to implement: As-needed, for errors and other types that an end-user will
-see.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
@@ -37,16 +34,23 @@ impl std::fmt::Display for NetworkError {
     }
 }
 
-impl std::error::Error for NetworkError {}
+fn main() {
+    let http = NetworkError::HttpCode(404);
+    let whale = NetworkError::WhaleBitTheUnderseaCable;
+
+    println!("http debug: {:?}", http);
+    println!("http display: {}", http);
+    println!("whale debug: {:?}", whale);
+    println!("whale display: {}", whale);
+}
 ```
 
 <details>
+
 - A trait similar to `Debug`, but with a focus on end-user readability.
 
-- Prerequisite for the `Error` trait.
-
-  If implementing for an error type, focus on providing a descriptive error for
-  users and programmers other than you.
+- Prerequisite for the `Error` trait. If implementing for an error type, focus
+  on providing a descriptive error for users and programmers other than you.
 
 - Same security considerations as Debug, consider the ways that sensitive data
   could be exposed in UI or logs.

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/from-into.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/from-into.md
@@ -13,44 +13,43 @@ Conversion from one type to another.
 
 Derivable: ❌, without crates like `derive_more`.
 
-When to implement: As-needed and convenient.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
-pub struct ObviousImplementation(String);
+pub struct Wrapper(String);
 
-impl From<String> for ObviousImplementation {
-    fn from(value: String) -> Self {
-        ObviousImplementation(value)
-    }
-}
-
-impl From<&str> for ObviousImplementation {
+impl From<&str> for Wrapper {
     fn from(value: &str) -> Self {
-        ObviousImplementation(value.to_owned())
+        Wrapper(value.to_owned())
     }
 }
+
+impl From<i32> for Wrapper {
+    fn from(value: i32) -> Self {
+        Wrapper(value.to_string())
+    }
+}
+
+// `Into` is more natural to use as a trait bound.
+fn into_string<S: Into<String>>(s: S) {}
+fn string_from<T>(t: T) where String: From<T> {}
 
 fn main() {
-    // From String
-    let obvious1 = ObviousImplementation::from("Hello, obvious!".to_string());
-    // From &str
-    let obvious2 = ObviousImplementation::from("Hello, obvious!");
-    // A From implementation implies an Into implementation, &str.into() ->
-    // ObviousImplementation
-    let obvious3: ObviousImplementation = "Hello, implementation!".into();
+    // `Wrapper` can be construct from `&str` and `i32`.
+    let a = Wrapper::from("Hello, obvious!");
+    let b = Wrapper::from(-123);
+
+    // A From implementation implies an Into implementation.
+    let c: Wrapper = "Hello, implementation!".into();
 }
 ```
 
 <details>
+
 - Provides conversion functionality to types.
 
-- The two traits exist to express different areas you'll find conversion in
-  codebases.
-
-- `From` provides a constructor-style function, whereas into provides a method
+- `From` provides a constructor-style function, whereas `Into` provides a method
   on an existing value.
 
 - Prefer writing `From<T>` implementations for a type you're authoring instead
@@ -59,9 +58,8 @@ fn main() {
   The `Into` trait is implemented for any type that implements `From`
   automatically.
 
-  `Into` is preferred as a trait bound for arguments to functions for clarity of
-  intent for what the function can take.
-
-  `T: Into<String>` has clearer intent than `String: From<T>`.
+- `Into` is preferred as a trait bound for arguments to functions for clarity of
+  intent for what the function can take: `T: Into<String>` has clearer intent
+  than `String: From<T>`.
 
 </details>

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/hash.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/hash.md
@@ -13,22 +13,10 @@ Performing a hash on a type.
 
 Derivable: ✅
 
-When to implement: Almost always.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
-// pub trait Hash {
-//     // Required method
-//     fn hash<H>(&self, state: &mut H)
-//        where H: Hasher;
-//
-//     // Provided method
-//     fn hash_slice<H>(data: &[Self], state: &mut H)
-//        where H: Hasher,
-//              Self: Sized { ... }
-// }
 use std::collections::HashMap;
 
 #[derive(PartialEq, Eq, Hash)]
@@ -45,8 +33,14 @@ fn main() {
 ```
 
 <details>
-- Allows a type to be used in hash algorithms.
 
-- Most commonly used with data structures like `HashMap`.
+- Allows a type to be used in hash algorithms, most commonly used with data
+  structures like `HashMap`.
+
+- Makes it very easy for us to use custom types as the keys in a `HashMap`!
+
+- `Hash` doesn't define any of the hashing logic itself, instead it just feeds
+  the type's data into a `Hasher`. This allows us to use different hash
+  algorithms without changing a type's `Hash` impl.
 
 </details>

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/partialeq-eq.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/partialeq-eq.md
@@ -7,29 +7,16 @@ Copyright 2025 Google LLC
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
-PartialEq and Eq
+# PartialEq and Eq
 
 Partial equality & Total equality.
 
 Derivable: ✅
 
-When to implement: Almost always.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
-// pub trait PartialEq<Rhs = Self>
-//{
-//    // Required method
-//     fn eq(&self, other: &Rhs) -> bool;
-// 
-//     // Provided method
-//     fn ne(&self, other: &Rhs) -> bool { ... }
-// }
-//
-// pub trait Eq: PartialEq { }
-
 #[derive(PartialEq, Eq)]
 pub struct User { name: String, favorite_number: i32 }
 
@@ -43,7 +30,9 @@ fn main() {
 ```
 
 <details>
-- Equality-related methods. If a type implements `PartialEq`/`Eq` then you can use the `==` operator with that type.
+
+- Equality-related methods. If a type implements `PartialEq` then you can use
+  the `==`/`!=` operator with that type.
 
 - A type can't implement `Eq` without implementing `PartialEq`.
 
@@ -56,7 +45,7 @@ fn main() {
   For example, with floating point values `NaN` is an outlier: `NaN == NaN` is
   false, despite bitwise equality.
 
-  `PartialEq` exists to separate types like f32/f64 from types with Total
+  `PartialEq` exists to separate types like `f32`/`f64` from types with Total
   Equality.
 
 - You can implement `PartialEq` between different types, but this is mostly

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/partialord-ord.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/partialord-ord.md
@@ -13,26 +13,10 @@ Partial ordering & Total ordering.
 
 Derivable: ✅
 
-When to implement: Almost always.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
 #
-// pub trait PartialOrd<Rhs = Self>: PartialEq<Rhs>
-// {
-//     // Required method
-//     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
-//
-//     /* Provided methods omitted */
-// }
-// pub trait Ord: Eq + PartialOrd {
-//     // Required method
-//     fn cmp(&self, other: &Self) -> Ordering;
-//
-//     /* Provided methods omitted */
-// }
-
 #[derive(PartialEq, PartialOrd)]
 pub struct Partially(f32);
 
@@ -41,12 +25,23 @@ pub struct Totally {
     id: u32,
     name: String,
 }
+
+fn main() {
+    let a = Totally { id: 0, name: "alice".into() };
+    let b = Totally { id: 1, name: "alice".into() };
+    let c = Totally { id: 0, name: "charlie".into() };
+
+    dbg!(a.cmp(&b));
+    dbg!(a.cmp(&c));
+}
 ```
 
 <details>
-- Comparison-related methods. If a type implements `PartialOrd`/`Ord` then you can use comparison operators (`<`, `<=`, `>`, `>=`) with that type.
 
-`Ord` gives access to `min`, `max`, and `clamp` methods.
+- Comparison-related methods. If a type implements `PartialOrd`/`Ord` then you
+  can use comparison operators (`<`, `<=`, `>`, `>=`) with that type.
+
+- `Ord` gives access to `min`, `max`, and `clamp` methods.
 
 - When derived, compares things in the order they are defined.
 

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/serde.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/serde.md
@@ -7,13 +7,11 @@ Copyright 2025 Google LLC
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
-Serialize/Deserialize style traits
+# Serialize/Deserialize style traits
 
 Crates like `serde` can implement serialization automatically.
 
 Derivable: ✅
-
-When to implement: Almost always.
 
 ```rust,compile_fail,editable
 # // Copyright 2025 Google LLC
@@ -34,7 +32,12 @@ struct Data {
 ```
 
 <details>
-- Provides serialization and deserialization functionality for a type.
+
+- Provides serialization and deserialization functionality for a type, allowing
+  for Rust data types to be converted to/from data formats like JSON.
+
+- The standard library doesn't have serialization functionality built-in, but
+  the serde crate is the community standard interface for doing serialization.
 
 - When not to implement: If a type contains sensitive data that should not be
   erroneously saved to disk or sent over a network, consider not implementing

--- a/src/idiomatic/foundations-api-design/predictable-api/common-traits/try-from-into.md
+++ b/src/idiomatic/foundations-api-design/predictable-api/common-traits/try-from-into.md
@@ -13,8 +13,6 @@ Fallible conversion from one type to another.
 
 Derivable: ❌
 
-When to implement: As-needed.
-
 ```rust,editable
 # // Copyright 2025 Google LLC
 # // SPDX-License-Identifier: Apache-2.0
@@ -27,6 +25,7 @@ pub struct DivisibleByTwo(usize);
 
 impl TryFrom<usize> for DivisibleByTwo {
     type Error = InvalidNumber;
+
     fn try_from(value: usize) -> Result<Self, InvalidNumber> {
         if value.rem_euclid(2) == 0 {
             Ok(DivisibleByTwo(value))
@@ -45,6 +44,7 @@ fn main() {
 ```
 
 <details>
+
 - Provides conversion that can fail, returning a result type.
 
 - Like `From`/`Into`, prefer implementing `TryFrom` for types rather than


### PR DESCRIPTION
Various tweaks and cleanup to the "Implementing Common Traits" section of Idiomatic based on my first time teaching the class.

- Remove the "When to implement" notes from the slides. I found these to be unhelpful, as the answer for "when do I implement this trait" is always "when you need to". I would generally not encourage people to implement traits, even derivable ones, just because they _can_ do so. Where necessary we have speaker notes that call out more specifically when there are extra caveats to implementing a trait, which I think better covers the nuances here.
- Remove the commented-out code showing the definition of the traits. This is cruft that adds visual noise, and I'd prefer to just pull up the standard library docs to show students what the trait API looks like.
- Add `main` function with example code to a few slides that were not demonstrating the behavior of the traits.
- Fix various issues with markdown formatting in slides and speaker notes.
- `copy.md`
  - Note that `Copy` is an implicit operation, whereas `Clone` is an explicit, user-defined operation.
  - Note that `Copy` and `Clone` should be derived together.
  - Note that `Copy` types cannot impl `Drop`, and reorganize notes so that they render more clearly in the speaker notes.
- `display.md` - Remove reference to the `Error` trait and shift focus to highlight the differences between `Debug` and `Display`. I don't think mentioning `Error` is bad per se, but I think it's the wrong thing to focus on here.\
- `from-into.md`
  - Rename `ObviousImplementation` to `Wrapper` to make things more concise and easier to read.
  - Change `From` impls to be for `&str` and `i32`, to better demonstrate how `From` can support conversions from multiple unrelated types.
  - Add example code showing how `Into` is a more natural trait bound than `From`.