### PR TITLE
Fix updated clippy warnings

### DIFF
--- a/src/concurrency/sync-exercises/dining-philosophers.rs
+++ b/src/concurrency/sync-exercises/dining-philosophers.rs
@@ -33,7 +33,7 @@ struct Philosopher {
 impl Philosopher {
     fn think(&self) {
         self.thoughts
-            .send(format!("Eureka! {} has a new idea!", &self.name))
+            .send(format!("Eureka! {} has a new idea!", self.name))
             .unwrap();
     }
     // ANCHOR_END: Philosopher-think
@@ -41,12 +41,12 @@ impl Philosopher {
     // ANCHOR: Philosopher-eat
     fn eat(&self) {
         // ANCHOR_END: Philosopher-eat
-        println!("{} is trying to eat", &self.name);
+        println!("{} is trying to eat", self.name);
         let _left = self.left_chopstick.lock().unwrap();
         let _right = self.right_chopstick.lock().unwrap();
 
         // ANCHOR: Philosopher-eat-end
-        println!("{} is eating...", &self.name);
+        println!("{} is eating...", self.name);
         thread::sleep(Duration::from_millis(10));
     }
 }

--- a/src/modules/exercise.rs
+++ b/src/modules/exercise.rs
@@ -88,7 +88,7 @@ impl Widget for Window {
         // TODO: Change draw_into to return Result<(), std::fmt::Error>. Then use the
         // ?-operator here instead of .unwrap().
         writeln!(buffer, "+-{:-<inner_width$}-+", "").unwrap();
-        writeln!(buffer, "| {:^inner_width$} |", &self.title).unwrap();
+        writeln!(buffer, "| {:^inner_width$} |", self.title).unwrap();
         writeln!(buffer, "+={:=<inner_width$}=+", "").unwrap();
         for line in inner.lines() {
             writeln!(buffer, "| {:inner_width$} |", line).unwrap();
@@ -109,7 +109,7 @@ impl Widget for Button {
 
         writeln!(buffer, "+{:-<width$}+", "").unwrap();
         for line in label.lines() {
-            writeln!(buffer, "|{:^width$}|", &line).unwrap();
+            writeln!(buffer, "|{:^width$}|", line).unwrap();
         }
         writeln!(buffer, "+{:-<width$}+", "").unwrap();
     }
@@ -121,7 +121,7 @@ impl Widget for Label {
     }
 
     fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {
-        writeln!(buffer, "{}", &self.label).unwrap();
+        writeln!(buffer, "{}", self.label).unwrap();
     }
 }
 


### PR DESCRIPTION
I assume these are from a rust version update.