### PR TITLE
Remove outdated `linkcheck` config

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -292,15 +292,6 @@ use-boolean-and = true
 [output.exerciser]
 output-directory = "comprehensive-rust-exercises"
 
-[output.linkcheck]
-optional = true
-follow-web-links = false # change to true to check web links
-exclude = [
-  "comprehensive-rust.pdf",
-  "comprehensive-rust-exercises.zip",
-  # "crates.io", # uncomment when follow-web-links is true
-]
-
 [output.linkcheck2]
 optional = true
 follow-web-links = false # change to true to check web links


### PR DESCRIPTION
This should no longer be necessary after https://github.com/marxin/mdbook-linkcheck2/commit/7904124ac7480855488208a8a30f5ee7bfc1210c was released as linkcheck2 0.11