### PR TITLE
bazel: avoid caching huge repository cache

### DIFF
--- a/.github/workflows/setup-bazel-cache/action.yml
+++ b/.github/workflows/setup-bazel-cache/action.yml
@@ -10,7 +10,10 @@ runs:
       with:
         bazelisk-cache: true
         disk-cache: true
-        repository-cache: true
+        # The LLVM toolchain weighs in at around 5 GB, which means we
+        # quickly fill up the GitHub Actions cache. Downloading it
+        # again is roughly equally fast.
+        repository-cache: false
         # Only save the cache on the main branch to avoid PRs filling
         # up the cache.
         cache-save: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
The LLVM toolchain repository is around 5 GB in the cache, which means that we quickly fill up the 10 GB cache quota we have for GitHub Actions. Downloading it should be roughtly equally fast.