### PR TITLE
ru: fix 25 factually wrong fuzzy entries

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
 "POT-Creation-Date: 2024-05-04T15:55:40+03:00\n"
-"PO-Revision-Date: 2023-08-25 14:28-0700\n"
-"Last-Translator: Yauheni Baltukha <evgenii.boltuho@gmail.com>\n"
+"PO-Revision-Date: 2026-05-21 12:00+0500\n"
+"Last-Translator: Arsen Ozhetov <yabanciinbt@gmail.com>\n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
@@ -205,9 +205,8 @@ msgstr "Ссылки"
 
 # Section describes borrowing, so that was used as a translation source
 #: src/SUMMARY.md src/references/shared.md
-#, fuzzy
 msgid "Shared References"
-msgstr "Заимствование"
+msgstr "Общие ссылки"
 
 # Section describes mutable borrowing o_O, so: Изменяемые ссылки
 #: src/SUMMARY.md src/references/exclusive.md
@@ -310,9 +309,8 @@ msgid "Supertraits"
 msgstr "Супер-типажи"
 
 #: src/SUMMARY.md src/methods-and-traits/traits/associated-types.md
-#, fuzzy
 msgid "Associated Types"
-msgstr "Скалярные типы"
+msgstr "Ассоциированные типы"
 
 #: src/SUMMARY.md src/methods-and-traits/deriving.md
 msgid "Deriving"
@@ -643,9 +641,8 @@ msgid "Try Operator"
 msgstr "Проброс ошибок"
 
 #: src/SUMMARY.md src/error-handling/try-conversions.md
-#, fuzzy
 msgid "Try Conversions"
-msgstr "Неявные преобразования"
+msgstr "Преобразования через Try"
 
 #: src/SUMMARY.md
 msgid "`Error` Trait"
@@ -830,9 +827,8 @@ msgid "C++ Bridge"
 msgstr ""
 
 #: src/SUMMARY.md src/android/interoperability/cpp/shared-types.md
-#, fuzzy
 msgid "Shared Types"
-msgstr "Скалярные типы"
+msgstr "Общие типы"
 
 #: src/SUMMARY.md src/android/interoperability/cpp/shared-enums.md
 msgid "Shared Enums"
@@ -1188,9 +1184,8 @@ msgid "`Send` and `Sync`"
 msgstr ""
 
 #: src/SUMMARY.md src/concurrency/send-sync/marker-traits.md
-#, fuzzy
 msgid "Marker Traits"
-msgstr "Небезопасные типажи"
+msgstr "Маркерные типажи"
 
 #: src/SUMMARY.md src/concurrency/send-sync/send.md
 msgid "`Send`"
@@ -2707,12 +2702,11 @@ msgid "High level of control."
 msgstr "Высокий уровень контроля."
 
 #: src/hello-world/what-is-rust.md
-#, fuzzy
 msgid ""
 "Can be scaled down to very constrained devices such as microcontrollers."
 msgstr ""
-"Может использоваться на очень ограниченных устройствах, таких как мобильные "
-"телефоны."
+"Может работать на устройствах с очень ограниченными ресурсами, например, на "
+"микроконтроллерах."
 
 #: src/hello-world/what-is-rust.md
 msgid "Has no runtime or garbage collection."
@@ -4108,11 +4102,8 @@ msgid "[Slices: &\\[T\\]](./references/slices.md) (10 minutes)"
 msgstr ""
 
 #: src/references.md
-#, fuzzy
 msgid "[Strings](./references/strings.md) (10 minutes)"
-msgstr ""
-"Больше информации об использовании шаблонов в языке Rust можно найти на "
-"[странице про сопоставление с шаблоном](../pattern-matching.md)."
+msgstr "[Строки](./references/strings.md) (10 минут)"
 
 #: src/references.md
 msgid "[Exercise: Geometry](./references/exercise.md) (15 minutes)"
@@ -4334,9 +4325,8 @@ msgid "\"s1: {s1}\""
 msgstr ""
 
 #: src/references/strings.md
