### PR TITLE
analytics: track language in Google Analytics

### DIFF
--- a/theme/head.hbs
+++ b/theme/head.hbs
@@ -6,7 +6,9 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-ZN78TEJMRW');
+  gtag('config', 'G-ZN78TEJMRW', {
+    'content_group': '{{ language }}'
+  });
 </script>
 
 {{! Move to template code after fixing this issue:


### PR DESCRIPTION
Use the `content_group` parameter in the `gtag` configuration to track which language version of the book is being viewed.

Fixes #3198