### PR TITLE
bazel: automatically show test failures

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+test --test_output=errors


### PR DESCRIPTION
Without this, the errors are only available in a Bazel log file.