### PR TITLE
Setup Bazel cache consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bazel cache
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          disk-cache: true
+        uses: ./.github/workflows/setup-bazel-cache
 
       - name: Test Rust code
         run: bazel test //...


### PR DESCRIPTION
I somehow forgot this in #3206 and this meant that we still uploaded per-branch Bazel caches.