### PR TITLE
fix: Explicitly call out dev-dependencies used in solutions

### DIFF
--- a/src/unsafe-rust/Cargo.toml
+++ b/src/unsafe-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-[dependencies]
+[dev-dependencies]
 tempfile = "3.27.0"
 
 [[bin]]

--- a/src/unsafe-rust/solution.md
+++ b/src/unsafe-rust/solution.md
@@ -5,6 +5,13 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Solution
 
+The unit tests use the [`tempfile`](https://docs.rs/tempfile/) crate. Add it as
+a dev-dependency with:
+
+```shell
+cargo add --dev tempfile
+```
+
 ```rust,editable
 # // Copyright 2023 Google LLC
 # // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Summary

## Root Cause

The `src/unsafe-rust/exercise.rs` solution has unit tests that use the
`tempfile` crate (`tempfile::TempDir::new()`). However:

1. `tempfile` was listed under `[dependencies]` instead of `[dev-dependencies]`
   in `src/unsafe-rust/Cargo.toml`, even though it is only needed at test time.
2. The `solution.md` page did not mention `tempfile` at all, so anyone who
   copy-pastes the solution into a new Cargo project would get compile errors
   without knowing they need to add the crate.

## Change Made

**`src/unsafe-rust/Cargo.toml`** — moved `tempfile` from `[dependencies]` to
`[dev-dependencies]`:

```toml
[dev-dependencies]
tempfile = "3.27.0"
```

**`src/unsafe-rust/solution.md`** — added a note at the top of the solution
page instructing readers to add `tempfile` as a dev-dependency:

```markdown
The unit tests use the [`tempfile`](https://docs.rs/tempfile/) crate. Add it as
a dev-dependency with:

```shell
cargo add --dev tempfile
```
```



## Issue

Fixes #1290

**Issue URL:** https://github.com/google/comprehensive-rust/issues/1290


## Changes

```
src/unsafe-rust/Cargo.toml  | 2 +-
 src/unsafe-rust/solution.md | 7 +++++++
 2 files changed, 8 insertions(+), 1 deletion(-)
```


## Testing


- Agent ran relevant tests during development

- Linting checks passed

- Changes are minimal and focused on the issue


## AI Assistance Disclosure


This pull request was prepared with the assistance of AI coding tools (GitHub Copilot). The change has been read, understood, and is owned by the human contributor submitting it, who will respond to review feedback.
