### PR TITLE
bazel: disable textual diffs for ``MODULE.bazel.lock`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Disable showing diffs: file has extremely long lines. Remove if/when
+# https://github.com/bazelbuild/rules_rust/issues/3946 is fixed.
+MODULE.bazel.lock -diff


### PR DESCRIPTION
The file has extremely long lines, which makes my poor Emacs very confused. We can clean this up if/when
https://github.com/bazelbuild/rules_rust/issues/3946 is fixed.