### PR TITLE
memory-management: rename `as_dependency` to `to_dependency`

### DIFF
--- a/src/memory-management/exercise.md
+++ b/src/memory-management/exercise.md
@@ -20,7 +20,7 @@ Fill in the missing pieces.
 # // SPDX-License-Identifier: Apache-2.0
 #
 {{#include exercise.rs:Package}}
-{{#include exercise.rs:as_dependency}}
+{{#include exercise.rs:to_dependency}}
         todo!("1")
     }
 }

--- a/src/memory-management/exercise.rs
+++ b/src/memory-management/exercise.rs
@@ -42,11 +42,11 @@ struct Package {
 
 impl Package {
     // ANCHOR_END: Package
-    // ANCHOR: as_dependency
+    // ANCHOR: to_dependency
     /// Return a representation of this package as a dependency, for use in
     /// building other packages.
-    fn as_dependency(&self) -> Dependency {
-        // ANCHOR_END: as_dependency
+    fn to_dependency(&self) -> Dependency {
+        // ANCHOR_END: to_dependency
         Dependency {
             name: self.name.clone(),
             version_expression: self.version.clone(),
@@ -121,8 +121,8 @@ fn main() {
     let serde = PackageBuilder::new("serde")
         .authors(vec!["djmitche".into()])
         .version(String::from("4.0"))
-        .dependency(base64.as_dependency())
-        .dependency(log.as_dependency())
+        .dependency(base64.to_dependency())
+        .dependency(log.to_dependency())
         .build();
     dbg!(serde);
 }


### PR DESCRIPTION
Because this function takes a reference to `self` and returns an owned object, it's more idiomatic to call it `to_` rather than `as_`: https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv

This was brought up when discussing the code with the students when running the course.