-#, fuzzy
 msgid "\"Hello \""
-msgstr "Привет, мир!"
+msgstr "\"Привет \""
 
 #: src/references/strings.md src/memory-management/move.md
 msgid "\"s2: {s2}\""
@@ -4482,11 +4472,8 @@ msgid "[Enums](./user-defined-types/enums.md) (5 minutes)"
 msgstr ""
 
 #: src/user-defined-types.md
-#, fuzzy
 msgid "[Static](./user-defined-types/static.md) (5 minutes)"
-msgstr ""
-"Больше информации об использовании шаблонов в языке Rust можно найти на "
-"[странице про сопоставление с шаблоном](../pattern-matching.md)."
+msgstr "[Static](./user-defined-types/static.md) (5 минут)"
 
 #: src/user-defined-types.md
 msgid "[Type Aliases](./user-defined-types/aliases.md) (2 minutes)"
@@ -4753,9 +4740,8 @@ msgid ""
 msgstr ""
 
 #: src/user-defined-types/static.md
-#, fuzzy
 msgid "\"Welcome to RustOS 3.14\""
-msgstr "Добро пожаловать в День 1"
+msgstr "\"Добро пожаловать в RustOS 3.14\""
 
 #: src/user-defined-types/static.md
 msgid "\"{BANNER}\""
@@ -4980,11 +4966,8 @@ msgid "[Welcome](./welcome-day-2.md) (3 minutes)"
 msgstr "[Добро пожаловать](./welcome-day-2.md) (3 минуты)"
 
 #: src/welcome-day-2.md
-#, fuzzy
 msgid "[Pattern Matching](./pattern-matching.md) (1 hour)"
-msgstr ""
-"Больше информации об использовании шаблонов в языке Rust можно найти на "
-"[странице про сопоставление с шаблоном](../pattern-matching.md)."
+msgstr "[Сопоставление с шаблоном](./pattern-matching.md) (1 час)"
 
 #: src/welcome-day-2.md
 msgid "[Methods and Traits](./methods-and-traits.md) (50 minutes)"
@@ -4998,11 +4981,8 @@ msgstr ""
 "Вместе с 10-ти минутными паузами урок займёт около 2-х часов и 10-и минут."
 
 #: src/pattern-matching.md
-#, fuzzy
 msgid "[Matching Values](./pattern-matching/match.md) (10 minutes)"
-msgstr ""
-"Больше информации об использовании шаблонов в языке Rust можно найти на "
-"[странице про сопоставление с шаблоном](../pattern-matching.md)."
+msgstr "[Сопоставление значений](./pattern-matching/match.md) (10 минут)"
 
 #: src/pattern-matching.md
 msgid "[Destructuring](./pattern-matching/destructuring.md) (10 minutes)"
@@ -5262,9 +5242,8 @@ msgid "`if let` expressions"
 msgstr "Выражение `if let`"
 
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "`while let` expressions"
-msgstr "Выражение `if let`"
+msgstr "Выражение `while let`"
 
 #: src/pattern-matching/let-control-flow.md
 msgid "`match` expressions"
@@ -5285,9 +5264,8 @@ msgid "\"slept for {:?}\""
 msgstr ""
 
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "`let else` expressions"
-msgstr "Выражение `if let`"
+msgstr "Выражение `let else`"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5387,9 +5365,8 @@ msgid "The rewritten version is:"
 msgstr ""
 
 #: src/pattern-matching/let-control-flow.md
-#, fuzzy
 msgid "while-let"
-msgstr "Выражение `while let`"
+msgstr "while-let"
 
 #: src/pattern-matching/let-control-flow.md
 msgid ""
@@ -5478,11 +5455,8 @@ msgid "[Traits](./methods-and-traits/traits.md) (15 minutes)"
 msgstr ""
 
 #: src/methods-and-traits.md
