### PR TITLE
Idiomatic: Misc. minor tweaks to the type system section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -487,7 +487,7 @@ SPDX-License-Identifier: CC-BY-4.0
 - [Leveraging the Type System](idiomatic/leveraging-the-type-system.md)
   - [Newtype Pattern](idiomatic/leveraging-the-type-system/newtype-pattern.md)
     - [Semantic Confusion](idiomatic/leveraging-the-type-system/newtype-pattern/semantic-confusion.md)
-    - [Parse, Don't Validate](idiomatic/leveraging-the-type-system/newtype-pattern/parse-don-t-validate.md)
+    - [Enforce Invariants](idiomatic/leveraging-the-type-system/newtype-pattern/parse-don-t-validate.md)
     - [Is It Encapsulated?](idiomatic/leveraging-the-type-system/newtype-pattern/is-it-encapsulated.md)
   - [RAII](idiomatic/leveraging-the-type-system/raii.md)
     - [Drop Skipped](idiomatic/leveraging-the-type-system/raii/drop_skipped.md)

--- a/src/idiomatic/leveraging-the-type-system/extension-traits.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Extension Traits
 
-It may desirable to **extend** foreign types with new inherent methods. For
+It may desirable to **extend** foreign types with new methods. For
 example, allow your code to check if a string is a palindrome using
 method-calling syntax: `s.is_palindrome()`.
 

--- a/src/idiomatic/leveraging-the-type-system/extension-traits.md
+++ b/src/idiomatic/leveraging-the-type-system/extension-traits.md
@@ -9,9 +9,9 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Extension Traits
 
-It may desirable to **extend** foreign types with new methods. For
-example, allow your code to check if a string is a palindrome using
-method-calling syntax: `s.is_palindrome()`.
+It may desirable to **extend** foreign types with new methods. For example,
+allow your code to check if a string is a palindrome using method-calling
+syntax: `s.is_palindrome()`.
 
 It might feel natural to reach out for an `impl` block:
 

--- a/src/idiomatic/leveraging-the-type-system/newtype-pattern/parse-don-t-validate.md
+++ b/src/idiomatic/leveraging-the-type-system/newtype-pattern/parse-don-t-validate.md
@@ -7,7 +7,7 @@ Copyright 2025 Google LLC
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
-# Parse, Don't Validate
+# Enforce Invariants at Construction
 
 The newtype pattern can be leveraged to enforce _invariants_.
 
@@ -25,7 +25,6 @@ impl Username {
         if username.len() > 32 {
             return Err(InvalidUsername::TooLong { len: username.len() })
         }
-        // Other validation checks...
         Ok(Self(username))
     }
 

--- a/src/idiomatic/leveraging-the-type-system/raii/scope_guard.md
+++ b/src/idiomatic/leveraging-the-type-system/raii/scope_guard.md
@@ -60,8 +60,8 @@ fn main() {
   fails, the file will still be cleaned up. This ordering is essential for
   correctness.
 
-- The `guard()` creates a `ScopeGuard` instance. It a user-defined value (in
-  this case, `path`) and the cleanup closure that later receives this value.
+- The `guard()` creates a `ScopeGuard` instance. It takes a user-defined value
+  (in this case, `path`) and the cleanup closure that later receives this value.
 
 - The guard's closure runs on scope exit unless it is _defused_ with
   `ScopeGuard::into_inner` (removing the value so the guard does nothing on
@@ -75,8 +75,7 @@ fn main() {
 
 - This pattern is also useful when you don't control the cleanup strategy of the
   resource object. In this example, `File::drop()` closes the file but does not
-  delete it, and we can't change the standard library to delete the file instead
-  (nor should we, it is not a good idea anyway).
+  delete it.
 
 - The `scopeguard` crate also supports cleanup strategies via the
   [`Strategy`](https://docs.rs/scopeguard/latest/scopeguard/trait.Strategy.html)

--- a/src/idiomatic/leveraging-the-type-system/token-types/branded-02-phantomdata.md
+++ b/src/idiomatic/leveraging-the-type-system/token-types/branded-02-phantomdata.md
@@ -72,7 +72,7 @@ fn main() {
   lifetimes have a common shorter lifetime (AKA being subtyped).
 
 - Note: This slide compiles, by the end of this slide it should only compile
-  when `subtyped_lifetimes` is commented out.
+  when `try_coerce_lifetimes` is commented out.
 
 - There are two important parts of this code:
   - The `impl for<'a>` bound on the closure passed to `lifetime_separator`.

--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern.md
@@ -7,7 +7,7 @@ Copyright 2025 Google LLC
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
-## Typestate Pattern: Problem
+# Typestate Pattern: Problem
 
 How can we ensure that only valid operations are allowed on a value based on its
 current state?

--- a/src/idiomatic/polymorphism/from-oop-to-rust/why-no-inheritance.md
+++ b/src/idiomatic/polymorphism/from-oop-to-rust/why-no-inheritance.md
@@ -57,8 +57,8 @@ impl SomeTrait for Data {
   interchangeably, without being able to specify a concrete type or if a type is
   identical to another.
 
-  For operations like equality, comparison this allows for comparison and
-  equality that throws and error or otherwise panics.
+  For operations like equality or comparison this allows for comparison and
+  equality that throws an error or otherwise panics.
 
 - Multiple sources of truth for what makes up a data structure and how it
   behaves:


### PR DESCRIPTION
A handful of minor fixes to the type systems section of Idiomatic. Mostly just fixing wording or markdown formatting.

Also rename the "Parse, Don't Validate" slide to "Enforce Invariants at Construction". The naming of this slide seems odd to me when the example code is validating inputs, not doing any parsing. I think what the slide demonstrates is fine, but makes more sense framed as "enforce invariants at construction time, then you can rely on those invariants later".