### PR TITLE
bazel: handle copying of read-only files

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -119,6 +119,22 @@ fn run_command(cmd: &mut Command) -> Result<()> {
     Ok(())
 }
 
+/// Copy `src` to `dest`, deleting `dest` first, if present.
+///
+/// This is unlike [`fs::copy`] which fails if `dest` exists and is a
+/// read-only file. Bazel creates read-only files in `bazel-bin/`.
+fn copy(src: &Path, dest: &Path) -> Result<u64> {
+    if let Err(e) = fs::remove_file(dest)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(anyhow!("Failed to remove {}: {}", dest.display(), e));
+    }
+    let len = fs::copy(src, dest).with_context(|| {
+        format!("Failed to copy {} to {}", src.display(), dest.display())
+    })?;
+    Ok(len)
+}
+
 fn install_tools(binstall: bool) -> Result<()> {
     println!("Installing project tools...");
 
@@ -174,13 +190,13 @@ fn install_tools(binstall: bool) -> Result<()> {
     };
     let bin_dir = cargo_home.join("bin");
 
-    fs::copy(
-        workspace_dir.join("bazel-bin/mdbook-course/mdbook-course"),
-        bin_dir.join("mdbook-course"),
+    copy(
+        &workspace_dir.join("bazel-bin/mdbook-course/mdbook-course"),
+        &bin_dir.join("mdbook-course"),
     )?;
-    fs::copy(
-        workspace_dir.join("bazel-bin/mdbook-exerciser/mdbook-exerciser"),
-        bin_dir.join("mdbook-exerciser"),
+    copy(
+        &workspace_dir.join("bazel-bin/mdbook-exerciser/mdbook-exerciser"),
+        &bin_dir.join("mdbook-exerciser"),
     )?;
 
     // Uninstall original linkcheck if currently installed (see issue no 2773)


### PR DESCRIPTION
With #3197, `cargo xtask` began copying binaries produced by Bazel to `~/.cargo/bin/`. These binaries are read-only files since Bazel likes to mark everything in its `bazel-bin/` directory as read-only.

As the files entered the cache on GitHub, our builds started failing, see thse jobs from unrelated PRs:

- https://github.com/google/comprehensive-rust/actions/runs/27474258285/job/81210548383
- https://github.com/google/comprehensive-rust/actions/runs/27474256814/job/81210554918

They fail with

```
[695 / 698] Compiling Rust rlib mdbook-course-lib (6 files); 0s disk-cache, processwrapper-sandbox
INFO: Found 2 targets...
INFO: Elapsed time: 93.311s, Critical Path: 21.20s
INFO: 698 processes: 261 disk cache hit, 306 internal, 131 processwrapper-sandbox.
INFO: Build completed successfully, 698 total actions
Error: Permission denied (os error 13)
Error: Process completed with exit code 1.
```

which is what I see locally as well when I run the `cargo xtask install-tools` on `main`.