### PR TITLE
bazel: Centralize cache configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,9 +111,7 @@ jobs:
         run: rustup update
 
       - name: Setup Bazel cache
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          disk-cache: true
+        uses: ./.github/workflows/setup-bazel-cache
 
       - name: Setup Rust cache
         uses: ./.github/workflows/setup-rust-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,11 +39,7 @@ jobs:
         run: rustup update
 
       - name: Setup Bazel cache
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          bazelisk-cache: true
-          disk-cache: true
-          repository-cache: true
+        uses: ./.github/workflows/setup-bazel-cache
 
       - name: Setup Rust cache
         uses: ./.github/workflows/setup-rust-cache

--- a/.github/workflows/setup-bazel-cache/action.yml
+++ b/.github/workflows/setup-bazel-cache/action.yml
@@ -1,0 +1,16 @@
+name: Setup Bazel cache
+
+description: Configure the Bazel caching.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust cache
+      uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: true
+        repository-cache: true
+        # Only save the cache on the main branch to avoid PRs filling
+        # up the cache.
+        cache-save: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This ensures we only need to update the cache configuration in one place and prevents PRs from filling up the cache.

Follow-up to #3203 where I managed to update only one of the two cache configurations.