### PR TITLE
bazel: Cache Bazel itself and fetched repositories

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Setup Bazel cache
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
+          bazelisk-cache: true
           disk-cache: true
+          repository-cache: true
 
       - name: Setup Rust cache
         uses: ./.github/workflows/setup-rust-cache


### PR DESCRIPTION
The build promptly failed after #3197 was merged:

> 2026/06/09 19:21:56 Downloading https://releases.bazel.build/9.1.1/release/bazel-9.1.1-linux-x86_64...
> 2026/06/09 19:21:58 could not download Bazel: failed to download bazel: failed to download bazel: could not copy from https://releases.bazel.build/9.1.1/release/bazel-9.1.1-linux-x86_64 to /home/runner/.cache/bazelisk/downloads/_tmp/download4253763382: stream error: stream ID 1; INTERNAL_ERROR; received from peer

See this job:
https://github.com/google/comprehensive-rust/actions/runs/27230090780/job/80407639773

This happened on 3 of the 22 jobs that build our translations. Caching the Bazel installation itself should help with this, and still respect the version in `.bazelverion`.

The repository cache will capture things like Rust crates downloaded from crates.io. I'm not 100% sure if this is faster than pulling down the tarballs again, but it might isolate us slightly from outside disturbances.