### PR TITLE
feat: make speaker notes translatable (fixes #1390)

### DIFF
--- a/mdbook-course/src/bin/mdbook-course.rs
+++ b/mdbook-course/src/bin/mdbook-course.rs
@@ -46,6 +46,14 @@ fn preprocess() -> anyhow::Result<()> {
 
     book.for_each_mut(|chapter| {
         if let BookItem::Chapter(chapter) = chapter {
+            chapter.content.push_str(
+                "\n\n<div id=\"speaker-notes-translations\" style=\"display: none;\">\n\
+                 \t<span class=\"str-close\">Close speaker notes</span>\n\
+                 \t<span class=\"str-speaker-notes\">Speaker Notes</span>\n\
+                 \t<span class=\"str-speaker-notes-for\">Speaker Notes for </span>\n\
+                 \t<span class=\"str-popup-error\">Could not open popup, please check your popup blocker settings.</span>\n\
+                 </div>\n",
+            );
             if let Some((course, session, segment, slide)) =
                 courses.find_slide(chapter)
             {

--- a/theme/speaker-notes.js
+++ b/theme/speaker-notes.js
@@ -14,6 +14,18 @@
 // limitations under the License.
 
 (function () {
+  // Helper to fetch translated strings injected by mdbook-course
+  function getTranslation(key, defaultText) {
+    let translations = document.getElementById("speaker-notes-translations");
+    if (translations) {
+      let el = translations.querySelector(".str-" + key);
+      if (el && el.textContent) {
+        return el.textContent;
+      }
+    }
+    return defaultText;
+  }
+
   // Valid speaker notes states
   const NotesState = {
     Popup: "popup",
@@ -151,8 +163,9 @@
     // Create pop-in button.
     popIn.setAttribute("id", "speaker-notes-toggle");
     popIn.setAttribute("type", "button");
-    popIn.setAttribute("title", "Close speaker notes");
-    popIn.setAttribute("aria-label", "Close speaker notes");
+    let closeTitle = getTranslation("close", "Close speaker notes");
+    popIn.setAttribute("title", closeTitle);
+    popIn.setAttribute("aria-label", closeTitle);
     popIn.classList.add("icon-button");
     popIn.innerHTML = document.getElementById("fa-xmark").innerHTML;
     popIn.addEventListener("click", (event) => {
@@ -175,7 +188,7 @@
 
     let h4 = document.createElement("h4");
     h4.setAttribute("id", "speaker-notes");
-    h4.append("Speaker Notes");
+    h4.append(getTranslation("speaker-notes", "Speaker Notes"));
     h4.addEventListener("click", (event) => {
       // Update fragment as if we had clicked a link. A regular a element would
       // result in double-fire of the event.
@@ -198,7 +211,7 @@
         setSpeakerNotesState(NotesState.Popup);
       } else {
         window.alert(
-          "Could not open popup, please check your popup blocker settings.",
+          getTranslation("popup-error", "Could not open popup, please check your popup blocker settings.")
         );
       }
     });
@@ -215,7 +228,7 @@
       let summary = document.createElement("summary");
       notes.insertBefore(summary, notes.firstChild);
       let h4 = document.createElement("h4");
-      h4.append("Speaker Notes");
+      h4.append(getTranslation("speaker-notes", "Speaker Notes"));
       summary.append(h4);
     }
   }
@@ -251,7 +264,7 @@
           let a = document.createElement("a");
           a.setAttribute("href", pageLocation.href);
           a.append(node.innerText);
-          h4.append("Speaker Notes for ", a);
+          h4.append(getTranslation("speaker-notes-for", "Speaker Notes for "), a);
           node.replaceWith(h4);
           i += 1;
           break;


### PR DESCRIPTION
Description
This PR resolves the issue where Speaker Notes strings were hardcoded in theme/speaker-notes.js, making them inaccessible to the mdbook-i18n-helpers gettext translation workflow.

Approach
Because xgettext extraction natively targets the markdown content, I integrated the strings into the existing translation pipeline:

Preprocessor HTML Injection: Modified mdbook-course to append a hidden div with the id speaker-notes-translations containing the required UI strings to the end of each chapter's content stream.

Translation Extraction: Because the strings are now embedded in the markdown stream, mdbook-i18n-helpers will automatically extract them into messages.pot for translators.

Dynamic UI Updates: Updated theme/speaker-notes.js to look for this injected div. If found, it dynamically extracts the translated textContent and updates the UI buttons and headings accordingly, falling back to English gracefully if not found.

This ensures translators can continue using their standard .po files without needing to touch JavaScript files.

Strings localized:

"Close speaker notes"

"Speaker Notes"

"Speaker Notes for"

"Could not open popup, please check your popup blocker settings."