-#, fuzzy
 msgid "[Deriving](./methods-and-traits/deriving.md) (3 minutes)"
-msgstr ""
-"Больше информации об использовании шаблонов в языке Rust можно найти на "
-"[странице про сопоставление с шаблоном](../pattern-matching.md)."
+msgstr "[Вывод типажей](./methods-and-traits/deriving.md) (3 минуты)"
 
 #: src/methods-and-traits.md
 msgid ""
@@ -8955,9 +8929,8 @@ msgid "b\"hello\""
 msgstr ""
 
 #: src/welcome-day-4.md
-#, fuzzy
 msgid "Welcome to Day 4"
-msgstr "Добро пожаловать в День 1"
+msgstr "Добро пожаловать в День 4"
 
 #: src/welcome-day-4.md
 msgid ""
@@ -14104,9 +14077,8 @@ msgid "Native support for C++'s `std::unique_ptr` in Rust"
 msgstr ""
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
-#, fuzzy
 msgid "Native support for Rust slices in C++"
-msgstr "Встроенная поддержка тестирования."
+msgstr "Встроенная поддержка срезов Rust в C++"
 
 #: src/chromium/interoperability-with-cpp/example-bindings.md
 msgid "Calls from C++ to Rust, and Rust types (in the top part)"
@@ -14422,9 +14394,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/chromium/interoperability-with-cpp.md
-#, fuzzy
 msgid "Some things to try:"
-msgstr "Примечания:"
+msgstr "Что можно попробовать:"
 
 #: src/exercises/chromium/interoperability-with-cpp.md
 msgid "Call back into C++ from Rust. You will need:"
@@ -15919,13 +15890,12 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/morning.md
-#, fuzzy
 msgid ""
 "After looking at the exercises, you can look at the [solutions](solutions-"
 "morning.md) provided."
 msgstr ""
-"Ознакомившись с упражнениями, вы можете изучить предоставленные "
-"\\[solutions\\]."
+"Ознакомившись с упражнениями, вы можете посмотреть предложенные "
+"[решения](solutions-morning.md)."
 
 #: src/exercises/bare-metal/compass.md
 msgid ""
@@ -17136,13 +17106,12 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md
-#, fuzzy
 msgid ""
 "After looking at the exercises, you can look at the [solutions](solutions-"
 "afternoon.md) provided."
 msgstr ""
-"Ознакомившись с упражнениями, вы можете изучить предоставленные "
-"\\[solutions\\]."
+"Ознакомившись с упражнениями, вы можете посмотреть предложенные "
+"[решения](solutions-afternoon.md)."
 
 #: src/exercises/bare-metal/rtc.md
 #: src/exercises/bare-metal/solutions-afternoon.md
@@ -17743,9 +17712,9 @@ msgid ""
 msgstr ""
 
 #: src/concurrency/send-sync.md
-#, fuzzy
 msgid "[Marker Traits](./concurrency/send-sync/marker-traits.md) (2 minutes)"
-msgstr "[Массивы](./tuples-and-arrays/arrays.md) (5 минут)"
+msgstr ""
+"[Маркерные типажи](./concurrency/send-sync/marker-traits.md) (2 минуты)"
 
 #: src/concurrency/send-sync.md
 msgid "[Send](./concurrency/send-sync/send.md) (2 minutes)"
@@ -20320,9 +20289,8 @@ msgstr ""
 #~ "Вы можете думать о нем как о `void`, который может быть знаком вам по "
 #~ "другим языкам программирования."
 
-#, fuzzy
 #~ msgid "Lives for the entire duration of the program"
-#~ msgstr "Функция `main` является точкой входа в программу."
+#~ msgstr "Живёт всё время работы программы"
 
 #~ msgid "Rust terminology:"
 #~ msgstr "Терминология Rust:"
@@ -20372,9 +20340,8 @@ msgstr ""
 #~ msgid "while let expressions"
 #~ msgstr "Выражение while let"
 
-#, fuzzy
 #~ msgid "Storing Books"
