### PR TITLE
ci: don't clear HTML redirects when building translations

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -33,10 +33,8 @@ else
     sed -i '/curly-quotes/d' book.toml
 
     # Set language and adjust site URL.
-    # TODO: Clearing the redirects is no longer necessary since we restore book.toml.
     export MDBOOK_BOOK__LANGUAGE=$book_lang
     export MDBOOK_OUTPUT__HTML__SITE_URL=/comprehensive-rust/$book_lang/
-    export MDBOOK_OUTPUT__HTML__REDIRECT='{}'
 
     # Include language-specific Pandoc configuration
     if [ -f ".github/pandoc/$book_lang.yaml" ]; then


### PR DESCRIPTION
Building a translation exported MDBOOK_OUTPUT__HTML__REDIRECT='{}', which
wiped the redirect table and made renamed or removed pages 404 in every
non-English book. Clearing the redirects is no longer needed because
book.toml is restored for each translation, so mdbook now emits the same
redirect pages as the English build.

Closes #2022.