### PR TITLE
other-resources: update Ferrous Systems teaching link

### DIFF
--- a/src/other-resources.md
+++ b/src/other-resources.md
@@ -50,7 +50,7 @@ A small selection of other guides and tutorial for Rust:
   such as C, C++, Java, JavaScript, and Python.
 - [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help
   you learn Rust.
-- [Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-material/index.html):
+- [Ferrous Systems Rust Training](https://github.com/ferrous-systems/rust-training):
   a series of small presentations covering both basic and advanced part of the
   Rust language. Other topics such as WebAssembly, and async/await are also
   covered.


### PR DESCRIPTION
The Ferrous Teaching Material page at ferrous-systems.github.io now only
displays a "this material has moved" notice. The slides have moved to the
ferrous-systems/rust-training repository, which the moved page itself
points to as the new home. Update the entry to that repository and use its
current name.

Closes #3015.