-#~ msgstr "Строки"
+#~ msgstr "Хранение книг"
 
 #~ msgid "The course is fast paced and covers a lot of ground:"
 #~ msgstr "Курс проходит в быстром темпе и охватывает много вопросов:"
@@ -21551,9 +21518,8 @@ msgstr ""
 #~ "}\n"
 #~ "```"
 
-#, fuzzy
 #~ msgid "An exercise on pattern matching."
-#~ msgstr "Перечисления и сопоставление с образцом."
+#~ msgstr "Упражнение на сопоставление с шаблоном."
 
 #~ msgid ""
 #~ "Memory management: stack vs heap, manual memory management, scope-based "


### PR DESCRIPTION
This PR fixes a narrow set of `po/ru.po` entries where the existing fuzzy translation is **factually wrong** — different concept, swapped link, wrong day number, broken markdown, etc. — not where it's merely stylistically outdated. The other ~50 fuzzy entries are left with their `#, fuzzy` flag untouched for @baltuky (the original translator) to revisit on their own pace.

## Scope

**Wrong chapter titles in SUMMARY**

| msgid | was | now |
|---|---|---|
| Associated Types | Скалярные типы | Ассоциированные типы |
| Shared Types (C++ interop) | Скалярные типы | Общие типы |
| Try Conversions | Неявные преобразования | Преобразования через Try |
| Marker Traits | Небезопасные типажи | Маркерные типажи |
| Shared References | Заимствование (= different section) | Общие ссылки |

**msgmerge nearest-match garbage.** Six chapter-link entries had been overwritten with the recurring `"Больше информации об использовании шаблонов..."` boilerplate or with an unrelated link — replaced with correct ones: `[Static]`, `[Pattern Matching]`, `[Matching Values]`, `[Deriving]`, `[Strings]`, `[Marker Traits]` (which pointed at the Arrays link).

**Wrong body translations**
- `Native support for Rust slices in C++` → was `"Встроенная поддержка тестирования"` (slices ≠ testing)
- `` `while let` expressions `` and `` `let else` expressions `` → both were `"Выражение `if let`"`
- `while-let` (anchor) → was `"Выражение `while let`"` (anchor name vs section title)
- `Lives for the entire duration of the program` → was `"Функция `main` является точкой входа в программу"`
- `Storing Books` → was `"Строки"` (Books ≠ Strings)
- `An exercise on pattern matching.` → was about enums + pattern matching
- `Welcome to Day 4` → was `"Добро пожаловать в День 1"`
- `Can be scaled down to very constrained devices such as microcontrollers.` → was `"...мобильные телефоны"` (microcontrollers ≠ phones)
- `Some things to try:` → was `"Примечания:"` (notes ≠ things to try)

**Wrong code literals**
- `"Welcome to RustOS 3.14"` → was `"Добро пожаловать в День 1"`
- `"Hello "` → was `"Привет, мир!"` (different literal)

**Broken markdown links** (literally not rendering as links)
- Two `After looking at the exercises... [solutions](solutions-*.md)` entries had `\\[solutions\\]` with escaped brackets and no working link target.

## Terminology

Followed the existing glossary in `ru.po` (Trait → Типаж, Borrow → Заимствование, Closure → Замыкание, Slice → Срез, Lifetime → Время жизни) and the established RU Rust canon for the new replacements (Marker Traits → Маркерные типажи; `#[derive]` → Вывод типажей). Shared/Exclusive References intentionally kept as Общие/Эксклюзивные ссылки, matching the modern shared/exclusive terminology that this course uses (not the older immutable/mutable framing) — happy to switch if reviewers prefer the canonical RU Book "неизменяемые/изменяемые".

## Verification

```
$ msgfmt --statistics -o /dev/null po/ru.po
574 translated messages, 50 fuzzy translations, 3136 untranslated messages.
```

(Before: 552 translated, 72 fuzzy, 3136 untranslated. Δ = +22 translated, −22 fuzzy.)