### PR TITLE
Idiomatic: Remove diagram from typestate-generics.md

### DIFF
--- a/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics.md
+++ b/src/idiomatic/leveraging-the-type-system/typestate-pattern/typestate-generics.md
@@ -30,22 +30,6 @@ We now have all the tools needed to implement the methods for the `Serializer`
 and its state type definitions. This ensures that our API only permits valid
 transitions, as illustrated in the following diagram:
 
-Diagram of valid transitions:
-
-```bob
-    +-----------+   +---------+------------+-----+
-    |           |   |         |            |     |
-    V           |   V         |            V     |
-                +                                |
-serializer --> structure --> property --> list +-+
-
-    |           |   ^           |          ^
-    V           |   |           |          |
-                |   +-----------+          |
-  String        |                          |
-                +--------------------------+
-```
-
 <details>
 
 - By leveraging generics to track the parent context, we can construct


### PR DESCRIPTION
The diagram was shown on the previous slide, and isn't terribly relevant on this slide. I think removing it helps for brevity and clarity.