### PR TITLE
references: correct the exclusive-reference speaker note for NLL

### DIFF
--- a/src/references/exclusive.md
+++ b/src/references/exclusive.md
@@ -30,10 +30,12 @@ fn main() {
 
 Key points:
 
-- "Exclusive" means that only this reference can be used to access the value. No
-  other references (shared or exclusive) can exist at the same time, and the
-  referenced value cannot be accessed while the exclusive reference exists. Try
-  making an `&point.0` or changing `point.0` while `x_coord` is alive.
+- "Exclusive" means only this reference can access the value: no other reference
+  (shared or exclusive) may coexist. A borrow stays active until its last use,
+  not until the end of the scope, so to observe the restriction, add a
+  conflicting access before that last use — for example, read `&point.0` or
+  write to `point.0` on the line before `*x_coord = 20;`. Adding it after the
+  last use compiles, because the borrow has already ended.
 
 - Be sure to note the difference between `let mut x_coord: &i32` and
   `let x_coord: &mut i32`. The first one is a shared reference that can be bound


### PR DESCRIPTION
The note suggested accessing `point.0` "while x_coord is alive", but under
non-lexical lifetimes the mutable borrow of `point.0` ends at the last use
of `x_coord` (`*x_coord = 20;`). Accessing `point.0` after that line
therefore compiles and no longer demonstrates the restriction. Reword the
note to explain that a borrow lasts until its last use, and to insert the
conflicting access before that last use to reproduce the borrow error.

Closes #2246.