### PR TITLE
bazel: define our own `mdbook` toolchain

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_rust_mdbook//:defs.bzl", "mdbook_toolchain")
+
+mdbook_toolchain(
+    name = "mdbook_toolchain_impl",
+    mdbook = "@binaries//:mdbook__mdbook",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "mdbook_toolchain",
+    toolchain = ":mdbook_toolchain_impl",
+    toolchain_type = "@rules_rust_mdbook//:toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
 )
 
 bazel_dep(name = "rules_rust", version = "0.70.0")
+bazel_dep(name = "rules_rust_mdbook", version = "0.70.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
@@ -12,6 +13,8 @@ rust.toolchain(
 use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")
+
+register_toolchains("//:mdbook_toolchain")
 
 rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
 rust_host_tools.host_tools(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -168,6 +168,8 @@
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_rust/0.70.0/MODULE.bazel": "5b1407b11c305bc2522e204e7f170faf8399e836e49b6afef9074dfe532e6c3f",
     "https://bcr.bazel.build/modules/rules_rust/0.70.0/source.json": "24ae6d23425359db1c3148aa22c389970fce9a06102b2b3a329a2800f9569de2",
+    "https://bcr.bazel.build/modules/rules_rust_mdbook/0.70.0/MODULE.bazel": "70e25e799e1e4c15db28ba3a6f5b470ab0e7383de1ac541332e4aff195ba0a2b",
+    "https://bcr.bazel.build/modules/rules_rust_mdbook/0.70.0/source.json": "320380a2174f3358bf4e59f7484480fb4e73222a37a6b568021210f8d7fc6d4f",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",


### PR DESCRIPTION
This ensures that future use of the `mdbook` rule will use the `mdbook` version we have specified in our `MODULE.bazel` file, and so will match #3207.